### PR TITLE
Hamish fix

### DIFF
--- a/data/hamish/fixed/vb5042sup1.cif
+++ b/data/hamish/fixed/vb5042sup1.cif
@@ -1,0 +1,8050 @@
+
+data_QPAPBMXGreaseSuspendedSamplePrep_publ
+_audit_creation_method  "created in GSAS-II"
+_audit_creation_date  2021-08-04T17:25
+_audit_author_name  "McDougall, Hamish"
+_audit_update_record
+   "2021-08-04T17:25  Initial software-generated CIF"
+_pd_block_id
+
+2021-08-04T17:25|QPAPBMXGreaseSuspendedSamplePrep|McDougallHamish|Overall
+
+# GSAS-II edited template follows Publication_Template
+#=============================================================================
+# this information describes the project, paper etc. for the CIF             #
+# Acta Cryst. Section C papers and editorial correspondence is generated     #
+# from the information in this section                                       #
+#                                                                            #
+#   (from)   CIF submission form for Rietveld refinements (Acta Cryst. C)    #
+#                                                 Version 14 December 1998   #
+#=============================================================================
+# 1. SUBMISSION DETAILS
+
+_publ_contact_author_name            "Suzanne Neville; Vanessa Peterson; Christophe Didier"   # Name of author for correspondence
+_publ_contact_author_address             # Address of author for correspondence
+; ?
+;
+_publ_contact_author_email           "s.neville@unsw.edu.au; vanessa.peterson@ansto.gov.au; drchristophedidier@gmail.com"
+_publ_contact_author_fax             ?
+_publ_contact_author_phone           ?
+
+_publ_contact_letter
+; ?
+;
+   
+_publ_requested_journal              ?
+_publ_requested_coeditor_name        ?
+_publ_requested_category             ?   # Acta C: one of CI/CM/CO/FI/FM/FO
+
+#==============================================================================
+
+# 2. PROCESSING SUMMARY (IUCr Office Use Only)
+
+_journal_data_validation_number      ?
+
+_journal_date_recd_electronic        ?
+_journal_date_to_coeditor            ?
+_journal_date_from_coeditor          ?
+_journal_date_accepted               ?
+_journal_date_printers_first         ?
+_journal_date_printers_final         ?
+_journal_date_proofs_out             ?
+_journal_date_proofs_in              ?
+_journal_coeditor_name               ?
+_journal_coeditor_code               ?
+_journal_coeditor_notes
+; ?
+;
+_journal_techeditor_code             ?
+_journal_techeditor_notes
+; ?
+;
+_journal_coden_ASTM                  ?
+_journal_name_full                   ?
+_journal_year                        ?
+_journal_volume                      ?
+_journal_issue                       ?
+_journal_page_first                  ?
+_journal_page_last                   ?
+_journal_paper_category              ?
+_journal_suppl_publ_number           ?
+_journal_suppl_publ_pages            ?
+
+#==============================================================================
+
+# 3. TITLE AND AUTHOR LIST
+
+_publ_section_title
+; ?
+;
+_publ_section_title_footnote
+; ?
+;         
+ 
+# The loop structure below should contain the names and addresses of all 
+# authors, in the required order of publication. Repeat as necessary.
+
+loop_
+	_publ_author_name
+        _publ_author_footnote
+	_publ_author_address
+ ?                                   #<--'Last name, first name' 
+; ?
+;
+; ?
+;
+
+#==============================================================================
+
+# 4. TEXT
+
+_publ_section_synopsis
+;  ?
+;
+_publ_section_abstract                         
+; ?
+;          
+_publ_section_comment                          
+; ?
+;
+_publ_section_exptl_prep      # Details of the preparation of the sample(s)
+                              # should be given here. 
+; ?
+;
+_publ_section_exptl_refinement                  
+; ?
+;
+_publ_section_references
+; ?
+;
+_publ_section_figure_captions
+; ?
+;
+_publ_section_acknowledgements
+; ?
+;
+
+#=============================================================================
+# 5. OVERALL REFINEMENT & COMPUTING DETAILS
+
+_refine_special_details
+; ?
+;
+_pd_proc_ls_special_details
+; ?
+;
+
+# The following items are used to identify the programs used.
+_computing_molecular_graphics     ?
+_computing_publication_material   ?
+
+_refine_ls_weighting_scheme       ?        
+_refine_ls_weighting_details      ?
+_refine_ls_hydrogen_treatment     ?        
+_refine_ls_extinction_method      ?        
+_refine_ls_extinction_coef        ?         
+_refine_ls_number_constraints     ?        
+
+_refine_ls_restrained_S_all       ?        
+_refine_ls_restrained_S_obs       ?
+
+#==============================================================================
+# 6. SAMPLE PREPARATION DATA
+
+# (In the unusual case where multiple samples are used in a single
+#  Rietveld study, this information should be moved into the phase
+#  blocks)
+
+# The following three fields describe the preparation of the material.
+# The cooling rate is in K/min.  The pressure at which the sample was  
+# prepared is in kPa.  The temperature of preparation is in K.
+               
+_pd_prep_cool_rate                N/A        
+_pd_prep_pressure                 101.3        
+_pd_prep_temperature              298         
+
+_pd_char_colour                   ?       # use ICDD colour descriptions
+
+data_QPAPBMXGreaseSuspendedSamplePrep_overall
+_pd_proc_info_datetime  2021-08-04T17:25
+_pd_calc_method  "Rietveld Refinement"
+_computing_structure_refinement
+   "GSAS-II (Toby & Von Dreele, J. Appl. Cryst. 46, 544-549, 2013)"
+_refine_ls_number_parameters  30
+_refine_ls_goodness_of_fit_all  1.783
+_refine_ls_shift/su_max  1.3150
+
+# OVERALL WEIGHTED R-FACTOR
+_refine_ls_wR_factor_obs  0.11424
+_refine_ls_matrix_type  full
+# POINTERS TO PHASE AND HISTOGRAM BLOCKS
+loop_   _pd_phase_block_id
+;
+2021-08-04T17:25|QPAPBMXGreaseSuspendedSamplePrep|phase_2|McDougallHamish
+;
+;
+2021-08-04T17:25|QPAPBMXGreaseSuspendedSamplePrep|phase_0|McDougallHamish
+;
+;
+2021-08-04T17:25|QPAPBMXGreaseSuspendedSamplePrep|phase_3|McDougallHamish
+;
+;
+2021-08-04T17:25|QPAPBMXGreaseSuspendedSamplePrep|phase_4|McDougallHamish
+;
+;
+2021-08-04T17:25|QPAPBMXGreaseSuspendedSamplePrep|phase_1|McDougallHamish
+;
+_pd_block_diffractogram_id
+;
+2021-08-04T17:25|QPAPBMXGreaseSuspendedSamplePrep|McDougallHamish|PANalytical,Co-EmpyreanII_hist_0
+;
+
+data_QPAPBMXGreaseSuspendedSamplePrep_phase_2
+# Information for phase 2
+_pd_block_id
+
+2021-08-04T17:25|QPAPBMXGreaseSuspendedSamplePrep|phase_2|McDougallHamish
+
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Albite NaAlSi3O8 - 68913 follows
+_pd_phase_name  "Albite NaAlSi3O8 - 68913"
+_cell_length_a  8.138925
+_cell_length_b  12.799307
+_cell_length_c  7.160071
+_cell_angle_alpha  94.2255
+_cell_angle_beta   116.5999
+_cell_angle_gamma  87.8097
+_cell_volume  665.111
+_exptl_crystal_density_diffrn  2.6187
+_symmetry_cell_setting  triclinic
+_symmetry_space_group_name_H-M  "C -1"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -x,-y,-z
+     3  1/2+x,1/2+y,z
+     4  1/2-x,1/2-y,-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Al1    Al3+ 0.00887     0.16846     0.20805     1.000      Uani 0.007      4   
+Si1    Si4+ 0.00375     0.82051     0.23737     1.000      Uani 0.006      4   
+Si2    Si4+ 0.69162     0.11021     0.31466     1.000      Uani 0.006      4   
+Si3    Si4+ 0.68129     0.88190     0.36076     1.000      Uani 0.006      4   
+Na1    Na1+ 0.26799     0.98865     0.14650     1.000      Uani 0.031      4   
+O1     O2-  0.00490     0.13103     0.96660     1.000      Uani 0.012      4   
+O2     O2-  0.59176     0.99756     0.28040     1.000      Uani 0.008      4   
+O3     O2-  0.81230     0.10966     0.19010     1.000      Uani 0.014      4   
+O4     O2-  0.82000     0.85101     0.25870     1.000      Uani 0.018      4   
+O5     O2-  0.01288     0.30238     0.27060     1.000      Uani 0.011      4   
+O6     O2-  0.02329     0.69368     0.22910     1.000      Uani 0.011      4   
+O7     O2-  0.20780     0.10896     0.38900     1.000      Uani 0.011      4   
+O8     O2-  0.18400     0.86817     0.43620     1.000      Uani 0.012      4   
+
+loop_
+   _atom_site_aniso_label
+   _atom_site_aniso_U_11
+   _atom_site_aniso_U_22
+   _atom_site_aniso_U_33
+   _atom_site_aniso_U_12
+   _atom_site_aniso_U_13
+   _atom_site_aniso_U_23
+Al1    0.0074      0.0068      0.0061      -0.0009     0.0031      0.0004      
+Si1    0.0068      0.0065      0.0055      0.0011      0.0030      0.0008      
+Si2    0.0061      0.0055      0.0073      -0.0002     0.0025      0.0004      
+Si3    0.0060      0.0055      0.0074      0.0006      0.0028      0.0009      
+Na1    0.0136      0.0471      0.0315      -0.0050     0.0084      -0.0219     
+O1     0.0164      0.0122      0.0074      -0.0002     0.0067      0.0014      
+O2     0.0074      0.0056      0.0119      0.0003      0.0033      0.0020      
+O3     0.0117      0.0130      0.0162      -0.0040     0.0093      -0.0017     
+O4     0.0134      0.0179      0.0216      0.0046      0.0129      0.0020      
+O5     0.0103      0.0076      0.0150      -0.0020     0.0052      -0.0009     
+O6     0.0101      0.0071      0.0145      0.0022      0.0034      0.0012      
+O7     0.0120      0.0129      0.0080      0.0024      0.0013      0.0015      
+O8     0.0140      0.0140      0.0084      -0.0026     -0.0002     -0.0006     
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Al   4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Na   4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  O    32     ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si   12     ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Al Na O8 Si3"
+_chemical_formula_weight  262.22
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Al1    O1     1.74597      1_555    1_554 yes
+  Al1    O3     1.74245      1_555    1_455 yes
+  Al1    O5     1.73718      1_555    1_555 yes
+  Al1    O7     1.74718      1_555    1_555 yes
+  Si1    O1     1.6002       1_555    2_566 yes
+  Si1    O4     1.60108      1_555    1_455 yes
+  Si1    O6     1.62436      1_555    1_555 yes
+  Si1    O8     1.61901      1_555    1_555 yes
+  Si2    O2     1.63051      1_555    1_545 yes
+  Si2    O3     1.59474      1_555    1_555 yes
+  Si2    O6     1.62068      1_555    3_545 yes
+  Si2    O8     1.61711      1_555    2_666 yes
+  Si3    O2     1.64959      1_555    1_555 yes
+  Si3    O4     1.62079      1_555    1_555 yes
+  Si3    O5     1.59651      1_555    3_555 yes
+  Si3    O7     1.60239      1_555    2_666 yes
+  Na1    O1     2.67262      1_555    1_564 yes
+  Na1    O1     2.53018      1_555    2_566 yes
+  Na1    O2     2.37077      1_555    1_555 yes
+  Na1    O3     2.45447      1_555    2_665 yes
+  Na1    O7     2.43641      1_555    1_565 yes
+  O1     Al1    1.74597      1_555    1_556 yes
+  O1     Si1    1.6002       1_555    2_566 yes
+  O1     Na1    2.67262      1_555    1_546 yes
+  O1     Na1    2.53018      1_555    2_566 yes
+  O2     Si2    1.63051      1_555    1_565 yes
+  O2     Si3    1.64959      1_555    1_555 yes
+  O2     Na1    2.37077      1_555    1_555 yes
+  O3     Al1    1.74245      1_555    1_655 yes
+  O3     Si2    1.59474      1_555    1_555 yes
+  O3     Na1    2.45447      1_555    2_665 yes
+  O4     Si1    1.60108      1_555    1_655 yes
+  O4     Si3    1.62079      1_555    1_555 yes
+  O5     Al1    1.73718      1_555    1_555 yes
+  O5     Si3    1.59651      1_555    3_445 yes
+  O6     Si1    1.62436      1_555    1_555 yes
+  O6     Si2    1.62068      1_555    3_455 yes
+  O7     Al1    1.74718      1_555    1_555 yes
+  O7     Si3    1.60239      1_555    2_666 yes
+  O7     Na1    2.43641      1_555    1_545 yes
+  O8     Si1    1.61901      1_555    1_555 yes
+  O8     Si2    1.61711      1_555    2_666 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Al1    O3     102.839       1_554  1_555    1_455 yes
+  O1     Al1    O5     116.078       1_554  1_555    1_555 yes
+  O3     Al1    O5     112.16        1_455  1_555    1_555 yes
+  O1     Al1    O7     103.947       1_554  1_555    1_555 yes
+  O3     Al1    O7     111.136       1_455  1_555    1_555 yes
+  O5     Al1    O7     110.225       1_555  1_555    1_555 yes
+  O1     Si1    O4     109.382       2_566  1_555    1_455 yes
+  O1     Si1    O6     112.467       2_566  1_555    1_555 yes
+  O4     Si1    O6     108.286       1_455  1_555    1_555 yes
+  O1     Si1    O8     107.201       2_566  1_555    1_555 yes
+  O4     Si1    O8     111.41        1_455  1_555    1_555 yes
+  O6     Si1    O8     108.124       1_555  1_555    1_555 yes
+  O2     Si2    O3     111.07        1_545  1_555    1_555 yes
+  O2     Si2    O6     104.318       1_545  1_555    3_545 yes
+  O3     Si2    O6     112.142       1_555  1_555    3_545 yes
+  O2     Si2    O8     106.953       1_545  1_555    2_666 yes
+  O3     Si2    O8     111.607       1_555  1_555    2_666 yes
+  O6     Si2    O8     110.392       3_545  1_555    2_666 yes
+  O2     Si3    O4     107.348       1_555  1_555    1_555 yes
+  O2     Si3    O5     105.916       1_555  1_555    3_555 yes
+  O4     Si3    O5     110.171       1_555  1_555    3_555 yes
+  O2     Si3    O7     108.553       1_555  1_555    2_666 yes
+  O4     Si3    O7     110.204       1_555  1_555    2_666 yes
+  O5     Si3    O7     114.325       3_555  1_555    2_666 yes
+  Al1    O1     Si1    141.36        1_556  1_555    2_566 yes
+  Si2    O2     Si3    130.051       1_565  1_555    1_555 yes
+  Si2    O2     Na1    120.258       1_565  1_555    1_555 yes
+  Si3    O2     Na1    108.874       1_555  1_555    1_555 yes
+  Al1    O3     Si2    139.443       1_655  1_555    1_555 yes
+  Si1    O4     Si3    161.159       1_655  1_555    1_555 yes
+  Al1    O5     Si3    129.66        1_555  1_555    3_445 yes
+  Si1    O6     Si2    135.75        1_555  1_555    3_455 yes
+  Al1    O7     Si3    133.908       1_555  1_555    2_666 yes
+  Si1    O8     Si2    151.752       1_555  1_555    2_666 yes
+_pd_proc_ls_pref_orient_corr  none
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.206(13), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_QPAPBMXGreaseSuspendedSamplePrep_phase_0
+# Information for phase 0
+_pd_block_id
+
+2021-08-04T17:25|QPAPBMXGreaseSuspendedSamplePrep|phase_0|McDougallHamish
+
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Pyrite FeS2 - 3919 follows
+_pd_phase_name  "Pyrite FeS2 - 3919"
+_cell_length_a  5.41928(5)
+_cell_length_b  5.41928(5)
+_cell_length_c  5.41928(5)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  90
+_cell_volume  159.157(4)
+_exptl_crystal_density_diffrn  5.0066
+_symmetry_cell_setting  cubic
+_symmetry_space_group_name_H-M  "P a -3"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  z,x,y
+     3  y,z,x
+     4  1/2+x,y,1/2-z
+     5  1/2-z,1/2+x,y
+     6  y,1/2-z,1/2+x
+     7  -z,1/2+x,1/2-y
+     8  1/2-y,-z,1/2+x
+     9  1/2+y,1/2-z,-x
+    10  -x,1/2+y,1/2-z
+    11  1/2-z,-x,1/2+y
+    12  1/2+x,1/2-y,-z
+    13  -x,-y,-z
+    14  -z,-x,-y
+    15  -y,-z,-x
+    16  1/2-x,-y,1/2+z
+    17  1/2+z,1/2-x,-y
+    18  -y,1/2+z,1/2-x
+    19  z,1/2-x,1/2+y
+    20  1/2+y,z,1/2-x
+    21  1/2-y,1/2+z,x
+    22  x,1/2-y,1/2+z
+    23  1/2+z,x,1/2-y
+    24  1/2-x,1/2+y,z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Fe1    Fe   0.00000     0.00000     0.00000     1.000      Uiso 0.0115(7)  4   
+S2     S    0.38435(13) 0.38435     0.38435     1.000      Uiso 0.0087(6)  8   
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Fe   4      11.7695    7.3573     3.5222     2.3045     4.7611     0.3072     15.3535    76.8805    1.0369     0.945
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S    8      6.9053     5.2034     1.4379     1.5863     1.4679     22.2151    0.2536     56.172     0.8669     0.2847
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Fe S2"
+_chemical_formula_weight  119.97
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Fe1    S2     2.26363(20)   1_555    4_455 yes
+  Fe1    S2     2.26363(20)   1_555    5_545 yes
+  Fe1    S2     2.26363(20)   1_555    6_554 yes
+  Fe1    S2     2.26363(20)   1_555    7_545 yes
+  Fe1    S2     2.26363(20)   1_555    8_554 yes
+  Fe1    S2     2.2636(7)    1_555    9_455 yes
+  S2     Fe1    2.26363(20)   1_555    4_555 yes
+  S2     Fe1    2.26363(20)   1_555    5_555 yes
+  S2     Fe1    2.2636(7)    1_555    6_555 yes
+  S2     S2     2.1712(8)    1_555   13_666 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.379(4), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_QPAPBMXGreaseSuspendedSamplePrep_phase_3
+# Information for phase 3
+_pd_block_id
+
+2021-08-04T17:25|QPAPBMXGreaseSuspendedSamplePrep|phase_3|McDougallHamish
+
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Pyrrhotite 4M Fe7S8 - 0723 follows
+_pd_phase_name  "Pyrrhotite 4M Fe7S8 - 0723"
+_cell_length_a  11.937(11)
+_cell_length_b  6.8622(15)
+_cell_length_c  12.812(13)
+_cell_angle_alpha  90
+_cell_angle_beta   117.247(23)
+_cell_angle_gamma  90
+_cell_volume  932.99(21)
+_exptl_crystal_density_diffrn  4.6090
+_symmetry_cell_setting  monoclinic
+_symmetry_space_group_name_H-M  "C 2/c"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -x,y,1/2-z
+     3  -x,-y,-z
+     4  x,-y,1/2+z
+     5  1/2+x,1/2+y,z
+     6  1/2-x,1/2+y,1/2-z
+     7  1/2-x,1/2-y,-z
+     8  1/2+x,1/2-y,1/2+z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+S1     S    0.01800     0.38330     0.11960     1.000      Uiso 0.010      8   
+S2     S    0.02910     0.11420     0.63900     1.000      Uiso 0.010      8   
+Fe3    Fe   0.10860     0.10250     0.49980     1.000      Uiso 0.010      8   
+S4     S    0.23410     0.13550     0.38260     1.000      Uiso 0.010      8   
+Fe5    Fe   0.24180     0.36600     0.24680     1.000      Uiso 0.010      8   
+S6     S    0.26790     0.13400     0.12360     1.000      Uiso 0.010      8   
+Fe7    Fe   0.38720     0.15000     0.01260     1.000      Uiso 0.010      8   
+Fe8    Fe   0.00000     0.14720     0.25000     1.000      Uiso 0.010      4   
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Fe   28     11.7695    7.3573     3.5222     2.3045     4.7611     0.3072     15.3535    76.8805    1.0369     0.945
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S    32     6.9053     5.2034     1.4379     1.5863     1.4679     22.2151    0.2536     56.172     0.8669     0.2847
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Fe7 S8"
+_chemical_formula_weight  647.41
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  S1     Fe3    2.494        1_555    2_555 yes
+  S1     Fe5    2.41247      1_555    1_555 yes
+  S1     Fe7    2.38885      1_555    5_455 yes
+  S1     Fe7    2.44056      1_555    7_555 yes
+  S1     Fe8    2.40643      1_555    1_555 yes
+  S2     Fe3    2.37426      1_555    1_555 yes
+  S2     Fe3    2.32355      1_555    3_556 yes
+  S2     Fe5    2.44416      1_555    7_556 yes
+  S2     Fe7    2.36604      1_555    8_456 yes
+  S2     Fe8    2.41103      1_555    3_556 yes
+  Fe3    S1     2.494        1_555    2_555 yes
+  Fe3    S2     2.37426      1_555    1_555 yes
+  Fe3    S2     2.32355      1_555    3_556 yes
+  Fe3    S6     2.45024      1_555    4_556 yes
+  S4     Fe5    2.38408      1_555    1_555 yes
+  Fe5    S1     2.41247      1_555    1_555 yes
+  Fe5    S2     2.44416      1_555    7_556 yes
+  Fe5    S4     2.38408      1_555    1_555 yes
+  Fe5    S6     2.36079      1_555    1_555 yes
+  S6     Fe3    2.45024      1_555    4_555 yes
+  S6     Fe5    2.36079      1_555    1_555 yes
+  S6     Fe7    2.43241      1_555    1_555 yes
+  S6     Fe7    2.38986      1_555    7_555 yes
+  Fe7    S1     2.38885      1_555    5_545 yes
+  Fe7    S1     2.44056      1_555    7_555 yes
+  Fe7    S2     2.36604      1_555    8_555 yes
+  Fe7    S6     2.43241      1_555    1_555 yes
+  Fe7    S6     2.38986      1_555    7_555 yes
+  Fe8    S1     2.40643      1_555    1_555 yes
+  Fe8    S1     2.40643      1_555    2_555 yes
+  Fe8    S2     2.41103      1_555    3_556 yes
+  Fe8    S2     2.41103      1_555    4_555 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.061(4), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_QPAPBMXGreaseSuspendedSamplePrep_phase_4
+# Information for phase 4
+_pd_block_id
+
+2021-08-04T17:25|QPAPBMXGreaseSuspendedSamplePrep|phase_4|McDougallHamish
+
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Rutile TiO2 follows
+_pd_phase_name  "Rutile TiO2"
+_cell_length_a  4.5970(29)
+_cell_length_b  4.5970(29)
+_cell_length_c  2.9629(26)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  90
+_cell_volume  62.61(6)
+_exptl_crystal_density_diffrn  4.2379
+_symmetry_cell_setting  tetragonal
+_symmetry_space_group_name_H-M  "P 42/m n m"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  1/2-y,1/2+x,1/2+z
+     3  -x,-y,z
+     4  1/2+y,1/2-x,1/2+z
+     5  1/2-x,1/2+y,1/2+z
+     6  -y,-x,z
+     7  1/2+x,1/2-y,1/2+z
+     8  y,x,z
+     9  -x,-y,-z
+    10  1/2+y,1/2-x,1/2-z
+    11  x,y,-z
+    12  1/2-y,1/2+x,1/2-z
+    13  1/2+x,1/2-y,1/2-z
+    14  y,x,-z
+    15  1/2-x,1/2+y,1/2-z
+    16  -y,-x,-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Ti1    Ti4+ 0.00000     0.00000     0.00000     1.000      Uani 0.006      2   
+O1     O2-  0.30493     0.30493     0.00000     1.000      Uani 0.006      4   
+
+loop_
+   _atom_site_aniso_label
+   _atom_site_aniso_U_11
+   _atom_site_aniso_U_22
+   _atom_site_aniso_U_33
+   _atom_site_aniso_U_12
+   _atom_site_aniso_U_13
+   _atom_site_aniso_U_23
+Ti1    0.0070      0.0070      0.0047      -0.0002     0.0000      0.0000      
+O1     0.0060      0.0060      0.0045      -0.0019     0.0000      0.0000      
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  O    4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Ti   2      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  2
+_chemical_formula_sum  "O2 Ti"
+_chemical_formula_weight  79.9
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Ti1    O1     1.98239      1_555    1_555 yes
+  Ti1    O1     1.95011      1_555    2_544 yes
+  Ti1    O1     1.95011      1_555    2_545 yes
+  Ti1    O1     1.98239      1_555    3_555 yes
+  Ti1    O1     1.95011      1_555    4_454 yes
+  Ti1    O1     1.95011      1_555    4_455 yes
+  O1     Ti1    1.98239      1_555    1_555 yes
+  O1     Ti1    1.95011      1_555    2_554 yes
+  O1     Ti1    1.95011      1_555    2_555 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Ti1    O1     90            1_555  1_555    2_544 yes
+  O1     Ti1    O1     90            1_555  1_555    2_545 yes
+  O1     Ti1    O1     98.87         2_544  1_555    2_545 yes
+  O1     Ti1    O1     180           1_555  1_555    3_555 yes
+  O1     Ti1    O1     90            2_544  1_555    3_555 yes
+  O1     Ti1    O1     90            2_545  1_555    3_555 yes
+  O1     Ti1    O1     90            1_555  1_555    4_454 yes
+  O1     Ti1    O1     81.13         2_544  1_555    4_454 yes
+  O1     Ti1    O1     180           2_545  1_555    4_454 yes
+  O1     Ti1    O1     90            3_555  1_555    4_454 yes
+  O1     Ti1    O1     90            1_555  1_555    4_455 yes
+  O1     Ti1    O1     180           2_544  1_555    4_455 yes
+  O1     Ti1    O1     81.13         2_545  1_555    4_455 yes
+  O1     Ti1    O1     90            3_555  1_555    4_455 yes
+  O1     Ti1    O1     98.87         4_454  1_555    4_455 yes
+  Ti1    O1     Ti1    130.565       1_555  1_555    2_554 yes
+  Ti1    O1     Ti1    130.565       1_555  1_555    2_555 yes
+  Ti1    O1     Ti1    98.87         2_554  1_555    2_555 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.100, 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_QPAPBMXGreaseSuspendedSamplePrep_phase_1
+# Information for phase 1
+_pd_block_id
+
+2021-08-04T17:25|QPAPBMXGreaseSuspendedSamplePrep|phase_1|McDougallHamish
+
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Silica SiO2 follows
+_pd_phase_name  "Silica SiO2"
+_cell_length_a  4.9149(5)
+_cell_length_b  4.9149(5)
+_cell_length_c  5.4057(4)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  120
+_cell_volume  113.086(10)
+_exptl_crystal_density_diffrn  2.6468
+_symmetry_cell_setting  trigonal
+_symmetry_space_group_name_H-M  "P 32 2 1"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -y,x-y,2/3+z
+     3  y-x,-x,1/3+z
+     4  y,x,-z
+     5  -x,y-x,2/3-z
+     6  x-y,-y,1/3-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Si1    Si4+ 0.47000     0.00000     0.66670     1.000      Uiso 0.010      3   
+O1     O2-  0.41460     0.26780     0.78543     1.000      Uiso 0.010      6   
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  O    6      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si   3      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  3
+_chemical_formula_sum  "O2 Si"
+_chemical_formula_weight  60.08
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Si1    O1     1.60526      1_555    1_555 yes
+  Si1    O1     1.61161      1_555    2_654 yes
+  Si1    O1     1.61135      1_555    5_656 yes
+  Si1    O1     1.6054       1_555    6_556 yes
+  O1     Si1    1.60526      1_555    1_555 yes
+  O1     Si1    1.61161      1_555    3_665 yes
+  O1     Si1    1.61135      1_555    5_666 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Si1    O1     110.256       1_555  1_555    2_654 yes
+  O1     Si1    O1     108.745       1_555  1_555    5_656 yes
+  O1     Si1    O1     109.685       2_654  1_555    5_656 yes
+  O1     Si1    O1     109.161       1_555  1_555    6_556 yes
+  O1     Si1    O1     108.725       2_654  1_555    6_556 yes
+  O1     Si1    O1     110.262       5_656  1_555    6_556 yes
+  Si1    O1     Si1    143.832       1_555  1_555    3_665 yes
+  Si1    O1     Si1    143.836       1_555  1_555    5_666 yes
+  Si1    O1     Si1    0.009         3_665  1_555    5_666 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.244(15), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_QPAPBMXGreaseSuspendedSamplePrep_pwd_0
+_pd_proc_ls_profile_function
+;
+Finger-Cox-Jephcoat function parameters U, V, W, X, Y, SH/L:
+  peak variance(Gauss) = Utan(Th)^2^+Vtan(Th)+W:
+  peak HW(Lorentz) = X/cos(Th)+Ytan(Th); SH/L = S/L+H/L
+  U, V, W in (centideg)^2^, X & Y in centideg
+    0.000, 0.000, 3.345, 2.239, -0.670, 0.034, 
+;
+# Information for histogram 0: PWDR 201103PBHMGR_PyriteSiGrease [201103PBHM].xrdml Scan 1
+_pd_block_id
+
+2021-08-04T17:25|QPAPBMXGreaseSuspendedSamplePrep|McDougallHamish|PANalytical,Co-EmpyreanII_hist_0
+
+# GSAS-II edited template follows Instrument_Template
+#==============================================================================
+# 9. INSTRUMENT CHARACTERIZATION
+
+_exptl_special_details
+; ?
+;
+
+# if regions of the data are excluded, the reason(s) are supplied here:
+_pd_proc_info_excluded_regions
+; ?
+;
+
+# The following item is used to identify the equipment used to record 
+# the powder pattern when the diffractogram was measured at a laboratory 
+# other than the authors' home institution, e.g. when neutron or synchrotron
+# radiation is used.
+
+_pd_instr_location
+; ?
+;
+_pd_calibration_special_details           # description of the method used
+                                          # to calibrate the instrument
+; ?
+;
+
+_diffrn_source                    Co-Ka       
+_diffrn_source_target             Co
+_diffrn_source_type               Graded_Flat
+_diffrn_measurement_device_type   Panalytical_Reflection_Transmission       
+_diffrn_detector                  PIXcel1D       
+_diffrn_detector_type             Empyrean_II       # make or model of detector
+
+_pd_meas_scan_method              ?       # options are 'step', 'cont',
+                                          # 'tof', 'fixed' or
+                                          # 'disp' (= dispersive)
+_pd_meas_special_details
+;  ?
+;
+
+# The following two items identify the program(s) used (if appropriate).
+_computing_data_collection        ?        
+_computing_data_reduction         ?                   
+
+# Describe any processing performed on the data, prior to refinement.
+# For example: a manual Lp correction or a precomputed absorption correction
+_pd_proc_info_data_reduction      ?
+
+# The following item is used for angular dispersive measurements only.
+
+_diffrn_radiation_monochromator   ?        
+
+# The following items are used to define the size of the instrument.
+# Not all distances are appropriate for all instrument types.
+
+_pd_instr_dist_src/mono           ?
+_pd_instr_dist_mono/spec          ?
+_pd_instr_dist_src/spec           ?
+_pd_instr_dist_spec/anal          ?
+_pd_instr_dist_anal/detc          ?
+_pd_instr_dist_spec/detc          ?
+
+# 10. Specimen size and mounting information
+
+# The next three fields give the specimen dimensions in mm.  The equatorial 
+# plane contains the incident and diffracted beam.
+
+_pd_spec_size_axial               ?       # perpendicular to 
+                                          # equatorial plane
+
+_pd_spec_size_equat               ?       # parallel to 
+                                          # scattering vector 
+                                          # in transmission
+
+_pd_spec_size_thick               ?       # parallel to 
+                                          # scattering vector 
+                                          # in reflection
+
+_pd_spec_mounting                         # This field should be
+                                          # used to give details of the 
+                                          # container.
+; ?
+;
+
+_pd_spec_mount_mode               ?       # options are 'reflection' 
+                                          # or 'transmission'
+    
+_pd_spec_shape                    ?       # options are 'cylinder' 
+                                          # 'flat_sheet' or 'irregular'
+
+
+loop_
+     _atom_type_symbol
+     _atom_type_scat_dispersion_real
+     _atom_type_scat_dispersion_imag
+     _atom_type_scat_dispersion_source
+  Al        0.255   0.328   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Fe       -3.332   0.490   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Na        0.167   0.167   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  O         0.063   0.044   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S         0.371   0.733   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si        0.298   0.438   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Ti       -0.063   2.321   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+_diffrn_radiation_type  K\a~1,2~
+loop_
+   _diffrn_radiation_wavelength
+   _diffrn_radiation_wavelength_wt
+   _diffrn_radiation_wavelength_id
+  1.78892         1.0             1     
+  1.79278         0.5000          2     
+
+# PHASE TABLE
+loop_
+   _pd_phase_id
+   _pd_phase_block_id
+   _pd_phase_mass_%
+  2  2021-08-04T17:25|QPAPBMXGreaseSuspendedSamplePrep|phase_2|McDougallHamish  0.1274(24)
+  0  2021-08-04T17:25|QPAPBMXGreaseSuspendedSamplePrep|phase_0|McDougallHamish  0.7533(28)
+  3  2021-08-04T17:25|QPAPBMXGreaseSuspendedSamplePrep|phase_3|McDougallHamish  0.0602(12)
+  4  2021-08-04T17:25|QPAPBMXGreaseSuspendedSamplePrep|phase_4|McDougallHamish  0.0044(5)
+  1  2021-08-04T17:25|QPAPBMXGreaseSuspendedSamplePrep|phase_1|McDougallHamish  0.0546(9)
+loop_
+   _gsas_proc_phase_R_F_factor
+   _gsas_proc_phase_R_Fsqd_factor
+   _gsas_proc_phase_id
+   _gsas_proc_phase_block_id
+    0.10687  0.39708  2  2021-08-04T17:25|QPAPBMXGreaseSuspendedSamplePrep|phase_2|McDougallHamish
+    0.02278  0.05179  0  2021-08-04T17:25|QPAPBMXGreaseSuspendedSamplePrep|phase_0|McDougallHamish
+    0.06926  0.11017  3  2021-08-04T17:25|QPAPBMXGreaseSuspendedSamplePrep|phase_3|McDougallHamish
+    0.05512  0.10491  4  2021-08-04T17:25|QPAPBMXGreaseSuspendedSamplePrep|phase_4|McDougallHamish
+    0.08988  0.19081  1  2021-08-04T17:25|QPAPBMXGreaseSuspendedSamplePrep|phase_1|McDougallHamish
+_pd_proc_ls_prof_R_factor     0.08119
+_pd_proc_ls_prof_wR_factor    0.11424
+_gsas_proc_ls_prof_R_B_factor   0.09066
+_gsas_proc_ls_prof_wR_B_factor  0.11657
+_pd_proc_ls_prof_wR_expected  0.06424
+_diffrn_radiation_probe  x-ray
+_diffrn_radiation_polarisn_ratio  0.7000
+_pd_proc_ls_background_function
+;
+Background function: "chebyschev-1" function with 7 terms:
+    181.2(5), -233.0(9), 140.3(8), -64.2(7), 23.5(7), -5.0(5), 
+    3.5(5), 
+;
+_diffrn_ambient_temperature  300
+_diffrn_ambient_pressure  100
+
+# STRUCTURE FACTOR TABLE
+loop_
+   _pd_refln_phase_id
+   _refln_index_h
+   _refln_index_k
+   _refln_index_l
+   _refln_F_squared_meas
+   _refln_F_squared_calc
+   _refln_phase_calc
+   _refln_d_spacing
+   _gsas_i100_meas
+  0  1    1    1    880.6142   862.3285   0.0     3.12882  23.64  
+  0  2    0    0    5936.7521  6060.3423  -0.0    2.70964  88.37  
+  0  2    1    0    3313.1826  3377.4384  0.0     2.42358  77.91  
+  0  2    1    1    1854.7944  1708.1513  -180.0  2.21241  71.89  
+  0  2    2    0    3375.0324  3164.7541  -0.0    1.91600  48.28  
+  0  2    2    1    33.7396    33.1676    -0.0    1.80643  0.85   
+  0  3    1    1    4835.5720  5045.6122  -0.0    1.63397  100.00 
+  0  2    2    2    2574.1005  2193.6808  0.0     1.56441  16.32  
+  0  3    0    2    2965.9778  2941.9535  -0.0    1.50304  26.20  
+  0  3    1    2    625.5014   603.7852   0.0     1.44836  10.36  
+  0  3    2    1    1625.6584  1569.2189  180.0   1.44836  26.93  
+  0  4    0    0    417.4178   425.2388   -180.0  1.35482  1.56   
+  0  3    2    2    35.3160    34.0840    -0.0    1.31437  0.51   
+  0  4    1    0    92.7173    89.4828    -0.0    1.31437  0.66   
+  0  4    1    1    46.5841    48.1452    180.0   1.27734  0.65   
+  1  1    0    0    420.7055   246.0001   180.0   4.25641  0.84   
+  1  1    0    1    655.5334   642.5993   120.0   3.34417  0.80   
+  1  1    0    -1   1576.5549  1545.4485  -120.0  3.34417  1.91   
+  1  1    1    0    336.9855   366.8305   -153.5  2.45744  0.21   
+  1  1    0    -2   128.9725   125.0260   -60.0   2.28170  0.07   
+  1  1    0    2    292.0484   283.1118   -120.0  2.28170  0.16   
+  1  1    1    1    134.7737   103.3422   90.1    2.23712  0.14   
+  1  2    0    0    261.5231   273.4863   0.0     2.12820  0.12   
+  1  2    0    -1   112.3739   82.3235    60.0    1.98026  0.05   
+  1  2    0    1    328.4764   240.6371   -60.0   1.98026  0.13   
+  1  1    1    2    565.0435   617.9827   9.8     1.81826  0.38   
+  1  0    0    3    49.8001    49.4912    0.0     1.80191  0.01   
+  1  2    0    2    75.5670    92.1401    60.0    1.67208  0.02   
+  1  2    0    -2   350.7077   427.6239   120.0   1.67208  0.10   
+  1  1    0    -3   143.5888   210.3288   180.0   1.65934  0.04   
+  1  1    0    3    7.0230     10.2873    0.0     1.65934  0.00   
+  1  2    1    0    24.4919    24.3799    -21.0   1.60877  0.01   
+  1  2    1    -1   621.0619   393.1170   95.4    1.54194  0.30   
+  1  2    1    1    422.8221   267.6360   -107.0  1.54194  0.21   
+  1  1    1    3    158.2322   149.1271   112.7   1.45313  0.07   
+  1  3    0    0    78.6188    84.2828    180.0   1.41880  0.02   
+  1  2    1    -2   358.9468   383.7375   -124.0  1.38242  0.14   
+  1  2    1    2    136.8040   146.2524   150.7   1.38242  0.06   
+  1  2    0    -3   193.4643   212.1659   -0.0    1.37519  0.04   
+  1  2    0    3    984.7400   1079.9318  0.0     1.37519  0.20   
+  1  3    0    -1   872.7549   836.5862   -120.0  1.37232  0.17   
+  1  3    0    1    8.3489     8.0029     -60.0   1.37232  0.00   
+  1  1    0    -4   125.7643   70.8900    -120.0  1.28806  0.02   
+  1  1    0    4    767.6514   432.7046   120.0   1.28806  0.14   
+  2  0    0    1    2371.7259  685.7867   180.0   6.38937  0.12   
+  2  0    2    0    1278.2068  396.4682   180.0   6.38215  0.05   
+  2  1    1    0    626.5458   238.2264   -0.0    6.33803  0.02   
+  2  1    -1   0    764.0634   287.5558   -0.0    6.30614  0.03   
+  2  1    1    -1   693.8461   406.2050   180.0   5.90981  0.02   
+  2  1    -1   -1   482.2860   415.7508   -180.0  5.59107  0.02   
+  2  0    2    -1   38.4761    16.5865    0.0     4.66552  0.00   
+  2  0    2    1    15.5665    1.8370     180.0   4.37892  0.00   
+  2  2    0    -1   28982.5537 21040.7682 -0.0    4.02860  0.43   
+  2  1    -1   1    5372.4994  3768.4641  -0.0    3.85490  0.08   
+  2  1    1    1    25626.0075 10390.7325 0.0     3.77570  0.41   
+  2  1    3    0    6601.8342  5887.8030  180.0   3.68247  0.08   
+  2  1    3    -1   3970.6851  4506.7668  0.0     3.66677  0.05   
+  2  1    -3   0    9616.0581  11684.2766 180.0   3.66371  0.12   
+  2  2    0    0    1.3493     2.5801     0.0     3.63867  0.00   
+  2  1    1    -2   4964.1875  4329.1619  0.0     3.50583  0.07   
+  2  2    2    -1   6963.5684  1650.0375  180.0   3.48036  0.08   
+  2  1    -3   -1   57.5213    12.1106    0.0     3.44114  0.00   
+  2  1    -1   -2   6381.3308  5252.5409  0.0     3.37438  0.08   
+  2  2    -2   -1   330.0901   365.4739   0.0     3.33748  0.00   
+  2  2    0    -2   28302.1491 26661.3709 -180.0  3.21590  0.29   
+  2  0    0    2    34930.4467 37077.8380 -180.0  3.19468  0.42   
+  2  0    4    0    22639.1713 25384.0136 180.0   3.19107  0.21   
+  2  2    2    0    13434.1253 13872.7626 180.0   3.16901  0.13   
+  2  2    -2   0    11649.1980 14957.3260 -180.0  3.15307  0.11   
+  2  1    -3   1    20974.8555 11184.2792 -180.0  2.96771  0.17   
+  2  2    2    -2   13411.5305 7187.7656  0.0     2.95490  0.11   
+  2  0    2    -2   6760.0343  5312.1771  0.0     2.93203  0.06   
+  2  0    4    -1   11263.6297 8593.0123  0.0     2.92994  0.09   
+  2  1    3    1    15939.2531 6898.1639  180.0   2.86181  0.14   
+  2  1    3    -2   2613.0782  1924.0931  -0.0    2.83981  0.02   
+  2  2    -2   -2   162.2316   183.4970   -0.0    2.79553  0.00   
+  2  0    2    2    161.5592   191.6866   0.0     2.78701  0.00   
+  2  0    4    1    334.7990   387.4011   -0.0    2.78521  0.00   
+  2  2    0    1    113.1057   109.6819   -0.0    2.68769  0.00   
+  2  3    1    -1   353.7622   431.0241   -180.0  2.66284  0.00   
+  2  1    -3   -2   5873.7326  6174.6196  -0.0    2.64084  0.04   
+  2  3    -1   -1   31.3741    33.5523    -180.0  2.62711  0.00   
+  2  2    4    -1   13301.8868 12552.3538 -180.0  2.55991  0.08   
+  2  3    1    -2   3037.0846  1812.2346  180.0   2.53714  0.02   
+  2  1    -1   2    690.7249   666.9600   180.0   2.51234  0.00   
+  2  2    -2   1    1745.2344  1688.6182  -180.0  2.49700  0.01   
+  2  3    -1   -2   526.0810   450.0307   180.0   2.48209  0.00   
+  2  1    1    2    109.6021   110.1448   180.0   2.46640  0.00   
+  2  2    2    1    1263.5199  1366.9989  -180.0  2.45748  0.01   
+  2  2    -4   -1   12321.6294 10461.9695 -180.0  2.44676  0.07   
+  2  1    5    -1   4206.9089  4096.3372  -0.0    2.43093  0.02   
+  2  1    5    0    55.9737    64.5696    180.0   2.41336  0.00   
+  2  2    4    0    3612.6016  3943.7501  -0.0    2.40616  0.02   
+  2  1    -5   0    2122.4826  2242.5238  180.0   2.40454  0.01   
+  2  2    -4   0    2187.8916  2083.3522  -0.0    2.39222  0.01   
+  2  3    1    0    1591.8596  1565.3631  -0.0    2.38569  0.01   
+  2  3    -1   0    1857.8763  2088.7747  -0.0    2.38057  0.01   
+  2  2    0    -3   8.7500     7.3432     180.0   2.35206  0.00   
+  2  2    4    -2   4.9406     2.9334     0.0     2.34748  0.00   
+  2  1    1    -3   146.1037   110.9384   -0.0    2.33711  0.00   
+  2  0    4    -2   1172.8981  886.6831   -180.0  2.33276  0.01   
+  2  1    -5   -1   1952.1352  1043.4163  0.0     2.31863  0.01   
+  2  3    3    -1   18818.0954 9807.0007  180.0   2.31702  0.09   
+  2  1    -1   -3   2249.9909  2293.9554  -0.0    2.27833  0.01   
+  2  2    2    -3   187.4998   155.6906   -0.0    2.26171  0.00   
+  2  3    3    -2   18.2959    15.9304    0.0     2.25027  0.00   
+  2  3    -3   -1   3207.4324  2706.8056  -180.0  2.24815  0.01   
+  2  1    -3   2    874.6291   822.9774   -0.0    2.22731  0.00   
+  2  2    -4   -2   1305.7954  1432.7781  0.0     2.19093  0.01   
+  2  0    4    2    1918.7236  2085.1188  0.0     2.18946  0.01   
+  2  1    -5   1    3885.0923  4197.6156  180.0   2.18795  0.02   
+  2  2    -2   -3   1792.2947  1854.0832  0.0     2.15599  0.01   
+  2  1    5    -2   309.7931   311.4551   -180.0  2.15295  0.00   
+  2  3    -3   -2   623.8943   515.3061   180.0   2.13987  0.00   
+  2  3    1    -3   247.1411   204.6081   0.0     2.13853  0.00   
+  2  1    3    2    192.9602   174.7022   -180.0  2.13468  0.00   
+  2  0    0    3    451.6686   454.6998   -0.0    2.12979  0.00   
+  2  0    6    0    10565.2026 11061.1686 -0.0    2.12738  0.04   
+  2  1    3    -3   661.8611   675.4873   -180.0  2.11945  0.00   
+  2  1    5    1    4635.9869  4736.6864  180.0   2.11687  0.02   
+  2  3    3    0    1458.8508  1497.2750  -180.0  2.11268  0.01   
+  2  3    -3   0    161.3219   181.2189   -180.0  2.10205  0.00   
+  2  3    -1   -3   1842.3023  2418.3608  0.0     2.09091  0.01   
+  2  2    -4   1    6786.4141  8393.2234  180.0   2.07866  0.03   
+  2  0    2    -3   275.3432   287.1519   -180.0  2.05980  0.00   
+  2  0    6    -1   82.3008    83.9647    -0.0    2.05787  0.00   
+  2  2    4    1    2484.7495  2723.6549  180.0   2.03347  0.01   
+  2  4    0    -2   2287.3734  1674.9121  -0.0    2.01430  0.01   
+  2  1    -5   -2   1399.1796  983.0910   -0.0    2.00783  0.01   
+  2  4    0    -1   4110.0688  3209.9366  -0.0    2.00082  0.01   
+  2  2    0    2    1122.0100  915.0412   0.0     1.99869  0.00   
+  2  1    -3   -3   2819.0536  2007.1870  -0.0    1.99475  0.01   
+  2  0    2    3    1715.1389  1320.7805  0.0     1.98292  0.01   
+  2  0    6    1    6273.9277  4765.5652  0.0     1.98119  0.02   
+  2  3    -1   1    2401.9429  1780.7293  0.0     1.97252  0.01   
+  2  3    3    -3   1124.4401  747.4554   -180.0  1.96994  0.00   
+  2  2    4    -3   281.7457   210.7067   -180.0  1.96372  0.00   
+  2  3    1    1    1390.8153  1050.0637  0.0     1.96357  0.01   
+  2  4    2    -2   1843.8646  1504.9735  0.0     1.94701  0.01   
+  2  2    -2   2    5730.2855  4437.4029  -0.0    1.92745  0.02   
+  2  4    2    -1   225.9099   195.3842   0.0     1.92368  0.00   
+  2  2    6    -1   28.1048    25.7062    -0.0    1.91832  0.00   
+  2  4    -2   -2   13814.3680 14629.7803 -0.0    1.89581  0.04   
+  2  4    -2   -1   80.1979    83.9500    180.0   1.89504  0.00   
+  2  2    2    2    12928.1285 11148.4273 -0.0    1.88785  0.05   
+  2  3    5    -1   3780.9729  3253.4383  -180.0  1.88777  0.01   
+  2  3    -3   -3   299.3028   242.0296   -0.0    1.86369  0.00   
+  2  3    5    -2   159.0300   152.0294   -180.0  1.86107  0.00   
+  2  4    0    -3   10398.4260 17237.0458 -180.0  1.85020  0.03   
+  2  2    -6   -1   426.9566   631.4007   -180.0  1.84615  0.00   
+  2  1    -5   2    24.9559    32.7572    -180.0  1.84484  0.00   
+  2  2    6    0    5083.8485  5974.4907  -0.0    1.84124  0.02   
+  2  2    6    -2   1675.4050  2234.4706  -180.0  1.83338  0.00   
+  2  2    -6   0    8421.3620  11189.5327 0.0     1.83185  0.02   
+  2  1    -1   3    1874.8056  2405.3085  -180.0  1.83014  0.01   
+  2  2    -4   -3   273.0833   350.1904   -0.0    1.83000  0.00   
+  2  3    -5   -1   479.4389   549.7524   -180.0  1.82598  0.00   
+  2  0    4    -3   5792.6769  6604.3122  180.0   1.82565  0.02   
+  2  0    6    -2   8239.0595  9390.0654  -180.0  1.82481  0.02   
+  2  4    0    0    15065.5075 16550.5982 -0.0    1.81933  0.04   
+  2  3    -3   1    1179.0252  1388.3670  -0.0    1.81439  0.00   
+  2  4    2    -3   1695.3896  1698.0774  -0.0    1.80673  0.00   
+  2  1    1    3    13005.9169 13208.6072 -180.0  1.80298  0.05   
+  2  3    3    1    679.7526   659.8898   -0.0    1.79371  0.00   
+  2  1    5    -3   33.0507    36.9628    180.0   1.79244  0.00   
+  2  1    7    -1   201.1032   370.4245   -180.0  1.78694  0.00   
+  2  2    0    -4   19442.0716 29316.3996 0.0     1.78509  0.06   
+  2  1    7    0    1240.0279  1189.2394  -0.0    1.77124  0.00   
+  2  1    -7   0    3063.2381  1867.8935  0.0     1.76635  0.01   
+  2  3    5    0    512.1298   192.4547   -180.0  1.76366  0.00   
+  2  3    -5   -2   1010.6300  294.6076   -180.0  1.75802  0.00   
+  2  1    5    2    4997.6510  1479.7333  -180.0  1.75788  0.02   
+  2  3    -5   0    1.3717     0.6626     -180.0  1.75337  0.00   
+  2  2    2    -4   10434.8050 5374.9726  180.0   1.75292  0.03   
+  2  4    2    0    5868.0233  3239.6883  180.0   1.75234  0.02   
+  2  4    -2   -3   2277.3769  1501.5813  -180.0  1.74875  0.01   
+  2  4    -2   0    2297.0065  1479.8081  -180.0  1.74693  0.01   
+  2  4    4    -2   50155.1279 11154.3525 -180.0  1.74018  0.13   
+  2  3    1    -4   72.4486    11.6995    0.0     1.73825  0.00   
+  2  1    1    -4   1761.8946  932.1602   180.0   1.73086  0.01   
+  2  1    -7   -1   715.0597   545.9938   -0.0    1.72344  0.00   
+  2  2    -4   2    6062.1806  5118.1822  -180.0  1.72229  0.02   
+  2  0    4    3    1883.2674  1650.1674  180.0   1.72185  0.01   
+  2  0    6    2    4443.9463  4048.7075  180.0   1.72115  0.01   
+  2  2    -6   -2   6348.6934  5855.0458  180.0   1.72057  0.02   
+  2  1    -3   3    4128.2475  3893.3583  0.0     1.71853  0.01   
+  2  4    4    -1   3206.1697  3425.5098  -0.0    1.71557  0.01   
+  2  3    -1   -4   25.9580    26.2827    -0.0    1.70464  0.00   
+  2  3    5    -3   2139.4942  1781.8537  180.0   1.70049  0.01   
+  2  1    -1   -4   1367.5788  1087.9492  180.0   1.69891  0.00   
+  2  2    -2   -4   6687.2836  6612.2591  -0.0    1.68719  0.02   
+  2  2    -6   1    113.2058   112.0146   180.0   1.68648  0.00   
+  2  1    -7   1    1094.7520  1039.6827  0.0     1.68229  0.00   
+  2  4    -4   -1   2971.3481  3117.8438  -0.0    1.67547  0.01   
+  2  1    7    -2   2878.7248  3017.8829  0.0     1.67463  0.01   
+  2  1    -5   -3   280.8585   323.7721   -180.0  1.66878  0.00   
+  2  4    -4   -2   2604.6963  3004.6747  -180.0  1.66874  0.01   
+  2  2    4    2    5544.0110  6981.7047  -180.0  1.66680  0.02   
+  2  1    3    3    494.0051   605.5747   0.0     1.65343  0.00   
+  2  3    3    -4   417.7705   474.5246   180.0   1.65095  0.00   
+  2  2    6    1    13.6829    15.1220    180.0   1.65026  0.00   
+  2  4    4    -3   84.5703    81.4112    0.0     1.64471  0.00   
+  2  1    3    -4   1329.4733  1267.8482  -180.0  1.64350  0.00   
+  2  2    6    -3   423.5616   439.5145   0.0     1.63900  0.00   
+  2  1    7    1    925.6519   960.5648   0.0     1.63668  0.00   
+  2  5    1    -2   58.4474    62.3567    -180.0  1.62137  0.00   
+  2  2    4    -4   6.8610     6.6665     0.0     1.60920  0.00   
+  2  3    -1   2    237.8659   237.2272   -180.0  1.60839  0.00   
+  2  4    0    -4   25.8073    25.5934    0.0     1.60795  0.00   
+  2  5    -1   -2   107.7592   104.7618   -0.0    1.60567  0.00   
+  2  0    0    4    1879.8688  1720.4582  -0.0    1.59734  0.01   
+  2  3    1    2    3.6586     3.3675     -180.0  1.59716  0.00   
+  2  0    8    0    4615.1210  4116.7097  -0.0    1.59554  0.01   
+  2  3    -5   -3   6110.6992  7055.7211  -180.0  1.58874  0.01   
+  2  4    2    -4   4300.5258  5769.2527  -180.0  1.58532  0.01   
+  2  4    4    0    59.2189    80.4878    180.0   1.58451  0.00   
+  2  3    -5   1    2489.9437  3546.2934  0.0     1.58189  0.01   
+  2  1    -7   -2   77.7393    106.1538   180.0   1.57755  0.00   
+  2  4    -4   0    655.9131   974.3843   180.0   1.57653  0.00   
+  2  4    0    1    1066.4365  1313.3307  0.0     1.57440  0.00   
+  2  0    2    -4   6026.0904  6841.0030  -180.0  1.57318  0.02   
+  2  5    1    -1   1655.0890  1839.1281  0.0     1.57235  0.00   
+  2  0    8    -1   4815.1993  5116.1501  -180.0  1.57157  0.01   
+  2  5    1    -3   4.5382     4.5420     0.0     1.57077  0.00   
+  2  3    -3   -4   215.2036   221.7439   -180.0  1.56860  0.00   
+  2  1    -3   -4   1299.3813  1168.5667  -180.0  1.56510  0.00   
+  2  5    -1   -1   4124.1773  3533.8617  -0.0    1.56393  0.01   
+  2  4    -4   -3   732.4938   669.0052   0.0     1.55988  0.00   
+  2  2    0    3    1878.8524  1763.7320  -180.0  1.55943  0.00   
+  2  3    5    1    6906.0204  6631.1418  -0.0    1.55915  0.02   
+  2  0    6    -3   46.3242    50.5436    180.0   1.55517  0.00   
+  2  5    -1   -3   2927.9131  3178.3511  180.0   1.55067  0.01   
+  2  5    3    -2   2706.6685  1684.7047  0.0     1.53933  0.01   
+  2  3    7    -1   391.6213   255.2823   -0.0    1.53564  0.00   
+  2  4    -2   -4   7040.0820  4569.4928  180.0   1.53438  0.02   
+  2  4    -2   1    588.1628   360.6797   -0.0    1.53233  0.00   
+  2  2    -2   3    5371.1359  3887.6768  0.0     1.53041  0.01   
+  2  1    -5   3    180.1326   114.3092   180.0   1.52901  0.00   
+  2  0    2    4    3034.4826  1999.7209  180.0   1.52694  0.01   
+  2  3    7    -2   2184.5159  1418.8476  180.0   1.52666  0.00   
+  2  0    8    1    86.3369    54.0376    0.0     1.52547  0.00   
+  2  4    2    1    85.8258    55.0493    -0.0    1.52485  0.00   
+  2  3    -3   2    1106.1493  712.9320   0.0     1.52462  0.00   
+  2  2    -6   -3   1381.5615  975.2512   180.0   1.52290  0.00   
+  2  1    -7   2    2574.6763  2097.0709  180.0   1.51590  0.01   
+  2  2    -4   -4   4396.9659  3478.4348  -180.0  1.51121  0.01   
+  2  2    8    -1   10067.2036 8940.6641  0.0     1.50758  0.02   
+  2  5    3    -3   12119.0368 11216.3189 -0.0    1.50105  0.02   
+  2  5    -3   -2   1343.3172  1283.3109  0.0     1.50000  0.00   
+  2  2    2    3    272.5218   261.5419   0.0     1.49978  0.00   
+  2  4    6    -2   1732.7662  1643.6348  -180.0  1.49778  0.00   
+  2  3    3    2    2753.2574  2828.3791  0.0     1.49643  0.01   
+  2  1    7    -3   760.7365   966.4998   -0.0    1.49239  0.00   
+  2  5    3    -1   1082.5442  1375.7326  180.0   1.49201  0.00   
+  2  3    -7   -1   3.4191     4.2383     -180.0  1.48891  0.00   
+  2  3    5    -4   810.0666   977.0519   0.0     1.48756  0.00   
+  2  2    -6   2    2310.4556  2226.8402  -180.0  1.48385  0.00   
+  2  1    5    -4   571.4830   568.7560   -0.0    1.48128  0.00   
+  2  4    4    -4   836.8946   936.4201   -0.0    1.47745  0.00   
+  2  4    6    -1   2151.3910  2425.6102  -0.0    1.47698  0.00   
+  2  5    -3   -1   1959.2884  2253.4175  180.0   1.47071  0.00   
+  2  2    8    -2   1771.8997  2039.6600  -0.0    1.47020  0.00   
+  2  0    4    -4   1414.1247  1800.0200  0.0     1.46602  0.00   
+  2  0    8    -2   2026.0794  2674.7818  0.0     1.46497  0.00   
+  2  2    8    0    13847.9117 17391.5418 180.0   1.46439  0.03   
+  2  3    7    0    1101.6290  1344.4765  -0.0    1.46170  0.00   
+  2  2    -8   -1   247.3362   277.6788   0.0     1.46041  0.00   
+  2  0    6    3    8874.3865  9734.9126  -180.0  1.45964  0.02   
+  2  2    -8   0    15008.5840 15008.2619 -180.0  1.45809  0.03   
+  2  1    5    3    91.5838    84.5203    0.0     1.45393  0.00   
+  2  3    -7   0    2014.6709  1879.8027  -0.0    1.45350  0.00   
+  2  5    -3   -3   4186.4855  3978.1354  -0.0    1.45011  0.01   
+  2  1    7    2    361.8429   339.9922   180.0   1.44810  0.00   
+  2  5    1    0    530.9883   468.9716   0.0     1.44705  0.00   
+  2  3    -7   -2   463.8845   408.4855   -180.0  1.44665  0.00   
+  2  5    -1   0    314.7059   283.3261   0.0     1.44514  0.00   
+  2  5    1    -4   428.6459   376.2186   -0.0    1.44459  0.00   
+  2  4    6    -3   4976.2274  4800.8441  180.0   1.44022  0.01   
+  2  3    7    -3   2155.9387  2067.0984  0.0     1.43881  0.00   
+  2  4    -6   -1   14562.9513 14009.4338 -0.0    1.43874  0.03   
+  2  1    -1   4    2459.4469  1748.6544  -0.0    1.43197  0.01   
+  2  2    6    2    20601.8030 14133.1721 -180.0  1.43091  0.04   
+  2  4    -6   -2   16140.0572 11520.2399 -180.0  1.42991  0.03   
+  2  2    -4   3    11209.3339 9317.7644  -0.0    1.42596  0.02   
+  2  3    1    -5   64.5608    54.6219    0.0     1.42530  0.00   
+  2  5    -1   -4   6972.0505  6194.2196  0.0     1.42440  0.01   
+  2  2    0    -5   494.9697   530.8298   -0.0    1.42009  0.00   
+  2  2    6    -4   3850.2712  4112.0229  -0.0    1.41990  0.01   
+  2  4    -4   1    2174.0867  2331.0251  -180.0  1.41784  0.00   
+  2  1    1    4    12087.1195 9767.8691  -0.0    1.41443  0.03   
+  2  2    2    -5   117.6694   102.1168   180.0   1.40805  0.00   
+  2  4    4    1    4720.8647  4250.5902  -180.0  1.40605  0.01   
+  2  1    9    -1   354.9274   313.4717   180.0   1.40550  0.00   
+  2  3    -1   -5   827.1965   559.9427   180.0   1.40229  0.00   
+  2  4    -4   -4   420.3694   334.7015   -180.0  1.39777  0.00   
+  2  5    5    -2   108.1562   121.7392   180.0   1.39651  0.00   
+  2  5    3    -4   8077.3691  10291.2963 -180.0  1.39399  0.01   
+  2  1    9    0    4725.8251  6066.4964  -180.0  1.39360  0.01   
+  2  0    4    4    470.2355   603.7543   180.0   1.39351  0.00   
+  2  0    8    2    716.3845   843.7699   -0.0    1.39261  0.00   
+  2  1    -7   -3   7.6830     8.7176     0.0     1.39217  0.00   
+  2  2    -8   -2   337.8695   389.4645   0.0     1.39162  0.00   
+  2  1    -9   0    4915.3744  5043.3215  -180.0  1.39054  0.01   
+  2  3    -5   -4   807.0536   715.7487   180.0   1.38969  0.00   
+  2  1    -5   -4   11.5956    12.1530    -0.0    1.38793  0.00   
+  2  4    6    0    6269.4891  6882.5745  0.0     1.38669  0.01   
+  2  2    -8   1    2401.7034  2594.3617  -0.0    1.38562  0.00   
+  2  3    -5   2    98.3552    107.2456   180.0   1.38282  0.00   
+  2  1    -3   4    12515.5424 11505.1596 180.0   1.38064  0.03   
+  2  3    3    -5   625.1316   601.8291   -0.0    1.38004  0.00   
+  2  5    3    0    2080.8309  2064.0651  180.0   1.37960  0.00   
+  2  4    -6   0    2871.6930  2934.9482  0.0     1.37868  0.00   
+  2  2    4    3    7881.8376  7685.0359  -0.0    1.37746  0.02   
+  2  5    -3   0    1784.4143  1849.3546  -180.0  1.37466  0.00   
+  2  4    0    -5   9715.7386  9857.0632  -0.0    1.37307  0.02   
+  2  5    5    -3   1167.2856  1000.0201  -0.0    1.37173  0.00   
+  2  1    1    -5   70.5435    51.8960    180.0   1.36910  0.00   
+  2  2    8    -3   1389.8508  899.5075   0.0     1.36808  0.00   
+  2  1    -9   -1   3236.8826  2522.4075  180.0   1.36534  0.01   
+  2  2    -2   -5   1143.4188  891.7625   -180.0  1.36532  0.00   
+  2  4    2    -5   12204.7731 11338.8231 180.0   1.36281  0.02   
+  2  2    8    1    4008.4056  3615.8412  -180.0  1.35876  0.01   
+  2  5    5    -1   1008.7472  869.9243   -180.0  1.35699  0.00   
+  2  4    -6   -3   4195.2872  4135.1598  180.0   1.35575  0.01   
+  2  3    -7   1    573.7022   580.3630   0.0     1.35509  0.00   
+  2  1    9    -2   13680.5884 16172.2051 0.0     1.35268  0.02   
+  2  1    -9   1    3156.0296  3746.0292  -0.0    1.35222  0.01   
+  2  6    0    -2   14528.5940 16989.5792 180.0   1.35173  0.02   
+  2  1    -1   -5   10234.2266 10688.1341 -0.0    1.34929  0.02   
+  2  5    -5   -2   643.2740   569.3346   180.0   1.34825  0.00   
+  2  3    5    2    241.5546   209.4399   0.0     1.34812  0.00   
+  2  3    -7   -3   1111.5759  988.1008   180.0   1.34405  0.00   
+  2  4    0    2    22123.9455 20274.1794 180.0   1.34385  0.04   
+  2  6    0    -3   478.1779   425.2904   0.0     1.34287  0.00   
+  2  5    -3   -4   29.4657    19.6105    -0.0    1.34152  0.00   
+  2  3    7    1    1023.4159  545.6813   0.0     1.33510  0.00   
+  2  1    3    4    564.9981   303.8950   180.0   1.33497  0.00   
+  2  2    4    -5   3722.8342  2139.1965  -0.0    1.33391  0.01   
+  2  6    2    -2   7524.9826  7470.8807  0.0     1.33142  0.01   
+  2  5    -5   -1   3093.8308  3084.2175  -180.0  1.33051  0.00   
+  2  3    -1   3    551.1874   551.8096   -0.0    1.33026  0.00   
+  2  1    -7   3    771.5668   847.9060   -180.0  1.32923  0.00   
+  2  1    3    -5   12953.2043 12963.7386 180.0   1.32825  0.03   
+  2  4    6    -4   1276.1944  1218.7973  0.0     1.32752  0.00   
+  2  6    2    -3   6.2057     6.0166     -0.0    1.32656  0.00   
+  2  4    -2   -5   3510.8178  3149.4557  0.0     1.32279  0.01   
+  2  1    9    1    1102.8628  1105.8107  -0.0    1.32155  0.00   
+  2  4    -2   2    2168.1980  2257.2205  0.0     1.32096  0.00   
+  2  2    -6   -4   108.8286   114.4574   0.0     1.32042  0.00   
+  2  3    1    3    3081.3435  3238.6207  0.0     1.32030  0.01   
+  2  3    -3   -5   2091.7166  2181.4186  180.0   1.32000  0.00   
+  2  0    6    -4   3842.6138  3689.8215  0.0     1.31805  0.01   
+  2  0    8    -3   4742.2823  4550.5215  -0.0    1.31760  0.01   
+  2  6    -2   -2   353.6784   330.9018   180.0   1.31355  0.00   
+  2  4    2    2    505.6905   505.4773   0.0     1.30914  0.00   
+  2  5    -5   -3   5803.6604  6222.4164  0.0     1.30818  0.01   
+  2  3    7    -4   13.2076    11.4827    -180.0  1.30628  0.00   
+  2  6    0    -1   755.9922   635.4990   -0.0    1.30296  0.00   
+  2  6    -2   -3   5699.9805  4804.0651  0.0     1.30197  0.01   
+  2  1    7    -4   1091.5810  817.9622   180.0   1.30147  0.00   
+  2  4    4    -5   1457.2270  840.0719   -180.0  1.29582  0.00   
+  2  5    -1   1    948.5228   561.3526   -180.0  1.29338  0.00   
+  2  5    5    -4   141.4215   102.0076   -0.0    1.29193  0.00   
+  2  5    1    1    291.6587   213.1141   180.0   1.29139  0.00   
+  2  5    1    -5   1968.2194  1297.9416  -180.0  1.28877  0.00   
+  2  1    -9   -2   10779.9048 7605.5427  0.0     1.28598  0.02   
+  2  3    -3   3    6151.0341  3825.8012  180.0   1.28497  0.01   
+  2  2    -6   3    158.8704   98.2873    -0.0    1.28486  0.00   
+  2  3    5    -5   3925.8300  3039.3601  -0.0    1.28354  0.01   
+  2  6    2    -1   2670.8046  2447.1852  180.0   1.28146  0.00   
+  2  4    8    -2   13485.9734 16045.7549 -0.0    1.27995  0.02   
+  2  1    -5   4    0.2301     0.2764     -0.0    1.27969  0.00   
+  2  6    0    -4   3860.3525  4645.7790  0.0     1.27955  0.01   
+  2  0    0    5    1410.5926  1505.5483  0.0     1.27787  0.00   
+  2  2    -8   -3   948.8342   973.6182   0.0     1.27738  0.00   
+  2  0    10   0    5789.9230  5627.3012  -0.0    1.27643  0.01   
+  2  1    -3   -5   1735.8713  1649.9476  -180.0  1.27603  0.00   
+  2  3    9    -1   779.8276   568.3524   180.0   1.27350  0.00   
+  2  4    -6   1    3058.0183  2161.8394  180.0   1.27195  0.00   
+  2  6    -2   -1   872.5873   605.9287   -180.0  1.27185  0.00   
+  2  3    9    -2   313.5037   209.1430   0.0     1.27155  0.00   
+  2  5    -1   -5   4937.0701  3290.1130  -0.0    1.27117  0.01   
+  2  2    -8   2    13360.6571 15705.3896 0.0     1.26967  0.02   
+  2  2    0    4    4941.7748  5973.8386  -0.0    1.26889  0.01   
+  2  6    2    -4   2342.0348  2642.9843  -180.0  1.26857  0.00   
+  2  0    2    -5   3680.5457  4143.5583  180.0   1.26856  0.01   
+  2  5    5    0    1350.4252  1539.1437  -0.0    1.26761  0.00   
+  2  0    10   -1   604.5125   723.8611   -180.0  1.26720  0.00   
+  3  1    1    0    6462.9134  5229.9972  0.0     5.76243  0.01   
+  3  1    1    -1   1680.5777  1404.4024  0.0     5.74978  0.00   
+  3  0    0    2    7005.8873  6632.0751  0.0     5.69511  0.01   
+  3  2    0    0    1488.2415  777.7143   180.0   5.30605  0.00   
+  3  2    0    -2   21140.5859 11506.7866 0.0     5.26686  0.02   
+  3  1    1    1    13970.0381 5910.1227  -180.0  4.69331  0.02   
+  3  1    1    -2   1267.6763  470.7033   -180.0  4.67287  0.00   
+  3  1    1    2    1316.9231  1806.5888  -180.0  3.62506  0.00   
+  3  1    1    -3   4939.6432  6208.1441  180.0   3.60936  0.00   
+  3  0    2    0    5124.5128  1737.5117  180.0   3.43112  0.00   
+  3  3    1    -1   1548.8615  1015.6842  -0.0    3.40730  0.00   
+  3  3    1    -2   4445.5770  3189.0727  180.0   3.39946  0.00   
+  3  0    2    1    4151.6942  5004.9132  -0.0    3.28530  0.00   
+  3  2    0    2    12142.5085 11581.7159 -0.0    3.21659  0.00   
+  3  2    0    -4   4731.1772  4994.1283  180.0   3.19043  0.00   
+  3  3    1    0    2114.0090  2137.9339  0.0     3.14421  0.00   
+  3  3    1    -3   2579.3113  2675.5752  180.0   3.12582  0.00   
+  3  4    0    -2   83591.4258 80955.5388 180.0   2.98402  0.02   
+  3  2    2    -1   97028.9591 75028.7714 -0.0    2.97457  0.04   
+  3  0    2    2    1020.4645  792.4187   0.0     2.93896  0.00   
+  3  2    2    0    2405.1621  1808.9742  0.0     2.88121  0.00   
+  3  2    2    -2   785.8946   529.2413   -0.0    2.87489  0.00   
+  3  1    1    3    4891.4384  2482.6233  -0.0    2.86050  0.00   
+  3  1    1    -4   9746.1959  5793.4416  -0.0    2.84970  0.00   
+  3  0    0    4    16370.1683 10326.0699 -0.0    2.84755  0.00   
+  3  3    1    1    2834.0667  3752.8231  -180.0  2.75673  0.00   
+  3  3    1    -4   2432.8645  3261.7566  -0.0    2.73612  0.00   
+  3  4    0    0    67320.4782 71075.1612 0.0     2.65303  0.01   
+  3  2    2    1    128590.5664 132934.8926 0.0     2.64148  0.05   
+  3  4    0    -4   131846.7560 140566.5919 180.0   2.63343  0.02   
+  3  2    2    -3   62325.3412 66230.8236 -180.0  2.63175  0.02   
+  3  0    2    3    17795.5151 14167.8457 180.0   2.54564  0.01   
+  3  3    1    2    9531.5825  9768.4331  -180.0  2.37399  0.00   
+  3  3    1    -5   6463.9401  5855.8096  -0.0    2.35557  0.00   
+  3  2    2    2    222.7777   143.7019   -180.0  2.34665  0.00   
+  3  2    2    -4   1259.8071  880.6884   180.0   2.33644  0.00   
+  3  1    1    4    4240.3919  2960.4837  -0.0    2.33289  0.00   
+  3  1    1    -5   488.2228   299.2434   -0.0    2.32535  0.00   
+  3  4    2    -2   1632.7572  1408.1184  -0.0    2.25162  0.00   
+  3  5    1    -2   2509.2187  2124.7582  180.0   2.24560  0.00   
+  3  5    1    -3   645.9889   539.5171   180.0   2.24185  0.00   
+  3  1    3    0    63.3418    52.4461    0.0     2.23606  0.00   
+  3  1    3    -1   5020.7335  4181.8084  -0.0    2.23532  0.00   
+  3  4    2    -1   968.0913   918.5295   0.0     2.21174  0.00   
+  3  4    2    -3   13087.8957 13298.3202 -0.0    2.20602  0.00   
+  3  0    2    4    902.1172   965.8131   180.0   2.19123  0.00   
+  3  5    1    -1   11723.1966 11527.2244 -0.0    2.16646  0.00   
+  3  5    1    -4   708.5232   710.1618   -180.0  2.15641  0.00   
+  3  1    3    1    1030.7403  1031.2370  -0.0    2.15523  0.00   
+  3  1    3    -2   11099.6804 10963.1875 0.0     2.15324  0.00   
+  3  2    0    4    1774.9887  1629.2256  0.0     2.13469  0.00   
+  3  2    0    -6   7062.0788  7194.2438  0.0     2.12190  0.00   
+  3  4    2    0    658.3205   728.4256   -180.0  2.09880  0.00   
+  3  4    2    -4   468.6518   548.5521   -180.0  2.08905  0.00   
+  3  4    0    2    280749.9470 285697.1154 180.0   2.06942  0.03   
+  3  2    2    3    297643.4967 292499.2164 0.0     2.06160  0.06   
+  3  2    2    -5   328434.7214 296721.1076 0.0     2.05236  0.07   
+  3  4    0    -6   335882.4134 301955.0922 -180.0  2.05086  0.03   
+  3  3    1    3    1138.5891  1080.4376  -180.0  2.04679  0.00   
+  3  3    1    -6   158.5739   154.5447   -0.0    2.03160  0.00   
+  3  5    1    0    872.2083   771.3042   180.0   2.02765  0.00   
+  3  1    3    2    18443.8294 14010.4047 -0.0    2.01626  0.00   
+  3  5    1    -5   18717.6396 14156.4238 -0.0    2.01397  0.00   
+  3  1    3    -3   1635.6096  1237.8085  -0.0    2.01355  0.00   
+  3  3    3    -1   9588.9579  7023.2908  -0.0    1.97634  0.00   
+  3  3    3    -2   257.8963   188.1445   0.0     1.97481  0.00   
+  3  6    0    -2   1156.6404  971.7452   180.0   1.96268  0.00   
+  3  1    1    5    4624.6709  4606.2730  180.0   1.95857  0.00   
+  3  6    0    -4   16856.9125 17275.4682 -180.0  1.95669  0.00   
+  3  1    1    -6   1572.1377  1558.5026  -0.0    1.95311  0.00   
+  3  4    2    1    23075.0238 20959.3815 -0.0    1.94247  0.00   
+  3  4    2    -5   81.4866    70.8854    180.0   1.93091  0.00   
+  3  3    3    0    10863.1280 9835.5595  180.0   1.92081  0.00   
+  3  3    3    -3   2978.3083  2768.8394  -0.0    1.91659  0.00   
+  3  0    0    6    1704.9756  1702.6346  -0.0    1.89837  0.00   
+  3  0    2    5    90.2296    90.0513    -180.0  1.89784  0.00   
+  3  5    1    1    2693.8016  2501.5063  -180.0  1.86077  0.00   
+  3  1    3    3    2489.3646  3420.3391  0.0     1.85027  0.00   
+  3  1    3    -4   372.0602   508.3369   -180.0  1.84734  0.00   
+  3  5    1    -6   2196.0109  2896.9866  -180.0  1.84599  0.00   
+  3  3    3    1    2992.1319  3295.1363  -0.0    1.82128  0.00   
+  3  3    3    -4   13514.1166 15068.8780 -180.0  1.81530  0.00   
+  3  2    2    4    1779.7423  2002.5242  180.0   1.81253  0.00   
+  3  2    2    -6   110.2449   110.6800   -0.0    1.80468  0.00   
+  3  3    1    4    1243.2696  1169.7925  -0.0    1.78066  0.00   
+  3  4    2    2    715.4414   569.6672   -0.0    1.77206  0.00   
+  3  6    0    0    48949.2588 33139.7797 180.0   1.76868  0.00   
+  3  3    1    -7   1084.6013  719.9125   -180.0  1.76843  0.00   
+  3  4    2    -6   3729.9871  1197.4426  -0.0    1.76037  0.00   
+  3  6    0    -6   5.3633     2.0506     0.0     1.75562  0.00   
+  3  6    2    -3   454604.2362 370234.8868 -180.0  1.72100  0.06   
+  3  0    4    0    364479.3776 348679.5186 -180.0  1.71556  0.03   
+  3  6    2    -2   426.3303   389.8073   -0.0    1.70365  0.00   
+  3  6    2    -4   1924.6030  1560.5305  180.0   1.69973  0.00   
+  3  3    3    2    4862.1527  3598.0790  -0.0    1.69681  0.00   
+  3  0    4    1    4434.4746  3256.7400  -0.0    1.69643  0.00   
+  3  5    1    2    3144.4361  2566.7981  -180.0  1.69076  0.00   
+  3  3    3    -5   12585.0084 10525.2457 0.0     1.69005  0.00   
+  3  1    1    6    788.8462   740.9601   -0.0    1.68299  0.00   
+  3  1    3    4    48.6019    44.8467    -0.0    1.68161  0.00   
+  3  1    1    -7   13278.1793 12401.2491 -180.0  1.67889  0.00   
+  3  1    3    -5   4997.4991  4674.4642  0.0     1.67878  0.00   
+  3  5    1    -7   271.3223   265.7177   -180.0  1.67652  0.00   
+  3  0    2    6    800.1583   1001.9111  0.0     1.66108  0.00   
+  3  7    1    -3   31.3809    35.5312    180.0   1.65153  0.00   
+  3  6    2    -1   773.3524   866.2621   -180.0  1.65099  0.00   
+  3  7    1    -4   512.5730   558.2160   -0.0    1.64944  0.00   
+  3  2    4    -1   2636.5033  2841.7267  180.0   1.64879  0.00   
+  3  5    3    -2   316.7110   336.8379   -180.0  1.64802  0.00   
+  3  5    3    -3   1196.8751  1233.2014  -180.0  1.64654  0.00   
+  3  6    2    -5   514.3797   505.4766   -180.0  1.64388  0.00   
+  3  0    4    2    628.0652   611.0322   -180.0  1.64265  0.00   
+  3  2    4    0    726.5140   753.0049   -0.0    1.63236  0.00   
+  3  2    4    -2   4271.1694  4458.8300  180.0   1.63121  0.00   
+  3  7    1    -2   3408.6432  3575.7790  180.0   1.61983  0.00   
+  3  5    3    -1   927.8908   966.8885   0.0     1.61596  0.00   
+  3  7    1    -5   894.1869   917.8818   -0.0    1.61395  0.00   
+  3  5    3    -4   3853.6974  3835.5929  -180.0  1.61178  0.00   
+  3  4    0    4    65753.5071 64322.9720 180.0   1.60830  0.00   
+  3  4    2    3    28.2278    27.4719    180.0   1.60687  0.00   
+  3  2    2    5    38793.9314 37088.0188 -180.0  1.60352  0.00   
+  3  2    2    -7   71757.5020 66430.6377 0.0     1.59700  0.01   
+  3  4    2    -7   2793.0948  2578.3163  -0.0    1.59598  0.00   
+  3  4    0    -8   40099.6748 36905.1679 0.0     1.59521  0.00   
+  3  2    4    1    1528.8498  1923.3657  0.0     1.58481  0.00   
+  3  2    4    -3   1453.1194  1875.0462  0.0     1.58270  0.00   
+  3  2    0    6    25061.0407 28841.3496 -0.0    1.57347  0.00   
+  3  6    2    0    291.4279   317.4777   -0.0    1.57210  0.00   
+  3  3    1    5    1821.7819  1735.4823  180.0   1.56656  0.00   
+  3  2    0    -8   5241.7432  4962.7905  -180.0  1.56629  0.00   
+  3  3    3    3    530.1518   484.0152   0.0     1.56444  0.00   
+  3  0    4    3    3214.8032  2912.9935  -0.0    1.56337  0.00   
+  3  6    2    -6   1374.8551  1247.3220  -180.0  1.56291  0.00   
+  3  7    1    -1   2163.2627  2044.2254  -0.0    1.55980  0.00   
+  3  3    3    -6   1495.0349  1491.2058  -180.0  1.55762  0.00   
+  3  3    1    -8   1831.7021  1854.6556  0.0     1.55671  0.00   
+  3  5    3    0    3673.3885  3763.1214  180.0   1.55584  0.00   
+  3  7    1    -6   3619.3497  3788.1306  -180.0  1.55106  0.00   
+  3  5    3    -5   1337.9640  1407.0908  0.0     1.54963  0.00   
+  3  5    1    3    1181.3963  786.3837   0.0     1.53172  0.00   
+  3  1    3    5    10.7405    7.4143     -180.0  1.52397  0.00   
+  3  1    3    -6   1549.8196  1153.0537  0.0     1.52139  0.00   
+  3  5    1    -8   6.6909     5.3825     0.0     1.51878  0.00   
+  3  2    4    2    5411.0894  4250.8779  180.0   1.51372  0.00   
+  3  2    4    -4   3069.7796  2485.2026  -0.0    1.51097  0.00   
+  3  6    0    2    9719.9678  8929.9401  -180.0  1.50516  0.00   
+  3  8    0    -4   16973.1907 20140.7975 0.0     1.49201  0.00   
+  3  6    0    -8   3678.8176  4382.0276  -180.0  1.49177  0.00   
+  3  4    4    -2   17822.6764 20487.7644 -0.0    1.48729  0.00   
+  3  7    1    0    497.0922   522.6657   0.0     1.48032  0.00   
+  3  6    2    1    462.5855   505.4649   180.0   1.47801  0.00   
+  3  5    3    1    1326.9603  1469.8216  180.0   1.47651  0.00   
+  3  4    4    -1   160.1640   180.5060   180.0   1.47562  0.00   
+  3  4    4    -3   1413.7876  1669.2122  180.0   1.47392  0.00   
+  3  1    1    7    7740.5102  9056.9869  -0.0    1.47309  0.00   
+  3  0    2    7    2214.0876  2492.8411  180.0   1.47022  0.00   
+  3  1    1    -8   6572.9070  7376.7327  0.0     1.46992  0.00   
+  3  7    1    -7   206.8237   232.0376   -180.0  1.46989  0.00   
+  3  0    4    4    518.9195   579.9965   180.0   1.46948  0.00   
+  3  5    3    -6   0.1612     0.1800     -180.0  1.46910  0.00   
+  3  6    2    -7   947.8391   1079.2150  180.0   1.46783  0.00   
+  3  4    2    4    320.0451   308.6587   -180.0  1.45625  0.00   
+  3  4    2    -8   333.4290   302.0947   -180.0  1.44652  0.00   
+  3  8    0    -2   57790.6913 52352.8419 0.0     1.44650  0.00   
+  3  4    4    0    43735.4530 40402.1009 -180.0  1.44061  0.00   
+  3  8    0    -6   42614.5148 39533.4246 -180.0  1.44012  0.00   
+  3  4    4    -4   59471.2714 54107.9904 0.0     1.43745  0.01   
+  3  3    3    4    5585.0019  4613.3994  -180.0  1.43552  0.00   
+  3  2    2    6    1.0759     0.7996     -180.0  1.43025  0.00   
+  3  3    3    -7   1902.2950  1446.2007  0.0     1.42909  0.00   
+  3  2    4    3    3493.3715  2695.8039  180.0   1.42841  0.00   
+  3  2    4    -5   1948.1268  1669.9616  180.0   1.42532  0.00   
+  3  2    2    -8   2077.9199  1817.1780  -0.0    1.42485  0.00   
+  3  0    0    8    288773.5638 266053.1220 -0.0    1.42378  0.01   
+  3  3    1    6    830.9072   935.4716   180.0   1.39348  0.00   
+  3  7    1    1    48.9100    50.2165    -180.0  1.39067  0.00   
+  3  5    1    4    780.6944   766.0861   0.0     1.38935  0.00   
+  3  5    3    2    429.4056   442.5311   -180.0  1.38715  0.00   
+  3  4    4    1    3501.0756  3622.6106  -0.0    1.38694  0.00   
+  3  3    1    -9   675.2394   705.1619   -0.0    1.38547  0.00   
+  3  1    3    6    3063.5512  3140.9418  0.0     1.38285  0.00   
+  3  4    4    -5   1197.3470  1223.5583  0.0     1.38272  0.00   
+  3  1    3    -7   501.1836   485.3817   -180.0  1.38058  0.00   
+  3  7    1    -8   236.5056   231.3490   0.0     1.37957  0.00   
+  3  5    3    -7   1094.6152  1074.6564  180.0   1.37926  0.00   
+  3  6    2    2    259.0662   255.4949   -180.0  1.37837  0.00   
+  3  5    1    -9   3200.8538  3156.4016  -0.0    1.37793  0.00   
+  3  0    4    5    450.5358   361.1570   -180.0  1.37042  0.00   
+  3  8    2    -4   1010.0426  739.8164   180.0   1.36825  0.00   
+  3  6    2    -8   3.9284     2.8653     0.0     1.36806  0.00   
+  3  7    3    -3   4044.5147  3200.3251  -180.0  1.36524  0.00   
+  3  7    3    -4   557.6397   462.7559   -180.0  1.36406  0.00   
+  3  1    5    0    5084.2706  4367.7824  -180.0  1.36111  0.00   
+  3  1    5    -1   66.6243    57.3337    -0.0    1.36095  0.00   
+  3  8    2    -3   2186.5929  1924.9351  180.0   1.35981  0.00   
+  3  8    2    -5   15784.9375 14166.5429 180.0   1.35715  0.00   
+  3  7    3    -2   8242.1115  6976.4729  0.0     1.34717  0.00   
+  3  7    3    -5   2945.2255  2392.0445  180.0   1.34378  0.00   
+  3  1    5    1    10077.5767 7430.2792  0.0     1.34224  0.00   
+  3  1    5    -2   4001.1469  2799.0015  180.0   1.34176  0.00   
+  3  2    4    4    391.4822   204.5762   -180.0  1.33724  0.00   
+  3  2    4    -6   6914.3176  4269.8920  180.0   1.33408  0.00   
+  3  8    2    -2   273.9036   192.4516   0.0     1.33290  0.00   
+  3  8    2    -6   123.2571   116.8054   0.0     1.32790  0.00   
+  3  8    0    0    136098.6902 126775.3192 0.0     1.32651  0.01   
+  3  4    2    5    13658.0607 12788.4716 0.0     1.32312  0.00   
+  3  4    4    2    115864.4937 113790.1896 0.0     1.32074  0.01   
+  3  8    0    -8   146918.9624 139228.4566 -0.0    1.31672  0.01   
+  3  3    3    5    1313.1904  1243.0138  -0.0    1.31606  0.00   
+  3  4    4    -6   127391.2673 120565.1659 0.0     1.31588  0.01   
+  3  0    2    8    388.8325   367.3456   180.0   1.31505  0.00   
+  3  4    2    -9   5844.2702  5515.5482  180.0   1.31460  0.00   
+  3  7    3    -1   1079.4173  1032.8378  180.0   1.31204  0.00   
+  3  3    3    -8   7382.7438  7084.1367  180.0   1.31020  0.00   
+  3  1    1    8    163.9068   156.9828   180.0   1.30853  0.00   
+  3  7    3    -6   8534.0134  7543.5146  -0.0    1.30683  0.00   
+  3  1    5    2    1981.0654  1736.1472  180.0   1.30660  0.00   
+  3  1    1    -9   828.1221   713.7481   180.0   1.30602  0.00   
+  3  1    5    -3   8522.4564  7313.8177  -0.0    1.30586  0.00   
+  3  9    1    -4   1162.8393  842.1832   0.0     1.30067  0.00   
+  3  9    1    -5   368.3164   257.1993   0.0     1.29936  0.00   
+  3  6    4    -3   3405.7139  2357.9821  -0.0    1.29919  0.00   
+  3  7    1    2    6126.8757  3971.7741  -180.0  1.29835  0.00   
+  3  3    5    -1   1058.7983  622.6553   0.0     1.29554  0.00   
+  3  5    3    3    573.0718   335.4314   180.0   1.29520  0.00   
+  3  3    5    -2   3745.8208  2190.9789  -0.0    1.29511  0.00   
+  3  6    4    -2   36.9601    25.6170    0.0     1.29167  0.00   
+  3  8    2    -1   12424.3071 8928.5418  180.0   1.29062  0.00   
+  3  6    4    -4   9939.0702  7143.6089  -0.0    1.28996  0.00   
+  3  4    0    6    26019.6460 18405.1729 180.0   1.28953  0.00   
+  3  5    3    -8   5436.3142  3481.6411  180.0   1.28734  0.00   
+  3  7    1    -9   207.7994   133.1829   180.0   1.28731  0.00   
+  3  2    2    7    24223.8930 16070.4759 -0.0    1.28650  0.00   
+  3  9    1    -3   8067.8097  5515.8132  180.0   1.28530  0.00   
+  3  8    2    -7   578.1091   429.7222   -180.0  1.28383  0.00   
+  3  2    2    -9   22438.4736 19688.6962 0.0     1.28200  0.00   
+  3  9    1    -6   205.5901   186.7579   -0.0    1.28151  0.00   
+  3  4    0    -10  20873.5692 20580.0151 -180.0  1.28052  0.00   
+  3  6    2    3    0.3719     0.3790     180.0   1.28002  0.00   
+  3  3    5    0    695.8992   721.5891   -0.0    1.27952  0.00   
+  3  3    5    -3   5949.6030  6044.6576  -0.0    1.27827  0.00   
+  3  0    4    6    153.5736   118.4522   180.0   1.27282  0.00   
+  3  6    2    -9   514.5016   464.6971   180.0   1.27012  0.00   
+  3  6    4    -1   451.3681   481.9605   -180.0  1.26827  0.00   
+  3  6    0    4    6404.1512  7251.2026  180.0   1.26511  0.00   
+  3  6    4    -5   515.5228   581.7440   -180.0  1.26503  0.00   
+  4  1    1    0    1246.0476  1271.8436  -0.0    3.25057  0.01   
+  4  1    0    1    607.2900   492.3700   -0.0    2.49041  0.01   
+  4  2    0    0    218.8020   149.3200   -0.0    2.29850  0.00   
+  4  1    1    1    349.2107   375.1577   180.0   2.18972  0.00   
+  4  2    1    0    159.4241   152.7098   0.0     2.05584  0.00   
+  4  2    1    1    1008.3678  880.3361   -0.0    1.68906  0.01   
+  4  2    2    0    1033.7742  1142.6066  -0.0    1.62528  0.00   
+  4  0    0    2    1395.3002  1420.2264  -0.0    1.48143  0.00   
+  4  3    1    0    379.9058   356.6589   -0.0    1.45370  0.00   
+  4  2    2    1    32.5900    28.2353    180.0   1.42497  0.00   
+  4  3    0    1    1244.4118  1055.1873  -0.0    1.36108  0.00   
+  4  1    1    2    618.7719   542.1781   -0.0    1.34804  0.00   
+  4  3    1    1    39.0424    32.7464    0.0     1.30508  0.00   
+  4  3    2    0    18.2288    15.0141    180.0   1.27498  0.00   
+_reflns_number_total  648
+_reflns_d_resolution_low    6.389
+_reflns_d_resolution_high   1.265
+
+# POWDER DATA TABLE
+_pd_meas_2theta_range_min  10.01687
+_pd_meas_2theta_range_max  89.99342
+_pd_meas_2theta_range_inc  0.01313
+_pd_meas_number_of_points  6092
+
+loop_
+   _pd_meas_intensity_total
+   _pd_calc_intensity_total
+   _pd_proc_intensity_bkg_calc
+   _pd_proc_ls_weight
+  973          0            0           0         
+  976          0            0           0         
+  997          0            0           0         
+  992          0            0           0         
+  982          0            0           0         
+  971          0            0           0         
+  966          0            0           0         
+  1003         0            0           0         
+  952          0            0           0         
+  1006         0            0           0         
+  955          0            0           0         
+  943          0            0           0         
+  921          0            0           0         
+  993          0            0           0         
+  992          0            0           0         
+  931          0            0           0         
+  989          0            0           0         
+  935          0            0           0         
+  980          0            0           0         
+  963          0            0           0         
+  973          0            0           0         
+  1019         0            0           0         
+  898          0            0           0         
+  935          0            0           0         
+  915          0            0           0         
+  956          0            0           0         
+  987          0            0           0         
+  994          0            0           0         
+  951          0            0           0         
+  925          0            0           0         
+  970          0            0           0         
+  961          0            0           0         
+  939          0            0           0         
+  962          0            0           0         
+  970          0            0           0         
+  964          0            0           0         
+  1027         0            0           0         
+  958          0            0           0         
+  979          0            0           0         
+  948          0            0           0         
+  976          0            0           0         
+  975          0            0           0         
+  916          0            0           0         
+  980          0            0           0         
+  932          0            0           0         
+  962          0            0           0         
+  953          0            0           0         
+  942          0            0           0         
+  956          0            0           0         
+  934          0            0           0         
+  951          0            0           0         
+  950          0            0           0         
+  916          0            0           0         
+  959          0            0           0         
+  1013         0            0           0         
+  932          0            0           0         
+  931          0            0           0         
+  947          0            0           0         
+  976          0            0           0         
+  912          0            0           0         
+  994          0            0           0         
+  928          0            0           0         
+  957          0            0           0         
+  991          0            0           0         
+  895          0            0           0         
+  884          0            0           0         
+  995          0            0           0         
+  954          0            0           0         
+  918          0            0           0         
+  913          0            0           0         
+  945          0            0           0         
+  956          0            0           0         
+  950          0            0           0         
+  917          0            0           0         
+  948          0            0           0         
+  974          0            0           0         
+  923          0            0           0         
+  895          0            0           0         
+  967          0            0           0         
+  924          0            0           0         
+  903          0            0           0         
+  927          0            0           0         
+  900          0            0           0         
+  908          0            0           0         
+  916          0            0           0         
+  934          0            0           0         
+  881          0            0           0         
+  933          0            0           0         
+  883          0            0           0         
+  891          0            0           0         
+  956          0            0           0         
+  936          0            0           0         
+  961          0            0           0         
+  892          0            0           0         
+  869          0            0           0         
+  890          0            0           0         
+  913          0            0           0         
+  892          0            0           0         
+  922          0            0           0         
+  922          0            0           0         
+  877          0            0           0         
+  886          0            0           0         
+  929          0            0           0         
+  909          0            0           0         
+  964          0            0           0         
+  933          0            0           0         
+  925          0            0           0         
+  931          0            0           0         
+  873          0            0           0         
+  908          0            0           0         
+  936          0            0           0         
+  883          0            0           0         
+  858          0            0           0         
+  929          0            0           0         
+  962          0            0           0         
+  871          0            0           0         
+  896          0            0           0         
+  955          0            0           0         
+  916          0            0           0         
+  889          0            0           0         
+  899          0            0           0         
+  877          0            0           0         
+  945          0            0           0         
+  938          0            0           0         
+  843          0            0           0         
+  869          0            0           0         
+  867          0            0           0         
+  928          0            0           0         
+  945          0            0           0         
+  913          0            0           0         
+  844          0            0           0         
+  935          0            0           0         
+  862          0            0           0         
+  897          0            0           0         
+  870          0            0           0         
+  840          0            0           0         
+  848          0            0           0         
+  925          0            0           0         
+  905          0            0           0         
+  883          0            0           0         
+  910          0            0           0         
+  926          0            0           0         
+  881          0            0           0         
+  924          0            0           0         
+  887          0            0           0         
+  910          0            0           0         
+  879          0            0           0         
+  896          0            0           0         
+  913          0            0           0         
+  898          0            0           0         
+  985          0            0           0         
+  891          0            0           0         
+  940          0            0           0         
+  853          0            0           0         
+  927          0            0           0         
+  885          0            0           0         
+  889          0            0           0         
+  897          0            0           0         
+  853          0            0           0         
+  921          0            0           0         
+  858          0            0           0         
+  894          0            0           0         
+  867          0            0           0         
+  901          0            0           0         
+  886          0            0           0         
+  890          0            0           0         
+  882          0            0           0         
+  903          0            0           0         
+  876          0            0           0         
+  868          0            0           0         
+  860          0            0           0         
+  878          0            0           0         
+  833          0            0           0         
+  876          0            0           0         
+  896          0            0           0         
+  823          0            0           0         
+  850          0            0           0         
+  880          0            0           0         
+  912          0            0           0         
+  870          0            0           0         
+  837          0            0           0         
+  866          0            0           0         
+  900          0            0           0         
+  892          0            0           0         
+  852          0            0           0         
+  893          0            0           0         
+  855          0            0           0         
+  885          0            0           0         
+  858          0            0           0         
+  853          0            0           0         
+  950          0            0           0         
+  881          0            0           0         
+  878          0            0           0         
+  826          0            0           0         
+  876          0            0           0         
+  898          0            0           0         
+  898          0            0           0         
+  831          0            0           0         
+  875          0            0           0         
+  892          0            0           0         
+  839          0            0           0         
+  873          0            0           0         
+  849          0            0           0         
+  849          0            0           0         
+  850          0            0           0         
+  878          0            0           0         
+  841          0            0           0         
+  838          0            0           0         
+  868          0            0           0         
+  871          0            0           0         
+  828          0            0           0         
+  843          0            0           0         
+  829          0            0           0         
+  848          0            0           0         
+  896          0            0           0         
+  845          0            0           0         
+  821          0            0           0         
+  857          0            0           0         
+  872          0            0           0         
+  858          0            0           0         
+  855          0            0           0         
+  833          0            0           0         
+  838          0            0           0         
+  837          0            0           0         
+  856          0            0           0         
+  779          0            0           0         
+  869          0            0           0         
+  845          0            0           0         
+  879          0            0           0         
+  843          0            0           0         
+  861          0            0           0         
+  870          0            0           0         
+  873          0            0           0         
+  826          0            0           0         
+  845          0            0           0         
+  824          0            0           0         
+  811          0            0           0         
+  876          0            0           0         
+  860          0            0           0         
+  871          0            0           0         
+  804          0            0           0         
+  848          0            0           0         
+  834          0            0           0         
+  776          0            0           0         
+  905          0            0           0         
+  898          0            0           0         
+  849          0            0           0         
+  829          0            0           0         
+  809          0            0           0         
+  758          0            0           0         
+  826          0            0           0         
+  857          0            0           0         
+  852          0            0           0         
+  859          0            0           0         
+  863          0            0           0         
+  834          0            0           0         
+  846          0            0           0         
+  801          0            0           0         
+  794          0            0           0         
+  803          0            0           0         
+  820          0            0           0         
+  852          0            0           0         
+  792          0            0           0         
+  843          0            0           0         
+  845          0            0           0         
+  870          0            0           0         
+  883          0            0           0         
+  827          0            0           0         
+  872          0            0           0         
+  854          0            0           0         
+  824          0            0           0         
+  825          0            0           0         
+  786          0            0           0         
+  774          0            0           0         
+  836          0            0           0         
+  816          0            0           0         
+  789          0            0           0         
+  818          0            0           0         
+  841          0            0           0         
+  804          0            0           0         
+  839          0            0           0         
+  820          0            0           0         
+  800          0            0           0         
+  805          0            0           0         
+  802          0            0           0         
+  786          0            0           0         
+  826          0            0           0         
+  801          0            0           0         
+  817          0            0           0         
+  727          0            0           0         
+  800          0            0           0         
+  789          0            0           0         
+  786          0            0           0         
+  766          0            0           0         
+  792          0            0           0         
+  762          0            0           0         
+  777          0            0           0         
+  790          0            0           0         
+  815          0            0           0         
+  778          0            0           0         
+  772          0            0           0         
+  833          0            0           0         
+  803          0            0           0         
+  780          0            0           0         
+  760          0            0           0         
+  742          0            0           0         
+  759          0            0           0         
+  733          0            0           0         
+  758          0            0           0         
+  788          0            0           0         
+  799          0            0           0         
+  777          0            0           0         
+  765          0            0           0         
+  821          0            0           0         
+  784          0            0           0         
+  772          0            0           0         
+  828          0            0           0         
+  785          0            0           0         
+  724          0            0           0         
+  786          0            0           0         
+  773          0            0           0         
+  799          0            0           0         
+  776          0            0           0         
+  747          0            0           0         
+  735          0            0           0         
+  744          0            0           0         
+  748          0            0           0         
+  736          0            0           0         
+  786          0            0           0         
+  759          0            0           0         
+  770          0            0           0         
+  817          0            0           0         
+  764          0            0           0         
+  770          0            0           0         
+  734          0            0           0         
+  785          0            0           0         
+  735          0            0           0         
+  750          0            0           0         
+  751          0            0           0         
+  771          0            0           0         
+  785          0            0           0         
+  737          0            0           0         
+  823          0            0           0         
+  750          0            0           0         
+  767          0            0           0         
+  739          0            0           0         
+  742          0            0           0         
+  738          0            0           0         
+  711          0            0           0         
+  740          0            0           0         
+  735          0            0           0         
+  697          0            0           0         
+  728          0            0           0         
+  763          0            0           0         
+  755          0            0           0         
+  690          0            0           0         
+  768          0            0           0         
+  743          0            0           0         
+  749          0            0           0         
+  729          0            0           0         
+  737          0            0           0         
+  724          0            0           0         
+  735          0            0           0         
+  717          0            0           0         
+  712          0            0           0         
+  719          0            0           0         
+  675          0            0           0         
+  707          0            0           0         
+  766          0            0           0         
+  670          0            0           0         
+  730          0            0           0         
+  727          0            0           0         
+  716          0            0           0         
+  742          0            0           0         
+  686          0            0           0         
+  738          0            0           0         
+  675          0            0           0         
+  646          0            0           0         
+  744          0            0           0         
+  719          0            0           0         
+  742          0            0           0         
+  687          0            0           0         
+  717          0            0           0         
+  640          0            0           0         
+  695          0            0           0         
+  699          0            0           0         
+  665          0            0           0         
+  700          0            0           0         
+  641          0            0           0         
+  730          0            0           0         
+  681          0            0           0         
+  695          0            0           0         
+  667          0            0           0         
+  744          0            0           0         
+  654          0            0           0         
+  704          0            0           0         
+  706          0            0           0         
+  659          0            0           0         
+  686          0            0           0         
+  688          0            0           0         
+  709          0            0           0         
+  751          0            0           0         
+  697          0            0           0         
+  713          0            0           0         
+  660          0            0           0         
+  658          0            0           0         
+  728          0            0           0         
+  677          0            0           0         
+  669          0            0           0         
+  648          0            0           0         
+  661          0            0           0         
+  661          650.964611   650.576995  0.00151286 
+  639          650.273773   649.874116  0.00156495 
+  651          649.58441    649.172034  0.0015361 
+  715          648.896576   648.470748  0.0013986 
+  653          648.21033    647.770259  0.00153139 
+  657          647.52574    647.070563  0.00152207 
+  686          646.842877   646.371662  0.00145773 
+  662          646.161825   645.673554  0.00151057 
+  672          645.482676   644.976239  0.0014881 
+  664          644.805531   644.279714  0.00150602 
+  666          644.130507   643.58398   0.0015015 
+  665          643.457733   642.889036  0.00150376 
+  676          642.787354   642.194881  0.00147929 
+  629          642.119537   641.501514  0.00158983 
+  709          641.454472   640.808934  0.00141044 
+  680          640.792369   640.11714   0.00147059 
+  670          640.133478   639.426132  0.00149254 
+  637          639.47808    638.735908  0.00156986 
+  655          638.826497   638.046468  0.00152672 
+  693          638.179108   637.357811  0.001443  
+  665          637.536353   636.669936  0.00150376 
+  693          636.898738   635.982843  0.001443  
+  642          636.266868   635.29653   0.00155763 
+  643          635.641458   634.610996  0.00155521 
+  715          635.023344   633.926241  0.0013986 
+  617          634.413541   633.242265  0.00162075 
+  661          633.813276   632.559065  0.00151286 
+  662          633.224013   631.876641  0.00151057 
+  644          632.647571   631.194993  0.0015528 
+  661          632.086196   630.51412   0.00151286 
+  640          631.542659   629.83402   0.0015625 
+  674          631.02049    629.154693  0.00148368 
+  609          630.524203   628.476138  0.00164204 
+  641          630.05963    627.798355  0.00156006 
+  652          629.634625   627.121342  0.00153374 
+  643          629.260107   626.445098  0.00155521 
+  655          628.951881   625.769624  0.00152672 
+  633          628.734068   625.094917  0.00157978 
+  692          628.644138   624.420977  0.00144509 
+  668          628.739461   623.747804  0.00149701 
+  724          629.104872   623.075396  0.00138122 
+  669          629.858295   622.403752  0.00149477 
+  659          631.150865   621.732873  0.00151745 
+  650          633.153362   621.062756  0.00153846 
+  652          635.998792   620.393402  0.00153374 
+  631          639.659309   619.724809  0.00158479 
+  722          643.912581   619.056976  0.00138504 
+  685          648.630013   618.389903  0.00145985 
+  723          653.895459   617.723589  0.00138313 
+  673          659.448924   617.058033  0.00148588 
+  753          664.071099   616.393235  0.00132802 
+  670          665.999258   615.729192  0.00149254 
+  726          664.497873   615.065906  0.00137741 
+  674          660.139378   614.403374  0.00148368 
+  681          653.967158   613.741596  0.00146843 
+  664          647.206218   613.080571  0.00150602 
+  676          640.997869   612.420299  0.00147929 
+  611          636.106323   611.760778  0.00163666 
+  663          632.799704   611.102008  0.0015083 
+  653          630.862225   610.443988  0.00153139 
+  655          629.709534   609.786717  0.00152672 
+  667          628.684897   609.130194  0.00149925 
+  594          627.492777   608.474418  0.0016835 
+  628          626.175506   607.81939   0.00159236 
+  623          624.868725   607.165107  0.00160514 
+  639          623.716087   606.511569  0.00156495 
+  639          622.610182   605.858776  0.00156495 
+  635          621.148045   605.206726  0.0015748 
+  626          619.123196   604.555418  0.00159744 
+  652          616.709256   603.904853  0.00153374 
+  607          614.080803   603.255028  0.00164745 
+  568          611.423119   602.605944  0.00176056 
+  615          608.985872   601.957599  0.00162602 
+  583          606.906189   601.309992  0.00171527 
+  598          605.181607   600.663124  0.00167224 
+  631          603.747589   600.016993  0.00158479 
+  597          602.529905   599.371597  0.00167504 
+  641          601.464674   598.726938  0.00156006 
+  640          600.503772   598.083012  0.0015625 
+  586          599.614097   597.439821  0.00170648 
+  583          598.774116   596.797363  0.00171527 
+  613          597.970211   596.155637  0.00163132 
+  589          597.193663   595.514642  0.00169779 
+  588          596.438617   594.874378  0.00170068 
+  601          595.700951   594.234844  0.00166389 
+  597          594.977628   593.596039  0.00167504 
+  598          594.266313   592.957963  0.00167224 
+  605          593.565187   592.320614  0.00165289 
+  576          592.872816   591.683991  0.00173611 
+  584          592.188034   591.048094  0.00171233 
+  583          591.509903   590.412923  0.00171527 
+  576          590.837658   589.778476  0.00173611 
+  627          590.170659   589.144752  0.0015949 
+  581          589.508379   588.511751  0.00172117 
+  626          588.85038    587.879472  0.00159744 
+  588          588.196287   587.247915  0.00170068 
+  589          587.545788   586.617077  0.00169779 
+  593          586.898619   585.98696   0.00168634 
+  597          586.254554   585.357561  0.00167504 
+  568          585.6134     584.72888   0.00176056 
+  581          584.974997   584.100917  0.00172117 
+  610          584.339204   583.47367   0.00163934 
+  594          583.705906   582.847138  0.0016835 
+  618          583.075005   582.221322  0.00161812 
+  610          582.446419   581.59622   0.00163934 
+  594          581.82008    580.971831  0.0016835 
+  565          581.195937   580.348155  0.00176991 
+  538          580.574001   579.72519   0.00185874 
+  563          579.954136   579.102937  0.0017762 
+  587          579.336377   578.481394  0.00170358 
+  540          578.720716   577.86056   0.00185185 
+  553          578.107156   577.240436  0.00180832 
+  583          577.495735   576.621019  0.00171527 
+  573          576.886426   576.002309  0.0017452 
+  587          576.279289   575.384306  0.00170358 
+  597          575.674369   574.767008  0.00167504 
+  549          575.071729   574.150415  0.00182149 
+  610          574.471441   573.534526  0.00163934 
+  617          573.873594   572.919341  0.00162075 
+  579          573.278295   572.304858  0.00172712 
+  560          572.685673   571.691077  0.00178571 
+  550          572.095877   571.077997  0.00181818 
+  563          571.509091   570.465618  0.0017762 
+  589          570.925584   569.853937  0.00169779 
+  574          570.345487   569.242956  0.00174216 
+  560          569.769165   568.632672  0.00178571 
+  578          569.196974   568.023086  0.0017301 
+  554          568.629349   567.414196  0.00180505 
+  576          568.066849   566.806002  0.00173611 
+  564          567.510243   566.198503  0.00177305 
+  568          566.959975   565.591698  0.00176056 
+  634          566.417229   564.985586  0.00157729 
+  514          565.883251   564.380167  0.00194553 
+  526          565.359643   563.77544   0.00190114 
+  539          564.848616   563.171404  0.00185529 
+  587          564.352825   562.568059  0.00170358 
+  570          563.876415   561.965403  0.00175439 
+  570          563.425432   561.363435  0.00175439 
+  536          563.009169   560.762156  0.00186567 
+  578          562.642119   560.161565  0.0017301 
+  565          562.346297   559.56166   0.00176991 
+  550          562.153399   558.962441  0.00181818 
+  574          562.106378   558.363906  0.00174216 
+  550          562.258295   557.766057  0.00181818 
+  521          562.662425   557.168891  0.00191939 
+  575          563.341722   556.572407  0.00173913 
+  568          564.249494   555.976606  0.00176056 
+  556          565.287996   555.381486  0.00179856 
+  583          566.463838   554.787047  0.00171527 
+  548          567.739009   554.193288  0.00182482 
+  562          568.722243   553.600208  0.00177936 
+  594          568.794103   553.007806  0.0016835 
+  540          567.756982   552.416081  0.00185185 
+  572          565.971644   551.825034  0.00174825 
+  563          563.734791   551.234663  0.0017762 
+  561          561.275785   550.644967  0.00178253 
+  586          558.938648   550.055946  0.00170648 
+  506          556.963126   549.467599  0.00197628 
+  539          555.395759   548.879925  0.00185529 
+  558          554.181853   548.292923  0.00179211 
+  544          553.241875   547.706593  0.00183824 
+  557          552.504194   547.120934  0.00179533 
+  509          551.914993   546.535945  0.00196464 
+  556          551.438805   545.951626  0.00179856 
+  558          551.055487   545.367976  0.00179211 
+  567          550.756169   544.784993  0.00176367 
+  531          550.539713   544.202678  0.00188324 
+  564          550.410326   543.621029  0.00177305 
+  543          550.376443   543.040046  0.00184162 
+  539          550.4501     542.459728  0.00185529 
+  504          550.646574   541.880075  0.00198413 
+  534          550.98452    541.301085  0.00187266 
+  516          551.485499   540.722758  0.00193798 
+  563          552.173279   540.145093  0.0017762 
+  498          553.072786   539.56809   0.00200803 
+  596          554.207032   538.991747  0.00167785 
+  537          555.591984   538.416065  0.0018622 
+  537          557.228733   537.841041  0.0018622 
+  545          559.090838   537.266676  0.00183486 
+  531          561.108911   536.692969  0.00188324 
+  538          563.158704   536.119919  0.00185874 
+  534          565.059884   535.547525  0.00187266 
+  549          566.598281   534.975787  0.00182149 
+  623          567.572054   534.404704  0.00160514 
+  563          567.841875   533.834275  0.0017762 
+  534          567.363774   533.264499  0.00187266 
+  578          566.19291    532.695376  0.0017301 
+  532          564.466354   532.126906  0.0018797 
+  554          562.373106   531.559086  0.00180505 
+  537          560.116581   530.991917  0.0018622 
+  595          557.88248    530.425398  0.00168067 
+  552          555.817904   529.859528  0.00181159 
+  532          554.022558   529.294306  0.0018797 
+  522          552.548612   528.729732  0.00191571 
+  510          551.402016   528.165805  0.00196078 
+  522          550.543731   527.602525  0.00191571 
+  502          549.891113   527.03989   0.00199203 
+  527          549.322833   526.477899  0.00189753 
+  538          548.695306   525.916553  0.00185874 
+  518          547.872361   525.355851  0.0019305 
+  508          546.758721   524.795791  0.0019685 
+  520          545.320976   524.236373  0.00192308 
+  537          543.58737    523.677596  0.0018622 
+  545          541.631452   523.11946   0.00183486 
+  523          539.549233   522.561964  0.00191205 
+  508          537.43753    522.005107  0.0019685 
+  530          535.37726    521.448888  0.00188679 
+  539          533.424448   520.893307  0.00185529 
+  507          531.610263   520.338363  0.00197239 
+  530          529.946562   519.784056  0.00188679 
+  495          528.432385   519.230384  0.0020202 
+  524          527.060151   518.677347  0.0019084 
+  522          525.81912    518.124944  0.00191571 
+  535          524.699914   517.573175  0.00186916 
+  544          523.695743   517.022039  0.00183824 
+  495          522.805076   516.471534  0.0020202 
+  492          522.034062   515.921662  0.00203252 
+  501          521.39843    515.37242   0.00199601 
+  528          520.926631   514.823807  0.00189394 
+  537          520.660023   514.275825  0.0018622 
+  509          520.649004   513.728471  0.00196464 
+  501          520.935562   513.181744  0.00199601 
+  554          521.511116   512.635645  0.00180505 
+  539          522.291311   512.090173  0.00185529 
+  514          523.216643   511.545326  0.00194553 
+  505          524.256777   511.001105  0.0019802 
+  513          525.174333   510.457508  0.00194932 
+  514          525.372344   509.914535  0.00194553 
+  525          524.480441   509.372184  0.00190476 
+  464          522.770629   508.830456  0.00215517 
+  530          520.613822   508.28935   0.00188679 
+  528          518.165003   507.748865  0.00189394 
+  504          515.678203   507.209     0.00198413 
+  486          513.442934   506.669755  0.00205761 
+  484          511.577648   506.131129  0.00206612 
+  507          510.060154   505.593121  0.00197239 
+  502          508.818311   505.05573   0.00199203 
+  499          507.776857   504.518956  0.00200401 
+  474          506.873583   503.982799  0.0021097 
+  490          506.063041   503.447257  0.00204082 
+  484          505.314714   502.91233   0.00206612 
+  513          504.60922    502.378017  0.00194932 
+  515          503.934558   501.844317  0.00194175 
+  473          503.283168   501.31123   0.00211416 
+  538          502.650036   500.778755  0.00185874 
+  466          502.031675   500.246892  0.00214592 
+  485          501.425534   499.715639  0.00206186 
+  502          500.829674   499.184996  0.00199203 
+  499          500.242605   498.654963  0.00200401 
+  530          499.663163   498.125538  0.00188679 
+  470          499.090412   497.596722  0.00212766 
+  483          498.523613   497.068512  0.00207039 
+  464          497.96217    496.540909  0.00215517 
+  473          497.405592   496.013913  0.00211416 
+  470          496.853485   495.487521  0.00212766 
+  507          496.305529   494.961734  0.00197239 
+  464          495.761459   494.436551  0.00215517 
+  518          495.221062   493.911972  0.0019305 
+  492          494.684172   493.387995  0.00203252 
+  498          494.15065    492.86462   0.00200803 
+  483          493.620396   492.341846  0.00207039 
+  487          493.093338   491.819672  0.00205339 
+  466          492.569424   491.298099  0.00214592 
+  493          492.048632   490.777125  0.0020284 
+  472          491.531271   490.256749  0.00211864 
+  540          491.016741   489.736971  0.00185185 
+  464          490.505392   489.217791  0.00215517 
+  477          489.997294   488.699207  0.00209644 
+  487          489.492529   488.181219  0.00205339 
+  508          488.991364   487.663826  0.0019685 
+  459          488.49363    487.147028  0.00217865 
+  474          487.999644   486.630824  0.0021097 
+  500          487.509602   486.115213  0.002     
+  480          487.023738   485.600194  0.00208333 
+  497          486.542319   485.085768  0.00201207 
+  497          486.065657   484.571932  0.00201207 
+  475          485.594122   484.058688  0.00210526 
+  507          485.128135   483.546033  0.00197239 
+  476          484.668188   483.033967  0.00210084 
+  480          484.214861   482.52249   0.00208333 
+  472          483.768821   482.011601  0.00211864 
+  498          483.33085    481.5013    0.00200803 
+  445          482.901879   480.991585  0.00224719 
+  474          482.482984   480.482456  0.0021097 
+  445          482.075574   479.973912  0.00224719 
+  499          481.680901   479.465953  0.00200401 
+  446          481.300869   478.958578  0.00224215 
+  470          480.937582   478.451786  0.00212766 
+  479          480.593527   477.945577  0.00208768 
+  458          480.271652   477.439951  0.00218341 
+  481          479.975446   476.934905  0.002079  
+  507          479.708827   476.43044   0.00197239 
+  452          479.476506   475.926556  0.00221239 
+  483          479.283777   475.42325   0.00207039 
+  438          479.136466   474.920524  0.00228311 
+  481          479.040744   474.418376  0.002079  
+  473          479.002549   473.916805  0.00211416 
+  448          479.027134   473.415811  0.00223214 
+  457          479.118462   472.915393  0.00218818 
+  464          479.278987   472.415551  0.00215517 
+  433          479.511058   471.916284  0.00230947 
+  512          479.819363   471.417591  0.00195312 
+  508          480.213458   470.919472  0.0019685 
+  469          480.709484   470.421926  0.0021322 
+  478          481.328263   469.924952  0.00209205 
+  473          482.090111   469.428549  0.00211416 
+  475          483.007919   468.932718  0.00210526 
+  452          484.076164   468.437457  0.00221239 
+  464          485.257156   467.942766  0.00215517 
+  435          486.469319   467.448644  0.00229885 
+  477          487.581902   466.955091  0.00209644 
+  447          488.427334   466.462105  0.00223714 
+  475          488.837245   465.969687  0.00210526 
+  475          488.688282   465.477835  0.00210526 
+  450          487.93784    464.986549  0.00222222 
+  451          486.622245   464.495829  0.00221729 
+  459          484.846349   464.005673  0.00217865 
+  445          482.75024    463.516081  0.00224719 
+  494          480.482996   463.027052  0.00202429 
+  470          478.179413   462.538587  0.00212766 
+  457          475.940755   462.050683  0.00218818 
+  454          473.833491   461.563341  0.00220264 
+  502          471.890126   461.07656   0.00199203 
+  445          470.119816   460.590339  0.00224719 
+  491          468.516646   460.104678  0.00203666 
+  443          467.066665   459.619575  0.00225734 
+  459          465.752816   459.135031  0.00217865 
+  477          464.557509   458.651045  0.00209644 
+  488          463.463822   458.167615  0.00204918 
+  470          462.456707   457.684743  0.00212766 
+  449          461.522871   457.202426  0.00222717 
+  425          460.65082    456.720664  0.00235294 
+  472          459.830852   456.239457  0.00211864 
+  455          459.054806   455.758804  0.0021978 
+  486          458.315841   455.278704  0.00205761 
+  452          457.608327   454.799156  0.00221239 
+  435          456.927599   454.320161  0.00229885 
+  454          456.269915   453.841718  0.00220264 
+  419          455.631829   453.363825  0.00238663 
+  430          455.010836   452.886482  0.00232558 
+  480          454.404718   452.409689  0.00208333 
+  454          453.811643   451.933445  0.00220264 
+  513          453.230127   451.457749  0.00194932 
+  450          452.658708   450.982601  0.00222222 
+  464          452.096341   450.508     0.00215517 
+  453          451.542064   450.033946  0.00220751 
+  421          450.99504    449.560438  0.0023753 
+  432          450.454557   449.087474  0.00231481 
+  418          449.91999    448.615056  0.00239234 
+  460          449.390792   448.143181  0.00217391 
+  466          448.866479   447.67185   0.00214592 
+  433          448.34664    447.201062  0.00230947 
+  425          447.830895   446.730816  0.00235294 
+  421          447.31892    446.261111  0.0023753 
+  391          446.810424   445.791948  0.00255754 
+  457          446.305145   445.323324  0.00218818 
+  423          445.802849   444.855241  0.00236407 
+  462          445.303335   444.387697  0.0021645 
+  470          444.810607   443.920691  0.00212766 
+  465          444.316127   443.454223  0.00215054 
+  399          443.823928   442.988292  0.00250627 
+  438          443.33387    442.522898  0.00228311 
+  414          442.845831   442.05804   0.00241546 
+  425          442.361803   441.593718  0.00235294 
+  466          441.877492   441.12993   0.00214592 
+  443          441.394899   440.666677  0.00225734 
+  403          440.913942   440.203958  0.00248139 
+  424          440.434545   439.741771  0.00235849 
+  486          439.956638   439.280117  0.00205761 
+  432          439.480159   438.818995  0.00231481 
+  423          439.00505    438.358404  0.00236407 
+  508          438.531257   437.898344  0.0019685 
+  456          438.058733   437.438813  0.00219298 
+  430          437.587433   436.979812  0.00232558 
+  396          437.117314   436.52134   0.00252525 
+  425          436.64834    436.063397  0.00235294 
+  396          436.180475   435.605981  0.00252525 
+  451          435.713687   435.149092  0.00221729 
+  426          435.247946   434.692729  0.00234742 
+  422          434.783225   434.236892  0.00236967 
+  468          434.319498   433.781581  0.00213675 
+  414          433.856742   433.326794  0.00241546 
+  442          433.394934   432.872531  0.00226244 
+  425          432.934054   432.418792  0.00235294 
+  428          432.474084   431.965575  0.00233645 
+  444          432.015006   431.512881  0.00225225 
+  416          431.556803   431.060709  0.00240385 
+  457          431.099462   430.609057  0.00218818 
+  422          430.642966   430.157926  0.00236967 
+  443          430.187305   429.707315  0.00225734 
+  450          429.732466   429.257224  0.00222222 
+  456          429.278438   428.807651  0.00219298 
+  421          428.825211   428.358596  0.0023753 
+  423          428.372774   427.910059  0.00236407 
+  436          427.92112    427.462039  0.00229358 
+  433          427.470241   427.014535  0.00230947 
+  403          427.020128   426.567547  0.00248139 
+  463          426.570776   426.121074  0.00215983 
+  460          426.122179   425.675115  0.00217391 
+  407          425.674329   425.229671  0.002457  
+  416          425.227223   424.78474   0.00240385 
+  441          424.780857   424.340322  0.00226757 
+  423          424.335226   423.896417  0.00236407 
+  431          423.890327   423.453023  0.00232019 
+  453          423.446156   423.01014   0.00220751 
+  435          423.002712   422.567768  0.00229885 
+  415          422.559992   422.125905  0.00240964 
+  417          422.117994   421.684552  0.00239808 
+  428          421.676719   421.243708  0.00233645 
+  409          421.236164   420.803372  0.00244499 
+  381          420.79633    420.363544  0.00262467 
+  386          420.357217   419.924222  0.00259067 
+  409          419.920742   419.485407  0.00244499 
+  417          419.483081   419.047098  0.00239808 
+  402          419.046145   418.609295  0.00248756 
+  452          418.609936   418.171996  0.00221239 
+  360          418.174456   417.735201  0.00277778 
+  403          417.740669   417.29891   0.00248139 
+  404          417.306663   416.863122  0.00247525 
+  397          416.873399   416.427836  0.00251889 
+  425          416.440881   415.993052  0.00235294 
+  400          416.009115   415.55877   0.0025    
+  414          415.579511   415.124988  0.00241546 
+  447          415.149274   414.691706  0.00223714 
+  391          414.723422   414.258924  0.00255754 
+  395          414.294754   413.826641  0.00253165 
+  412          413.866877   413.394856  0.00242718 
+  370          413.440504   412.96357   0.0027027 
+  417          413.014244   412.53278   0.00239808 
+  385          412.590618   412.102488  0.0025974 
+  423          412.166029   411.672691  0.00236407 
+  421          411.742294   411.24339   0.0023753 
+  379          411.319431   410.814584  0.00263852 
+  400          410.897453   410.386273  0.0025    
+  397          410.476382   409.958456  0.00251889 
+  391          410.056238   409.531131  0.00255754 
+  399          409.637044   409.1043    0.00250627 
+  406          409.218825   408.677961  0.00246305 
+  426          408.801607   408.252113  0.00234742 
+  428          408.385419   407.826757  0.00233645 
+  372          407.970293   407.401891  0.00268817 
+  408          407.556263   406.977515  0.00245098 
+  396          407.143367   406.553629  0.00252525 
+  408          406.731648   406.130231  0.00245098 
+  377          406.321152   405.707322  0.00265252 
+  400          405.911925   405.2849    0.0025    
+  417          405.504023   404.862966  0.00239808 
+  422          405.097505   404.441518  0.00236967 
+  439          404.692439   404.020556  0.0022779 
+  416          404.288895   403.60008   0.00240385 
+  374          403.886956   403.180089  0.0026738 
+  423          403.486705   402.760582  0.00236407 
+  388          403.088241   402.341558  0.00257732 
+  383          402.691673   401.923019  0.00261097 
+  398          402.29712    401.504962  0.00251256 
+  379          401.904715   401.087387  0.00263852 
+  390          401.51461    400.670293  0.0025641 
+  411          401.126962   400.253681  0.00243309 
+  421          400.741962   399.837549  0.0023753 
+  390          400.359816   399.421898  0.0025641 
+  388          399.982611   399.006725  0.00257732 
+  402          399.60691    398.592032  0.00248756 
+  358          399.234861   398.177817  0.0027933 
+  382          398.866793   397.764079  0.0026178 
+  386          398.503094   397.350819  0.00259067 
+  411          398.144201   396.938036  0.00243309 
+  429          397.791541   396.525728  0.002331  
+  371          397.443839   396.113897  0.00269542 
+  434          397.106095   395.70254   0.00230415 
+  395          396.772251   395.291658  0.00253165 
+  389          396.446613   394.881249  0.00257069 
+  396          396.130228   394.471315  0.00252525 
+  389          395.824333   394.061853  0.00257069 
+  428          395.530392   393.652863  0.00233645 
+  406          395.250159   393.244345  0.00246305 
+  345          394.98745    392.836298  0.00289855 
+  399          394.741348   392.428722  0.00250627 
+  350          394.516634   392.021616  0.00285714 
+  389          394.31701    391.61498   0.00257069 
+  408          394.146954   391.208813  0.00245098 
+  358          394.011886   390.803114  0.0027933 
+  390          393.918317   390.397884  0.0025641 
+  379          393.873912   389.99312   0.00263852 
+  400          393.887845   389.588824  0.0025    
+  416          393.970765   389.184994  0.00240385 
+  379          394.134867   388.78163   0.00263852 
+  381          394.393809   388.378731  0.00262467 
+  395          394.7623     387.976297  0.00253165 
+  383          395.254837   387.574328  0.00261097 
+  400          395.884336   387.172822  0.0025    
+  384          396.658303   386.771779  0.00260417 
+  376          397.573287   386.371199  0.00265957 
+  415          398.606918   385.97108   0.00240964 
+  383          399.708357   385.571424  0.00261097 
+  391          400.790967   385.172228  0.00255754 
+  412          401.735856   384.773493  0.00242718 
+  368          402.409981   384.375218  0.00271739 
+  384          402.699345   383.977403  0.00260417 
+  366          402.542296   383.580046  0.00273224 
+  401          401.934889   383.183148  0.00249377 
+  408          400.92978    382.786708  0.00245098 
+  387          399.609407   382.390724  0.00258398 
+  351          398.071143   381.995198  0.002849  
+  393          396.413843   381.600128  0.00254453 
+  374          394.72191    381.205514  0.0026738 
+  394          393.060065   380.811355  0.00253807 
+  388          391.469279   380.417651  0.00257732 
+  363          389.971115   380.024401  0.00275482 
+  378          388.567443   379.631605  0.0026455 
+  370          387.2452     379.239261  0.0027027 
+  401          385.998959   378.847371  0.00249377 
+  404          384.837008   378.455932  0.00247525 
+  418          383.761325   378.064945  0.00239234 
+  398          382.763681   377.674409  0.00251256 
+  360          381.838525   377.284324  0.00277778 
+  401          380.983949   376.894688  0.00249377 
+  370          380.195102   376.505503  0.0027027 
+  366          379.463967   376.116766  0.00273224 
+  381          378.781833   375.728477  0.00262467 
+  380          378.140628   375.340637  0.00263158 
+  357          377.533469   374.953244  0.00280112 
+  364          376.954682   374.566297  0.00274725 
+  393          376.399679   374.179798  0.00254453 
+  362          375.864755   373.793744  0.00276243 
+  389          375.348456   373.408135  0.00257069 
+  346          374.845428   373.022971  0.00289017 
+  354          374.355153   372.638252  0.00282486 
+  359          373.875993   372.253976  0.00278552 
+  386          373.406579   371.870144  0.00259067 
+  398          372.946474   371.486755  0.00251256 
+  342          372.493265   371.103807  0.00292398 
+  363          372.046834   370.721302  0.00275482 
+  381          371.606469   370.339238  0.00262467 
+  353          371.171552   369.957614  0.00283286 
+  402          370.741557   369.576431  0.00248756 
+  374          370.316017   369.195688  0.0026738 
+  362          369.894532   368.815383  0.00276243 
+  346          369.476753   368.435518  0.00289017 
+  357          369.062365   368.05609   0.00280112 
+  392          368.651096   367.677101  0.00255102 
+  341          368.242703   367.298548  0.00293255 
+  374          367.837431   366.920433  0.0026738 
+  398          367.434169   366.542753  0.00251256 
+  357          367.03321    366.165509  0.00280112 
+  358          366.634399   365.7887    0.0027933 
+  361          366.237599   365.412326  0.00277008 
+  392          365.842917   365.036386  0.00255102 
+  346          365.449784   364.66088   0.00289017 
+  387          365.058328   364.285807  0.00258398 
+  355          364.668464   363.911167  0.0028169 
+  377          364.280109   363.536958  0.00265252 
+  374          363.893187   363.163182  0.0026738 
+  366          363.507633   362.789836  0.00273224 
+  371          363.123387   362.416921  0.00269542 
+  353          362.740392   362.044437  0.00283286 
+  383          362.358601   361.672382  0.00261097 
+  366          361.977966   361.300756  0.00273224 
+  384          361.598524   360.929559  0.00260417 
+  368          361.220082   360.55879   0.00271739 
+  347          360.842681   360.188448  0.00288184 
+  365          360.466292   359.818534  0.00273973 
+  362          360.090885   359.449047  0.00276243 
+  389          359.716434   359.079985  0.00257069 
+  360          359.342975   358.71135   0.00277778 
+  391          358.970365   358.343139  0.00255754 
+  376          358.598643   357.975354  0.00265957 
+  368          358.227793   357.607992  0.00271739 
+  357          357.857802   357.241054  0.00280112 
+  364          357.488647   356.87454   0.00274725 
+  367          357.120318   356.508448  0.0027248 
+  315          356.752814   356.142778  0.0031746 
+  401          356.386101   355.77753   0.00249377 
+  318          356.020182   355.412704  0.00314465 
+  362          355.655049   355.048298  0.00276243 
+  373          355.290691   354.684312  0.00268097 
+  384          354.927105   354.320747  0.00260417 
+  339          354.564282   353.9576    0.00294985 
+  366          354.20222    353.594873  0.00273224 
+  369          353.841018   353.232563  0.00271003 
+  336          353.480467   352.870672  0.00297619 
+  376          353.120667   352.509198  0.00265957 
+  370          352.761618   352.148141  0.0027027 
+  350          352.403319   351.7875    0.00285714 
+  354          352.045771   351.427275  0.00282486 
+  382          351.689027   351.067466  0.0026178 
+  363          351.332986   350.708071  0.00275482 
+  307          350.977703   350.349091  0.00325733 
+  383          350.623182   349.990525  0.00261097 
+  376          350.269667   349.632373  0.00265957 
+  368          349.916684   349.274633  0.00271739 
+  339          349.564479   348.917306  0.00294985 
+  345          349.213277   348.560391  0.00289855 
+  367          348.862655   348.203888  0.0027248 
+  327          348.512839   347.847796  0.0030581 
+  355          348.163837   347.492114  0.0028169 
+  355          347.815785   347.136842  0.0028169 
+  356          347.468453   346.781981  0.00280899 
+  337          347.122085   346.427528  0.00296736 
+  338          346.776482   346.073484  0.00295858 
+  372          346.431771   345.719848  0.00268817 
+  351          346.087969   345.366621  0.002849  
+  308          345.7451     345.0138    0.00324675 
+  385          345.403187   344.661386  0.0025974 
+  346          345.062257   344.309379  0.00289017 
+  350          344.722342   343.957777  0.00285714 
+  326          344.383473   343.606581  0.00306748 
+  355          344.045693   343.255789  0.0028169 
+  331          343.709042   342.905403  0.00302115 
+  379          343.373577   342.55542   0.00263852 
+  335          343.039368   342.20584   0.00298507 
+  350          342.706508   341.856664  0.00285714 
+  362          342.375116   341.50789   0.00276243 
+  381          342.045363   341.159519  0.00262467 
+  321          341.717457   340.811549  0.00311526 
+  353          341.393374   340.46398   0.00283286 
+  350          341.069933   340.116812  0.00285714 
+  351          340.748965   339.770044  0.002849  
+  361          340.430308   339.423676  0.00277008 
+  347          340.113598   339.077707  0.00288184 
+  329          339.798368   338.732137  0.00303951 
+  352          339.484394   338.386965  0.00284091 
+  336          339.168592   338.042191  0.00297619 
+  325          338.852104   337.697815  0.00307692 
+  319          338.536597   337.353835  0.0031348 
+  364          338.222993   337.010253  0.00274725 
+  327          337.91129    336.667066  0.0030581 
+  359          337.601944   336.324274  0.00278552 
+  367          337.295907   335.981878  0.0027248 
+  323          336.993834   335.639877  0.00309598 
+  341          336.695989   335.29827   0.00293255 
+  355          336.402485   334.957056  0.0028169 
+  329          336.113423   334.616236  0.00303951 
+  320          335.828982   334.275808  0.003125  
+  325          335.549411   333.935773  0.00307692 
+  338          335.27505    333.59613   0.00295858 
+  275          335.006326   333.256878  0.00363636 
+  354          334.743755   332.918018  0.00282486 
+  322          334.48792    332.579547  0.00310559 
+  351          334.239529   332.241467  0.002849  
+  351          333.999389   331.903777  0.002849  
+  337          333.768435   331.566475  0.00296736 
+  318          333.54785    331.229563  0.00314465 
+  341          333.338711   330.893038  0.00293255 
+  336          333.142555   330.556902  0.00297619 
+  323          332.961127   330.221153  0.00309598 
+  295          332.796464   329.88579   0.00338983 
+  357          332.650981   329.550814  0.00280112 
+  335          332.527616   329.216224  0.00298507 
+  312          332.42975    328.88202   0.00320513 
+  326          332.361556   328.548201  0.00306748 
+  311          332.328157   328.214766  0.00321543 
+  357          332.335802   327.881716  0.00280112 
+  332          332.392234   327.549049  0.00301205 
+  334          332.507147   327.216765  0.00299401 
+  360          332.692805   326.884865  0.00277778 
+  369          332.964699   326.553347  0.00271003 
+  331          333.34311    326.22221   0.00302115 
+  332          333.854633   325.891456  0.00301205 
+  316          334.535078   325.561082  0.00316456 
+  356          335.434403   325.231089  0.00280899 
+  377          336.626023   324.901476  0.00265252 
+  354          338.223771   324.572243  0.00282486 
+  356          340.415153   324.243389  0.00280899 
+  337          343.512119   323.914914  0.00296736 
+  378          348.021204   323.586817  0.0026455 
+  370          354.717014   323.259098  0.0027027 
+  375          364.680584   322.931757  0.00266667 
+  408          379.246045   322.604793  0.00245098 
+  470          399.453981   322.278205  0.00212766 
+  571          425.200434   321.951993  0.00175131 
+  617          454.314299   321.626158  0.00162075 
+  570          483.884898   321.300697  0.00175439 
+  582          509.422342   320.975612  0.00171821 
+  586          521.363867   320.650901  0.00170648 
+  559          514.446433   320.326563  0.00178891 
+  523          496.490207   320.0026    0.00191205 
+  488          476.319698   319.679009  0.00204918 
+  458          454.206443   319.355791  0.00218341 
+  414          428.425445   319.032946  0.00241546 
+  361          402.446702   318.710472  0.00277008 
+  363          380.523212   318.388369  0.00275482 
+  358          363.922591   318.066638  0.0027933 
+  333          352.042866   317.745276  0.003003  
+  338          343.764236   317.424285  0.00295858 
+  341          338.005642   317.103664  0.00293255 
+  287          333.904612   316.783411  0.00348432 
+  317          330.860718   316.463528  0.00315457 
+  312          328.494633   316.144013  0.00320513 
+  326          326.580535   315.824865  0.00306748 
+  359          324.984601   315.506085  0.00278552 
+  336          323.623749   315.187672  0.00297619 
+  310          322.443003   314.869626  0.00322581 
+  350          321.403581   314.551946  0.00285714 
+  313          320.47663    314.234632  0.00319489 
+  345          319.640606   313.917682  0.00289855 
+  337          318.878898   313.601098  0.00296736 
+  301          318.178524   313.284878  0.00332226 
+  313          317.529313   312.969023  0.00319489 
+  326          316.923162   312.65353   0.00306748 
+  320          316.353494   312.338401  0.003125  
+  292          315.814994   312.023635  0.00342466 
+  321          315.303321   311.709231  0.00311526 
+  350          314.814877   311.395189  0.00285714 
+  349          314.346706   311.081508  0.00286533 
+  357          313.89635    310.768188  0.00280112 
+  328          313.46171    310.455229  0.00304878 
+  299          313.041032   310.142631  0.00334448 
+  344          312.632957   309.830391  0.00290698 
+  349          312.235962   309.518512  0.00286533 
+  344          311.848492   309.206991  0.00290698 
+  298          311.470591   308.895828  0.0033557 
+  326          311.101089   308.585024  0.00306748 
+  332          310.739649   308.274578  0.00301205 
+  360          310.385253   307.964488  0.00277778 
+  316          310.037731   307.654756  0.00316456 
+  302          309.696405   307.345379  0.00331126 
+  327          309.360987   307.036359  0.0030581 
+  360          309.031169   306.727694  0.00277778 
+  351          308.706699   306.419385  0.002849  
+  310          308.387202   306.11143   0.00322581 
+  308          308.072841   305.80383   0.00324675 
+  345          307.76324    305.496583  0.00289855 
+  344          307.458482   305.18969   0.00290698 
+  334          307.158417   304.88315   0.00299401 
+  294          306.863021   304.576962  0.00340136 
+  280          306.572107   304.271127  0.00357143 
+  328          306.286084   303.965643  0.00304878 
+  306          306.004835   303.660511  0.00326797 
+  317          305.728356   303.35573   0.00315457 
+  291          305.456976   303.0513    0.00343643 
+  325          305.190763   302.747219  0.00307692 
+  315          304.92992    302.443489  0.0031746 
+  313          304.674673   302.140108  0.00319489 
+  325          304.425313   301.837075  0.00307692 
+  302          304.189189   301.534391  0.00331126 
+  289          303.952665   301.232056  0.00346021 
+  308          303.723178   300.930067  0.00324675 
+  322          303.501232   300.628427  0.00310559 
+  298          303.28738    300.327133  0.0033557 
+  324          303.082292   300.026185  0.00308642 
+  293          302.890235   299.725584  0.00341297 
+  265          302.705045   299.425328  0.00377358 
+  255          302.53122    299.125418  0.00392157 
+  290          302.369874   298.825852  0.00344828 
+  311          302.222337   298.526631  0.00321543 
+  321          302.090066   298.227753  0.00311526 
+  302          301.974815   297.92922   0.00331126 
+  287          301.878602   297.631029  0.00348432 
+  312          301.803785   297.333182  0.00320513 
+  285          301.753092   297.035677  0.00350877 
+  307          301.729806   296.738513  0.00325733 
+  277          301.749125   296.441692  0.00361011 
+  292          301.792747   296.145211  0.00342466 
+  309          301.877509   295.849072  0.00323625 
+  327          302.016001   295.553272  0.0030581 
+  323          302.203971   295.257813  0.00309598 
+  297          302.457167   294.962694  0.003367  
+  268          302.79297    294.667913  0.00373134 
+  330          303.214616   294.373471  0.0030303 
+  298          303.749123   294.079368  0.0033557 
+  349          304.413575   293.785603  0.00286533 
+  322          305.240362   293.492175  0.00310559 
+  300          306.267809   293.199084  0.00333333 
+  308          307.545502   292.906331  0.00324675 
+  303          309.140632   292.613913  0.00330033 
+  339          311.146069   292.321832  0.00294985 
+  319          313.69718    292.030086  0.0031348 
+  342          317.003563   291.738676  0.00292398 
+  359          321.410069   291.4476    0.00278552 
+  323          327.4912     291.156859  0.00309598 
+  346          336.18569    290.866451  0.00289017 
+  345          348.911534   290.576378  0.00289855 
+  398          367.58274    290.286637  0.00251256 
+  415          394.385131   289.99723   0.00240964 
+  426          431.216378   289.708155  0.00234742 
+  488          478.277248   289.419412  0.00204918 
+  558          530.966733   289.131     0.00179211 
+  687          575.688919   288.84292   0.0014556 
+  712          594.692823   288.555171  0.00140449 
+  678          585.592263   288.267752  0.00147493 
+  635          563.595171   287.980663  0.0015748 
+  606          539.387746   287.693904  0.00165017 
+  605          510.548517   287.407475  0.00165289 
+  509          473.609011   287.121374  0.00196464 
+  479          433.779263   286.835602  0.00208768 
+  455          398.362046   286.550158  0.0021978 
+  361          370.399445   286.265042  0.00277008 
+  339          349.665886   285.980253  0.00294985 
+  318          334.783588   285.695791  0.00314465 
+  282          324.22839    285.411656  0.0035461 
+  276          316.683473   285.127847  0.00362319 
+  279          311.151999   284.844363  0.00358423 
+  296          306.946304   284.561206  0.00337838 
+  307          303.630233   284.278373  0.00325733 
+  305          300.933133   283.995865  0.00327869 
+  306          298.686526   283.713681  0.00326797 
+  283          296.780732   283.431822  0.00353357 
+  275          295.140045   283.150285  0.00363636 
+  312          293.709939   282.869072  0.00320513 
+  291          292.449526   282.588182  0.00343643 
+  324          291.327331   282.307614  0.00308642 
+  273          290.320227   282.027368  0.003663  
+  286          289.406439   281.747444  0.0034965 
+  289          288.571885   281.467841  0.00346021 
+  278          287.804349   281.188559  0.00359712 
+  287          287.093747   280.909597  0.00348432 
+  303          286.431998   280.630956  0.00330033 
+  266          285.812322   280.352634  0.0037594 
+  293          285.229769   280.074631  0.00341297 
+  290          284.678132   279.796948  0.00344828 
+  312          284.154664   279.519583  0.00320513 
+  266          283.655761   279.242536  0.0037594 
+  296          283.178537   278.965807  0.00337838 
+  293          282.720817   278.689396  0.00341297 
+  283          282.280427   278.413302  0.00353357 
+  288          281.860327   278.137524  0.00347222 
+  304          281.449561   277.862063  0.00328947 
+  269          281.051516   277.586918  0.00371747 
+  285          280.665082   277.312088  0.00350877 
+  283          280.289259   277.037574  0.00353357 
+  265          279.923191   276.763374  0.00377358 
+  284          279.566129   276.489489  0.00352113 
+  271          279.219813   276.215918  0.00369004 
+  261          278.878939   275.942661  0.00383142 
+  243          278.547894   275.669717  0.00411523 
+  278          278.221295   275.397086  0.00359712 
+  303          277.903619   275.124768  0.00330033 
+  256          277.589906   274.852762  0.00390625 
+  272          277.282254   274.581067  0.00367647 
+  263          276.98049    274.309685  0.00380228 
+  274          276.684487   274.038613  0.00364964 
+  275          276.395405   273.767853  0.00363636 
+  279          276.110729   273.497402  0.00358423 
+  279          275.832893   273.227262  0.00358423 
+  271          275.559628   272.957431  0.00369004 
+  282          275.292242   272.68791   0.0035461 
+  238          275.030926   272.418698  0.00420168 
+  280          274.775943   272.149794  0.00357143 
+  296          274.527637   271.881198  0.00337838 
+  275          274.286447   271.612911  0.00363636 
+  291          274.052908   271.344931  0.00343643 
+  283          273.827702   271.077257  0.00353357 
+  273          273.611635   270.809891  0.003663  
+  305          273.405716   270.542831  0.00327869 
+  286          273.211177   270.276077  0.0034965 
+  278          273.029533   270.009629  0.00359712 
+  311          272.862637   269.743486  0.00321543 
+  241          272.712824   269.477648  0.00414938 
+  274          272.58294    269.212114  0.00364964 
+  287          272.47662    268.946885  0.00348432 
+  300          272.398461   268.68196   0.00333333 
+  280          272.354362   268.417338  0.00357143 
+  274          272.351952   268.153019  0.00364964 
+  280          272.401377   267.889003  0.00357143 
+  261          272.516156   267.62529   0.00383142 
+  274          272.715402   267.361878  0.00364964 
+  297          273.02729    267.098768  0.003367  
+  286          273.496201   266.83596   0.0034965 
+  291          274.195451   266.573453  0.00343643 
+  283          275.247823   266.311246  0.00353357 
+  282          276.849501   266.049339  0.0035461 
+  281          279.290276   265.787733  0.00355872 
+  320          282.946599   265.526426  0.003125  
+  293          288.227657   265.265418  0.00341297 
+  291          295.440196   265.004709  0.00343643 
+  319          304.470592   264.744299  0.0031348 
+  309          314.098803   264.484186  0.00323625 
+  342          321.356949   264.224372  0.00292398 
+  313          323.23742    263.964855  0.00319489 
+  337          320.338342   263.705635  0.00296736 
+  330          315.845987   263.446711  0.0030303 
+  309          311.349439   263.188085  0.00323625 
+  312          306.046066   262.929754  0.00320513 
+  322          299.194076   262.671719  0.00310559 
+  313          291.775651   262.413979  0.00319489 
+  292          285.152649   262.156534  0.00342466 
+  304          279.889038   261.899384  0.00328947 
+  289          275.951263   261.642528  0.00346021 
+  258          273.092546   261.385966  0.00387597 
+  243          271.037591   261.129698  0.00411523 
+  266          269.546551   260.873723  0.0037594 
+  263          268.4373     260.61804   0.00380228 
+  258          267.585008   260.362651  0.00387597 
+  237          266.910745   260.107553  0.00421941 
+  265          266.366433   259.852748  0.00377358 
+  268          265.923011   259.598233  0.00373134 
+  265          265.5633     259.34401   0.00377358 
+  264          265.276248   259.090078  0.00378788 
+  248          265.055503   258.836437  0.00403226 
+  262          264.897986   258.583085  0.00381679 
+  289          264.803734   258.330023  0.00346021 
+  256          264.774953   258.077251  0.00390625 
+  272          264.816641   257.824768  0.00367647 
+  271          264.936724   257.572573  0.00369004 
+  273          265.146551   257.320667  0.003663  
+  257          265.508096   257.069049  0.00389105 
+  248          265.950312   256.817719  0.00403226 
+  246          266.548054   256.566676  0.00406504 
+  241          267.341368   256.31592   0.00414938 
+  283          268.387603   256.065451  0.00353357 
+  281          269.773422   255.815268  0.00355872 
+  282          271.661117   255.565371  0.0035461 
+  274          274.237109   255.31576   0.00364964 
+  306          277.909751   255.066434  0.00326797 
+  289          283.287769   254.817394  0.00346021 
+  325          291.242355   254.568638  0.00307692 
+  335          302.861345   254.320166  0.00298507 
+  329          319.252363   254.071978  0.00303951 
+  428          341.081198   253.824074  0.00233645 
+  474          367.457973   253.576453  0.0021097 
+  547          393.799693   253.329115  0.00182815 
+  525          410.955304   253.08206   0.00190476 
+  621          412.33273    252.835287  0.00161031 
+  712          402.490612   252.588796  0.00140449 
+  745          390.266013   252.342587  0.00134228 
+  704          378.399778   252.096659  0.00142045 
+  633          363.799379   251.851012  0.00157978 
+  561          344.932144   251.605646  0.00178253 
+  525          325.021924   251.36056   0.00190476 
+  464          307.613802   251.115754  0.00215517 
+  425          293.963429   250.871228  0.00235294 
+  382          283.85304    250.626981  0.0026178 
+  358          276.580597   250.383013  0.0027933 
+  303          271.398949   250.139323  0.00330033 
+  280          267.666683   249.895912  0.00357143 
+  271          264.902857   249.652779  0.00369004 
+  237          262.780182   249.409923  0.00421941 
+  237          261.09128    249.167345  0.00421941 
+  217          259.707922   248.925044  0.00460829 
+  284          258.550405   248.68302   0.00352113 
+  277          257.5663     248.441272  0.00361011 
+  249          256.71947    248.199799  0.00401606 
+  241          255.984212   247.958603  0.00414938 
+  259          255.340276   247.717682  0.003861  
+  231          254.773346   247.477036  0.004329  
+  260          254.272307   247.236665  0.00384615 
+  247          253.828597   246.996568  0.00404858 
+  231          253.43577    246.756745  0.004329  
+  276          253.089007   246.517196  0.00362319 
+  262          252.785174   246.27792   0.00381679 
+  204          252.521492   246.038917  0.00490196 
+  234          252.296983   245.800187  0.0042735 
+  266          252.111371   245.56173   0.0037594 
+  260          251.965343   245.323544  0.00384615 
+  263          251.860548   245.085631  0.00380228 
+  226          251.799733   244.847989  0.00442478 
+  265          251.786837   244.610618  0.00377358 
+  270          251.827254   244.373518  0.0037037 
+  225          251.930596   244.136688  0.00444444 
+  224          252.101505   243.900128  0.00446429 
+  232          252.35482    243.663839  0.00431034 
+  230          252.707092   243.427819  0.00434783 
+  220          253.180487   243.192068  0.00454545 
+  216          253.806039   242.956586  0.00462963 
+  239          254.630615   242.721372  0.0041841 
+  227          255.723037   242.486427  0.00440529 
+  255          257.200345   242.25175   0.00392157 
+  247          259.251376   242.01734   0.00404858 
+  273          262.170283   241.783198  0.003663  
+  220          266.372605   241.549323  0.00454545 
+  260          272.378611   241.315714  0.00384615 
+  297          280.715306   241.082372  0.003367  
+  304          291.712699   240.849296  0.00328947 
+  320          304.994584   240.616485  0.003125  
+  334          318.504646   240.38394   0.00299401 
+  332          328.173323   240.15166   0.00301205 
+  349          331.309409   239.919645  0.00286533 
+  355          330.479832   239.687894  0.0028169 
+  364          330.350376   239.456407  0.00274725 
+  344          333.061344   239.225184  0.00290698 
+  399          338.241402   238.994225  0.00250627 
+  382          346.098709   238.763529  0.0026178 
+  344          358.827517   238.533096  0.00290698 
+  369          377.793463   238.302925  0.00271003 
+  386          400.656613   238.073017  0.00259067 
+  383          421.237489   237.843371  0.00261097 
+  381          432.121634   237.613986  0.00262467 
+  401          429.17412    237.384862  0.00249377 
+  365          416.252339   237.156     0.00273973 
+  361          400.569129   236.927399  0.00277008 
+  311          384.703556   236.699057  0.00321543 
+  331          366.874597   236.470976  0.00302115 
+  309          345.692456   236.243155  0.00323625 
+  287          323.502982   236.015593  0.00348432 
+  287          303.817361   235.78829   0.00348432 
+  291          288.205699   235.561246  0.00343643 
+  255          276.561896   235.334461  0.00392157 
+  234          268.154575   235.107934  0.0042735 
+  228          262.16478    234.881665  0.00438596 
+  263          257.88038    234.655654  0.00380228 
+  213          254.762423   234.4299    0.00469484 
+  230          252.435834   234.204403  0.00434783 
+  235          250.660913   233.979162  0.00425532 
+  229          249.290283   233.754178  0.00436681 
+  235          248.232839   233.529451  0.00425532 
+  211          247.427274   233.304979  0.00473934 
+  214          246.826388   233.080762  0.0046729 
+  279          246.389512   232.856801  0.00358423 
+  247          246.080294   232.633094  0.00404858 
+  241          245.86756    232.409643  0.00414938 
+  210          245.727683   232.186445  0.0047619 
+  231          245.648256   231.963502  0.004329  
+  238          245.627339   231.740812  0.00420168 
+  228          245.667494   231.518376  0.00438596 
+  233          245.767568   231.296192  0.00429185 
+  238          245.915658   231.074262  0.00420168 
+  237          246.084389   230.852584  0.00421941 
+  231          246.227974   230.631158  0.004329  
+  234          246.286762   230.409984  0.0042735 
+  259          246.198771   230.189062  0.003861  
+  232          245.918289   229.968391  0.00431034 
+  242          245.429564   229.74797   0.00413223 
+  256          244.746026   229.527801  0.00390625 
+  223          243.897693   229.307882  0.0044843 
+  243          242.918624   229.088213  0.00411523 
+  228          241.843651   228.868794  0.00438596 
+  225          240.710687   228.649625  0.00444444 
+  231          239.560653   228.430704  0.004329  
+  196          238.432427   228.212033  0.00510204 
+  207          237.357293   227.99361   0.00483092 
+  224          236.354835   227.775436  0.00446429 
+  236          235.433997   227.557509  0.00423729 
+  212          234.595585   227.339831  0.00471698 
+  255          233.83528    227.122399  0.00392157 
+  257          233.146042   226.905215  0.00389105 
+  219          232.52007    226.688278  0.00456621 
+  232          231.94935    226.471587  0.00431034 
+  205          231.42648    226.255143  0.00487805 
+  194          230.944833   226.038945  0.00515464 
+  215          230.498613   225.822992  0.00465116 
+  210          230.082818   225.607284  0.0047619 
+  234          229.693293   225.391822  0.0042735 
+  224          229.326466   225.176605  0.00446429 
+  210          228.979377   224.961632  0.0047619 
+  220          228.649578   224.746903  0.00454545 
+  206          228.335045   224.532419  0.00485437 
+  225          228.034103   224.318178  0.00444444 
+  237          227.745426   224.10418   0.00421941 
+  219          227.467891   223.890425  0.00456621 
+  198          227.200615   223.676913  0.00505051 
+  213          226.942896   223.463644  0.00469484 
+  234          226.694192   223.250617  0.0042735 
+  246          226.454084   223.037832  0.00406504 
+  209          226.222314   222.825288  0.00478469 
+  224          225.998721   222.612986  0.00446429 
+  237          225.783262   222.400925  0.00421941 
+  226          225.576014   222.189105  0.00442478 
+  207          225.377182   221.977525  0.00483092 
+  219          225.187076   221.766185  0.00456621 
+  235          225.006177   221.555086  0.00425532 
+  226          224.835122   221.344225  0.00442478 
+  256          224.676265   221.133605  0.00390625 
+  257          224.527602   220.923223  0.00389105 
+  218          224.392001   220.71308   0.00458716 
+  207          224.271106   220.503176  0.00483092 
+  213          224.167027   220.29351   0.00469484 
+  239          224.08241    220.084082  0.0041841 
+  228          224.020575   219.874891  0.00438596 
+  221          223.986542   219.665938  0.00452489 
+  200          223.984261   219.457222  0.005     
+  229          224.02151    219.248743  0.00436681 
+  218          224.107643   219.0405    0.00458716 
+  250          224.255227   218.832494  0.004     
+  256          224.481751   218.624723  0.00390625 
+  211          224.812943   218.417188  0.00473934 
+  221          225.289128   218.209889  0.00452489 
+  209          225.97631    218.002825  0.00478469 
+  244          226.985121   217.795996  0.00409836 
+  220          228.493734   217.589401  0.00454545 
+  225          230.766639   217.38304   0.00444444 
+  241          234.151589   217.176914  0.00414938 
+  233          239.033848   216.971021  0.00429185 
+  228          245.714046   216.765362  0.00438596 
+  199          254.139971   216.559936  0.00502513 
+  243          263.296428   216.354743  0.00411523 
+  232          270.519114   216.149782  0.00431034 
+  289          272.742459   215.945054  0.00346021 
+  289          270.092037   215.740558  0.00346021 
+  240          265.740874   215.536294  0.00416667 
+  274          261.927917   215.332261  0.00364964 
+  247          258.364967   215.12846   0.00404858 
+  232          253.595252   214.924889  0.00431034 
+  242          247.444269   214.72155   0.00413223 
+  246          241.222195   214.51844   0.00406504 
+  250          236.029848   214.315561  0.004     
+  243          232.22555    214.112912  0.00411523 
+  228          229.786597   213.910493  0.00438596 
+  226          228.593756   213.708302  0.00442478 
+  233          228.52806    213.506341  0.00429185 
+  226          229.475884   213.304609  0.00442478 
+  227          231.247168   213.103105  0.00440529 
+  257          233.366323   212.90183   0.00389105 
+  246          234.872402   212.700782  0.00406504 
+  243          234.827627   212.499962  0.00411523 
+  295          233.412805   212.29937   0.00338983 
+  327          231.641619   212.099005  0.0030581 
+  345          230.120068   211.898867  0.00289855 
+  366          228.673141   211.698955  0.00273224 
+  391          226.834697   211.49927   0.00255754 
+  307          224.590822   211.299811  0.00325733 
+  270          222.35661    211.100578  0.0037037 
+  319          220.443343   210.90157   0.0031348 
+  297          218.928077   210.702788  0.003367  
+  309          217.769943   210.504231  0.00323625 
+  272          216.894487   210.305898  0.00367647 
+  238          216.226737   210.10779   0.00420168 
+  231          215.704507   209.909907  0.004329  
+  216          215.282259   209.712247  0.00462963 
+  221          214.929716   209.514811  0.00452489 
+  228          214.628037   209.317598  0.00438596 
+  195          214.36593    209.120609  0.00512821 
+  200          214.136674   208.923843  0.005     
+  200          213.93638    208.727299  0.005     
+  226          213.763001   208.530978  0.00442478 
+  231          213.615738   208.334878  0.004329  
+  236          213.49446    208.139001  0.00423729 
+  245          213.399103   207.943345  0.00408163 
+  230          213.328292   207.747911  0.00434783 
+  265          213.277257   207.552698  0.00377358 
+  267          213.238119   207.357705  0.00374532 
+  236          213.207137   207.162933  0.00423729 
+  239          213.188511   206.968382  0.0041841 
+  220          213.186086   206.77405   0.00454545 
+  244          213.195832   206.579938  0.00409836 
+  246          213.207075   206.386046  0.00406504 
+  242          213.209358   206.192373  0.00413223 
+  225          213.198644   205.998919  0.00444444 
+  230          213.176349   205.805684  0.00434783 
+  227          213.146699   205.612667  0.00440529 
+  220          213.115581   205.419869  0.00454545 
+  228          213.08928    205.227288  0.00438596 
+  212          213.074401   205.034925  0.00471698 
+  222          213.077857   204.84278   0.0045045 
+  190          213.107883   204.650852  0.00526316 
+  210          213.173324   204.459141  0.0047619 
+  222          213.282909   204.267646  0.0045045 
+  232          213.444073   204.076368  0.00431034 
+  210          213.662099   203.885306  0.0047619 
+  211          213.939667   203.69446   0.00473934 
+  203          214.276045   203.50383   0.00492611 
+  201          214.666962   203.313415  0.00497512 
+  216          215.105102   203.123215  0.00462963 
+  230          215.581037   202.93323   0.00434783 
+  208          216.084294   202.74346   0.00480769 
+  226          216.602767   202.553904  0.00442478 
+  226          217.120629   202.364563  0.00442478 
+  240          217.617301   202.175435  0.00416667 
+  221          218.071372   201.986521  0.00452489 
+  215          218.469057   201.79782   0.00465116 
+  203          218.812686   201.609333  0.00492611 
+  202          219.122575   201.421058  0.0049505 
+  237          219.43134    201.232996  0.00421941 
+  233          219.777292   201.045146  0.00429185 
+  202          220.202738   200.857508  0.0049505 
+  213          220.7591     200.670083  0.00469484 
+  223          221.516907   200.482869  0.0044843 
+  236          222.579618   200.295866  0.00423729 
+  237          224.102899   200.109074  0.00421941 
+  218          226.320067   199.922494  0.00458716 
+  231          229.562351   199.736124  0.004329  
+  222          234.25005    199.549964  0.0045045 
+  258          240.837303   199.364014  0.00387597 
+  286          249.664363   199.178275  0.0034965 
+  285          260.618602   198.992745  0.00350877 
+  274          272.395462   198.807424  0.00364964 
+  316          281.768398   198.622313  0.00316456 
+  273          285.32403    198.43741   0.003663  
+  290          283.636512   198.252716  0.00344828 
+  273          280.596163   198.068231  0.003663  
+  299          278.837063   197.883953  0.00334448 
+  281          278.101616   197.699884  0.00355872 
+  273          276.640606   197.516022  0.003663  
+  286          274.013874   197.332368  0.0034965 
+  325          271.773905   197.148921  0.00307692 
+  277          271.526563   196.965681  0.00361011 
+  329          274.077519   196.782647  0.00303951 
+  324          279.847959   196.59982   0.00308642 
+  356          289.372588   196.417199  0.00280899 
+  391          303.722357   196.234784  0.00255754 
+  382          325.039413   196.052575  0.0026178 
+  441          357.229355   195.870571  0.00226757 
+  481          406.56277    195.688773  0.002079  
+  529          481.546442   195.507179  0.00189036 
+  614          591.454343   195.325791  0.00162866 
+  738          742.550223   195.144607  0.00135501 
+  897          929.837473   194.963627  0.00111483 
+  1110         1119.808024  194.782851  0.0009009 
+  1296         1239.19793   194.602279  0.0007716 
+  1306         1232.629562  194.42191   0.0007657 
+  1203         1142.335157  194.241745  0.00083126 
+  1099         1049.01743   194.061783  0.00090992 
+  865          985.691921   193.882024  0.00115607 
+  847          929.598178   193.702467  0.00118064 
+  751          840.527811   193.523112  0.00133156 
+  710          718.00934    193.34396   0.00140845 
+  578          594.520896   193.16501   0.0017301 
+  458          491.9712     192.986261  0.00218341 
+  340          414.974501   192.807714  0.00294118 
+  289          360.272541   192.629368  0.00346021 
+  272          322.523605   192.451223  0.00367647 
+  225          296.574171   192.273278  0.00444444 
+  231          278.337917   192.095534  0.004329  
+  230          265.008025   191.91799   0.00434783 
+  230          254.850052   191.740646  0.00434783 
+  255          246.837302   191.563502  0.00392157 
+  228          240.357306   191.386558  0.00438596 
+  234          235.023743   191.209813  0.0042735 
+  214          230.573928   191.033266  0.0046729 
+  223          226.820589   190.856919  0.0044843 
+  218          223.626504   190.68077   0.00458716 
+  204          220.887328   190.50482   0.00490196 
+  207          218.52331    190.329068  0.00483092 
+  223          216.473232   190.153513  0.0044843 
+  192          214.688776   189.978156  0.00520833 
+  186          213.132093   189.802997  0.00537634 
+  205          211.773831   189.628035  0.00487805 
+  228          210.59066    189.45327   0.00438596 
+  213          209.564551   189.278701  0.00469484 
+  206          208.681979   189.104329  0.00485437 
+  184          207.932701   188.930153  0.00543478 
+  226          207.3094     188.756174  0.00442478 
+  183          206.80721    188.58239   0.00546448 
+  205          206.422548   188.408802  0.00487805 
+  173          206.15232    188.235409  0.00578035 
+  198          205.992265   188.062211  0.00505051 
+  193          205.934457   187.889208  0.00518135 
+  208          205.964422   187.7164    0.00480769 
+  202          206.057831   187.543786  0.0049505 
+  199          206.178537   187.371366  0.00502513 
+  192          206.281215   187.199141  0.00520833 
+  205          206.31917    187.027109  0.00487805 
+  185          206.257923   186.85527   0.00540541 
+  175          206.08455    186.683625  0.00571429 
+  213          205.808055   186.512173  0.00469484 
+  187          205.450027   186.340914  0.00534759 
+  195          205.034064   186.169847  0.00512821 
+  216          204.581878   185.998973  0.00462963 
+  194          204.115736   185.828291  0.00515464 
+  225          203.661928   185.657801  0.00444444 
+  191          203.250812   185.487503  0.0052356 
+  198          202.913262   185.317396  0.00505051 
+  198          202.677274   185.14748   0.00505051 
+  209          202.567255   184.977756  0.00478469 
+  198          202.606114   184.808222  0.00505051 
+  228          202.818099   184.638879  0.00438596 
+  182          203.232722   184.469726  0.00549451 
+  213          203.88801    184.300763  0.00469484 
+  195          204.833384   184.131991  0.00512821 
+  229          206.130376   183.963408  0.00436681 
+  214          207.85406    183.795014  0.0046729 
+  178          210.08888    183.62681   0.00561798 
+  199          212.920381   183.458795  0.00502513 
+  209          216.41324    183.290968  0.00478469 
+  208          220.564927   183.123331  0.00480769 
+  235          225.217573   182.955881  0.00425532 
+  214          229.953653   182.78862   0.0046729 
+  257          234.063      182.621547  0.00389105 
+  245          236.772496   182.454661  0.00408163 
+  276          237.71424    182.287963  0.00362319 
+  240          237.178419   182.121452  0.00416667 
+  205          235.798955   181.955128  0.00487805 
+  258          234.021425   181.788991  0.00387597 
+  219          231.90908    181.623041  0.00456621 
+  229          229.371709   181.457277  0.00436681 
+  222          226.489373   181.291699  0.0045045 
+  228          223.576149   181.126308  0.00438596 
+  188          220.996479   180.961102  0.00531915 
+  190          218.999642   180.796081  0.00526316 
+  205          217.700166   180.631246  0.00487805 
+  224          217.127032   180.466596  0.00446429 
+  216          217.280696   180.302131  0.00462963 
+  207          218.170094   180.13785   0.00483092 
+  217          219.839378   179.973754  0.00460829 
+  233          222.391971   179.809843  0.00429185 
+  200          226.037242   179.646115  0.005     
+  240          231.158258   179.482571  0.00416667 
+  234          238.407204   179.319211  0.0042735 
+  271          248.811378   179.156034  0.00369004 
+  289          263.809031   178.99304   0.00346021 
+  297          285.131498   178.830229  0.003367  
+  330          314.421531   178.667601  0.0030303 
+  332          352.381399   178.505155  0.00301205 
+  353          396.756402   178.342892  0.00283286 
+  461          438.806544   178.180811  0.0021692 
+  491          463.200675   178.018912  0.00203666 
+  549          461.581215   177.857194  0.00182149 
+  476          444.280694   177.695658  0.00210084 
+  465          427.051869   177.534303  0.00215054 
+  439          416.281103   177.373129  0.0022779 
+  394          407.822225   177.212136  0.00253807 
+  405          394.079808   177.051324  0.00246914 
+  402          374.64432    176.890692  0.00248756 
+  370          356.515044   176.73024   0.0027027 
+  352          346.146635   176.569968  0.00284091 
+  363          347.15275    176.409876  0.00275482 
+  384          362.055856   176.249964  0.00260417 
+  441          393.412894   176.090231  0.00226757 
+  504          443.715912   175.930677  0.00198413 
+  510          513.962885   175.771302  0.00196078 
+  597          599.796905   175.612106  0.00167504 
+  677          685.151216   175.453088  0.0014771 
+  736          744.568581   175.294249  0.0013587 
+  753          766.502333   175.135588  0.00132802 
+  684          762.174487   174.977104  0.00146199 
+  700          742.056689   174.818799  0.00142857 
+  563          710.399373   174.660671  0.0017762 
+  610          670.230766   174.50272   0.00163934 
+  569          620.720174   174.344946  0.00175747 
+  512          565.328317   174.187349  0.00195312 
+  415          509.049233   174.029929  0.00240964 
+  364          453.267502   173.872685  0.00274725 
+  315          401.276442   173.715618  0.0031746 
+  315          358.032653   173.558727  0.0031746 
+  273          325.766862   173.402011  0.003663  
+  282          303.766182   173.245471  0.0035461 
+  278          290.805991   173.089107  0.00359712 
+  271          285.773421   172.932917  0.00369004 
+  318          287.959343   172.776903  0.00314465 
+  302          296.843593   172.621064  0.00331126 
+  351          311.374417   172.465399  0.002849  
+  299          328.433265   172.309909  0.00334448 
+  334          341.324272   172.154593  0.00299401 
+  347          343.109551   171.999451  0.00288184 
+  349          334.760547   171.844483  0.00286533 
+  339          323.997184   171.689688  0.00294985 
+  324          316.483641   171.535067  0.00308642 
+  333          312.558271   171.380619  0.003003  
+  310          308.9232     171.226344  0.00322581 
+  274          303.386556   171.072242  0.00364964 
+  283          298.34107    170.918313  0.00353357 
+  265          297.811072   170.764556  0.00377358 
+  261          304.063317   170.610971  0.00383142 
+  268          317.042655   170.457558  0.00373134 
+  292          333.730274   170.304317  0.00342466 
+  300          347.111929   170.151248  0.00333333 
+  292          349.853535   169.99835   0.00342466 
+  266          342.709438   169.845623  0.0037594 
+  244          333.36812    169.693068  0.00409836 
+  236          327.465235   169.540683  0.00423729 
+  267          325.194617   169.388469  0.00374532 
+  248          322.905832   169.236425  0.00403226 
+  313          317.815204   169.084551  0.00319489 
+  284          311.719792   168.932848  0.00352113 
+  324          308.308352   168.781314  0.00308642 
+  334          309.98758    168.62995   0.00299401 
+  347          318.135736   168.478756  0.00288184 
+  413          334.384232   168.32773   0.00242131 
+  455          362.028728   168.176874  0.0021978 
+  512          407.888085   168.026187  0.00195312 
+  627          484.538273   167.875668  0.0015949 
+  806          611.460375   167.725318  0.00124069 
+  937          812.259186   167.575136  0.00106724 
+  1191         1102.596175  167.425122  0.00083963 
+  1505         1464.286316  167.275276  0.00066445 
+  1971         1825.119539  167.125598  0.00050736 
+  2300         2072.259636  166.976087  0.00043478 
+  2249         2078.646033  166.826744  0.00044464 
+  1976         1871.900072  166.677567  0.00050607 
+  1659         1642.114165  166.528558  0.00060277 
+  1438         1497.653013  166.379715  0.00069541 
+  1346         1422.784509  166.231039  0.00074294 
+  1345         1337.142248  166.082529  0.00074349 
+  1179         1162.624192  165.934186  0.00084818 
+  877          928.207966   165.786008  0.00114025 
+  609          711.258429   165.637996  0.00164204 
+  454          546.619709   165.49015   0.00220264 
+  368          434.820455   165.342469  0.00271739 
+  257          363.635393   165.194953  0.00389105 
+  239          318.95522    165.047603  0.0041841 
+  233          289.807528   164.900417  0.00429185 
+  221          269.427543   164.753396  0.00452489 
+  222          254.211125   164.606539  0.0045045 
+  194          242.316204   164.459846  0.00515464 
+  216          232.747941   164.313318  0.00462963 
+  218          224.903798   164.166953  0.00458716 
+  186          218.377396   164.020753  0.00537634 
+  198          212.879582   163.874715  0.00505051 
+  206          208.197177   163.728841  0.00485437 
+  194          204.171007   163.58313   0.00515464 
+  208          200.678112   163.437582  0.00480769 
+  191          197.62429    163.292197  0.0052356 
+  221          194.934837   163.146974  0.00452489 
+  198          192.55065    163.001914  0.00505051 
+  195          190.424132   162.857016  0.00512821 
+  187          188.517162   162.71228   0.00534759 
+  194          186.7981     162.567705  0.00515464 
+  164          185.241022   162.423293  0.00609756 
+  147          183.824439   162.279041  0.00680272 
+  165          182.530316   162.134951  0.00606061 
+  156          181.343424   161.991023  0.00641026 
+  159          180.251096   161.847255  0.00628931 
+  191          179.242319   161.703647  0.0052356 
+  176          178.307669   161.5602    0.00568182 
+  166          177.439259   161.416914  0.0060241 
+  182          176.630112   161.273788  0.00549451 
+  170          175.874051   161.130821  0.00588235 
+  167          175.167914   160.988015  0.00598802 
+  152          174.503193   160.845368  0.00657895 
+  157          173.877751   160.70288   0.00636943 
+  158          173.288138   160.560552  0.00632911 
+  176          172.73118    160.418383  0.00568182 
+  179          172.204081   160.276373  0.00558659 
+  149          171.704444   160.134521  0.00671141 
+  159          171.231024   159.992828  0.00628931 
+  170          170.779913   159.851293  0.00588235 
+  177          170.350398   159.709916  0.00564972 
+  170          169.940893   159.568698  0.00588235 
+  177          169.549989   159.427637  0.00564972 
+  177          169.176471   159.286733  0.00564972 
+  178          168.8192     159.145988  0.00561798 
+  155          168.477149   159.005399  0.00645161 
+  176          168.149453   158.864967  0.00568182 
+  157          167.83528    158.724693  0.00636943 
+  196          167.533885   158.584575  0.00510204 
+  152          167.244639   158.444613  0.00657895 
+  156          166.966943   158.304808  0.00641026 
+  158          166.700257   158.165159  0.00632911 
+  171          166.444147   158.025666  0.00584795 
+  159          166.198182   157.886329  0.00628931 
+  183          165.961997   157.747148  0.00546448 
+  170          165.735283   157.608122  0.00588235 
+  142          165.517763   157.469251  0.00704225 
+  138          165.309189   157.330535  0.00724638 
+  143          165.109399   157.191975  0.00699301 
+  156          164.918217   157.053569  0.00641026 
+  166          164.735804   156.915317  0.0060241 
+  158          164.561559   156.77722   0.00632911 
+  167          164.395656   156.639278  0.00598802 
+  166          164.238096   156.501489  0.0060241 
+  161          164.088935   156.363854  0.00621118 
+  173          163.948214   156.226373  0.00578035 
+  178          163.816042   156.089045  0.00561798 
+  154          163.692554   155.951871  0.00649351 
+  159          163.578073   155.81485   0.00628931 
+  163          163.472539   155.677982  0.00613497 
+  147          163.376377   155.541267  0.00680272 
+  183          163.290209   155.404704  0.00546448 
+  150          163.213768   155.268294  0.00666667 
+  158          163.147812   155.132036  0.00632911 
+  169          163.092829   154.99593   0.00591716 
+  157          163.043862   154.859976  0.00636943 
+  156          163.012619   154.724174  0.00641026 
+  157          162.99427    154.588524  0.00636943 
+  189          162.989647   154.453025  0.00529101 
+  141          162.996933   154.317677  0.0070922 
+  151          163.022846   154.182481  0.00662252 
+  156          163.065478   154.047435  0.00641026 
+  185          163.126354   153.91254   0.00540541 
+  138          163.206969   153.777796  0.00724638 
+  156          163.309062   153.643202  0.00641026 
+  178          163.434598   153.508758  0.00561798 
+  168          163.585776   153.374465  0.00595238 
+  142          163.765163   153.240321  0.00704225 
+  164          163.975688   153.106327  0.00609756 
+  154          164.220663   152.972483  0.00649351 
+  160          164.503991   152.838788  0.00625   
+  159          164.830177   152.705242  0.00628931 
+  152          165.204406   152.571845  0.00657895 
+  160          165.632967   152.438597  0.00625   
+  153          166.122857   152.305498  0.00653595 
+  150          166.682645   152.172547  0.00666667 
+  146          167.322492   152.039745  0.00684932 
+  184          168.054469   151.907091  0.00543478 
+  173          168.892762   151.774585  0.00578035 
+  163          169.854482   151.642227  0.00613497 
+  158          170.959958   151.510017  0.00632911 
+  148          172.233061   151.377954  0.00675676 
+  185          173.702107   151.246038  0.00540541 
+  176          175.400392   151.11427   0.00568182 
+  161          177.366295   150.982649  0.00621118 
+  184          179.644021   150.851174  0.00543478 
+  169          182.283145   150.719847  0.00591716 
+  185          185.336627   150.588666  0.00540541 
+  182          188.859182   150.457631  0.00549451 
+  204          192.900426   150.326742  0.00490196 
+  181          197.494221   150.196     0.00552486 
+  210          202.644318   150.065403  0.0047619 
+  213          208.303851   149.934952  0.00469484 
+  192          214.359724   149.804647  0.00520833 
+  207          220.629707   149.674487  0.00483092 
+  246          226.896679   149.544472  0.00406504 
+  210          232.972927   149.414603  0.0047619 
+  208          238.777308   149.284878  0.00480769 
+  208          244.360241   149.155298  0.00480769 
+  212          249.853245   149.025862  0.00471698 
+  263          255.363915   148.896571  0.00380228 
+  240          260.882928   148.767424  0.00416667 
+  262          266.267346   148.638422  0.00381679 
+  255          271.314414   148.509563  0.00392157 
+  236          275.918639   148.380848  0.00423729 
+  270          280.236221   148.252276  0.0037037 
+  233          284.779273   148.123848  0.00429185 
+  278          290.323211   147.995563  0.00359712 
+  243          297.566341   147.867422  0.00411523 
+  303          306.440999   147.739423  0.00330033 
+  289          314.938011   147.611567  0.00346021 
+  344          318.397418   147.483854  0.00290698 
+  367          312.803352   147.356283  0.0027248 
+  432          300.203083   147.228855  0.00231481 
+  517          286.508542   147.101568  0.00193424 
+  618          275.697835   146.974424  0.00161812 
+  592          268.242044   146.847421  0.00168919 
+  551          262.004306   146.720561  0.00181488 
+  473          254.788698   146.593841  0.00211416 
+  430          247.303165   146.467263  0.00232558 
+  445          241.970191   146.340827  0.00224719 
+  446          239.966918   146.214531  0.00224215 
+  420          240.147917   146.088376  0.00238095 
+  381          239.214562   145.962362  0.00262467 
+  327          234.239959   145.836488  0.0030581 
+  263          226.143206   145.710755  0.00380228 
+  258          218.166848   145.585162  0.00387597 
+  235          212.298409   145.459709  0.00425532 
+  238          208.394269   145.334396  0.00420168 
+  225          204.729729   145.209223  0.00444444 
+  207          199.61047    145.08419   0.00483092 
+  202          193.239972   144.959296  0.0049505 
+  200          187.027911   144.834541  0.005     
+  164          181.929538   144.709926  0.00609756 
+  187          178.210475   144.585449  0.00534759 
+  189          175.824999   144.461111  0.00529101 
+  191          174.665556   144.336912  0.0052356 
+  184          174.690096   144.212852  0.00543478 
+  183          175.999813   144.08893   0.00546448 
+  173          178.881981   143.965146  0.00578035 
+  191          183.80616    143.8415    0.0052356 
+  184          191.341933   143.717992  0.00543478 
+  201          201.948368   143.594622  0.00497512 
+  223          215.475163   143.471389  0.0044843 
+  232          230.304128   143.348294  0.00431034 
+  264          243.008313   143.225337  0.00378788 
+  268          250.079492   143.102516  0.00373134 
+  312          249.852974   142.979832  0.00320513 
+  271          243.509861   142.857286  0.00369004 
+  283          235.127116   142.734875  0.00353357 
+  260          228.008282   142.612602  0.00384615 
+  255          222.250852   142.490465  0.00392157 
+  272          216.179656   142.368464  0.00367647 
+  241          208.327757   142.246599  0.00414938 
+  200          198.489669   142.12487   0.005     
+  213          188.142455   142.003277  0.00469484 
+  205          178.95659    141.881819  0.00487805 
+  154          171.621078   141.760497  0.00649351 
+  188          166.085003   141.639311  0.00531915 
+  184          162.019589   141.518259  0.00543478 
+  147          159.052536   141.397343  0.00680272 
+  170          156.858399   141.276561  0.00588235 
+  160          155.188998   141.155914  0.00625   
+  157          153.874898   141.035402  0.00636943 
+  152          152.803329   140.915024  0.00657895 
+  148          151.906606   140.79478   0.00675676 
+  145          151.141083   140.674671  0.00689655 
+  145          150.477651   140.554695  0.00689655 
+  142          149.896067   140.434854  0.00704225 
+  131          149.381468   140.315146  0.00763359 
+  148          148.922745   140.195571  0.00675676 
+  146          148.511904   140.07613   0.00684932 
+  161          148.140816   139.956822  0.00621118 
+  133          147.805062   139.837648  0.0075188 
+  152          147.500572   139.718606  0.00657895 
+  140          147.22418    139.599697  0.00714286 
+  137          146.973487   139.480921  0.00729927 
+  154          146.746726   139.362277  0.00649351 
+  159          146.542694   139.243765  0.00628931 
+  143          146.360599   139.125386  0.00699301 
+  134          146.202705   139.007139  0.00746269 
+  134          146.064028   138.889024  0.00746269 
+  151          145.947624   138.77104   0.00662252 
+  142          145.854374   138.653188  0.00704225 
+  141          145.785455   138.535468  0.0070922 
+  142          145.742336   138.417879  0.00704225 
+  143          145.727171   138.300421  0.00699301 
+  186          145.741483   138.183094  0.00537634 
+  131          145.784197   138.065898  0.00763359 
+  143          145.853354   137.948833  0.00699301 
+  157          145.95253    137.831899  0.00636943 
+  119          146.073916   137.715095  0.00840336 
+  140          146.20994    137.598421  0.00714286 
+  146          146.351509   137.481877  0.00684932 
+  144          146.489817   137.365464  0.00694444 
+  150          146.624309   137.24918   0.00666667 
+  144          146.757439   137.133027  0.00694444 
+  142          146.898486   137.017002  0.00704225 
+  156          147.059341   136.901108  0.00641026 
+  165          147.252389   136.785342  0.00606061 
+  155          147.491247   136.669706  0.00645161 
+  140          147.79473    136.554199  0.00714286 
+  167          148.192144   136.43882   0.00598802 
+  157          148.73032    136.323571  0.00636943 
+  159          149.482306   136.20845   0.00628931 
+  146          150.563049   136.093457  0.00684932 
+  157          152.149568   135.978593  0.00636943 
+  168          154.499413   135.863857  0.00595238 
+  146          157.94676    135.749249  0.00684932 
+  183          162.860949   135.634769  0.00546448 
+  188          169.533241   135.520417  0.00531915 
+  193          177.924881   135.406193  0.00518135 
+  217          187.10674    135.292096  0.00460829 
+  241          194.549094   135.178126  0.00414938 
+  311          197.047893   135.064283  0.00321543 
+  334          194.279433   134.950568  0.00299401 
+  348          189.41541    134.836979  0.00287356 
+  304          185.47436    134.723518  0.00328947 
+  294          183.424716   134.610183  0.00340136 
+  281          182.365699   134.496974  0.00355872 
+  240          180.372986   134.383892  0.00416667 
+  272          176.444883   134.270936  0.00367647 
+  268          171.516948   134.158106  0.00373134 
+  218          166.929703   134.045402  0.00458716 
+  192          163.291692   133.932824  0.00520833 
+  193          160.639083   133.820372  0.00518135 
+  188          158.787304   133.708045  0.00531915 
+  179          157.513392   133.595844  0.00558659 
+  170          156.641524   133.483768  0.00588235 
+  133          156.080292   133.371817  0.0075188 
+  162          155.822216   133.259991  0.00617284 
+  154          155.917262   133.14829   0.00649351 
+  156          156.429763   133.036713  0.00641026 
+  189          157.375237   132.925262  0.00529101 
+  165          158.600572   132.813934  0.00606061 
+  183          159.592047   132.702731  0.00546448 
+  170          159.528417   132.591653  0.00588235 
+  156          158.068333   132.480698  0.00641026 
+  155          155.870183   132.369867  0.00645161 
+  146          153.810833   132.25916   0.00684932 
+  154          152.294072   132.148577  0.00649351 
+  154          151.216115   132.038117  0.00649351 
+  173          150.120144   131.92778   0.00578035 
+  166          148.605299   131.817567  0.0060241 
+  156          146.766882   131.707477  0.00641026 
+  154          144.961417   131.59751   0.00649351 
+  150          143.411624   131.487666  0.00666667 
+  143          142.167514   131.377944  0.00699301 
+  132          141.197941   131.268345  0.00757576 
+  120          140.449598   131.158868  0.00833333 
+  145          139.865975   131.049514  0.00689655 
+  135          139.399898   130.940282  0.00740741 
+  142          139.017024   130.831172  0.00704225 
+  138          138.692391   130.722184  0.00724638 
+  129          138.412946   130.613318  0.00775194 
+  126          138.165357   130.504573  0.00793651 
+  132          137.948064   130.39595   0.00757576 
+  126          137.753877   130.287448  0.00793651 
+  152          137.578879   130.179067  0.00657895 
+  136          137.42015    130.070808  0.00735294 
+  120          137.278068   129.96267   0.00833333 
+  134          137.148943   129.854652  0.00746269 
+  136          137.03192    129.746755  0.00735294 
+  155          136.925971   129.638979  0.00645161 
+  151          136.830305   129.531323  0.00662252 
+  148          136.744411   129.423788  0.00675676 
+  133          136.667831   129.316373  0.0075188 
+  145          136.600326   129.209078  0.00689655 
+  129          136.541984   129.101902  0.00775194 
+  136          136.492641   128.994847  0.00735294 
+  115          136.452823   128.887911  0.00869565 
+  123          136.423284   128.781095  0.00813008 
+  129          136.405386   128.674399  0.00775194 
+  140          136.401489   128.567821  0.00714286 
+  133          136.415464   128.461363  0.0075188 
+  153          136.45269    128.355024  0.00653595 
+  152          136.522116   128.248804  0.00657895 
+  153          136.632617   128.142703  0.00653595 
+  132          136.792428   128.03672   0.00757576 
+  140          137.004813   127.930856  0.00714286 
+  141          137.255256   127.82511   0.0070922 
+  133          137.494876   127.719482  0.0075188 
+  121          137.649245   127.613973  0.00826446 
+  132          137.696939   127.508582  0.00757576 
+  135          137.713778   127.403308  0.00740741 
+  143          137.797037   127.298152  0.00699301 
+  112          138.004852   127.193114  0.00892857 
+  143          138.352691   127.088194  0.00699301 
+  136          138.818695   126.983391  0.00735294 
+  118          139.530067   126.878705  0.00847458 
+  137          140.096781   126.774136  0.00729927 
+  121          140.5891     126.669685  0.00826446 
+  158          140.879015   126.56535   0.00632911 
+  146          140.88387    126.461132  0.00684932 
+  128          140.652526   126.357031  0.0078125 
+  143          140.36839    126.253046  0.00699301 
+  145          140.180249   126.149177  0.00689655 
+  130          140.187081   126.045425  0.00769231 
+  141          140.143572   125.941789  0.0070922 
+  125          140.047803   125.838269  0.008     
+  137          139.86205    125.734865  0.00729927 
+  152          139.633793   125.631576  0.00657895 
+  108          139.443952   125.528404  0.00925926 
+  120          139.337412   125.425346  0.00833333 
+  164          139.32462    125.322405  0.00609756 
+  127          139.390265   125.219578  0.00787402 
+  139          139.52421    125.116867  0.00719424 
+  136          139.71432    125.01427   0.00735294 
+  116          139.951562   124.911789  0.00862069 
+  133          140.230412   124.809422  0.0075188 
+  136          140.548331   124.70717   0.00735294 
+  127          140.904949   124.605033  0.00787402 
+  131          141.301563   124.50301   0.00763359 
+  151          141.741925   124.401101  0.00662252 
+  159          142.22575    124.299306  0.00628931 
+  140          142.757588   124.197626  0.00714286 
+  104          143.339968   124.096059  0.00961538 
+  127          143.974196   123.994607  0.00787402 
+  159          144.659348   123.893267  0.00628931 
+  138          145.390589   123.792042  0.00724638 
+  144          146.164135   123.69093   0.00694444 
+  137          146.951981   123.589931  0.00729927 
+  130          147.741416   123.489046  0.00769231 
+  159          148.514809   123.388273  0.00628931 
+  145          149.262769   123.287614  0.00689655 
+  136          149.987692   123.187067  0.00735294 
+  142          150.702479   123.086633  0.00704225 
+  129          151.424703   122.986312  0.00775194 
+  146          152.17016    122.886103  0.00684932 
+  159          152.953557   122.786006  0.00628931 
+  120          153.77801    122.686022  0.00833333 
+  157          154.657306   122.58615   0.00636943 
+  137          155.605941   122.48639   0.00729927 
+  143          156.642108   122.386742  0.00699301 
+  149          157.785208   122.287205  0.00671141 
+  148          159.053558   122.187781  0.00675676 
+  139          160.464283   122.088467  0.00719424 
+  139          162.032686   121.989266  0.00719424 
+  156          163.779297   121.890175  0.00641026 
+  156          165.705396   121.791196  0.00641026 
+  140          167.830749   121.692328  0.00714286 
+  143          170.171487   121.59357   0.00699301 
+  157          172.731785   121.494924  0.00636943 
+  147          175.524802   121.396388  0.00680272 
+  166          178.55947    121.297963  0.0060241 
+  167          181.847786   121.199648  0.00598802 
+  165          185.410712   121.101444  0.00606061 
+  161          189.284297   121.00335   0.00621118 
+  152          193.524182   120.905366  0.00657895 
+  150          198.19424    120.807492  0.00666667 
+  188          203.37999    120.709728  0.00531915 
+  172          209.176073   120.612074  0.00581395 
+  175          215.686427   120.514529  0.00571429 
+  188          223.040969   120.417094  0.00531915 
+  207          231.395241   120.319769  0.00483092 
+  200          240.944442   120.222552  0.005     
+  222          251.935076   120.125445  0.0045045 
+  261          264.669994   120.028447  0.00383142 
+  246          279.533535   119.931558  0.00406504 
+  255          297.013063   119.834778  0.00392157 
+  315          317.736887   119.738107  0.0031746 
+  341          342.543367   119.641544  0.00293255 
+  377          372.553403   119.54509   0.00265252 
+  440          409.303125   119.448744  0.00227273 
+  469          454.958397   119.352507  0.0021322 
+  490          512.726425   119.256377  0.00204082 
+  634          587.755455   119.160356  0.00157729 
+  722          689.507054   119.064443  0.00138504 
+  985          837.073526   118.968637  0.00101523 
+  1237         1068.97675   118.87294   0.00080841 
+  1657         1454.799898  118.77735   0.0006035 
+  2226         2097.066982  118.681867  0.00044924 
+  3129         3103.878579  118.586492  0.00031959 
+  4415         4519.137551  118.491224  0.0002265 
+  5843         6183.022274  118.396063  0.00017114 
+  7432         7501.921389  118.301009  0.00013455 
+  8013         7626.446118  118.206063  0.0001248 
+  7095         6606.633271  118.111223  0.00014094 
+  5604         5374.697711  118.016489  0.00017844 
+  4438         4574.960018  117.921863  0.00022533 
+  3800         4358.345046  117.827343  0.00026316 
+  4020         4523.194648  117.732929  0.00024876 
+  4279         4562.008229  117.638621  0.0002337 
+  4206         4046.394734  117.54442   0.00023776 
+  3269         3158.789788  117.450325  0.0003059 
+  2157         2289.832797  117.356335  0.00046361 
+  1338         1617.132142  117.262452  0.00074738 
+  934          1158.598868  117.168674  0.00107066 
+  692          868.944687   117.075002  0.00144509 
+  520          690.194655   116.981435  0.00192308 
+  409          575.978493   116.887974  0.00244499 
+  440          497.628675   116.794618  0.00227273 
+  362          439.976013   116.701367  0.00276243 
+  376          395.419567   116.608222  0.00265957 
+  303          359.935992   116.515181  0.00330033 
+  301          331.123078   116.422245  0.00332226 
+  325          307.39473    116.329414  0.00307692 
+  276          287.625201   116.236687  0.00362319 
+  267          270.984716   116.144065  0.00374532 
+  278          256.839706   116.051547  0.00359712 
+  288          244.682348   115.959134  0.00347222 
+  224          234.108807   115.866825  0.00446429 
+  213          224.842683   115.77462   0.00469484 
+  242          216.707194   115.682519  0.00413223 
+  206          209.560597   115.590521  0.00485437 
+  215          203.270098   115.498628  0.00465116 
+  204          197.707528   115.406838  0.00490196 
+  192          192.750047   115.315152  0.00520833 
+  168          188.298321   115.223569  0.00595238 
+  195          184.293657   115.13209   0.00512821 
+  196          180.7006     115.040713  0.00510204 
+  194          177.485497   114.94944   0.00515464 
+  176          174.613022   114.85827   0.00568182 
+  184          172.049879   114.767203  0.00543478 
+  194          169.766359   114.676238  0.00515464 
+  156          167.738178   114.585377  0.00641026 
+  167          165.944786   114.494618  0.00598802 
+  175          164.370157   114.403961  0.00571429 
+  183          163.002838   114.313407  0.00546448 
+  147          161.834445   114.222955  0.00680272 
+  156          160.86212    114.132605  0.00641026 
+  173          160.068994   114.042357  0.00578035 
+  181          159.501307   113.952211  0.00552486 
+  175          159.154212   113.862167  0.00571429 
+  162          159.048565   113.772225  0.00617284 
+  147          159.208066   113.682385  0.00680272 
+  142          159.652529   113.592646  0.00704225 
+  147          160.373064   113.503008  0.00680272 
+  158          161.3378     113.413472  0.00632911 
+  146          162.418427   113.324037  0.00684932 
+  146          163.527011   113.234703  0.00684932 
+  153          164.753873   113.14547   0.00653595 
+  159          166.29273    113.056338  0.00628931 
+  151          168.282957   112.967307  0.00662252 
+  136          170.771096   112.878376  0.00735294 
+  160          173.719559   112.789546  0.00625   
+  169          177.022092   112.700817  0.00591716 
+  154          180.570288   112.612188  0.00649351 
+  164          184.303742   112.52366   0.00609756 
+  185          188.161514   112.435231  0.00540541 
+  194          192.055666   112.346903  0.00515464 
+  189          195.926389   112.258674  0.00529101 
+  185          199.80796    112.170546  0.00540541 
+  190          203.843485   112.082517  0.00526316 
+  189          208.25039    111.994588  0.00529101 
+  206          213.263738   111.906759  0.00485437 
+  250          219.105177   111.819029  0.004     
+  227          225.974222   111.731398  0.00440529 
+  276          234.068623   111.643867  0.00362319 
+  236          243.599731   111.556435  0.00423729 
+  288          254.733607   111.469102  0.00347222 
+  304          267.488967   111.381868  0.00328947 
+  320          281.58096    111.294732  0.003125  
+  316          296.189041   111.207696  0.00316456 
+  314          309.568462   111.120758  0.00318471 
+  313          319.026307   111.033919  0.00319489 
+  298          322.802241   110.947178  0.0033557 
+  305          322.3835     110.860536  0.00327869 
+  300          320.93484    110.773992  0.00333333 
+  292          320.528838   110.687546  0.00342466 
+  317          321.542786   110.601198  0.00315457 
+  279          322.957192   110.514948  0.00358423 
+  287          322.850386   110.428796  0.00348432 
+  267          319.826727   110.342742  0.00374532 
+  261          314.107335   110.256785  0.00383142 
+  263          306.624688   110.170926  0.00380228 
+  296          298.036041   110.085165  0.00337838 
+  237          288.736951   109.999501  0.00421941 
+  276          279.038516   109.913934  0.00362319 
+  257          269.182633   109.828464  0.00389105 
+  245          259.292407   109.743092  0.00408163 
+  239          249.372446   109.657816  0.0041841 
+  213          239.382208   109.572637  0.00469484 
+  212          229.323963   109.487555  0.00471698 
+  201          219.305018   109.40257   0.00497512 
+  233          209.516154   109.317681  0.00429185 
+  201          200.174499   109.232889  0.00497512 
+  177          191.464787   109.148193  0.00564972 
+  199          183.50616    109.063594  0.00502513 
+  165          176.342712   108.97909   0.00606061 
+  158          169.966659   108.894683  0.00632911 
+  173          164.335028   108.810372  0.00578035 
+  137          159.384192   108.726157  0.00729927 
+  155          155.03905    108.642037  0.00645161 
+  140          151.224808   108.558014  0.00714286 
+  158          147.870166   108.474085  0.00632911 
+  165          144.911472   108.390253  0.00606061 
+  155          142.292596   108.306516  0.00645161 
+  132          139.965307   108.222874  0.00757576 
+  134          137.887972   108.139327  0.00746269 
+  120          136.025809   108.055876  0.00833333 
+  138          134.348921   107.972519  0.00724638 
+  132          132.83232    107.889258  0.00757576 
+  123          131.454853   107.806091  0.00813008 
+  131          130.198784   107.723019  0.00763359 
+  109          129.048947   107.640042  0.00917431 
+  117          127.992683   107.557159  0.00854701 
+  130          127.019128   107.474371  0.00769231 
+  142          126.119029   107.391678  0.00704225 
+  126          125.284591   107.309078  0.00793651 
+  133          124.508745   107.226573  0.0075188 
+  148          123.750854   107.144161  0.00675676 
+  111          123.075568   107.061844  0.00900901 
+  116          122.443466   106.979621  0.00862069 
+  141          121.850578   106.897491  0.0070922 
+  124          121.293503   106.815456  0.00806452 
+  118          120.769161   106.733513  0.00847458 
+  121          120.257609   106.651665  0.00826446 
+  107          119.791145   106.56991   0.00934579 
+  122          119.350189   106.488248  0.00819672 
+  115          118.932908   106.406679  0.00869565 
+  121          118.537676   106.325204  0.00826446 
+  128          118.163001   106.243821  0.0078125 
+  123          117.807564   106.162532  0.00813008 
+  136          117.470238   106.081335  0.00735294 
+  101          117.149994   106.000232  0.00990099 
+  146          116.845985   105.91922   0.00684932 
+  111          116.557345   105.838302  0.00900901 
+  117          116.283454   105.757476  0.00854701 
+  124          116.023762   105.676743  0.00806452 
+  114          115.777819   105.596101  0.00877193 
+  109          115.545271   105.515552  0.00917431 
+  118          115.327063   105.435095  0.00847458 
+  123          115.120644   105.354731  0.00813008 
+  115          114.92718    105.274458  0.00869565 
+  119          114.746744   105.194277  0.00840336 
+  124          114.579535   105.114188  0.00806452 
+  124          114.425903   105.03419   0.00806452 
+  121          114.28635    104.954284  0.00826446 
+  102          114.16158    104.87447   0.00980392 
+  105          114.052485   104.794747  0.00952381 
+  123          113.960861   104.715115  0.00813008 
+  124          113.887001   104.635575  0.00806452 
+  119          113.833384   104.556125  0.00840336 
+  121          113.802397   104.476767  0.00826446 
+  122          113.797057   104.3975    0.00819672 
+  104          113.821159   104.318323  0.00961538 
+  117          113.879557   104.239238  0.00854701 
+  117          113.978586   104.160243  0.00854701 
+  134          114.126065   104.081338  0.00746269 
+  123          114.33268    104.002525  0.00813008 
+  125          114.612634   103.923801  0.008     
+  124          114.985729   103.845168  0.00806452 
+  127          115.480249   103.766625  0.00787402 
+  108          116.140701   103.688173  0.00925926 
+  120          117.038876   103.60981   0.00833333 
+  122          118.2944     103.531537  0.00819672 
+  114          120.099938   103.453354  0.00877193 
+  110          122.743659   103.375261  0.00909091 
+  122          126.609554   103.297258  0.00819672 
+  122          132.133271   103.219345  0.00819672 
+  151          139.676972   103.14152   0.00662252 
+  138          149.265251   103.063786  0.00724638 
+  149          159.971097   102.98614   0.00671141 
+  169          169.0203     102.908584  0.00591716 
+  196          172.418959   102.831117  0.00510204 
+  170          168.982561   102.75374   0.00588235 
+  168          162.136407   102.676451  0.00595238 
+  163          155.928932   102.599251  0.00613497 
+  140          152.291193   102.52214   0.00714286 
+  156          151.188285   102.445118  0.00641026 
+  169          151.020164   102.368184  0.00591716 
+  170          149.324105   102.291339  0.00588235 
+  131          144.949218   102.214582  0.00763359 
+  135          139.134205   102.137914  0.00740741 
+  133          133.596589   102.061334  0.0075188 
+  114          129.185314   101.984843  0.00877193 
+  148          126.033708   101.908439  0.00675676 
+  133          123.980558   101.832124  0.0075188 
+  96           122.768175   101.755896  0.01041667 
+  103          122.124777   101.679757  0.00970874 
+  130          121.81345    101.603705  0.00769231 
+  122          121.638928   101.527741  0.00819672 
+  126          121.466895   101.451864  0.00793651 
+  141          121.230281   101.376075  0.0070922 
+  120          120.923046   101.300374  0.00833333 
+  120          120.589584   101.22476   0.00833333 
+  125          120.299338   101.149233  0.008     
+  120          120.125827   101.073793  0.00833333 
+  123          120.137403   100.99844   0.00813008 
+  130          120.387049   100.923175  0.00769231 
+  131          120.893046   100.847996  0.00763359 
+  144          121.567197   100.772904  0.00694444 
+  135          122.117548   100.697899  0.00740741 
+  171          121.99167    100.622981  0.00584795 
+  142          120.885999   100.548149  0.00704225 
+  129          119.196263   100.473404  0.00775194 
+  117          117.541463   100.398745  0.00854701 
+  133          116.288763   100.324173  0.0075188 
+  122          115.490997   100.249687  0.00819672 
+  129          114.969796   100.175287  0.00775194 
+  130          114.379997   100.100973  0.00769231 
+  116          113.451461   100.026745  0.00862069 
+  130          112.266761   99.952603   0.00769231 
+  128          111.081328   99.878547   0.0078125 
+  133          110.054219   99.804577   0.0075188 
+  104          109.225364   99.730692   0.00961538 
+  105          108.578623   99.656893   0.00952381 
+  90           108.079671   99.583179   0.01111111 
+  108          107.692559   99.509551   0.00925926 
+  116          107.386906   99.436008   0.00862069 
+  97           107.140335   99.362551   0.01030928 
+  112          106.937977   99.289179   0.00892857 
+  106          106.768411   99.215891   0.00943396 
+  118          106.63126    99.142689   0.00847458 
+  94           106.521913   99.069572   0.0106383 
+  103          106.440556   98.996539   0.00970874 
+  104          106.390228   98.923592   0.00961538 
+  96           106.376744   98.850729   0.01041667 
+  90           106.414964   98.77795    0.01111111 
+  95           106.522284   98.705257   0.01052632 
+  95           106.723483   98.632647   0.01052632 
+  105          107.045032   98.560122   0.00952381 
+  125          107.505801   98.487681   0.008     
+  109          108.096003   98.415325   0.00917431 
+  102          108.730406   98.343052   0.00980392 
+  108          109.19914    98.270864   0.00925926 
+  116          109.27428    98.19876    0.00862069 
+  104          108.964912   98.126739   0.00961538 
+  124          108.526394   98.054802   0.00806452 
+  113          108.185207   97.982949   0.00884956 
+  102          108.029118   97.91118    0.00980392 
+  90           108.039973   97.839494   0.01111111 
+  105          108.105762   97.767892   0.00952381 
+  124          108.076398   97.696373   0.00806452 
+  104          107.902956   97.624937   0.00961538 
+  99           107.682222   97.553584   0.01010101 
+  110          107.529361   97.482315   0.00909091 
+  103          107.654994   97.411129   0.00970874 
+  102          107.802016   97.340026   0.00980392 
+  107          108.147929   97.269005   0.00934579 
+  115          108.735031   97.198068   0.00869565 
+  92           109.617354   97.127213   0.01086957 
+  118          110.848308   97.056441   0.00847458 
+  127          112.449505   96.985751   0.00787402 
+  110          114.336467   96.915145   0.00909091 
+  115          116.265932   96.84462    0.00869565 
+  109          117.56156    96.774178   0.00917431 
+  106          118.047056   96.703818   0.00943396 
+  112          118.142793   96.63354    0.00892857 
+  102          118.471796   96.563345   0.00980392 
+  137          119.382358   96.493231   0.00729927 
+  122          120.909867   96.4232     0.00819672 
+  133          122.802086   96.35325    0.0075188 
+  123          124.52634    96.283382   0.00813008 
+  145          125.502069   96.213596   0.00689655 
+  129          125.50016    96.143892   0.00775194 
+  141          124.694131   96.074269   0.0070922 
+  140          123.455012   96.004727   0.00714286 
+  135          122.167566   95.935267   0.00740741 
+  124          121.087321   95.865889   0.00806452 
+  137          120.278958   95.796591   0.00729927 
+  124          119.643635   95.727375   0.00806452 
+  133          119.012296   95.65824    0.0075188 
+  133          118.269484   95.589186   0.0075188 
+  129          117.41655    95.520213   0.00775194 
+  137          116.501085   95.451321   0.00729927 
+  121          115.514362   95.38251    0.00826446 
+  105          114.444684   95.313779   0.00952381 
+  114          113.39383    95.245129   0.00877193 
+  117          112.505916   95.17656    0.00854701 
+  128          111.855117   95.108071   0.0078125 
+  98           111.441335   95.039662   0.01020408 
+  104          111.212624   94.971334   0.00961538 
+  125          111.075065   94.903086   0.008     
+  108          110.937725   94.834918   0.00925926 
+  107          110.788443   94.766831   0.00934579 
+  109          110.679168   94.698823   0.00917431 
+  117          110.65332    94.630896   0.00854701 
+  111          110.72544    94.563048   0.00900901 
+  107          110.895432   94.49528    0.00934579 
+  98           111.159617   94.427592   0.01020408 
+  88           111.515914   94.359983   0.01136364 
+  111          111.966047   94.292454   0.00900901 
+  101          112.515838   94.225005   0.00990099 
+  124          113.174624   94.157635   0.00806452 
+  126          113.951747   94.090344   0.00793651 
+  109          114.850701   94.023133   0.00917431 
+  115          115.862001   93.956001   0.00869565 
+  112          116.980377   93.888948   0.00892857 
+  130          118.256046   93.821974   0.00769231 
+  119          119.81357    93.755079   0.00840336 
+  130          121.835495   93.688263   0.00769231 
+  129          124.588111   93.621526   0.00775194 
+  110          128.482742   93.554868   0.00909091 
+  131          134.117996   93.488288   0.00763359 
+  157          142.24096    93.421787   0.00636943 
+  143          153.602502   93.355364   0.00699301 
+  160          168.567495   93.28902    0.00625   
+  169          186.217123   93.222754   0.00591716 
+  163          202.677668   93.156567   0.00613497 
+  202          210.875933   93.090458   0.0049505 
+  200          207.015366   93.024427   0.005     
+  179          196.211501   92.958474   0.00558659 
+  187          185.988151   92.892599   0.00534759 
+  167          180.302174   92.826802   0.00598802 
+  177          179.848573   92.761083   0.00564972 
+  160          182.991537   92.695442   0.00625   
+  163          185.936163   92.629879   0.00613497 
+  178          184.98328    92.564393   0.00561798 
+  168          180.707466   92.498985   0.00595238 
+  176          176.723307   92.433654   0.00568182 
+  170          175.623182   92.368401   0.00588235 
+  177          178.146099   92.303225   0.00564972 
+  202          183.561578   92.238126   0.0049505 
+  198          189.509146   92.173105   0.00505051 
+  238          192.528248   92.10816    0.00420168 
+  230          191.079254   92.043293   0.00434783 
+  261          187.323119   91.978503   0.00383142 
+  235          184.316979   91.91379    0.00425532 
+  205          183.686862   91.849154   0.00487805 
+  177          185.669849   91.784594   0.00564972 
+  213          189.454468   91.720111   0.00469484 
+  228          193.324156   91.655705   0.00438596 
+  221          195.77555    91.591375   0.00452489 
+  204          197.092387   91.527122   0.00490196 
+  213          198.75678    91.462946   0.00469484 
+  204          201.898212   91.398845   0.00490196 
+  196          207.008396   91.334821   0.00510204 
+  215          214.277467   91.270874   0.00465116 
+  218          223.840566   91.207002   0.00458716 
+  248          235.903757   91.143206   0.00403226 
+  262          250.808707   91.079487   0.00381679 
+  261          269.082308   91.015843   0.00383142 
+  279          291.457593   90.952276   0.00358423 
+  304          318.855836   90.888784   0.00328947 
+  325          352.390273   90.825367   0.00307692 
+  387          393.257003   90.762027   0.00258398 
+  434          442.935465   90.698762   0.00230415 
+  514          504.667148   90.635572   0.00194553 
+  685          586.295117   90.572458   0.00145985 
+  794          703.751744   90.50942    0.00125945 
+  1056         887.643402   90.446456   0.00094697 
+  1413         1193.093509  90.383568   0.00070771 
+  1735         1703.765445  90.320755   0.00057637 
+  2401         2514.184639  90.258017   0.00041649 
+  3425         3677.530642  90.195355   0.00029197 
+  4757         5098.52358   90.132767   0.00021022 
+  6312         6342.597983  90.070254   0.00015843 
+  7150         6648.076195  90.007815   0.00013986 
+  6331         5832.236107  89.945452   0.00015795 
+  4848         4629.031283  89.883163   0.00020627 
+  3551         3690.433795  89.820949   0.00028161 
+  2869         3255.675895  89.75881    0.00034855 
+  2773         3308.210111  89.696744   0.00036062 
+  3224         3637.600981  89.634754   0.00031017 
+  3734         3820.700729  89.572837   0.00026781 
+  3465         3480.669276  89.510995   0.0002886 
+  2759         2756.484221  89.449227   0.00036245 
+  1847         2008.712918  89.387533   0.00054142 
+  1264         1416.736479  89.325914   0.00079114 
+  737          1008.208319  89.264368   0.00135685 
+  598          748.719271   89.202896   0.00167224 
+  466          588.937675   89.141498   0.00214592 
+  412          487.858916   89.080174   0.00242718 
+  346          419.473408   89.018923   0.00289017 
+  322          369.86707    88.957747   0.00310559 
+  305          332.13714    88.896643   0.00327869 
+  309          302.762232   88.835613   0.00323625 
+  257          279.753832   88.774657   0.00389105 
+  219          261.86935    88.713774   0.00456621 
+  226          248.174926   88.652965   0.00442478 
+  198          237.746448   88.592228   0.00505051 
+  192          229.291102   88.531565   0.00520833 
+  207          221.187042   88.470975   0.00483092 
+  196          212.442658   88.410458   0.00510204 
+  187          203.173114   88.350014   0.00534759 
+  194          193.92506    88.289643   0.00515464 
+  197          185.435315   88.229344   0.00507614 
+  161          178.334155   88.169119   0.00621118 
+  167          172.665379   88.108966   0.00598802 
+  180          167.836269   88.048886   0.00555556 
+  131          163.073745   87.988878   0.00763359 
+  164          158.060834   87.928943   0.00609756 
+  165          152.89054    87.86908    0.00606061 
+  136          147.799513   87.80929    0.00735294 
+  160          143.135305   87.749572   0.00625   
+  150          139.162814   87.689926   0.00666667 
+  142          135.972814   87.630353   0.00704225 
+  128          133.554605   87.570851   0.0078125 
+  106          131.86944    87.511422   0.00943396 
+  146          130.849655   87.452064   0.00684932 
+  117          130.354706   87.392779   0.00854701 
+  133          130.051954   87.333565   0.0075188 
+  136          129.364528   87.274423   0.00735294 
+  115          127.863309   87.215353   0.00869565 
+  133          125.801165   87.156354   0.0075188 
+  124          123.808655   87.097427   0.00806452 
+  111          122.338241   87.038571   0.00900901 
+  151          121.563118   86.979787   0.00662252 
+  122          121.449739   86.921075   0.00819672 
+  148          121.749691   86.862433   0.00675676 
+  124          122.021123   86.803863   0.00806452 
+  121          121.825767   86.745364   0.00826446 
+  131          120.929554   86.686937   0.00763359 
+  130          119.467621   86.62858    0.00769231 
+  102          117.980371   86.570294   0.00980392 
+  134          117.012329   86.512079   0.00746269 
+  109          116.825481   86.453935   0.00917431 
+  109          117.395135   86.395862   0.00917431 
+  121          118.364071   86.33786    0.00826446 
+  117          118.960523   86.279928   0.00854701 
+  103          118.395266   86.222067   0.00970874 
+  98           116.721265   86.164276   0.01020408 
+  108          114.730636   86.106556   0.00925926 
+  106          113.087441   86.048907   0.00943396 
+  123          112.043168   85.991327   0.00813008 
+  105          111.558976   85.933818   0.00952381 
+  93           111.380179   85.876379   0.01075269 
+  121          111.091045   85.819011   0.00826446 
+  100          110.381713   85.761712   0.01      
+  123          109.310655   85.704483   0.00813008 
+  104          108.11651    85.647325   0.00961538 
+  89           106.958951   85.590236   0.01123596 
+  122          105.90138    85.533217   0.00819672 
+  85           104.955204   85.476268   0.01176471 
+  106          104.112956   85.419389   0.00943396 
+  101          103.349743   85.362579   0.00990099 
+  94           102.636523   85.305839   0.0106383 
+  105          101.947218   85.249168   0.00952381 
+  117          101.267956   85.192567   0.00854701 
+  96           100.596406   85.136036   0.01041667 
+  81           99.9426      85.079573   0.01234568 
+  103          99.319871    85.02318    0.00970874 
+  98           98.740972    84.966856   0.01020408 
+  115          98.215121    84.910601   0.00869565 
+  92           97.747606    84.854416   0.01086957 
+  108          97.340494    84.798299   0.00925926 
+  89           96.993809    84.742251   0.01123596 
+  106          96.706627    84.686272   0.00943396 
+  89           96.477395    84.630362   0.01123596 
+  91           96.304177    84.574521   0.01098901 
+  98           96.184248    84.518748   0.01020408 
+  98           96.11328     84.463045   0.01020408 
+  101          96.083794    84.407409   0.00990099 
+  102          96.084126    84.351842   0.00980392 
+  86           96.09703     84.296344   0.01162791 
+  84           96.100458    84.240914   0.01190476 
+  86           96.070955    84.185553   0.01162791 
+  90           95.98967     84.130259   0.01111111 
+  91           95.848488    84.075034   0.01098901 
+  99           95.652128    84.019877   0.01010101 
+  114          95.414645    83.964788   0.00877193 
+  92           95.15168     83.909768   0.01086957 
+  89           94.873443    83.854815   0.01123596 
+  87           94.582818    83.79993    0.01149425 
+  84           94.279453    83.745113   0.01190476 
+  87           93.963061    83.690363   0.01149425 
+  107          93.635561    83.635682   0.00934579 
+  85           93.302367    83.581068   0.01176471 
+  98           92.971483    83.526521   0.01020408 
+  97           92.64995     83.472042   0.01030928 
+  89           92.345432    83.417631   0.01123596 
+  101          92.061835    83.363287   0.00990099 
+  118          91.803584    83.309011   0.00847458 
+  88           91.57411     83.254801   0.01136364 
+  129          91.375164    83.200659   0.00775194 
+  97           91.206925    83.146584   0.01030928 
+  97           91.070583    83.092577   0.01030928 
+  103          90.966269    83.038636   0.00970874 
+  107          90.895667    82.984762   0.00934579 
+  91           90.862271    82.930955   0.01098901 
+  98           90.871246    82.877215   0.01020408 
+  112          90.928567    82.823542   0.00892857 
+  89           91.039722    82.769936   0.01123596 
+  95           91.207124    82.716396   0.01052632 
+  92           91.424085    82.662923   0.01086957 
+  86           91.671161    82.609517   0.01162791 
+  90           91.935711    82.556177   0.01111111 
+  97           92.247178    82.502903   0.01030928 
+  94           92.662627    82.449696   0.0106383 
+  108          93.215668    82.396556   0.00925926 
+  96           93.876371    82.343481   0.01041667 
+  89           94.503705    82.290473   0.01123596 
+  83           94.838148    82.237531   0.01204819 
+  103          94.696262    82.184655   0.00970874 
+  99           94.196359    82.131845   0.01010101 
+  92           93.618342    82.079101   0.01086957 
+  109          93.160872    82.026422   0.00917431 
+  84           92.897158    81.97381    0.01190476 
+  108          92.808782    81.921264   0.00925926 
+  96           92.79879     81.868783   0.01041667 
+  85           92.716076    81.816368   0.01176471 
+  95           92.481816    81.764019   0.01052632 
+  109          92.168847    81.711735   0.00917431 
+  99           91.903372    81.659516   0.01010101 
+  99           91.766763    81.607364   0.01010101 
+  96           91.802065    81.555276   0.01041667 
+  84           92.044341    81.503254   0.01190476 
+  108          92.545554    81.451297   0.00925926 
+  117          93.394182    81.399405   0.00854701 
+  106          94.729958    81.347579   0.00943396 
+  114          96.753311    81.295817   0.00877193 
+  122          99.709742    81.244121   0.00819672 
+  108          103.828046   81.192489   0.00925926 
+  145          109.182948   81.140923   0.00689655 
+  122          115.49306    81.089421   0.00819672 
+  148          121.917606   81.037984   0.00675676 
+  170          126.761914   80.986612   0.00588235 
+  165          127.843302   80.935305   0.00606061 
+  158          124.73818    80.884062   0.00632911 
+  166          119.689308   80.832884   0.0060241 
+  129          115.17414    80.78177    0.00775194 
+  168          112.343446   80.730721   0.00595238 
+  146          111.247754   80.679736   0.00684932 
+  149          111.255839   80.628816   0.00671141 
+  150          111.177147   80.577959   0.00666667 
+  148          109.645233   80.527167   0.00675676 
+  136          106.351454   80.47644    0.00735294 
+  116          102.156624   80.425776   0.00862069 
+  122          98.36116     80.375176   0.00819672 
+  107          95.2697      80.324641   0.00934579 
+  114          92.928047    80.274169   0.00877193 
+  109          91.227089    80.223761   0.00917431 
+  114          90.017619    80.173417   0.00877193 
+  108          89.160953    80.123137   0.00925926 
+  95           88.479719    80.07292    0.01052632 
+  101          88.033526    80.022768   0.00990099 
+  101          87.706938    79.972678   0.00990099 
+  97           87.472016    79.922653   0.01030928 
+  102          87.31319     79.87269    0.00980392 
+  106          87.222207    79.822792   0.00943396 
+  89           87.194287    79.772956   0.01123596 
+  92           87.226509    79.723184   0.01086957 
+  83           87.313973    79.673475   0.01204819 
+  81           87.445586    79.62383    0.01234568 
+  98           87.598618    79.574247   0.01020408 
+  93           87.73658     79.524728   0.01075269 
+  84           87.818737    79.475271   0.01190476 
+  93           87.822522    79.425878   0.01075269 
+  104          87.76056     79.376547   0.00961538 
+  92           87.671696    79.32728    0.01086957 
+  78           87.59666     79.278075   0.01282051 
+  88           87.560322    79.228933   0.01136364 
+  108          87.566976    79.179854   0.00925926 
+  91           87.60483     79.130837   0.01098901 
+  86           87.655443    79.081883   0.01162791 
+  91           87.70899     79.032991   0.01098901 
+  84           87.773833    78.984162   0.01190476 
+  79           87.873387    78.935396   0.01265823 
+  84           88.034642    78.886691   0.01190476 
+  100          88.282261    78.838049   0.01      
+  98           88.638948    78.78947    0.01020408 
+  84           89.130353    78.740952   0.01190476 
+  111          89.792025    78.692497   0.00900901 
+  77           90.680146    78.644103   0.01298701 
+  97           91.891324    78.595772   0.01030928 
+  87           93.596398    78.547503   0.01149425 
+  98           96.088047    78.499295   0.01020408 
+  99           99.825493    78.45115    0.01010101 
+  104          105.436974   78.403066   0.00961538 
+  138          113.627719   78.355044   0.00724638 
+  137          124.921693   78.307084   0.00729927 
+  140          139.135298   78.259185   0.00714286 
+  149          154.189605   78.211348   0.00671141 
+  179          164.838822   78.163573   0.00558659 
+  166          165.548651   78.115859   0.0060241 
+  147          157.601312   78.068206   0.00680272 
+  158          147.625145   78.020615   0.00632911 
+  111          140.436854   77.973085   0.00900901 
+  120          137.385442   77.925617   0.00833333 
+  136          137.634626   77.87821    0.00735294 
+  150          139.25633    77.830863   0.00666667 
+  144          139.451983   77.783578   0.00694444 
+  137          135.470036   77.736354   0.00729927 
+  125          127.7054     77.689191   0.008     
+  120          119.148216   77.642089   0.00833333 
+  99           111.912947   77.595048   0.01010101 
+  80           106.432786   77.548067   0.0125    
+  102          102.226646   77.501148   0.00980392 
+  85           98.737498    77.454289   0.01176471 
+  100          95.798991    77.407491   0.01      
+  105          93.433523    77.360753   0.00952381 
+  103          91.606083    77.314076   0.00970874 
+  91           90.223801    77.267459   0.01098901 
+  83           89.188151    77.220903   0.01204819 
+  95           88.41457     77.174408   0.01052632 
+  96           87.834806    77.127972   0.01041667 
+  86           87.397306    77.081597   0.01162791 
+  85           87.065482    77.035282   0.01176471 
+  89           86.815213    76.989028   0.01123596 
+  78           86.631759    76.942833   0.01282051 
+  92           86.506886    76.896699   0.01086957 
+  96           86.437015    76.850625   0.01041667 
+  91           86.420546    76.80461    0.01098901 
+  94           86.45562     76.758656   0.0106383 
+  85           86.535267    76.712761   0.01176471 
+  84           86.63828     76.666926   0.01190476 
+  82           86.724663    76.621151   0.01219512 
+  85           86.759026    76.575436   0.01176471 
+  91           86.753532    76.52978    0.01098901 
+  91           86.7527      76.484184   0.01098901 
+  94           86.790824    76.438648   0.0106383 
+  84           86.881903    76.393171   0.01190476 
+  99           87.026724    76.347753   0.01010101 
+  90           87.214259    76.302395   0.01111111 
+  91           87.42405     76.257096   0.01098901 
+  88           87.635966    76.211857   0.01136364 
+  98           87.853268    76.166676   0.01020408 
+  94           88.099649    76.121555   0.0106383 
+  105          88.397731    76.076493   0.00952381 
+  85           88.763493    76.03149    0.01176471 
+  84           89.213521    75.986546   0.01190476 
+  79           89.772083    75.941661   0.01265823 
+  89           90.476389    75.896835   0.01123596 
+  83           91.380203    75.852068   0.01204819 
+  95           92.547166    75.80736    0.01052632 
+  104          94.03585     75.76271    0.00961538 
+  96           95.863098    75.718119   0.01041667 
+  110          97.922361    75.673587   0.00909091 
+  100          99.839649    75.629114   0.01      
+  102          100.984814   75.584699   0.00980392 
+  115          101.020627   75.540342   0.00869565 
+  111          100.361903   75.496044   0.00900901 
+  92           99.68241     75.451804   0.01086957 
+  98           99.386819    75.407623   0.01020408 
+  99           99.60053     75.3635     0.01010101 
+  117          100.279196   75.319435   0.00854701 
+  118          101.222381   75.275429   0.00847458 
+  121          102.085437   75.23148    0.00826446 
+  102          102.631043   75.18759    0.00980392 
+  90           103.032165   75.143757   0.01111111 
+  114          103.713586   75.099983   0.00877193 
+  100          105.074184   75.056267   0.01      
+  102          107.458937   75.012608   0.00980392 
+  108          111.198262   74.969007   0.00925926 
+  128          116.55279    74.925465   0.0078125 
+  128          123.518183   74.881979   0.0078125 
+  143          131.359578   74.838552   0.00699301 
+  173          137.897585   74.795182   0.00578035 
+  171          140.098047   74.75187    0.00584795 
+  203          137.439372   74.708615   0.00492611 
+  181          132.763679   74.665418   0.00552486 
+  162          128.873464   74.622278   0.00617284 
+  145          127.023646   74.579195   0.00689655 
+  125          127.415443   74.53617    0.008     
+  129          129.589286   74.493202   0.00775194 
+  163          132.33098    74.450292   0.00613497 
+  124          133.823233   74.407438   0.00806452 
+  165          133.167923   74.364642   0.00606061 
+  128          131.378379   74.321902   0.0078125 
+  139          129.867521   74.27922    0.00719424 
+  142          129.336325   74.236595   0.00704225 
+  143          129.942423   74.194026   0.00699301 
+  107          131.601767   74.151515   0.00934579 
+  133          134.104048   74.10906    0.0075188 
+  134          137.149424   74.066662   0.00746269 
+  142          140.477803   74.024321   0.00704225 
+  162          144.099876   73.982036   0.00617284 
+  135          148.265796   73.939808   0.00740741 
+  152          153.230809   73.897637   0.00657895 
+  175          159.170337   73.855522   0.00571429 
+  191          166.225403   73.813463   0.0052356 
+  183          174.522203   73.771461   0.00546448 
+  195          184.178365   73.729516   0.00512821 
+  214          195.350216   73.687626   0.0046729 
+  215          208.367564   73.645793   0.00465116 
+  225          223.799108   73.604016   0.00444444 
+  235          242.389194   73.562296   0.00425532 
+  264          265.062402   73.520631   0.00378788 
+  270          293.043716   73.479023   0.0037037 
+  327          328.062448   73.43747    0.0030581 
+  392          372.738675   73.395974   0.00255102 
+  419          431.496499   73.354533   0.00238663 
+  526          512.665315   73.313148   0.00190114 
+  722          633.243203   73.271819   0.00138504 
+  990          826.360788   73.230546   0.0010101 
+  1331         1148.221457  73.189328   0.00075131 
+  1759         1674.502146  73.148167   0.0005685 
+  2427         2473.776597  73.10706    0.00041203 
+  3469         3548.00298   73.06601    0.00028827 
+  4729         4713.930587  73.025015   0.00021146 
+  5875         5451.930243  72.984075   0.00017021 
+  6202         5228.232913  72.943191   0.00016124 
+  5310         4287.547213  72.902362   0.00018832 
+  4185         3281.767368  72.861589   0.00023895 
+  2973         2582.044408  72.82087    0.00033636 
+  2540         2292.232342  72.780207   0.0003937 
+  2374         2382.115836  72.739599   0.00042123 
+  2686         2721.975543  72.699047   0.0003723 
+  3135         3041.499559  72.658549   0.00031898 
+  3235         2984.061085  72.618106   0.00030912 
+  2860         2497.920103  72.577719   0.00034965 
+  2229         1874.769359  72.537386   0.00044863 
+  1565         1335.521141  72.497108   0.00063898 
+  975          943.976158   72.456885   0.00102564 
+  613          687.463309   72.416717   0.00163132 
+  489          528.379223   72.376603   0.00204499 
+  411          429.431062   72.336545   0.00243309 
+  324          364.435827   72.29654    0.00308642 
+  280          318.398252   72.256591   0.00357143 
+  238          283.650909   72.216696   0.00420168 
+  205          256.307697   72.176855   0.00487805 
+  181          234.222847   72.137069   0.00552486 
+  175          216.067062   72.097337   0.00571429 
+  198          200.944375   72.05766    0.00505051 
+  160          188.220888   72.018037   0.00625   
+  151          177.433706   71.978468   0.00662252 
+  160          168.235154   71.938953   0.00625   
+  145          160.36658    71.899493   0.00689655 
+  139          153.629871   71.860086   0.00719424 
+  123          147.876765   71.820734   0.00813008 
+  139          143.004888   71.781436   0.00719424 
+  107          138.953093   71.742191   0.00934579 
+  150          135.700298   71.703001   0.00666667 
+  118          133.263084   71.663864   0.00847458 
+  106          131.688628   71.624781   0.00943396 
+  139          131.034417   71.585752   0.00719424 
+  127          131.315064   71.546777   0.00787402 
+  115          132.395935   71.507855   0.00869565 
+  137          133.907724   71.468987   0.00729927 
+  123          135.392282   71.430173   0.00813008 
+  116          136.481002   71.391412   0.00862069 
+  136          136.806185   71.352705   0.00735294 
+  113          136.138307   71.314051   0.00884956 
+  146          134.371856   71.27545    0.00684932 
+  127          131.380666   71.236903   0.00787402 
+  105          127.587985   71.198409   0.00952381 
+  102          123.869373   71.159968   0.00980392 
+  138          120.728955   71.12158    0.00724638 
+  133          118.184942   71.083246   0.0075188 
+  127          115.998379   71.044965   0.00787402 
+  114          113.851201   71.006736   0.00877193 
+  106          111.508822   70.968561   0.00943396 
+  74           108.742327   70.930439   0.01351351 
+  110          105.499125   70.892369   0.00909091 
+  96           102.135437   70.854353   0.01041667 
+  97           99.068138    70.816389   0.01030928 
+  106          96.483036    70.778478   0.00943396 
+  107          94.380782    70.74062    0.00934579 
+  91           92.689527    70.702814   0.01098901 
+  97           91.322632    70.665061   0.01030928 
+  88           90.201184    70.62736    0.01136364 
+  83           89.262518    70.589713   0.01204819 
+  91           88.460816    70.552117   0.01098901 
+  90           87.766128    70.514574   0.01111111 
+  82           87.157873    70.477084   0.01219512 
+  92           86.623167    70.439645   0.01086957 
+  92           86.153393    70.402259   0.01086957 
+  97           85.743087    70.364926   0.01030928 
+  98           85.388935    70.327644   0.01020408 
+  87           85.089229    70.290415   0.01149425 
+  92           84.843526    70.253238   0.01086957 
+  80           84.65239     70.216112   0.0125    
+  77           84.517127    70.179039   0.01298701 
+  81           84.439392    70.142018   0.01234568 
+  94           84.420607    70.105049   0.0106383 
+  85           84.460996    70.068131   0.01176471 
+  92           84.558255    70.031266   0.01086957 
+  75           84.705676    69.994452   0.01333333 
+  93           84.889233    69.95769    0.01075269 
+  77           85.08662     69.920979   0.01298701 
+  72           85.267211    69.88432    0.01388889 
+  89           85.401919    69.847713   0.01123596 
+  88           85.449902    69.811157   0.01136364 
+  95           85.401637    69.774653   0.01052632 
+  79           85.262719    69.738201   0.01265823 
+  79           85.056627    69.701799   0.01265823 
+  100          84.814866    69.665449   0.01      
+  62           84.565674    69.629151   0.01612903 
+  94           84.326776    69.592903   0.0106383 
+  85           84.104297    69.556707   0.01176471 
+  85           83.897249    69.520562   0.01176471 
+  84           83.706097    69.484468   0.01190476 
+  87           83.540893    69.448426   0.01149425 
+  87           83.429902    69.412434   0.01149425 
+  80           83.409381    69.376493   0.0125    
+  71           83.537674    69.340603   0.01408451 
+  71           83.878022    69.304764   0.01408451 
+  91           84.491131    69.268976   0.01098901 
+  96           85.419155    69.233239   0.01041667 
+  98           86.634777    69.197553   0.01020408 
+  95           87.970766    69.161917   0.01052632 
+  84           89.024901    69.126332   0.01190476 
+  87           89.353324    69.090797   0.01149425 
+  76           88.959729    69.055313   0.01315789 
+  76           88.287086    69.01988    0.01315789 
+  95           87.718399    68.984497   0.01052632 
+  74           87.380518    68.949165   0.01351351 
+  82           87.221209    68.913882   0.01219512 
+  102          87.12557     68.878651   0.00980392 
+  77           86.963172    68.843469   0.01298701 
+  87           86.55226     68.808338   0.01149425 
+  90           85.771486    68.773257   0.01111111 
+  74           84.748245    68.738226   0.01351351 
+  81           83.71208     68.703246   0.01234568 
+  86           82.786573    68.668315   0.01162791 
+  92           81.975134    68.633434   0.01086957 
+  94           81.227754    68.598604   0.0106383 
+  88           80.510952    68.563823   0.01136364 
+  72           79.834603    68.529092   0.01388889 
+  72           79.220945    68.494411   0.01388889 
+  71           78.682118    68.45978    0.01408451 
+  78           78.221266    68.425199   0.01282051 
+  87           77.837779    68.390667   0.01149425 
+  87           77.53054     68.356185   0.01149425 
+  77           77.301499    68.321753   0.01298701 
+  79           77.152148    68.28737    0.01265823 
+  64           77.091697    68.253036   0.015625  
+  80           77.130686    68.218753   0.0125    
+  78           77.278162    68.184518   0.01282051 
+  84           77.531496    68.150333   0.01190476 
+  63           77.855159    68.116197   0.01587302 
+  85           78.1574      68.082111   0.01176471 
+  80           78.327974    68.048074   0.0125    
+  94           78.344739    68.014086   0.0106383 
+  86           78.277203    67.980147   0.01162791 
+  77           78.205333    67.946258   0.01298701 
+  80           78.212523    67.912417   0.0125    
+  67           78.367076    67.878626   0.01492537 
+  83           78.695493    67.844883   0.01204819 
+  97           79.174167    67.811189   0.01030928 
+  84           79.7303      67.777545   0.01190476 
+  76           80.28221     67.743949   0.01315789 
+  79           80.820599    67.710402   0.01265823 
+  82           81.437263    67.676904   0.01219512 
+  81           82.295065    67.643454   0.01234568 
+  92           83.597251    67.610053   0.01086957 
+  84           85.608746    67.576701   0.01190476 
+  94           88.686581    67.543397   0.0106383 
+  108          93.299386    67.510142   0.00925926 
+  94           99.969606    67.476935   0.0106383 
+  111          109.113322   67.443777   0.00900901 
+  116          120.781665   67.410667   0.00862069 
+  115          134.084205   67.377606   0.00869565 
+  144          146.098692   67.344593   0.00694444 
+  141          152.259313   67.311628   0.0070922 
+  158          150.233847   67.278711   0.00632911 
+  112          142.012948   67.245843   0.00892857 
+  146          131.862254   67.213022   0.00684932 
+  109          123.522424   67.18025    0.00917431 
+  113          118.785834   67.147526   0.00884956 
+  118          117.7859     67.11485    0.00847458 
+  125          119.429044   67.082222   0.008     
+  114          121.354652   67.049641   0.00877193 
+  118          120.830615   67.017109   0.00847458 
+  110          116.86258    66.984624   0.00909091 
+  97           110.561749   66.952187   0.01030928 
+  101          103.857478   66.919798   0.00990099 
+  97           98.205496    66.887457   0.01030928 
+  108          94.17267     66.855163   0.00925926 
+  110          91.729309    66.822917   0.00909091 
+  80           90.584116    66.790718   0.0125    
+  75           90.435476    66.758567   0.01333333 
+  86           91.252822    66.726463   0.01162791 
+  87           92.690685    66.694407   0.01149425 
+  84           94.338912    66.662398   0.01190476 
+  101          95.161379    66.630437   0.00990099 
+  100          94.337732    66.598523   0.01      
+  109          92.262592    66.566656   0.00917431 
+  84           90.028619    66.534836   0.01190476 
+  84           88.376519    66.503064   0.01190476 
+  93           87.570415    66.471338   0.01075269 
+  96           87.626993    66.43966    0.01041667 
+  94           88.338824    66.408028   0.0106383 
+  93           88.90726     66.376444   0.01075269 
+  74           88.492268    66.344907   0.01351351 
+  81           86.800122    66.313416   0.01234568 
+  81           84.425982    66.281972   0.01234568 
+  82           82.12517     66.250576   0.01219512 
+  72           80.295051    66.219225   0.01388889 
+  81           79.021452    66.187922   0.01234568 
+  78           78.230429    66.156665   0.01282051 
+  83           77.742806    66.125455   0.01204819 
+  69           77.307498    66.094292   0.01449275 
+  94           76.741505    66.063175   0.0106383 
+  76           76.068466    66.032105   0.01315789 
+  68           75.417662    66.001081   0.01470588 
+  65           74.873392    65.970103   0.01538462 
+  75           74.458097    65.939172   0.01333333 
+  73           74.165374    65.908287   0.01369863 
+  76           73.979096    65.877449   0.01315789 
+  70           73.882089    65.846656   0.01428571 
+  77           73.857559    65.81591    0.01298701 
+  87           73.88515     65.78521    0.01149425 
+  68           73.814098    65.754556   0.01470588 
+  67           73.839832    65.723949   0.01492537 
+  62           73.820864    65.693387   0.01612903 
+  69           73.779174    65.662871   0.01449275 
+  67           73.750874    65.632401   0.01492537 
+  93           73.756641    65.601977   0.01075269 
+  78           73.801944    65.571599   0.01282051 
+  72           73.884445    65.541267   0.01388889 
+  77           73.937136    65.510981   0.01298701 
+  67           74.063866    65.48074    0.01492537 
+  67           74.187015    65.450545   0.01492537 
+  69           74.303385    65.420395   0.01449275 
+  77           74.433264    65.390291   0.01298701 
+  83           74.604559    65.360233   0.01204819 
+  86           74.842644    65.33022    0.01162791 
+  62           75.175016    65.300253   0.01612903 
+  76           75.638685    65.270331   0.01315789 
+  71           76.281469    65.240454   0.01408451 
+  65           77.15685     65.210623   0.01538462 
+  73           78.3096      65.180837   0.01369863 
+  77           79.739803    65.151096   0.01298701 
+  74           81.323017    65.121401   0.01351351 
+  77           82.695389    65.091751   0.01298701 
+  73           83.327126    65.062145   0.01369863 
+  69           83.029302    65.032585   0.01449275 
+  79           82.216733    65.00307    0.01265823 
+  70           81.428663    64.9736     0.01428571 
+  77           80.96372     64.944175   0.01298701 
+  88           80.913836    64.914795   0.01136364 
+  77           81.257702    64.885459   0.01298701 
+  76           81.878131    64.856169   0.01315789 
+  73           82.532062    64.826923   0.01369863 
+  88           82.914225    64.797722   0.01136364 
+  81           82.924601    64.768565   0.01234568 
+  94           82.766637    64.739453   0.0106383 
+  91           82.690386    64.710386   0.01098901 
+  81           82.831492    64.681364   0.01234568 
+  87           83.245374    64.652386   0.01149425 
+  74           83.961408    64.623452   0.01351351 
+  91           85.02916     64.594563   0.01098901 
+  77           86.533617    64.565718   0.01298701 
+  81           88.60515     64.536917   0.01234568 
+  90           91.409147    64.508161   0.01111111 
+  78           95.106313    64.479449   0.01282051 
+  90           99.774022    64.450782   0.01111111 
+  99           105.200573   64.422158   0.01010101 
+  104          110.530665   64.393579   0.00961538 
+  92           114.138171   64.365043   0.01086957 
+  123          114.811301   64.336552   0.00813008 
+  101          113.287585   64.308105   0.00990099 
+  83           111.406596   64.279702   0.01204819 
+  120          110.469223   64.251342   0.00833333 
+  108          111.000999   64.223027   0.00925926 
+  105          113.077556   64.194755   0.00952381 
+  111          116.485431   64.166527   0.00900901 
+  100          120.648128   64.138343   0.01      
+  93           124.623317   64.110203   0.01075269 
+  103          127.72058    64.082106   0.00970874 
+  115          130.249536   64.054053   0.00869565 
+  134          133.045574   64.026043   0.00746269 
+  103          136.640377   63.998077   0.00970874 
+  107          141.130249   63.970155   0.00934579 
+  125          146.331591   63.942276   0.008     
+  157          151.905461   63.91444    0.00636943 
+  124          157.430052   63.886648   0.00806452 
+  154          162.499848   63.858899   0.00649351 
+  146          166.843694   63.831193   0.00684932 
+  185          170.418455   63.803531   0.00540541 
+  161          173.424579   63.775911   0.00621118 
+  189          176.228957   63.748335   0.00529101 
+  192          179.237933   63.720802   0.00520833 
+  187          182.783815   63.693312   0.00534759 
+  230          187.064949   63.665865   0.00434783 
+  240          192.128375   63.638461   0.00416667 
+  246          197.928526   63.6111     0.00406504 
+  222          204.361317   63.583782   0.0045045 
+  240          211.305193   63.556507   0.00416667 
+  271          218.600652   63.529275   0.00369004 
+  259          225.988851   63.502085   0.003861  
+  238          233.047918   63.474938   0.00420168 
+  279          239.209524   63.447834   0.00358423 
+  264          243.889826   63.420772   0.00378788 
+  266          246.705482   63.393753   0.0037594 
+  255          247.652849   63.366777   0.00392157 
+  198          247.124208   63.339843   0.00505051 
+  249          245.757163   63.312952   0.00401606 
+  227          244.218213   63.286103   0.00440529 
+  194          243.06273    63.259296   0.00515464 
+  227          242.620448   63.232532   0.00440529 
+  226          242.938066   63.20581    0.00442478 
+  190          243.87736    63.17913    0.00526316 
+  228          245.299852   63.152493   0.00438596 
+  223          247.180358   63.125898   0.0044843 
+  208          249.647423   63.099345   0.00480769 
+  227          252.921766   63.072834   0.00440529 
+  219          257.225089   63.046365   0.00456621 
+  233          262.665229   63.019938   0.00429185 
+  243          269.091778   62.993553   0.00411523 
+  300          276.00211    62.96721    0.00333333 
+  308          282.575223   62.940909   0.00324675 
+  385          287.864878   62.914649   0.0025974 
+  410          291.034051   62.888432   0.00243902 
+  419          291.583461   62.862256   0.00238663 
+  362          289.449133   62.836122   0.00276243 
+  344          284.978873   62.81003    0.00290698 
+  353          278.76822    62.783979   0.00283286 
+  306          271.451687   62.75797    0.00326797 
+  293          263.520554   62.732003   0.00341297 
+  296          255.207781   62.706077   0.00337838 
+  287          246.499613   62.680192   0.00348432 
+  279          237.249871   62.654349   0.00358423 
+  326          227.328733   62.628547   0.00306748 
+  300          216.72184    62.602787   0.00333333 
+  240          205.572726   62.577068   0.00416667 
+  227          194.14933    62.55139    0.00440529 
+  172          182.780266   62.525753   0.00581395 
+  153          171.794907   62.500158   0.00653595 
+  162          161.457439   62.474604   0.00617284 
+  149          151.944225   62.44909    0.00671141 
+  141          143.33927    62.423618   0.0070922 
+  123          135.652779   62.398187   0.00813008 
+  113          128.842065   62.372797   0.00884956 
+  104          122.838233   62.347448   0.00961538 
+  106          117.560626   62.32214    0.00943396 
+  87           112.925982   62.296872   0.01149425 
+  106          108.857572   62.271645   0.00943396 
+  104          105.284603   62.24646    0.00961538 
+  97           102.145044   62.221314   0.01030928 
+  84           99.386402    62.19621    0.01190476 
+  99           96.966259    62.171146   0.01010101 
+  86           94.85196     62.146123   0.01162791 
+  88           93.024665    62.12114    0.01136364 
+  94           91.478484    62.096198   0.0106383 
+  91           90.227451    62.071296   0.01098901 
+  76           89.301299    62.046435   0.01315789 
+  101          88.739836    62.021614   0.00990099 
+  78           88.576661    61.996833   0.01282051 
+  88           88.8045      61.972093   0.01136364 
+  71           89.293143    61.947393   0.01408451 
+  85           89.665456    61.922733   0.01176471 
+  67           89.340645    61.898114   0.01492537 
+  92           88.045887    61.873534   0.01086957 
+  101          86.170143    61.848995   0.00990099 
+  58           84.299934    61.824496   0.01724138 
+  89           82.778107    61.800036   0.01123596 
+  73           81.716742    61.775617   0.01369863 
+  70           81.105551    61.751238   0.01428571 
+  83           80.847913    61.726898   0.01204819 
+  83           80.730136    61.702598   0.01204819 
+  84           80.419057    61.678339   0.01190476 
+  84           79.673466    61.654119   0.01190476 
+  72           78.589097    61.629938   0.01388889 
+  81           77.437633    61.605798   0.01234568 
+  78           76.40154     61.581697   0.01282051 
+  73           75.539548    61.557635   0.01369863 
+  85           74.849132    61.533613   0.01176471 
+  79           74.305595    61.509631   0.01265823 
+  81           73.88554     61.485688   0.01234568 
+  84           73.553572    61.461785   0.01190476 
+  77           73.29561     61.437921   0.01298701 
+  73           73.099082    61.414096   0.01369863 
+  68           72.956821    61.390311   0.01470588 
+  67           72.865933    61.366565   0.01492537 
+  77           72.826772    61.342858   0.01298701 
+  88           72.842103    61.31919    0.01136364 
+  74           72.917734    61.295562   0.01351351 
+  70           73.057426    61.271972   0.01428571 
+  82           73.268695    61.248422   0.01219512 
+  66           73.56149     61.224911   0.01515152 
+  73           73.937365    61.201438   0.01369863 
+  67           74.404774    61.178005   0.01492537 
+  78           74.967349    61.15461    0.01282051 
+  79           75.62605     61.131255   0.01265823 
+  99           76.378811    61.107938   0.01010101 
+  88           77.220145    61.08466    0.01136364 
+  89           78.143204    61.061421   0.01123596 
+  76           79.142341    61.03822    0.01315789 
+  100          80.207263    61.015058   0.01      
+  91           81.30901     60.991935   0.01098901 
+  112          82.346062    60.96885    0.00892857 
+  94           83.078892    60.945804   0.0106383 
+  80           83.209038    60.922796   0.0125    
+  96           82.687026    60.899827   0.01041667 
+  71           81.79329     60.876896   0.01408451 
+  80           80.838815    60.854003   0.0125    
+  81           79.99809     60.831149   0.01234568 
+  82           79.341412    60.808333   0.01219512 
+  88           78.884297    60.785556   0.01136364 
+  76           78.597128    60.762816   0.01315789 
+  81           78.384394    60.740115   0.01234568 
+  92           78.092313    60.717452   0.01086957 
+  99           77.63339     60.694826   0.01010101 
+  91           77.083481    60.672239   0.01098901 
+  80           76.536695    60.64969    0.0125    
+  88           75.939373    60.627179   0.01136364 
+  62           75.142657    60.604706   0.01612903 
+  84           74.134098    60.582271   0.01190476 
+  75           73.091183    60.559873   0.01333333 
+  67           72.191247    60.537513   0.01492537 
+  73           71.521555    60.515191   0.01369863 
+  74           71.104601    60.492907   0.01351351 
+  77           70.938405    60.470661   0.01298701 
+  88           71.005154    60.448452   0.01136364 
+  82           71.25983     60.42628    0.01219512 
+  87           71.636883    60.404146   0.01149425 
+  75           72.128959    60.38205    0.01333333 
+  86           72.837929    60.359991   0.01162791 
+  85           73.86396     60.33797    0.01176471 
+  82           75.146266    60.315986   0.01219512 
+  82           76.325094    60.294039   0.01219512 
+  80           76.844517    60.27213    0.0125    
+  72           76.494804    60.250258   0.01388889 
+  64           75.692516    60.228423   0.015625  
+  75           74.941428    60.206625   0.01333333 
+  76           74.406567    60.184864   0.01315789 
+  69           74.024714    60.163141   0.01449275 
+  78           73.821988    60.141454   0.01282051 
+  87           73.933629    60.119805   0.01149425 
+  78           74.385389    60.098192   0.01282051 
+  96           74.979065    60.076617   0.01041667 
+  78           75.488054    60.055078   0.01282051 
+  68           75.901613    60.033577   0.01470588 
+  73           76.215307    60.012112   0.01369863 
+  68           76.116315    59.990683   0.01470588 
+  71           75.262604    59.969292   0.01408451 
+  83           73.804534    59.947937   0.01204819 
+  72           72.239664    59.926619   0.01388889 
+  79           70.949926    59.905337   0.01265823 
+  87           70.079378    59.884092   0.01149425 
+  70           69.638301    59.862884   0.01428571 
+  91           69.561548    59.841712   0.01098901 
+  73           69.7124      59.820576   0.01369863 
+  76           69.85539     59.799477   0.01315789 
+  80           69.736582    59.778415   0.0125    
+  78           69.308887    59.757388   0.01282051 
+  66           68.756052    59.736398   0.01515152 
+  89           68.266406    59.715444   0.01123596 
+  77           67.927576    59.694526   0.01298701 
+  74           67.7603      59.673645   0.01351351 
+  77           67.760888    59.652799   0.01298701 
+  75           67.923252    59.63199    0.01333333 
+  81           68.250337    59.611217   0.01234568 
+  67           68.761991    59.590479   0.01492537 
+  60           69.500848    59.569778   0.01666667 
+  81           70.534953    59.549113   0.01234568 
+  69           71.964391    59.528483   0.01449275 
+  90           73.921709    59.507889   0.01111111 
+  80           76.560965    59.487331   0.0125    
+  75           80.014997    59.466809   0.01333333 
+  94           84.362971    59.446322   0.0106383 
+  90           89.757107    59.425872   0.01111111 
+  104          96.53005     59.405456   0.00961538 
+  102          104.734448   59.385077   0.00980392 
+  127          113.444729   59.364733   0.00787402 
+  132          120.627096   59.344424   0.00757576 
+  154          123.445977   59.324151   0.00649351 
+  135          120.116021   59.303913   0.00740741 
+  140          112.656265   59.283711   0.00714286 
+  129          104.855031   59.263544   0.00775194 
+  121          98.973757    59.243413   0.00826446 
+  105          95.70997     59.223316   0.00952381 
+  99           95.016803    59.203255   0.01010101 
+  101          96.27957     59.183229   0.00990099 
+  117          98.307912    59.163238   0.00854701 
+  108          99.483973    59.143283   0.00925926 
+  124          98.173314    59.123362   0.00806452 
+  121          94.137871    59.103476   0.00826446 
+  120          88.98504     59.083626   0.00833333 
+  103          84.341303    59.06381    0.00970874 
+  100          80.890283    59.044029   0.01      
+  79           78.676234    59.024283   0.01265823 
+  63           77.413013    59.004572   0.01587302 
+  80           76.594848    58.984895   0.0125    
+  84           75.705224    58.965254   0.01190476 
+  76           74.585862    58.945647   0.01315789 
+  76           73.459352    58.926075   0.01315789 
+  81           72.56332     58.906537   0.01234568 
+  73           71.958       58.887034   0.01369863 
+  67           71.54737     58.867565   0.01492537 
+  90           71.19343     58.848131   0.01111111 
+  66           70.856507    58.828731   0.01515152 
+  92           70.545179    58.809366   0.01086957 
+  69           70.178865    58.790035   0.01449275 
+  66           69.674328    58.770739   0.01515152 
+  66           69.106416    58.751477   0.01515152 
+  79           68.640084    58.732249   0.01265823 
+  95           68.372063    58.713055   0.01052632 
+  69           68.304253    58.693895   0.01449275 
+  90           68.379627    58.67477    0.01111111 
+  83           68.556884    58.655678   0.01204819 
+  74           68.849028    58.636621   0.01351351 
+  49           69.239066    58.617598   0.02040816 
+  84           69.578877    58.598608   0.01190476 
+  92           69.635925    58.579653   0.01086957 
+  71           69.338042    58.560731   0.01408451 
+  85           68.871617    58.541844   0.01176471 
+  65           68.464378    58.52299    0.01538462 
+  56           68.237738    58.50417    0.01785714 
+  59           68.228011    58.485383   0.01694915 
+  60           68.428145    58.46663    0.01666667 
+  61           68.80077     58.447911   0.01639344 
+  82           69.264255    58.429226   0.01219512 
+  70           69.679655    58.410574   0.01428571 
+  60           69.916213    58.391955   0.01666667 
+  68           69.963843    58.37337    0.01470588 
+  78           69.916522    58.354819   0.01282051 
+  71           69.85182     58.336301   0.01408451 
+  68           69.79451     58.317816   0.01470588 
+  66           69.741163    58.299365   0.01515152 
+  74           69.681053    58.280946   0.01351351 
+  68           69.609548    58.262561   0.01470588 
+  65           69.525149    58.24421    0.01538462 
+  67           69.436966    58.225891   0.01492537 
+  63           69.349711    58.207606   0.01587302 
+  56           69.266284    58.189353   0.01785714 
+  60           69.185293    58.171134   0.01666667 
+  77           69.102511    58.152948   0.01298701 
+  62           69.013143    58.134794   0.01612903 
+  63           68.915124    58.116674   0.01587302 
+  67           68.811056    58.098586   0.01492537 
+  56           68.712685    58.080531   0.01785714 
+  58           68.635484    58.062509   0.01724138 
+  57           68.599436    58.04452    0.01754386 
+  76           68.627768    58.026563   0.01315789 
+  86           68.745848    58.00864    0.01162791 
+  65           68.981582    57.990748   0.01538462 
+  88           69.363089    57.97289    0.01136364 
+  77           69.913146    57.955064   0.01298701 
+  59           70.633582    57.93727    0.01694915 
+  85           71.470222    57.919509   0.01176471 
+  89           72.258466    57.90178    0.01123596 
+  70           72.75389     57.884084   0.01428571 
+  73           72.861773    57.86642    0.01369863 
+  77           72.769251    57.848788   0.01298701 
+  79           72.729501    57.831189   0.01265823 
+  75           72.883968    57.813622   0.01333333 
+  81           73.27182     57.796087   0.01234568 
+  90           73.776103    57.778584   0.01111111 
+  90           74.536835    57.761113   0.01111111 
+  71           75.347973    57.743674   0.01408451 
+  70           76.0414      57.726268   0.01428571 
+  71           76.440097    57.708893   0.01408451 
+  69           76.497224    57.69155    0.01449275 
+  86           76.321313    57.67424    0.01162791 
+  74           76.048826    57.656961   0.01351351 
+  85           75.721895    57.639714   0.01176471 
+  83           75.49089     57.622498   0.01204819 
+  72           75.327658    57.605315   0.01388889 
+  72           75.23249     57.588163   0.01388889 
+  78           75.186813    57.571042   0.01282051 
+  74           75.166481    57.553954   0.01351351 
+  81           75.147618    57.536897   0.01234568 
+  67           75.116174    57.519871   0.01492537 
+  75           75.072197    57.502877   0.01333333 
+  71           75.028779    57.485915   0.01408451 
+  70           75.005662    57.468983   0.01428571 
+  87           75.02367     57.452084   0.01149425 
+  85           75.09991     57.435215   0.01176471 
+  59           75.246697    57.418378   0.01694915 
+  71           75.472184    57.401572   0.01408451 
+  64           75.780255    57.384798   0.015625  
+  72           76.174623    57.368054   0.01388889 
+  71           76.658321    57.351342   0.01408451 
+  72           77.235226    57.33466    0.01388889 
+  80           77.910752    57.31801    0.0125    
+  84           78.69311     57.301391   0.01190476 
+  75           79.596173    57.284803   0.01333333 
+  98           80.639777    57.268246   0.01020408 
+  78           81.85616     57.251719   0.01282051 
+  73           83.295386    57.235224   0.01369863 
+  82           85.026135    57.218759   0.01219512 
+  95           87.136977    57.202325   0.01052632 
+  94           89.725019    57.185922   0.0106383 
+  100          92.867856    57.169549   0.01      
+  117          96.566736    57.153207   0.00854701 
+  110          100.612005   57.136896   0.00909091 
+  133          104.413077   57.120615   0.0075188 
+  156          107.175417   57.104365   0.00641026 
+  115          108.718162   57.088145   0.00869565 
+  138          109.77103    57.071956   0.00724638 
+  168          111.200227   57.055797   0.00595238 
+  136          113.501593   57.039669   0.00735294 
+  125          116.883277   57.023571   0.008     
+  187          121.421212   57.007503   0.00534759 
+  161          127.113224   56.991465   0.00621118 
+  132          133.844962   56.975458   0.00757576 
+  147          141.340875   56.959481   0.00680272 
+  143          149.343566   56.943533   0.00699301 
+  138          158.058405   56.927616   0.00724638 
+  176          168.202602   56.911729   0.00568182 
+  196          180.608024   56.895872   0.00510204 
+  195          196.051084   56.880045   0.00512821 
+  209          215.428744   56.864248   0.00478469 
+  229          239.972043   56.848481   0.00436681 
+  266          271.59647    56.832744   0.0037594 
+  337          313.646946   56.817036   0.00296736 
+  424          372.626461   56.801358   0.00235849 
+  560          461.630891   56.78571    0.00178571 
+  740          605.320051   56.770092   0.00135135 
+  955          843.359401   56.754503   0.00104712 
+  1325         1225.546481  56.738944   0.00075472 
+  1844         1791.366241  56.723414   0.0005423 
+  2456         2527.11194   56.707914   0.00040717 
+  3240         3278.238092  56.692444   0.00030864 
+  3858         3670.530589  56.677003   0.0002592 
+  3865         3407.18604   56.661591   0.00025873 
+  3019         2722.867942  56.646208   0.00033124 
+  2243         2022.691335  56.630855   0.00044583 
+  1607         1506.433767  56.615531   0.00062228 
+  1330         1223.32713   56.600237   0.00075188 
+  1223         1163.805563  56.584971   0.00081766 
+  1364         1297.009861  56.569735   0.00073314 
+  1542         1571.284052  56.554528   0.00064851 
+  1922         1876.948763  56.53935    0.00052029 
+  2171         2007.21151   56.524201   0.00046062 
+  2078         1816.951379  56.509081   0.00048123 
+  1573         1431.081999  56.49399    0.00063573 
+  1138         1043.044564  56.478928   0.00087873 
+  745          739.056425   56.463895   0.00134228 
+  524          529.988808   56.44889    0.0019084 
+  402          397.070069   56.433915   0.00248756 
+  286          314.946977   56.418968   0.0034965 
+  268          262.808878   56.40405    0.00373134 
+  200          227.423107   56.38916    0.005     
+  178          201.619657   56.374299   0.00561798 
+  165          181.792037   56.359467   0.00606061 
+  146          166.036811   56.344663   0.00684932 
+  174          153.246655   56.329888   0.00574713 
+  154          142.703853   56.315141   0.00649351 
+  121          133.903131   56.300423   0.00826446 
+  114          126.478299   56.285733   0.00877193 
+  114          120.157004   56.271071   0.00877193 
+  117          114.733195   56.256438   0.00854701 
+  109          110.04888    56.241833   0.00917431 
+  89           105.981483   56.227256   0.01123596 
+  99           102.435553   56.212708   0.01010101 
+  82           99.334736    56.198187   0.01219512 
+  100          96.62157     56.183695   0.01      
+  92           94.249289    56.169231   0.01086957 
+  93           92.18266     56.154795   0.01075269 
+  77           90.397558    56.140386   0.01298701 
+  101          88.87898     56.126006   0.00990099 
+  93           87.624604    56.111654   0.01075269 
+  78           86.648955    56.097329   0.01282051 
+  82           85.992462    56.083032   0.01219512 
+  90           85.732364    56.068764   0.01111111 
+  83           85.996159    56.054522   0.01204819 
+  89           86.964738    56.040309   0.01123596 
+  93           88.857272    56.026123   0.01075269 
+  106          91.884214    56.011965   0.00943396 
+  89           96.137834    55.997834   0.01123596 
+  89           101.34331    55.983731   0.01123596 
+  100          106.390579   55.969656   0.01      
+  108          109.126838   55.955607   0.00925926 
+  98           107.794902   55.941587   0.01020408 
+  80           103.130544   55.927593   0.0125    
+  104          97.476034    55.913627   0.00961538 
+  97           92.598986    55.899689   0.01030928 
+  87           89.251097    55.885777   0.01149425 
+  98           87.59811     55.871893   0.01020408 
+  81           87.535022    55.858036   0.01234568 
+  73           88.734602    55.844206   0.01369863 
+  85           90.496959    55.830404   0.01176471 
+  93           91.644948    55.816628   0.01075269 
+  88           91.185154    55.802879   0.01136364 
+  76           89.402247    55.789157   0.01315789 
+  85           87.547086    55.775463   0.01176471 
+  83           86.702605    55.761795   0.01204819 
+  91           87.462567    55.748154   0.01098901 
+  88           90.081575    55.734539   0.01136364 
+  115          94.5086      55.720952   0.00869565 
+  100          100.129076   55.707391   0.01      
+  105          105.24665    55.693857   0.00952381 
+  119          107.197067   55.68035    0.00840336 
+  117          104.501713   55.666869   0.00854701 
+  116          98.666254    55.653415   0.00862069 
+  111          92.338685    55.639987   0.00900901 
+  91           87.189101    55.626586   0.01098901 
+  85           83.824782    55.613211   0.01176471 
+  96           82.319796    55.599863   0.01041667 
+  78           82.479908    55.586541   0.01282051 
+  94           83.840649    55.573245   0.0106383 
+  91           85.458731    55.559976   0.01098901 
+  83           85.888107    55.546733   0.01204819 
+  87           84.123237    55.533516   0.01149425 
+  87           80.654005    55.520325   0.01149425 
+  73           76.739263    55.507161   0.01369863 
+  75           73.224162    55.494022   0.01333333 
+  71           70.392459    55.48091    0.01408451 
+  75           68.233542    55.467823   0.01333333 
+  71           66.632578    55.454763   0.01408451 
+  67           65.452405    55.441728   0.01492537 
+  61           64.56976     55.42872    0.01639344 
+  71           63.889683    55.415737   0.01408451 
+  69           63.346438    55.40278    0.01449275 
+  62           62.897668    55.389849   0.01612903 
+  53           62.516815    55.376943   0.01886792 
+  57           62.187233    55.364063   0.01754386 
+  66           61.897484    55.351209   0.01515152 
+  76           61.639908    55.338381   0.01315789 
+  73           61.408836    55.325577   0.01369863 
+  73           61.199918    55.3128     0.01369863 
+  64           61.009755    55.300048   0.015625  
+  64           60.835666    55.287321   0.015625  
+  57           60.675527    55.27462    0.01754386 
+  64           60.527601    55.261944   0.015625  
+  71           60.390477    55.249294   0.01408451 
+  55           60.263       55.236669   0.01818182 
+  46           60.14421     55.224069   0.02173913 
+  64           60.033304    55.211494   0.015625  
+  55           59.929641    55.198944   0.01818182 
+  61           59.832658    55.18642    0.01639344 
+  68           59.741908    55.17392    0.01470588 
+  73           59.657036    55.161446   0.01369863 
+  72           59.578344    55.148996   0.01388889 
+  62           59.504392    55.136572   0.01612903 
+  60           59.435516    55.124172   0.01666667 
+  69           59.37185     55.111798   0.01449275 
+  69           59.313231    55.099448   0.01449275 
+  60           59.259534    55.087123   0.01666667 
+  63           59.211247    55.074822   0.01587302 
+  50           59.168416    55.062547   0.02      
+  59           59.131111    55.050296   0.01694915 
+  57           59.100544    55.03807    0.01754386 
+  66           59.077336    55.025868   0.01515152 
+  59           59.062888    55.013691   0.01694915 
+  61           59.059819    55.001538   0.01639344 
+  65           59.070626    54.98941    0.01538462 
+  60           59.099623    54.977306   0.01666667 
+  62           59.151658    54.965227   0.01612903 
+  67           59.2308      54.953172   0.01492537 
+  53           59.338698    54.941141   0.01886792 
+  64           59.468766    54.929135   0.015625  
+  37           59.597866    54.917153   0.02702703 
+  58           59.688578    54.905195   0.01724138 
+  65           59.722362    54.893261   0.01538462 
+  68           59.72546     54.881351   0.01470588 
+  59           59.738605    54.869465   0.01694915 
+  63           59.783661    54.857604   0.01587302 
+  63           59.859371    54.845766   0.01587302 
+  50           59.945564    54.833952   0.02      
+  53           60.013924    54.822162   0.01886792 
+  64           60.051516    54.810397   0.015625  
+  56           60.065302    54.798654   0.01785714 
+  73           60.059482    54.786936   0.01369863 
+  62           60.033461    54.775241   0.01612903 
+  51           60.001121    54.76357    0.01960784 
+  58           59.986545    54.751923   0.01724138 
+  59           60.005899    54.7403     0.01694915 
+  49           60.062536    54.728699   0.02040816 
+  63           60.149765    54.717123   0.01587302 
+  60           60.255148    54.70557    0.01666667 
+  57           60.37222     54.69404    0.01754386 
+  65           60.510396    54.682534   0.01538462 
+  51           60.687222    54.671051   0.01960784 
+  63           60.920952    54.659592   0.01587302 
+  61           61.229338    54.648156   0.01639344 
+  55           61.635965    54.636743   0.01818182 
+  64           62.173262    54.625353   0.015625  
+  67           62.893094    54.613987   0.01492537 
+  67           63.879231    54.602643   0.01492537 
+  62           65.260695    54.591323   0.01612903 
+  64           67.224339    54.580026   0.015625  
+  59           70.009554    54.568752   0.01694915 
+  75           73.878451    54.5575     0.01333333 
+  72           79.036557    54.546272   0.01388889 
+  72           85.459004    54.535067   0.01388889 
+  82           92.501643    54.523884   0.01219512 
+  79           98.352635    54.512724   0.01265823 
+  88           100.406369   54.501587   0.01136364 
+  56           97.682197    54.490473   0.01785714 
+  74           92.116488    54.479382   0.01351351 
+  62           86.337058    54.468313   0.01612903 
+  55           81.842926    54.457266   0.01818182 
+  67           79.155518    54.446243   0.01492537 
+  58           78.321861    54.435241   0.01724138 
+  73           79.157943    54.424263   0.01369863 
+  82           81.22644     54.413306   0.01219512 
+  68           83.615336    54.402373   0.01470588 
+  68           84.830693    54.391461   0.01470588 
+  56           83.679342    54.380572   0.01785714 
+  63           80.525596    54.369705   0.01587302 
+  74           76.74224     54.35886    0.01351351 
+  69           73.354001    54.348038   0.01449275 
+  55           70.777779    54.337238   0.01818182 
+  89           69.098674    54.326459   0.01123596 
+  56           68.291561    54.315703   0.01785714 
+  66           68.302653    54.304969   0.01515152 
+  61           69.072568    54.294257   0.01639344 
+  78           70.502221    54.283567   0.01282051 
+  69           72.376612    54.272899   0.01449275 
+  62           74.220314    54.262253   0.01612903 
+  68           75.213917    54.251628   0.01470588 
+  68           74.654976    54.241025   0.01470588 
+  63           72.770231    54.230445   0.01587302 
+  89           70.465128    54.219885   0.01123596 
+  70           68.456931    54.209348   0.01428571 
+  70           67.051906    54.198832   0.01428571 
+  71           66.321203    54.188338   0.01408451 
+  58           66.232916    54.177865   0.01724138 
+  58           66.686126    54.167414   0.01724138 
+  68           67.482057    54.156984   0.01470588 
+  49           68.23693     54.146576   0.02040816 
+  71           68.466213    54.136189   0.01408451 
+  79           68.00536     54.125823   0.01265823 
+  66           67.198193    54.115479   0.01515152 
+  64           66.498096    54.105156   0.015625  
+  62           66.178817    54.094854   0.01612903 
+  61           66.370825    54.084574   0.01639344 
+  67           67.15391     54.074314   0.01492537 
+  57           68.598254    54.064076   0.01754386 
+  70           70.750792    54.053859   0.01428571 
+  63           73.563402    54.043663   0.01587302 
+  73           76.86182     54.033487   0.01369863 
+  77           80.494877    54.023333   0.01298701 
+  88           84.41923     54.0132     0.01136364 
+  66           88.184391    54.003087   0.01515152 
+  75           90.548072    53.992995   0.01333333 
+  77           90.501117    53.982925   0.01298701 
+  80           88.672124    53.972874   0.0125    
+  79           86.554445    53.962845   0.01265823 
+  88           84.949887    53.952836   0.01136364 
+  71           83.789044    53.942848   0.01408451 
+  61           82.877031    53.93288    0.01639344 
+  83           82.3774      53.922933   0.01204819 
+  63           82.608369    53.913007   0.01587302 
+  83           83.685988    53.903101   0.01204819 
+  75           85.261713    53.893215   0.01333333 
+  76           86.717594    53.88335    0.01315789 
+  80           87.982249    53.873505   0.0125    
+  83           89.782376    53.86368    0.01204819 
+  73           92.786478    53.853876   0.01369863 
+  112          96.897078    53.844092   0.00892857 
+  90           101.165244   53.834328   0.01111111 
+  123          104.260847   53.824584   0.00813008 
+  93           105.248349   53.81486    0.01075269 
+  79           103.796476   53.805156   0.01265823 
+  101          100.193408   53.795473   0.00990099 
+  89           95.734737    53.785809   0.01123596 
+  84           92.007764    53.776165   0.01190476 
+  82           89.961397    53.766541   0.01219512 
+  80           89.922662    53.756937   0.0125    
+  91           91.885579    53.747353   0.01098901 
+  100          95.616207    53.737788   0.01      
+  85           100.680601   53.728244   0.01176471 
+  97           106.714737   53.718719   0.01030928 
+  104          113.856371   53.709213   0.00961538 
+  131          122.79667    53.699728   0.00763359 
+  155          134.758833   53.690261   0.00645161 
+  127          151.015731   53.680815   0.00787402 
+  141          171.520871   53.671387   0.0070922 
+  182          194.255358   53.66198    0.00549451 
+  186          215.931577   53.652591   0.00537634 
+  230          230.897911   53.643222   0.00434783 
+  209          230.581861   53.633873   0.00478469 
+  207          212.941984   53.624542   0.00483092 
+  207          187.341463   53.615231   0.00483092 
+  157          163.98922    53.605939   0.00636943 
+  147          147.69681    53.596666   0.00680272 
+  139          139.498449   53.587413   0.00719424 
+  134          138.600952   53.578178   0.00746269 
+  139          143.057876   53.568963   0.00719424 
+  131          150.279118   53.559766   0.00763359 
+  140          157.355687   53.550589   0.00714286 
+  145          159.983129   53.54143    0.00689655 
+  152          153.773151   53.53229    0.00657895 
+  130          139.76903    53.523169   0.00769231 
+  110          123.479643   53.514067   0.00909091 
+  105          109.02561    53.504984   0.00952381 
+  88           97.775224    53.495919   0.01136364 
+  79           89.653397    53.486873   0.01265823 
+  76           84.075918    53.477846   0.01315789 
+  84           80.365342    53.468837   0.01190476 
+  62           77.926389    53.459847   0.01612903 
+  72           76.291293    53.450875   0.01388889 
+  54           75.118496    53.441922   0.01851852 
+  70           74.243134    53.432987   0.01428571 
+  85           73.71424     53.424071   0.01176471 
+  67           73.719652    53.415173   0.01492537 
+  48           74.55014     53.406293   0.02083333 
+  68           76.677182    53.397432   0.01470588 
+  74           80.825085    53.388589   0.01351351 
+  95           87.883186    53.379764   0.01052632 
+  100          98.521044    53.370957   0.01      
+  126          112.375245   53.362168   0.00793651 
+  147          126.481411   53.353397   0.00680272 
+  117          133.950807   53.344645   0.00854701 
+  149          129.433978   53.33591    0.00671141 
+  112          117.348917   53.327193   0.00892857 
+  111          105.386407   53.318495   0.00900901 
+  104          97.480864    53.309814   0.00961538 
+  95           94.726287    53.301151   0.01052632 
+  89           97.072675    53.292505   0.01123596 
+  103          103.956689   53.283878   0.00970874 
+  110          114.092409   53.275268   0.00909091 
+  128          124.683283   53.266676   0.0078125 
+  140          131.200021   53.258101   0.00714286 
+  114          129.40104    53.249544   0.00877193 
+  145          119.547523   53.241005   0.00689655 
+  105          106.73176    53.232483   0.00952381 
+  88           95.336686    53.223978   0.01136364 
+  79           87.087585    53.215491   0.01265823 
+  64           82.1588      53.207021   0.015625  
+  77           80.053852    53.198569   0.01298701 
+  73           79.987164    53.190134   0.01369863 
+  88           80.901836    53.181716   0.01136364 
+  74           81.374353    53.173316   0.01351351 
+  70           80.169717    53.164932   0.01428571 
+  72           77.300541    53.156566   0.01388889 
+  81           73.753645    53.148217   0.01234568 
+  60           70.352157    53.139885   0.01666667 
+  67           67.464716    53.131569   0.01492537 
+  68           65.196898    53.123271   0.01470588 
+  77           63.512848    53.11499    0.01298701 
+  82           62.311916    53.106726   0.01219512 
+  55           61.48493     53.098478   0.01818182 
+  74           60.941489    53.090248   0.01351351 
+  72           60.617105    53.082034   0.01388889 
+  59           60.46663     53.073837   0.01694915 
+  71           60.449658    53.065656   0.01408451 
+  69           60.505376    53.057493   0.01449275 
+  45           60.533349    53.049345   0.02222222 
+  63           60.438664    53.041215   0.01587302 
+  62           60.227326    53.033101   0.01612903 
+  46           59.991054    53.025003   0.02173913 
+  72           59.809243    53.016922   0.01388889 
+  64           59.719156    53.008857   0.015625  
+  61           59.73737     53.000809   0.01639344 
+  50           59.87266     52.992777   0.02      
+  60           60.127752    52.984761   0.01666667 
+  51           60.498656    52.976762   0.01960784 
+  59           60.967846    52.968779   0.01694915 
+  54           61.502388    52.960811   0.01851852 
+  59           62.090107    52.95286    0.01694915 
+  56           62.786128    52.944926   0.01785714 
+  45           63.70516     52.937007   0.02222222 
+  53           64.988522    52.929104   0.01886792 
+  62           66.817667    52.921217   0.01612903 
+  52           69.446766    52.913346   0.01923077 
+  59           73.215162    52.905491   0.01694915 
+  57           78.530174    52.897652   0.01754386 
+  73           85.815643    52.889828   0.01369863 
+  61           95.413309    52.882021   0.01639344 
+  67           107.205534   52.874229   0.01492537 
+  65           119.779496   52.866452   0.01538462 
+  93           129.476495   52.858692   0.01075269 
+  82           131.629579   52.850947   0.01219512 
+  100          125.233212   52.843217   0.01      
+  98           114.303635   52.835503   0.01020408 
+  87           103.40155    52.827805   0.01149425 
+  75           94.917941    52.820122   0.01333333 
+  78           89.585342    52.812454   0.01282051 
+  69           87.406106    52.804802   0.01449275 
+  69           88.097174    52.797165   0.01449275 
+  85           91.081233    52.789544   0.01176471 
+  83           95.159721    52.781937   0.01204819 
+  69           98.093736    52.774346   0.01449275 
+  89           97.396909    52.76677    0.01123596 
+  92           92.681853    52.759209   0.01086957 
+  97           85.971649    52.751663   0.01030928 
+  88           79.354448    52.744132   0.01136364 
+  59           73.807656    52.736616   0.01694915 
+  58           69.524501    52.729115   0.01724138 
+  69           66.368742    52.721629   0.01449275 
+  79           64.102878    52.714158   0.01265823 
+  57           62.486409    52.706702   0.01754386 
+  63           61.321027    52.699261   0.01587302 
+  59           60.459837    52.691834   0.01694915 
+  76           59.804937    52.684422   0.01315789 
+  58           59.294467    52.677024   0.01724138 
+  60           58.889963    52.669642   0.01666667 
+  59           58.567948    52.662274   0.01694915 
+  51           58.313861    52.65492    0.01960784 
+  67           58.11869     52.647581   0.01492537 
+  67           57.977317    52.640256   0.01492537 
+  51           57.88767     52.632946   0.01960784 
+  64           57.850777    52.62565    0.015625  
+  66           57.871117    52.618369   0.01515152 
+  66           57.95728     52.611102   0.01515152 
+  51           58.121809    52.603849   0.01960784 
+  43           58.380105    52.596611   0.02325581 
+  55           58.747093    52.589386   0.01818182 
+  58           59.229801    52.582176   0.01724138 
+  63           59.810271    52.57498    0.01587302 
+  58           60.413361    52.567798   0.01724138 
+  54           60.892504    52.56063    0.01851852 
+  66           61.125115    52.553475   0.01515152 
+  57           61.154579    52.546335   0.01754386 
+  62           61.133009    52.539209   0.01612903 
+  54           61.170179    52.532097   0.01851852 
+  64           61.299897    52.524998   0.015625  
+  51           61.515598    52.517913   0.01960784 
+  78           61.800404    52.510842   0.01282051 
+  72           62.14373     52.503785   0.01388889 
+  62           62.542818    52.496742   0.01612903 
+  53           62.985611    52.489712   0.01886792 
+  65           63.428544    52.482695   0.01538462 
+  65           64.080078    52.475692   0.01538462 
+  53           64.345388    52.468703   0.01886792 
+  67           64.370976    52.461727   0.01492537 
+  46           64.013517    52.454765   0.02173913 
+  71           63.321914    52.447815   0.01408451 
+  65           62.523886    52.44088    0.01538462 
+  64           61.804774    52.433957   0.015625  
+  54           61.239029    52.427048   0.01851852 
+  67           60.836144    52.420152   0.01492537 
+  71           60.577509    52.413269   0.01408451 
+  59           60.427943    52.4064     0.01694915 
+  55           60.346408    52.399543   0.01818182 
+  64           60.286045    52.3927     0.015625  
+  69           60.298969    52.385869   0.01449275 
+  84           60.023937    52.379052   0.01190476 
+  68           59.605475    52.372247   0.01470588 
+  72           59.156166    52.365456   0.01388889 
+  84           58.776663    52.358677   0.01190476 
+  73           58.512245    52.351911   0.01369863 
+  95           58.37441     52.345158   0.01052632 
+  91           58.361996    52.338417   0.01098901 
+  87           58.470906    52.33169    0.01149425 
+  86           58.703863    52.324975   0.01162791 
+  87           59.077971    52.318272   0.01149425 
+  95           59.604962    52.311582   0.01052632 
+  83           60.246509    52.304905   0.01204819 
+  88           60.855115    52.29824    0.01136364 
+  82           61.178296    52.291588   0.01219512 
+  87           61.057089    52.284948   0.01149425 
+  85           60.622102    52.278321   0.01176471 
+  78           60.143688    52.271705   0.01282051 
+  82           59.812411    52.265102   0.01219512 
+  90           59.717779    52.258512   0.01111111 
+  70           59.906597    52.251933   0.01428571 
+  83           60.422458    52.245367   0.01204819 
+  81           61.320702    52.238813   0.01234568 
+  79           62.660744    52.232271   0.01265823 
+  110          64.472742    52.225741   0.00909091 
+  90           66.720587    52.219223   0.01111111 
+  99           69.322603    52.212717   0.01010101 
+  82           72.114758    52.206223   0.01219512 
+  82           74.593389    52.199741   0.01219512 
+  101          75.884269    52.193271   0.00990099 
+  93           75.418856    52.186813   0.01075269 
+  84           73.456365    52.180366   0.01190476 
+  83           70.806087    52.173931   0.01204819 
+  67           68.305576    52.167508   0.01492537 
+  81           66.467897    52.161097   0.01234568 
+  76           65.485615    52.154697   0.01315789 
+  80           65.380209    52.148308   0.0125    
+  69           66.085505    52.141932   0.01449275 
+  83           67.424705    52.135566   0.01204819 
+  54           69.008364    52.129213   0.01851852 
+  85           70.196636    52.12287    0.01176471 
+  96           70.400477    52.116539   0.01041667 
+  77           69.528124    52.110219   0.01298701 
+  65           68.030136    52.103911   0.01538462 
+  65           66.502043    52.097614   0.01538462 
+  57           65.268685    52.091328   0.01754386 
+  50           64.305592    52.085053   0.02      
+  62           63.434204    52.07879    0.01612903 
+  67           62.598682    52.072537   0.01492537 
+  70           61.906933    52.066296   0.01428571 
+  75           61.449485    52.060066   0.01333333 
+  53           61.212801    52.053846   0.01886792 
+  48           61.096959    52.047638   0.02083333 
+  69           61.002667    52.04144    0.01449275 
+  57           60.934146    52.035254   0.01754386 
+  66           60.969861    52.029078   0.01515152 
+  63           61.155787    52.022913   0.01587302 
+  57           61.465631    52.016759   0.01754386 
+  75           61.846961    52.010615   0.01333333 
+  66           62.333959    52.004482   0.01515152 
+  98           63.091045    51.99836    0.01020408 
+  71           64.324025    51.992248   0.01408451 
+  74           66.206046    51.986147   0.01351351 
+  92           68.839139    51.980056   0.01086957 
+  92           72.169442    51.973976   0.01086957 
+  106          75.776623    51.967906   0.00943396 
+  101          78.607246    51.961847   0.00990099 
+  129          79.309304    51.955798   0.00775194 
+  145          77.5497      51.949759   0.00689655 
+  172          74.445696    51.94373    0.00581395 
+  162          71.309391    51.937712   0.00617284 
+  164          68.842769    51.931704   0.00609756 
+  205          67.268558    51.925706   0.00487805 
+  206          66.598878    51.919719   0.00485437 
+  203          66.764042    51.913741   0.00492611 
+  201          67.63749     51.907773   0.00497512 
+  204          68.96758     51.901815   0.00490196 
+  185          70.243844    51.895868   0.00540541 
+  142          70.725492    51.88993    0.00704225 
+  139          69.995739    51.884002   0.00719424 
+  147          68.420608    51.878084   0.00680272 
+  125          66.671147    51.872175   0.008     
+  160          65.163543    51.866277   0.00625   
+  149          64.029607    51.860388   0.00671141 
+  139          63.26081     51.854509   0.00719424 
+  140          62.799285    51.848639   0.00714286 
+  121          62.583672    51.842779   0.00826446 
+  121          62.559373    51.836929   0.00826446 
+  115          62.690528    51.831088   0.00869565 
+  97           62.958958    51.825256   0.01030928 
+  106          63.359538    51.819434   0.00943396 
+  101          63.89251     51.813622   0.00990099 
+  56           64.551811    51.807819   0.01785714 
+  90           65.301578    51.802025   0.01111111 
+  73           66.046243    51.79624    0.01369863 
+  87           66.643643    51.790465   0.01149425 
+  77           67.032381    51.784699   0.01298701 
+  55           67.311433    51.778942   0.01818182 
+  64           67.630505    51.773194   0.015625  
+  70           68.083636    51.767455   0.01428571 
+  61           68.709534    51.761725   0.01639344 
+  61           69.522973    51.756004   0.01639344 
+  82           70.53022     51.750292   0.01219512 
+  49           71.735659    51.74459    0.02040816 
+  67           73.13473     51.738896   0.01492537 
+  73           74.704763    51.73321    0.01369863 
+  66           76.397156    51.727534   0.01515152 
+  76           78.182409    51.721867   0.01315789 
+  87           80.115282    51.716208   0.01149425 
+  79           82.309703    51.710558   0.01265823 
+  97           84.875422    51.704916   0.01030928 
+  85           87.903232    51.699283   0.01176471 
+  107          91.480149    51.693659   0.00934579 
+  101          95.708995    51.688043   0.00990099 
+  125          100.713065   51.682436   0.008     
+  150          106.635272   51.676837   0.00666667 
+  177          113.618459   51.671246   0.00564972 
+  177          121.774157   51.665664   0.00564972 
+  153          131.151617   51.660091   0.00653595 
+  161          141.689349   51.654525   0.00621118 
+  187          153.026053   51.648968   0.00534759 
+  156          164.320368   51.643419   0.00641026 
+  166          174.583586   51.637878   0.0060241 
+  179          183.252915   51.632346   0.00558659 
+  158          190.008668   51.626821   0.00632911 
+  191          194.335137   51.621305   0.0052356 
+  181          195.753649   51.615796   0.00552486 
+  192          194.413326   51.610296   0.00520833 
+  207          191.376625   51.604803   0.00483092 
+  215          188.174749   51.599319   0.00465116 
+  198          185.979728   51.593842   0.00505051 
+  201          185.202663   51.588373   0.00497512 
+  218          185.414355   51.582912   0.00458716 
+  190          185.648121   51.577459   0.00526316 
+  193          185.305615   51.572013   0.00518135 
+  185          184.533939   51.566575   0.00540541 
+  180          183.521877   51.561145   0.00555556 
+  197          182.083615   51.555722   0.00507614 
+  162          179.953456   51.550307   0.00617284 
+  164          177.110584   51.544899   0.00609756 
+  152          173.772733   51.539499   0.00657895 
+  164          169.931495   51.534106   0.00609756 
+  162          165.428399   51.528721   0.00617284 
+  140          159.922218   51.523343   0.00714286 
+  133          153.509762   51.517972   0.0075188 
+  158          146.558558   51.512609   0.00632911 
+  145          139.604495   51.507253   0.00689655 
+  114          133.180656   51.501904   0.00877193 
+  103          127.606907   51.496562   0.00970874 
+  119          122.966923   51.491227   0.00840336 
+  122          119.143524   51.4859     0.00819672 
+  105          116.001682   51.480579   0.00952381 
+  86           113.20132    51.475266   0.01162791 
+  96           110.351704   51.469959   0.01041667 
+  78           107.113728   51.46466    0.01282051 
+  98           103.428817   51.459367   0.01020408 
+  95           99.504133    51.454081   0.01052632 
+  81           95.583718    51.448802   0.01234568 
+  92           91.836751    51.44353    0.01086957 
+  70           88.357557    51.438264   0.01428571 
+  71           85.192316    51.433006   0.01408451 
+  70           82.350771    51.427753   0.01428571 
+  69           79.820789    51.422508   0.01449275 
+  100          77.578974    51.417269   0.01      
+  79           75.596136    51.412037   0.01265823 
+  76           73.844038    51.406811   0.01315789 
+  72           72.295777    51.401591   0.01388889 
+  70           70.926968    51.396378   0.01428571 
+  70           69.715923    51.391172   0.01428571 
+  72           68.643625    51.385972   0.01388889 
+  51           67.693842    51.380778   0.01960784 
+  71           66.852339    51.37559    0.01408451 
+  73           66.107011    51.370409   0.01369863 
+  58           65.447645    51.365234   0.01724138 
+  64           64.864867    51.360065   0.015625  
+  51           64.349368    51.354902   0.01960784 
+  63           63.891806    51.349745   0.01587302 
+  63           63.485139    51.344594   0.01587302 
+  61           63.127461    51.339449   0.01639344 
+  74           62.822117    51.334311   0.01351351 
+  63           62.574485    51.329178   0.01587302 
+  51           62.394058    51.324051   0.01960784 
+  65           62.290708    51.31893    0.01538462 
+  71           62.283877    51.313815   0.01408451 
+  57           62.395802    51.308705   0.01754386 
+  70           62.64918     51.303601   0.01428571 
+  63           63.057746    51.298503   0.01587302 
+  71           63.60452     51.293411   0.01408451 
+  58           64.200175    51.288324   0.01724138 
+  62           64.662414    51.283243   0.01612903 
+  66           64.833687    51.278168   0.01515152 
+  64           64.768822    51.273097   0.015625  
+  66           64.660163    51.268033   0.01515152 
+  57           64.604607    51.262974   0.01754386 
+  67           64.52836     51.25792    0.01492537 
+  64           64.315259    51.252871   0.015625  
+  58           63.992286    51.247828   0.01724138 
+  69           63.707412    51.242791   0.01449275 
+  63           63.568497    51.237758   0.01587302 
+  71           63.590162    51.232731   0.01408451 
+  74           63.699373    51.227708   0.01351351 
+  64           63.772309    51.222691   0.015625  
+  88           63.734981    51.217679   0.01136364 
+  68           63.632847    51.212673   0.01470588 
+  79           63.547169    51.207671   0.01265823 
+  68           63.493331    51.202674   0.01470588 
+  82           63.417836    51.197682   0.01219512 
+  63           63.282453    51.192695   0.01587302 
+  73           63.132248    51.187713   0.01369863 
+  71           63.046936    51.182735   0.01408451 
+  69           63.076321    51.177763   0.01449275 
+  65           63.237725    51.172795   0.01538462 
+  74           63.535017    51.167832   0.01351351 
+  80           63.971116    51.162873   0.0125    
+  51           64.554114    51.157919   0.01960784 
+  70           65.299954    51.15297    0.01428571 
+  70           66.232653    51.148026   0.01428571 
+  82           67.382416    51.143086   0.01219512 
+  85           68.782312    51.13815    0.01176471 
+  77           70.463584    51.133219   0.01298701 
+  78           72.44916     51.128292   0.01282051 
+  81           74.741863    51.12337    0.01234568 
+  85           77.298957    51.118452   0.01176471 
+  96           80.001351    51.113538   0.01041667 
+  90           82.620248    51.108628   0.01111111 
+  84           84.843103    51.103723   0.01190476 
+  106          86.408794    51.098822   0.00943396 
+  98           87.301914    51.093925   0.01020408 
+  91           87.816404    51.089033   0.01098901 
+  95           88.370724    51.084144   0.01052632 
+  73           89.170259    51.079259   0.01369863 
+  89           89.893044    51.074378   0.01123596 
+  87           89.742958    51.069502   0.01149425 
+  98           88.25876     51.064629   0.01020408 
+  81           85.939295    51.05976    0.01234568 
+  81           83.593031    51.054895   0.01234568 
+  82           81.622891    51.050034   0.01219512 
+  86           80.025152    51.045176   0.01162791 
+  69           78.655103    51.040323   0.01449275 
+  82           77.44052     51.035473   0.01219512 
+  74           76.441829    51.030626   0.01351351 
+  77           75.759434    51.025784   0.01298701 
+  73           75.371884    51.020945   0.01369863 
+  59           74.997822    51.016109   0.01694915 
+  70           74.199572    51.011277   0.01428571 
+  66           72.826684    51.006448   0.01515152 
+  73           71.181331    51.001623   0.01369863 
+  62           69.630664    50.996801   0.01612903 
+  71           68.196514    50.991983   0.01408451 
+  66           66.913775    50.987168   0.01515152 
+  62           65.833795    50.982356   0.01612903 
+  84           65.018202    50.977548   0.01190476 
+  68           64.477692    50.972743   0.01470588 
+  61           64.183655    50.967941   0.01639344 
+  75           64.094378    50.963142   0.01333333 
+  63           64.167046    50.958346   0.01587302 
+  76           64.359463    50.953553   0.01315789 
+  56           64.626614    50.948763   0.01785714 
+  67           64.915098    50.943977   0.01492537 
+  59           65.156539    50.939193   0.01694915 
+  75           65.289442    50.934412   0.01333333 
+  63           65.335077    50.929634   0.01587302 
+  63           65.34072     50.924859   0.01587302 
+  65           65.433771    50.920087   0.01538462 
+  76           65.707185    50.915317   0.01315789 
+  78           66.239853    50.91055    0.01282051 
+  74           67.098837    50.905786   0.01351351 
+  68           68.328472    50.901025   0.01470588 
+  74           69.915125    50.896266   0.01351351 
+  56           71.696348    50.89151    0.01785714 
+  81           73.354478    50.886756   0.01234568 
+  63           74.591933    50.882005   0.01587302 
+  76           75.375599    50.877257   0.01315789 
+  80           75.8362      50.872511   0.0125    
+  80           76.260751    50.867767   0.0125    
+  98           77.252872    50.863025   0.01020408 
+  83           79.543487    50.858286   0.01204819 
+  71           83.720043    50.85355    0.01408451 
+  81           90.081762    50.848815   0.01234568 
+  84           98.388812    50.844083   0.01190476 
+  98           107.17507    50.839353   0.01020408 
+  96           113.109473   50.834625   0.01041667 
+  87           112.810727   50.829899   0.01149425 
+  95           106.768967   50.825176   0.01052632 
+  89           98.57665     50.820454   0.01123596 
+  68           91.029782    50.815734   0.01470588 
+  76           85.283949    50.811017   0.01315789 
+  75           81.724928    50.806301   0.01333333 
+  79           80.443583    50.801587   0.01265823 
+  76           81.359701    50.796875   0.01315789 
+  93           84.249326    50.792165   0.01075269 
+  80           88.58114     50.787457   0.0125    
+  96           93.127774    50.78275    0.01041667 
+  87           95.861969    50.778045   0.01149425 
+  75           95.320691    50.773342   0.01333333 
+  73           92.371926    50.768641   0.01369863 
+  81           89.120852    50.763941   0.01234568 
+  92           86.763606    50.759242   0.01086957 
+  74           85.146256    50.754546   0.01351351 
+  80           83.343083    50.74985    0.0125    
+  60           80.764009    50.745157   0.01666667 
+  59           77.794456    50.740464   0.01694915 
+  79           75.133607    50.735773   0.01265823 
+  68           73.105054    50.731084   0.01470588 
+  83           71.637848    50.726395   0.01204819 
+  67           70.539308    50.721708   0.01492537 
+  70           69.767645    50.717023   0.01428571 
+  74           69.428154    50.712338   0.01351351 
+  74           69.576249    50.707655   0.01351351 
+  73           70.094267    50.702973   0.01369863 
+  56           70.631383    50.698292   0.01785714 
+  71           70.689898    50.693612   0.01408451 
+  49           70.041782    50.688933   0.02040816 
+  61           68.975441    50.684255   0.01639344 
+  55           67.937521    50.679578   0.01818182 
+  61           67.207535    50.674902   0.01639344 
+  70           66.912639    50.670226   0.01428571 
+  64           67.131133    50.665552   0.015625  
+  76           67.950616    50.660879   0.01315789 
+  66           69.478536    50.656206   0.01515152 
+  70           71.811093    50.651534   0.01428571 
+  68           74.94583     50.646863   0.01470588 
+  69           78.573686    50.642193   0.01449275 
+  71           81.733689    50.637523   0.01408451 
+  57           82.8958      50.632853   0.01754386 
+  68           81.379762    50.628185   0.01470588 
+  61           78.263629    50.623517   0.01639344 
+  60           75.019763    50.618849   0.01666667 
+  80           72.428132    50.614182   0.0125    
+  62           70.712516    50.609515   0.01612903 
+  75           69.868048    50.604849   0.01333333 
+  64           69.823761    50.600183   0.015625  
+  71           70.497625    50.595518   0.01408451 
+  75           71.785819    50.590852   0.01333333 
+  52           73.472257    50.586187   0.01923077 
+  66           75.052463    50.581523   0.01515152 
+  70           75.739645    50.576858   0.01428571 
+  68           75.134997    50.572194   0.01470588 
+  67           73.735418    50.567529   0.01492537 
+  55           72.280963    50.562865   0.01818182 
+  58           71.170767    50.558201   0.01724138 
+  55           70.501187    50.553537   0.01818182 
+  52           70.220014    50.548873   0.01923077 
+  64           70.197209    50.544209   0.015625  
+  71           70.275407    50.539544   0.01408451 
+  74           70.360743    50.53488    0.01351351 
+  70           70.470626    50.530216   0.01428571 
+  67           70.665038    50.525551   0.01492537 
+  75           70.982511    50.520886   0.01333333 
+  73           71.432821    50.516221   0.01369863 
+  75           72.005113    50.511555   0.01333333 
+  55           72.665457    50.50689    0.01818182 
+  70           73.35446     50.502223   0.01428571 
+  71           74.019094    50.497557   0.01408451 
+  72           74.657644    50.49289    0.01388889 
+  67           75.293653    50.488222   0.01492537 
+  93           75.927072    50.483554   0.01075269 
+  68           76.552973    50.478886   0.01470588 
+  86           77.201128    50.474217   0.01162791 
+  67           77.910853    50.469547   0.01492537 
+  69           78.706415    50.464877   0.01449275 
+  81           79.595324    50.460206   0.01234568 
+  76           80.575866    50.455534   0.01315789 
+  70           81.636643    50.450862   0.01428571 
+  78           82.755       50.446189   0.01282051 
+  81           83.909678    50.441515   0.01234568 
+  83           85.107667    50.43684    0.01204819 
+  87           86.381391    50.432165   0.01149425 
+  90           87.764535    50.427488   0.01111111 
+  72           89.280695    50.422811   0.01388889 
+  80           90.949665    50.418132   0.0125    
+  97           92.791347    50.413453   0.01030928 
+  91           94.826595    50.408772   0.01098901 
+  101          97.075094    50.40409    0.00990099 
+  105          99.55475     50.399408   0.00952381 
+  94           102.27579    50.394724   0.0106383 
+  104          105.221839   50.390039   0.00961538 
+  111          108.309457   50.385353   0.00900901 
+  111          111.409042   50.380665   0.00900901 
+  123          114.492097   50.375976   0.00813008 
+  109          117.708064   50.371286   0.00917431 
+  155          121.254548   50.366595   0.00645161 
+  153          125.27015    50.361902   0.00653595 
+  162          129.841802   50.357208   0.00617284 
+  167          135.038537   50.352512   0.00598802 
+  150          140.931045   50.347815   0.00666667 
+  182          147.603595   50.343117   0.00549451 
+  176          155.152149   50.338416   0.00568182 
+  196          163.693213   50.333715   0.00510204 
+  200          173.343454   50.329011   0.005     
+  170          184.223876   50.324306   0.00588235 
+  198          196.530344   50.3196     0.00505051 
+  219          210.595521   50.314891   0.00456621 
+  184          226.855      50.310181   0.00543478 
+  196          245.83312    50.305469   0.00510204 
+  233          268.221052   50.300755   0.00429185 
+  247          294.942403   50.29604    0.00404858 
+  292          327.201034   50.291322   0.00342466 
+  338          366.609147   50.286603   0.00295858 
+  384          415.344767   50.281882   0.00260417 
+  420          476.619023   50.277158   0.00238095 
+  523          555.515221   50.272433   0.00191205 
+  643          661.155045   50.267706   0.00155521 
+  801          811.40343    50.262976   0.00124844 
+  1098         1041.00792   50.258245   0.00091075 
+  1461         1411.323701  50.253511   0.00068446 
+  2183         2013.432576  50.248775   0.00045809 
+  3050         2950.670962  50.244037   0.00032787 
+  4253         4287.687371  50.239297   0.00023513 
+  5610         5945.68564   50.234555   0.00017825 
+  6917         7497.252914  50.22981    0.00014457 
+  7395         8081.764673  50.225063   0.00013523 
+  6775         7250.174558  50.220313   0.0001476 
+  5358         5661.810421  50.215561   0.00018664 
+  3764         4114.437726  50.210807   0.00026567 
+  2861         2943.156137  50.20605    0.00034953 
+  2253         2195.325625  50.201291   0.00044385 
+  1880         1817.233269  50.196529   0.00053191 
+  1816         1746.485518  50.191765   0.00055066 
+  2078         1949.80734   50.186998   0.00048123 
+  2491         2415.165965  50.182228   0.00040145 
+  3126         3104.389563  50.177456   0.0003199 
+  3594         3857.751253  50.172681   0.00027824 
+  3841         4289.388006  50.167903   0.00026035 
+  3584         4031.461798  50.163123   0.00027902 
+  3136         3255.511962  50.158339   0.00031888 
+  2334         2397.135277  50.153553   0.00042845 
+  1593         1692.077306  50.148764   0.00062775 
+  1193         1190.303085  50.143973   0.00083822 
+  841          862.902135   50.139178   0.00118906 
+  610          658.204343   50.13438    0.00163934 
+  522          529.150664   50.12958    0.00191571 
+  406          443.37617    50.124776   0.00246305 
+  352          382.278812   50.11997    0.00284091 
+  273          336.168559   50.11516    0.003663  
+  275          300.009169   50.110347   0.00363636 
+  278          271.00025    50.105531   0.00359712 
+  227          247.341405   50.100712   0.00440529 
+  217          227.790702   50.09589    0.00460829 
+  201          211.413028   50.091064   0.00497512 
+  164          197.463701   50.086235   0.00609756 
+  167          185.339835   50.081403   0.00598802 
+  171          174.588233   50.076568   0.00584795 
+  144          164.925685   50.071729   0.00694444 
+  149          156.214193   50.066887   0.00671141 
+  131          148.393564   50.062041   0.00763359 
+  142          141.419448   50.057192   0.00704225 
+  106          135.234489   50.05234    0.00943396 
+  107          129.770011   50.047484   0.00934579 
+  111          124.951752   50.042624   0.00900901 
+  127          120.697959   50.037761   0.00787402 
+  103          116.920689   50.032894   0.00970874 
+  96           113.520144   50.028024   0.01041667 
+  89           110.387806   50.02315    0.01123596 
+  97           107.4251     50.018272   0.01030928 
+  105          104.569838   50.013391   0.00952381 
+  93           101.813851   50.008506   0.01075269 
+  100          99.183963    50.003617   0.01      
+  93           96.714279    49.998724   0.01075269 
+  103          94.422618    49.993827   0.00970874 
+  84           92.308847    49.988927   0.01190476 
+  88           90.362069    49.984022   0.01136364 
+  91           88.56733     49.979114   0.01098901 
+  82           86.91085     49.974201   0.01219512 
+  86           85.381352    49.969285   0.01162791 
+  84           83.96933     49.964365   0.01190476 
+  81           82.665296    49.95944    0.01234568 
+  96           81.460309    49.954512   0.01041667 
+  75           80.343126    49.949579   0.01333333 
+  72           79.304797    49.944642   0.01388889 
+  86           78.339539    49.939701   0.01162791 
+  85           77.441822    49.934756   0.01176471 
+  69           76.605445    49.929807   0.01449275 
+  80           75.823692    49.924853   0.0125    
+  85           75.090533    49.919895   0.01176471 
+  76           74.402031    49.914933   0.01315789 
+  56           73.756398    49.909966   0.01785714 
+  51           73.153628    49.904995   0.01960784 
+  76           72.594507    49.900019   0.01315789 
+  75           72.079876    49.895039   0.01333333 
+  64           71.610657    49.890055   0.015625  
+  60           71.18689     49.885066   0.01666667 
+  66           70.808417    49.880072   0.01515152 
+  74           70.475       49.875074   0.01351351 
+  73           70.186643    49.870071   0.01369863 
+  66           69.943187    49.865064   0.01515152 
+  69           69.743993    49.860052   0.01449275 
+  71           69.588189    49.855035   0.01408451 
+  82           69.475085    49.850014   0.01219512 
+  49           69.40547     49.844988   0.02040816 
+  62           69.383066    49.839957   0.01612903 
+  80           69.416757    49.834921   0.0125    
+  67           69.518448    49.829881   0.01492537 
+  83           69.716358    49.824835   0.01204819 
+  81           70.037133    49.819785   0.01234568 
+  66           70.515152    49.81473    0.01515152 
+  72           71.184526    49.80967    0.01388889 
+  71           72.065184    49.804605   0.01408451 
+  85           73.138131    49.799534   0.01176471 
+  81           74.29299     49.794459   0.01234568 
+  75           75.259783    49.789379   0.01333333 
+  67           75.679563    49.784294   0.01492537 
+  68           75.504618    49.779203   0.01470588 
+  75           74.828439    49.774107   0.01333333 
+  58           74.016721    49.769007   0.01724138 
+  78           73.254336    49.763901   0.01282051 
+  65           72.637618    49.758789   0.01538462 
+  86           72.216382    49.753673   0.01162791 
+  76           72.017755    49.748551   0.01315789 
+  84           72.05478     49.743424   0.01190476 
+  67           72.323413    49.738291   0.01492537 
+  75           72.785303    49.733153   0.01333333 
+  64           73.338166    49.72801    0.015625  
+  59           73.801301    49.722861   0.01694915 
+  84           74.012336    49.717707   0.01190476 
+  80           73.977558    49.712547   0.0125    
+  80           73.852941    49.707382   0.0125    
+  89           73.651331    49.702212   0.01123596 
+  88           73.426444    49.697035   0.01136364 
+  67           73.16082     49.691853   0.01492537 
+  63           72.833304    49.686666   0.01587302 
+  66           72.437115    49.681472   0.01515152 
+  63           71.986373    49.676273   0.01587302 
+  66           71.513718    49.671069   0.01515152 
+  65           71.056963    49.665858   0.01538462 
+  78           70.652926    49.660642   0.01282051 
+  73           70.332344    49.65542    0.01369863 
+  82           70.118729    49.650193   0.01219512 
+  71           70.022777    49.644959   0.01408451 
+  81           70.041659    49.639719   0.01234568 
+  79           70.163121    49.634474   0.01265823 
+  77           70.370633    49.629223   0.01298701 
+  62           70.65151     49.623965   0.01612903 
+  64           71.003806    49.618702   0.015625  
+  61           71.440711    49.613433   0.01639344 
+  81           71.990873    49.608157   0.01234568 
+  81           72.693648    49.602876   0.01234568 
+  79           73.588813    49.597588   0.01265823 
+  76           74.704942    49.592295   0.01315789 
+  88           76.04448     49.586995   0.01136364 
+  86           77.56483     49.581689   0.01162791 
+  77           79.135367    49.576377   0.01298701 
+  78           80.517875    49.571058   0.01282051 
+  86           81.47389     49.565733   0.01162791 
+  67           81.98743     49.560402   0.01492537 
+  65           82.273025    49.555065   0.01538462 
+  91           82.551355    49.549721   0.01098901 
+  75           82.898655    49.544371   0.01333333 
+  96           83.17749     49.539015   0.01041667 
+  76           83.049473    49.533652   0.01315789 
+  109          82.260284    49.528283   0.00917431 
+  92           80.972913    49.522907   0.01086957 
+  79           79.587194    49.517525   0.01265823 
+  83           78.371012    49.512136   0.01204819 
+  81           77.369574    49.506741   0.01234568 
+  96           76.477792    49.501339   0.01041667 
+  78           75.577484    49.495931   0.01282051 
+  99           74.665212    49.490515   0.01010101 
+  72           73.8238      49.485094   0.01388889 
+  81           73.115597    49.479665   0.01234568 
+  84           72.526183    49.47423    0.01190476 
+  66           71.935735    49.468788   0.01515152 
+  74           71.150561    49.463339   0.01351351 
+  73           70.078935    49.457884   0.01369863 
+  77           68.852944    49.452422   0.01298701 
+  61           67.688235    49.446953   0.01639344 
+  55           66.737185    49.441477   0.01818182 
+  63           66.086917    49.435994   0.01587302 
+  82           65.796461    49.430504   0.01219512 
+  73           65.92229     49.425008   0.01369863 
+  65           66.513867    49.419504   0.01538462 
+  76           67.589687    49.413993   0.01315789 
+  71           69.07202     49.408476   0.01408451 
+  70           70.653428    49.402951   0.01428571 
+  84           71.689869    49.397419   0.01190476 
+  64           71.510443    49.391881   0.015625  
+  47           70.116142    49.386335   0.0212766 
+  62           68.185889    49.380782   0.01612903 
+  65           66.382256    49.375221   0.01538462 
+  59           65.043124    49.369654   0.01694915 
+  54           64.289608    49.364079   0.01851852 
+  62           64.164497    49.358498   0.01612903 
+  53           64.69113     49.352908   0.01886792 
+  64           65.882539    49.347312   0.015625  
+  73           67.713665    49.341708   0.01369863 
+  53           70.019674    49.336097   0.01886792 
+  72           72.308323    49.330479   0.01388889 
+  83           73.669718    49.324853   0.01204819 
+  60           73.315727    49.31922    0.01666667 
+  58           71.4376      49.313579   0.01724138 
+  58           68.960126    49.307931   0.01724138 
+  67           66.651335    49.302276   0.01492537 
+  70           64.857981    49.296613   0.01428571 
+  64           63.677938    49.290942   0.015625  
+  54           63.111972    49.285264   0.01851852 
+  62           63.133303    49.279578   0.01612903 
+  70           63.707476    49.273885   0.01428571 
+  56           64.775232    49.268184   0.01785714 
+  77           66.187099    49.262476   0.01298701 
+  58           67.570306    49.256759   0.01724138 
+  50           68.290032    49.251035   0.02      
+  64           67.850969    49.245304   0.015625  
+  48           66.437543    49.239564   0.02083333 
+  46           64.676326    49.233817   0.02173913 
+  62           63.050613    49.228062   0.01612903 
+  52           61.760373    49.2223     0.01923077 
+  56           60.844389    49.216529   0.01785714 
+  59           60.277499    49.210751   0.01694915 
+  45           60.016319    49.204964   0.02222222 
+  55           60.017179    49.19917    0.01818182 
+  71           60.237173    49.193368   0.01408451 
+  57           60.617256    49.187558   0.01754386 
+  58           61.044244    49.18174    0.01724138 
+  72           61.344297    49.175914   0.01388889 
+  51           61.392757    49.17008    0.01960784 
+  62           61.252955    49.164238   0.01612903 
+  50           61.097558    49.158387   0.02      
+  64           61.050622    49.152529   0.015625  
+  61           61.157597    49.146663   0.01639344 
+  54           61.405597    49.140788   0.01851852 
+  58           61.727968    49.134906   0.01724138 
+  54           62.041699    49.129015   0.01851852 
+  46           62.34271     49.123116   0.02173913 
+  54           62.726932    49.117209   0.01851852 
+  49           63.308042    49.111293   0.02040816 
+  42           64.169842    49.10537    0.02380952 
+  63           65.368874    49.099438   0.01587302 
+  59           66.930592    49.093497   0.01694915 
+  64           68.827431    49.087549   0.015625  
+  68           70.997568    49.081592   0.01470588 
+  77           73.436766    49.075626   0.01298701 
+  55           76.177856    49.069653   0.01818182 
+  70           79.020491    49.06367    0.01428571 
+  95           81.334734    49.05768    0.01052632 
+  71           82.448274    49.051681   0.01408451 
+  71           82.422473    49.045673   0.01408451 
+  85           81.948171    49.039657   0.01176471 
+  80           81.574264    49.033633   0.0125    
+  77           81.459257    49.0276     0.01298701 
+  71           81.460753    49.021558   0.01408451 
+  79           81.262464    49.015508   0.01265823 
+  80           80.786017    49.009449   0.0125    
+  102          80.348945    49.003381   0.00980392 
+  80           80.328143    48.997305   0.0125    
+  80           80.917872    48.991221   0.0125    
+  96           82.053944    48.985127   0.01041667 
+  82           83.410755    48.979025   0.01219512 
+  79           84.628809    48.972914   0.01265823 
+  84           85.704792    48.966794   0.01190476 
+  81           86.947374    48.960666   0.01234568 
+  79           88.610686    48.954529   0.01265823 
+  79           90.785515    48.948383   0.01265823 
+  90           93.460008    48.942228   0.01111111 
+  85           96.606231    48.936064   0.01176471 
+  88           100.380874   48.929891   0.01136364 
+  101          105.219513   48.92371    0.00990099 
+  128          111.683537   48.91752    0.0078125 
+  134          120.431101   48.91132    0.00746269 
+  128          132.442904   48.905112   0.0078125 
+  156          149.529196   48.898895   0.00641026 
+  173          175.218391   48.892668   0.00578035 
+  225          215.994048   48.886433   0.00444444 
+  295          282.168032   48.880189   0.00338983 
+  382          386.841783   48.873936   0.0026178 
+  498          541.262598   48.867673   0.00200803 
+  808          744.950262   48.861402   0.00123762 
+  1127         964.750417   48.855121   0.00088731 
+  1402         1108.290808  48.848831   0.00071327 
+  1445         1074.536142  48.842532   0.00069204 
+  1149         893.347817   48.836224   0.00087032 
+  791          678.627734   48.829907   0.00126422 
+  574          499.3622     48.823581   0.00174216 
+  416          373.80811    48.817245   0.00240385 
+  379          298.118724   48.8109     0.00263852 
+  305          262.5736     48.804546   0.00327869 
+  276          259.744113   48.798182   0.00362319 
+  344          287.261083   48.79181    0.00290698 
+  381          345.851546   48.785428   0.00262467 
+  459          433.698871   48.779036   0.00217865 
+  626          535.709625   48.772635   0.00159744 
+  739          608.790742   48.766225   0.00135318 
+  765          598.434953   48.759806   0.00130719 
+  666          509.379083   48.753377   0.0015015 
+  509          397.537806   48.746939   0.00196464 
+  369          301.084279   48.740491   0.00271003 
+  269          230.835671   48.734033   0.00371747 
+  224          184.494128   48.727567   0.00446429 
+  186          155.171575   48.72109    0.00537634 
+  149          135.827763   48.714605   0.00671141 
+  125          121.67774    48.708109   0.008     
+  110          110.536713   48.701605   0.00909091 
+  91           101.649179   48.69509    0.01098901 
+  76           94.638702    48.688566   0.01315789 
+  96           89.200368    48.682033   0.01041667 
+  81           85.062411    48.675489   0.01234568 
+  73           82.001027    48.668936   0.01369863 
+  82           79.833725    48.662374   0.01219512 
+  87           78.396825    48.655802   0.01149425 
+  71           77.506481    48.64922    0.01408451 
+  78           76.910198    48.642628   0.01282051 
+  68           76.245147    48.636027   0.01470588 
+  77           75.11235     48.629416   0.01298701 
+  74           73.361884    48.622795   0.01351351 
+  69           71.241518    48.616164   0.01449275 
+  56           69.127147    48.609524   0.01785714 
+  60           67.248846    48.602874   0.01666667 
+  69           65.678052    48.596214   0.01449275 
+  59           64.403792    48.589544   0.01694915 
+  72           63.384168    48.582864   0.01388889 
+  56           62.567994    48.576175   0.01785714 
+  69           61.919539    48.569475   0.01449275 
+  69           61.404055    48.562766   0.01449275 
+  66           61.003503    48.556046   0.01515152 
+  47           60.70882     48.549317   0.0212766 
+  55           60.52529     48.542578   0.01818182 
+  53           60.466216    48.535829   0.01886792 
+  48           60.550016    48.529069   0.02083333 
+  66           60.793489    48.5223     0.01515152 
+  69           61.199454    48.515521   0.01449275 
+  57           61.733029    48.508732   0.01754386 
+  71           62.254986    48.501933   0.01408451 
+  63           62.499018    48.495123   0.01587302 
+  63           62.227998    48.488304   0.01587302 
+  58           61.493145    48.481474   0.01724138 
+  58           60.57409     48.474635   0.01724138 
+  64           59.709246    48.467785   0.015625  
+  64           59.007527    48.460925   0.015625  
+  49           58.49394     48.454055   0.02040816 
+  55           58.165043    48.447175   0.01818182 
+  50           58.005014    48.440285   0.02      
+  59           58.007948    48.433384   0.01694915 
+  67           58.156434    48.426473   0.01492537 
+  60           58.422365    48.419552   0.01666667 
+  48           58.749739    48.412621   0.02083333 
+  60           59.014615    48.405679   0.01666667 
+  55           59.078064    48.398728   0.01818182 
+  50           58.914516    48.391766   0.02      
+  55           58.646928    48.384793   0.01818182 
+  47           58.413438    48.377811   0.0212766 
+  54           58.294748    48.370818   0.01851852 
+  68           58.319877    48.363814   0.01470588 
+  45           58.495827    48.356801   0.02222222 
+  55           58.833333    48.349776   0.01818182 
+  47           59.344113    48.342742   0.0212766 
+  52           60.05602     48.335697   0.01923077 
+  61           61.018272    48.328642   0.01639344 
+  63           62.319136    48.321576   0.01587302 
+  69           64.110514    48.3145     0.01449275 
+  75           66.650449    48.307414   0.01333333 
+  68           70.347331    48.300317   0.01470588 
+  86           75.788928    48.293209   0.01162791 
+  86           83.799895    48.286091   0.01162791 
+  107          94.910271    48.278963   0.00934579 
+  119          109.636587   48.271824   0.00840336 
+  159          127.35106    48.264674   0.00628931 
+  193          144.913033   48.257514   0.00518135 
+  209          155.624597   48.250344   0.00478469 
+  223          153.34003    48.243162   0.0044843 
+  211          139.83266    48.235971   0.00473934 
+  194          122.474091   48.228768   0.00515464 
+  156          106.767363   48.221555   0.00641026 
+  146          94.801427    48.214332   0.00684932 
+  141          86.866183    48.207098   0.0070922 
+  96           82.637859    48.199853   0.01041667 
+  110          81.703744    48.192597   0.00909091 
+  116          83.716575    48.185331   0.00862069 
+  115          88.354936    48.178055   0.00869565 
+  116          95.143147    48.170767   0.00862069 
+  121          102.764838   48.163469   0.00826446 
+  130          108.587152   48.15616    0.00769231 
+  146          108.997092   48.14884    0.00684932 
+  145          103.024425   48.14151    0.00689655 
+  143          93.679051    48.134169   0.00699301 
+  132          84.339081    48.126817   0.00757576 
+  117          76.61229     48.119455   0.00854701 
+  119          70.825764    48.112081   0.00840336 
+  89           66.775682    48.104697   0.01123596 
+  71           64.096125    48.097302   0.01408451 
+  87           62.416401    48.089897   0.01149425 
+  67           61.417762    48.08248    0.01492537 
+  64           60.843346    48.075053   0.015625  
+  52           60.521467    48.067614   0.01923077 
+  59           60.407176    48.060165   0.01694915 
+  65           60.548832    48.052705   0.01538462 
+  62           60.985382    48.045235   0.01612903 
+  75           61.641213    48.037753   0.01333333 
+  68           62.232074    48.03026    0.01470588 
+  71           62.314731    48.022757   0.01408451 
+  58           61.651842    48.015243   0.01724138 
+  79           60.485362    48.007717   0.01265823 
+  84           59.246787    48.000181   0.01190476 
+  64           58.216245    47.992634   0.015625  
+  72           57.496073    47.985076   0.01388889 
+  63           57.097453    47.977507   0.01587302 
+  59           56.990137    47.969927   0.01694915 
+  64           57.126817    47.962336   0.015625  
+  76           57.477488    47.954734   0.01315789 
+  75           58.06306     47.947121   0.01333333 
+  49           58.921885    47.939497   0.02040816 
+  61           60.01697     47.931862   0.01639344 
+  61           61.171114    47.924216   0.01639344 
+  72           62.120634    47.916559   0.01388889 
+  70           62.644231    47.908891   0.01428571 
+  58           62.55074     47.901212   0.01724138 
+  61           61.742139    47.893521   0.01639344 
+  56           60.447022    47.88582    0.01785714 
+  51           59.083524    47.878108   0.01960784 
+  65           57.939513    47.870384   0.01538462 
+  80           57.107526    47.86265    0.0125    
+  70           56.574062    47.854904   0.01428571 
+  55           56.315153    47.847148   0.01818182 
+  54           56.339804    47.83938    0.01851852 
+  62           56.678516    47.831601   0.01612903 
+  65           57.356781    47.823811   0.01538462 
+  68           58.368528    47.81601    0.01470588 
+  57           59.622229    47.808198   0.01754386 
+  64           60.854745    47.800374   0.015625  
+  63           61.625238    47.792539   0.01587302 
+  77           61.572401    47.784694   0.01298701 
+  57           60.731522    47.776837   0.01754386 
+  62           59.477974    47.768969   0.01612903 
+  86           58.216118    47.761089   0.01162791 
+  70           57.18587     47.753199   0.01428571 
+  65           56.465722    47.745297   0.01538462 
+  54           56.051168    47.737384   0.01851852 
+  61           55.901208    47.72946    0.01639344 
+  55           55.952311    47.721525   0.01818182 
+  63           56.11906     47.713578   0.01587302 
+  67           56.342352    47.70562    0.01492537 
+  69           56.621116    47.697651   0.01449275 
+  61           56.943682    47.689671   0.01639344 
+  62           57.21212     47.68168    0.01612903 
+  54           57.296385    47.673677   0.01851852 
+  62           57.149581    47.665663   0.01612903 
+  52           56.803937    47.657638   0.01923077 
+  68           56.318444    47.649601   0.01470588 
+  58           55.787558    47.641553   0.01724138 
+  70           55.317225    47.633494   0.01428571 
+  52           54.965842    47.625424   0.01923077 
+  60           54.734999    47.617342   0.01666667 
+  62           54.587099    47.609249   0.01612903 
+  56           54.471808    47.601145   0.01785714 
+  53           54.364156    47.593029   0.01886792 
+  69           54.280559    47.584902   0.01449275 
+  50           54.246822    47.576764   0.02      
+  55           54.274001    47.568615   0.01818182 
+  54           54.351452    47.560454   0.01851852 
+  58           54.444217    47.552281   0.01724138 
+  58           54.501326    47.544098   0.01724138 
+  53           54.496222    47.535903   0.01886792 
+  62           54.453542    47.527697   0.01612903 
+  49           54.416845    47.519479   0.02040816 
+  60           54.414478    47.51125    0.01666667 
+  60           54.457417    47.50301    0.01666667 
+  44           54.549315    47.494758   0.02272727 
+  64           54.693638    47.486495   0.015625  
+  52           54.896927    47.478221   0.01923077 
+  64           55.170332    47.469935   0.015625  
+  46           55.528791    47.461638   0.02173913 
+  51           55.987829    47.45333    0.01960784 
+  43           56.556296    47.44501    0.02325581 
+  59           57.219061    47.436679   0.01694915 
+  64           57.904756    47.428336   0.015625  
+  61           58.459695    47.419982   0.01639344 
+  64           58.719875    47.411617   0.015625  
+  50           58.679207    47.40324    0.02      
+  60           58.499194    47.394852   0.01666667 
+  63           58.342259    47.386452   0.01587302 
+  60           58.289668    47.378041   0.01666667 
+  56           58.363893    47.369619   0.01785714 
+  73           58.562765    47.361185   0.01369863 
+  58           58.877751    47.35274    0.01724138 
+  68           59.302454    47.344283   0.01470588 
+  62           59.835844    47.335815   0.01612903 
+  52           60.481398    47.327336   0.01923077 
+  74           61.238676    47.318845   0.01351351 
+  74           62.08576     47.310343   0.01351351 
+  78           62.971167    47.301829   0.01282051 
+  76           63.861974    47.293304   0.01315789 
+  67           64.814455    47.284768   0.01492537 
+  94           65.931882    47.27622    0.0106383 
+  71           67.245746    47.26766    0.01408451 
+  70           68.621449    47.25909    0.01428571 
+  67           69.745238    47.250507   0.01492537 
+  79           70.327009    47.241914   0.01265823 
+  87           70.421012    47.233309   0.01149425 
+  63           70.363777    47.224692   0.01587302 
+  95           70.453366    47.216064   0.01052632 
+  73           70.839232    47.207425   0.01369863 
+  64           71.581372    47.198774   0.015625  
+  90           72.714413    47.190112   0.01111111 
+  87           74.279124    47.181439   0.01149425 
+  59           76.335654    47.172754   0.01694915 
+  92           78.960647    47.164057   0.01086957 
+  91           82.233652    47.155349   0.01098901 
+  101          86.191897    47.14663    0.00990099 
+  109          90.74352     47.137899   0.00917431 
+  96           95.550058    47.129157   0.01041667 
+  91           100.003849   47.120404   0.01098901 
+  104          103.508483   47.111639   0.00961538 
+  122          106.05283    47.102862   0.00819672 
+  121          108.392428   47.094075   0.00826446 
+  145          111.450857   47.085275   0.00689655 
+  107          115.860847   47.076465   0.00934579 
+  137          122.020867   47.067643   0.00729927 
+  131          130.273095   47.058809   0.00763359 
+  148          141.060344   47.049964   0.00675676 
+  148          155.038022   47.041108   0.00675676 
+  167          173.261187   47.03224    0.00598802 
+  207          197.575355   47.023361   0.00483092 
+  239          231.457754   47.014471   0.0041841 
+  331          281.563881   47.005569   0.00302115 
+  415          359.835577   46.996656   0.00240964 
+  520          484.963266   46.987731   0.00192308 
+  759          680.54492    46.978795   0.00131752 
+  1030         966.576286   46.969847   0.00097087 
+  1362         1340.839066  46.960888   0.00073421 
+  1677         1739.588609  46.951918   0.0005963 
+  1779         1991.453907  46.942937   0.00056211 
+  1766         1918.177931  46.933944   0.00056625 
+  1441         1582.178349  46.924939   0.00069396 
+  1136         1189.791805  46.915923   0.00088028 
+  834          863.265713   46.906896   0.00119904 
+  704          633.691796   46.897858   0.00142045 
+  555          492.492852   46.888808   0.0018018 
+  518          419.905153   46.879747   0.0019305 
+  471          399.341277   46.870674   0.00212314 
+  457          423.61135    46.86159    0.00218818 
+  550          494.698151   46.852495   0.00181818 
+  676          617.676168   46.843388   0.00147929 
+  810          788.336042   46.83427    0.00123457 
+  909          971.391232   46.825141   0.00110011 
+  1036         1077.558765  46.816      0.00096525 
+  931          1020.698396  46.806848   0.00107411 
+  741          838.511807   46.797685   0.00134953 
+  634          633.461166   46.78851    0.00157729 
+  477          463.175527   46.779324   0.00209644 
+  378          340.887085   46.770127   0.0026455 
+  316          260.727879   46.760918   0.00316456 
+  224          210.752704   46.751699   0.00446429 
+  206          179.473198   46.742468   0.00485437 
+  188          158.447667   46.733225   0.00531915 
+  131          142.790992   46.723971   0.00763359 
+  138          130.407537   46.714706   0.00724638 
+  129          120.522011   46.70543    0.00775194 
+  127          112.611512   46.696143   0.00787402 
+  112          106.081766   46.686844   0.00892857 
+  98           100.351793   46.677534   0.01020408 
+  108          95.101383    46.668213   0.00925926 
+  96           90.352259    46.65888    0.01041667 
+  85           86.234537    46.649537   0.01176471 
+  91           82.78855     46.640182   0.01098901 
+  70           79.968088    46.630815   0.01428571 
+  72           77.682933    46.621438   0.01388889 
+  88           75.818114    46.61205    0.01136364 
+  80           74.249344    46.60265    0.0125    
+  73           72.898585    46.593239   0.01369863 
+  80           71.771744    46.583817   0.0125    
+  66           70.905866    46.574383   0.01515152 
+  72           70.294956    46.564939   0.01388889 
+  58           69.853527    46.555483   0.01724138 
+  54           69.441928    46.546017   0.01851852 
+  50           68.976973    46.536539   0.02      
+  66           68.48458     46.52705    0.01515152 
+  62           67.981449    46.517549   0.01612903 
+  64           67.392065    46.508038   0.015625  
+  63           66.619514    46.498516   0.01587302 
+  61           65.648284    46.488982   0.01639344 
+  62           64.5761      46.479438   0.01612903 
+  58           63.537669    46.469882   0.01724138 
+  50           62.467161    46.460315   0.02      
+  67           61.707014    46.450737   0.01492537 
+  58           61.107078    46.441148   0.01724138 
+  55           60.662545    46.431549   0.01818182 
+  61           60.366686    46.421938   0.01639344 
+  49           60.212374    46.412316   0.02040816 
+  56           60.188787    46.402683   0.01785714 
+  65           60.271697    46.393039   0.01538462 
+  63           60.411531    46.383384   0.01587302 
+  50           60.536379    46.373718   0.02      
+  66           60.585969    46.364041   0.01515152 
+  51           60.549477    46.354353   0.01960784 
+  57           60.472498    46.344654   0.01754386 
+  53           60.335512    46.334944   0.01886792 
+  58           60.304056    46.325223   0.01724138 
+  63           60.237807    46.315491   0.01587302 
+  60           60.043511    46.305749   0.01666667 
+  50           59.681933    46.295995   0.02      
+  42           59.205548    46.286231   0.02380952 
+  52           58.694355    46.276455   0.01923077 
+  60           58.203614    46.266669   0.01666667 
+  46           57.765198    46.256872   0.02173913 
+  47           57.399072    46.247064   0.0212766 
+  64           57.12086     46.237245   0.015625  
+  51           56.944523    46.227416   0.01960784 
+  57           56.883248    46.217576   0.01754386 
+  59           56.951558    46.207724   0.01694915 
+  43           57.158002    46.197862   0.02325581 
+  62           57.496964    46.18799    0.01612903 
+  66           57.930999    46.178106   0.01515152 
+  60           58.375216    46.168212   0.01666667 
+  45           58.696323    46.158307   0.02222222 
+  66           58.737639    46.148391   0.01515152 
+  67           58.420675    46.138465   0.01492537 
+  61           57.853141    46.128528   0.01639344 
+  59           57.241149    46.11858    0.01694915 
+  66           56.736581    46.108621   0.01515152 
+  52           56.405305    46.098652   0.01923077 
+  54           56.263059    46.088673   0.01851852 
+  59           56.298804    46.078682   0.01694915 
+  46           56.483283    46.068681   0.02173913 
+  67           56.764224    46.058669   0.01492537 
+  56           57.063799    46.048647   0.01785714 
+  68           57.288347    46.038614   0.01470588 
+  58           57.347619    46.028571   0.01724138 
+  55           57.211994    46.018517   0.01818182 
+  53           56.886174    46.008453   0.01886792 
+  67           56.390202    45.998378   0.01492537 
+  42           55.7982      45.988292   0.02380952 
+  52           55.227091    45.978196   0.01923077 
+  47           54.763975    45.96809    0.0212766 
+  50           54.445815    45.957973   0.02      
+  64           54.27976     45.947846   0.015625  
+  61           54.260068    45.937708   0.01639344 
+  51           54.375906    45.92756    0.01960784 
+  45           54.611859    45.917401   0.02222222 
+  48           54.943316    45.907232   0.02083333 
+  37           55.339363    45.897053   0.02702703 
+  61           55.768222    45.886864   0.01639344 
+  65           56.210321    45.876664   0.01538462 
+  64           56.633845    45.866453   0.015625  
+  55           56.96273     45.856233   0.01818182 
+  47           57.07359     45.846002   0.0212766 
+  59           56.849437    45.835761   0.01694915 
+  57           56.285462    45.825509   0.01754386 
+  57           55.544162    45.815248   0.01754386 
+  51           54.824111    45.804976   0.01960784 
+  64           54.239574    45.794694   0.015625  
+  42           53.825651    45.784402   0.02380952 
+  67           53.58115     45.7741     0.01492537 
+  56           53.493448    45.763787   0.01785714 
+  52           53.550022    45.753464   0.01923077 
+  45           53.737764    45.743132   0.02222222 
+  50           54.039614    45.732789   0.02      
+  50           54.420185    45.722436   0.02      
+  53           54.814998    45.712073   0.01886792 
+  49           55.138142    45.7017     0.02040816 
+  55           55.306087    45.691317   0.01818182 
+  44           55.278517    45.680924   0.02272727 
+  40           55.104818    45.670521   0.025     
+  45           54.885076    45.660109   0.02222222 
+  69           54.695471    45.649686   0.01449275 
+  48           54.577017    45.639253   0.02083333 
+  58           54.540884    45.62881    0.01724138 
+  55           54.607075    45.618358   0.01818182 
+  46           54.795092    45.607896   0.02173913 
+  54           55.128412    45.597423   0.01851852 
+  52           55.630694    45.586941   0.01923077 
+  48           56.315284    45.576449   0.02083333 
+  62           57.161645    45.565948   0.01612903 
+  53           58.074921    45.555437   0.01886792 
+  66           58.866372    45.544915   0.01515152 
+  48           59.336634    45.534385   0.02083333 
+  55           59.393343    45.523844   0.01818182 
+  60           59.051392    45.513294   0.01666667 
+  55           58.424453    45.502734   0.01818182 
+  57           57.703356    45.492165   0.01754386 
+  61           57.050155    45.481586   0.01639344 
+  56           56.540888    45.470997   0.01785714 
+  55           56.200848    45.460399   0.01818182 
+  68           56.037186    45.449791   0.01470588 
+  59           56.049614    45.439174   0.01694915 
+  54           56.236445    45.428547   0.01851852 
+  56           56.589849    45.417911   0.01785714 
+  52           57.081088    45.407265   0.01923077 
+  73           57.642586    45.39661    0.01369863 
+  51           58.185174    45.385945   0.01960784 
+  50           58.661153    45.375271   0.02      
+  56           59.089167    45.364588   0.01785714 
+  50           59.53837     45.353895   0.02      
+  61           60.121473    45.343193   0.01639344 
+  55           60.933223    45.332482   0.01818182 
+  63           61.980952    45.321761   0.01587302 
+  57           63.238468    45.311031   0.01754386 
+  61           64.799916    45.300292   0.01639344 
+  62           66.890403    45.289544   0.01612903 
+  49           69.671793    45.278787   0.02040816 
+  67           73.048673    45.26802    0.01492537 
+  71           76.602685    45.257245   0.01408451 
+  60           79.542302    45.24646    0.01666667 
+  69           80.724048    45.235666   0.01449275 
+  76           79.413142    45.224863   0.01315789 
+  79           76.221216    45.214051   0.01265823 
+  69           72.516463    45.20323    0.01449275 
+  64           69.292552    45.1924     0.015625  
+  71           66.940108    45.181561   0.01408451 
+  61           65.484397    45.170714   0.01639344 
+  54           64.803029    45.159857   0.01851852 
+  64           64.77425     45.148991   0.015625  
+  65           65.366861    45.138117   0.01538462 
+  57           66.590031    45.127234   0.01754386 
+  50           68.366449    45.116342   0.02      
+  63           70.453678    45.105441   0.01587302 
+  61           72.465647    45.094531   0.01639344 
+  73           73.932108    45.083613   0.01369863 
+  66           74.444273    45.072686   0.01515152 
+  85           74.089086    45.06175    0.01176471 
+  59           73.547598    45.050806   0.01694915 
+  64           73.523458    45.039853   0.015625  
+  88           74.348636    45.028892   0.01136364 
+  59           75.953022    45.017922   0.01694915 
+  68           77.83576     45.006943   0.01470588 
+  75           79.165226    44.995956   0.01333333 
+  66           79.44137     44.984961   0.01515152 
+  76           79.10736     44.973957   0.01315789 
+  76           79.06436     44.962945   0.01315789 
+  75           79.885917    44.951924   0.01333333 
+  73           81.571976    44.940895   0.01369863 
+  92           83.533688    44.929857   0.01086957 
+  76           84.703144    44.918812   0.01315789 
+  79           84.224117    44.907758   0.01265823 
+  80           82.360699    44.896695   0.0125    
+  77           80.174856    44.885625   0.01298701 
+  74           78.526864    44.874546   0.01351351 
+  84           77.743978    44.86346    0.01190476 
+  81           77.744614    44.852365   0.01234568 
+  79           78.146532    44.841262   0.01265823 
+  75           78.473483    44.830151   0.01333333 
+  94           78.58622     44.819032   0.0106383 
+  69           78.803242    44.807905   0.01449275 
+  81           79.522463    44.79677    0.01234568 
+  90           80.932528    44.785627   0.01111111 
+  90           82.955282    44.774476   0.01111111 
+  92           85.224733    44.763317   0.01086957 
+  98           87.214149    44.752151   0.01020408 
+  107          88.720314    44.740976   0.00934579 
+  102          90.165128    44.729794   0.00980392 
+  93           92.200113    44.718604   0.01075269 
+  100          95.25562     44.707406   0.01      
+  125          99.445269    44.696201   0.008     
+  117          104.554345   44.684988   0.00854701 
+  105          109.913511   44.673767   0.00952381 
+  130          114.310376   44.662539   0.00769231 
+  110          116.631928   44.651303   0.00909091 
+  132          117.153305   44.64006    0.00757576 
+  125          117.374182   44.628809   0.008     
+  106          118.593913   44.617551   0.00943396 
+  134          121.449474   44.606286   0.00746269 
+  115          126.200558   44.595013   0.00869565 
+  131          133.017677   44.583732   0.00763359 
+  134          142.117531   44.572444   0.00746269 
+  137          153.843395   44.561149   0.00729927 
+  171          168.717051   44.549847   0.00584795 
+  198          187.485825   44.538538   0.00505051 
+  180          211.201496   44.527221   0.00555556 
+  221          241.420868   44.515897   0.00452489 
+  293          280.796435   44.504566   0.00341297 
+  367          334.702429   44.493228   0.0027248 
+  420          414.465219   44.481883   0.00238095 
+  613          540.682543   44.470531   0.00163132 
+  762          743.004468   44.459172   0.00131234 
+  1041         1053.139226  44.447806   0.00096061 
+  1475         1489.717511  44.436433   0.00067797 
+  1920         2025.931895  44.425053   0.00052083 
+  2348         2525.872939  44.413667   0.00042589 
+  2595         2720.669625  44.402273   0.00038536 
+  2427         2463.246981  44.390873   0.00041203 
+  2095         1950.337165  44.379466   0.00047733 
+  1570         1436.535246  44.368053   0.00063694 
+  1126         1034.005515  44.356632   0.0008881 
+  879          759.160827   44.345206   0.00113766 
+  695          591.508597   44.333772   0.00143885 
+  618          502.943276   44.322332   0.00161812 
+  570          472.964386   44.310886   0.00175439 
+  590          494.183134   44.299433   0.00169492 
+  691          571.045853   44.287973   0.00144718 
+  759          713.104871   44.276508   0.00131752 
+  981          923.5948     44.265035   0.00101937 
+  1136         1179.110446  44.253557   0.00088028 
+  1362         1394.730228  44.242072   0.00073421 
+  1324         1431.995718  44.230581   0.00075529 
+  1210         1252.509767  44.219084   0.00082645 
+  1024         976.657839   44.207581   0.00097656 
+  794          718.301685   44.196071   0.00125945 
+  639          519.626254   44.184556   0.00156495 
+  492          382.451041   44.173034   0.00203252 
+  398          293.715974   44.161507   0.00251256 
+  277          237.625795   44.149973   0.00361011 
+  229          201.346564   44.138434   0.00436681 
+  195          176.529214   44.126889   0.00512821 
+  180          158.474629   44.115337   0.00555556 
+  142          144.71951    44.10378    0.00704225 
+  139          133.945131   44.092218   0.00719424 
+  133          125.379186   44.080649   0.0075188 
+  138          118.528086   44.069075   0.00724638 
+  127          113.039663   44.057495   0.00787402 
+  119          108.662609   44.04591    0.00840336 
+  128          105.217839   44.034319   0.0078125 
+  112          102.572278   44.022723   0.00892857 
+  122          100.628945   44.011121   0.00819672 
+  116          99.311899    43.999513   0.00862069 
+  107          98.532264    43.987901   0.00934579 
+  110          98.133774    43.976283   0.00909091 
+  98           97.847437    43.964659   0.01020408 
+  88           97.393082    43.953031   0.01136364 
+  103          96.783529    43.941397   0.00970874 
+  115          96.404969    43.929758   0.00869565 
+  97           96.681368    43.918113   0.01030928 
+  99           97.77451     43.906464   0.01010101 
+  114          99.409931    43.89481    0.00877193 
+  109          100.734307   43.883151   0.00917431 
+  103          100.609626   43.871486   0.00970874 
+  85           98.610339    43.859817   0.01176471 
+  76           95.481071    43.848143   0.01315789 
+  79           92.264231    43.836464   0.01265823 
+  82           89.544612    43.82478    0.01219512 
+  73           87.452077    43.813092   0.01369863 
+  67           85.868963    43.801399   0.01492537 
+  70           84.560408    43.789701   0.01428571 
+  71           83.299114    43.777999   0.01408451 
+  80           82.042955    43.766292   0.0125    
+  72           80.958595    43.75458    0.01388889 
+  74           80.242101    43.742864   0.01351351 
+  78           79.96124     43.731144   0.01282051 
+  80           79.96532     43.719419   0.0125    
+  93           79.81202     43.70769    0.01075269 
+  95           78.932416    43.695957   0.01052632 
+  91           77.138582    43.684219   0.01098901 
+  76           74.81888     43.672478   0.01315789 
+  62           72.485835    43.660732   0.01612903 
+  80           70.420509    43.648982   0.0125    
+  82           68.691424    43.637228   0.01219512 
+  76           67.248721    43.62547    0.01315789 
+  75           66.079039    43.613708   0.01333333 
+  72           65.114337    43.601942   0.01388889 
+  86           64.327037    43.590172   0.01162791 
+  69           63.711147    43.578399   0.01449275 
+  62           63.280768    43.566621   0.01612903 
+  61           63.065383    43.55484    0.01639344 
+  80           63.107995    43.543055   0.0125    
+  73           63.462719    43.531267   0.01369863 
+  74           64.19041     43.519475   0.01351351 
+  64           65.317834    43.50768    0.015625  
+  95           66.839332    43.495881   0.01052632 
+  83           68.732521    43.484079   0.01204819 
+  76           71.060776    43.472273   0.01315789 
+  78           73.972497    43.460464   0.01282051 
+  92           77.331417    43.448652   0.01086957 
+  118          80.45245     43.436836   0.00847458 
+  113          82.297824    43.425017   0.00884956 
+  116          82.456363    43.413196   0.00862069 
+  98           81.627972    43.401371   0.01020408 
+  95           80.651555    43.389543   0.01052632 
+  93           79.574523    43.377712   0.01075269 
+  101          77.851873    43.365878   0.00990099 
+  96           75.309531    43.354042   0.01041667 
+  74           72.510986    43.342202   0.01351351 
+  87           70.138027    43.33036    0.01149425 
+  80           68.521383    43.318515   0.0125    
+  64           67.694945    43.306667   0.015625  
+  65           67.624423    43.294817   0.01538462 
+  78           68.279011    43.282965   0.01282051 
+  97           69.522819    43.271109   0.01030928 
+  95           70.973727    43.259252   0.01052632 
+  75           72.076848    43.247392   0.01333333 
+  89           72.579573    43.235529   0.01123596 
+  86           72.825409    43.223665   0.01162791 
+  88           73.304388    43.211798   0.01136364 
+  80           74.140497    43.199929   0.0125    
+  80           75.12018     43.188057   0.0125    
+  96           76.114649    43.176184   0.01041667 
+  93           77.227635    43.164309   0.01075269 
+  75           78.373246    43.152431   0.01333333 
+  89           79.039457    43.140552   0.01123596 
+  105          78.814972    43.128671   0.00952381 
+  94           78.003899    43.116788   0.0106383 
+  80           77.319661    43.104904   0.0125    
+  95           77.263293    43.093018   0.01052632 
+  88           77.968641    43.08113    0.01136364 
+  88           79.262621    43.06924    0.01136364 
+  76           80.69536     43.057349   0.01315789 
+  103          81.679074    43.045457   0.00970874 
+  93           81.907795    43.033563   0.01075269 
+  75           81.570974    43.021668   0.01333333 
+  92           81.031718    43.009771   0.01086957 
+  72           80.51813     42.997873   0.01388889 
+  76           80.082944    42.985975   0.01315789 
+  81           79.606708    42.974075   0.01234568 
+  64           78.81403     42.962173   0.015625  
+  77           77.489749    42.950271   0.01298701 
+  73           75.780068    42.938368   0.01369863 
+  75           74.092187    42.926464   0.01333333 
+  69           72.753371    42.91456    0.01449275 
+  62           71.893745    42.902654   0.01612903 
+  85           71.475701    42.890748   0.01176471 
+  72           71.315947    42.878841   0.01388889 
+  77           71.132969    42.866933   0.01298701 
+  77           70.740457    42.855025   0.01298701 
+  77           70.199619    42.843117   0.01298701 
+  63           69.694793    42.831208   0.01587302 
+  64           69.344371    42.819298   0.015625  
+  59           69.132477    42.807389   0.01694915 
+  72           68.888832    42.795479   0.01388889 
+  61           68.345042    42.783569   0.01639344 
+  66           67.374006    42.771659   0.01515152 
+  67           66.186588    42.759749   0.01492537 
+  68           65.131037    42.747838   0.01470588 
+  51           64.360164    42.735928   0.01960784 
+  61           63.706089    42.724018   0.01639344 
+  58           62.834936    42.712108   0.01724138 
+  58           61.659835    42.700199   0.01724138 
+  53           60.444585    42.68829    0.01886792 
+  52           59.427495    42.676381   0.01923077 
+  49           58.606523    42.664472   0.02040816 
+  55           57.86553     42.652564   0.01818182 
+  49           57.185317    42.640657   0.02040816 
+  53           56.650769    42.62875    0.01886792 
+  57           56.28701     42.616844   0.01754386 
+  62           55.993173    42.604939   0.01612903 
+  48           55.658276    42.593034   0.02083333 
+  55           55.321762    42.581131   0.01818182 
+  60           55.147431    42.569228   0.01666667 
+  55           55.259308    42.557326   0.01818182 
+  51           55.649297    42.545426   0.01960784 
+  59           56.208692    42.533526   0.01694915 
+  70           56.905056    42.521628   0.01428571 
+  66           57.899398    42.509731   0.01515152 
+  55           59.365871    42.497835   0.01818182 
+  73           61.256964    42.485941   0.01369863 
+  63           63.16963     42.474048   0.01587302 
+  71           64.342706    42.462157   0.01408451 
+  66           64.013168    42.450267   0.01515152 
+  57           62.133438    42.438379   0.01754386 
+  57           59.447668    42.426493   0.01754386 
+  56           56.753168    42.414608   0.01785714 
+  54           54.46662     42.402726   0.01851852 
+  51           52.702898    42.390845   0.01960784 
+  46           51.4422      42.378966   0.02173913 
+  71           50.625295    42.367089   0.01408451 
+  49           50.194664    42.355215   0.02040816 
+  53           50.110825    42.343342   0.01886792 
+  54           50.353924    42.331472   0.01851852 
+  53           50.910128    42.319604   0.01886792 
+  64           51.74093     42.307739   0.015625  
+  61           52.718786    42.295876   0.01639344 
+  63           53.539897    42.284016   0.01587302 
+  54           53.770102    42.272158   0.01851852 
+  50           53.18054     42.260303   0.02      
+  60           52.001608    42.24845    0.01666667 
+  56           50.656052    42.236601   0.01785714 
+  52           49.426879    42.224754   0.01923077 
+  61           48.417671    42.21291    0.01639344 
+  50           47.634392    42.20107    0.02      
+  45           47.045852    42.189232   0.02222222 
+  50           46.610802    42.177398   0.02      
+  60           46.29179     42.165566   0.01666667 
+  44           46.057411    42.153739   0.02272727 
+  39           45.885422    42.141914   0.02564103 
+  46           45.761259    42.130093   0.02173913 
+  39           45.676342    42.118275   0.02564103 
+  45           45.625619    42.106461   0.02222222 
+  45           45.604927    42.094651   0.02222222 
+  36           45.61069     42.082844   0.02777778 
+  53           45.639266    42.071042   0.01886792 
+  49           45.696344    42.059243   0.02040816 
+  47           45.801976    42.047448   0.0212766 
+  50           45.986167    42.035657   0.02      
+  37           46.281886    42.02387    0.02702703 
+  31           46.721862    42.012087   0.03225806 
+  48           47.331657    42.000309   0.02083333 
+  37           48.11347     41.988535   0.02702703 
+  47           49.006671    41.976765   0.0212766 
+  43           49.826805    41.965      0.02325581 
+  42           50.266521    41.953239   0.02380952 
+  48           50.107305    41.941483   0.02083333 
+  47           49.448873    41.929732   0.0212766 
+  50           48.580057    41.917985   0.02      
+  47           47.726574    41.906243   0.0212766 
+  52           46.997113    41.894506   0.01923077 
+  44           46.42806     41.882774   0.02272727 
+  33           46.021342    41.871048   0.03030303 
+  53           45.7669      41.859326   0.01886792 
+  37           45.653444    41.84761    0.02702703 
+  50           45.673431    41.835898   0.02      
+  54           45.824095    41.824193   0.01851852 
+  43           46.102703    41.812492   0.02325581 
+  57           46.492809    41.800797   0.01754386 
+  54           46.936246    41.789108   0.01851852 
+  64           47.305539    41.777425   0.015625  
+  50           47.447363    41.765747   0.02      
+  49           47.314146    41.754075   0.02040816 
+  51           46.995885    41.742409   0.01960784 
+  42           46.591288    41.730749   0.02380952 
+  43           46.144255    41.719095   0.02325581 
+  45           45.69064     41.707447   0.02222222 
+  50           45.277002    41.695806   0.02      
+  44           44.934246    41.684171   0.02272727 
+  47           44.667951    41.672542   0.0212766 
+  39           44.469387    41.660919   0.02564103 
+  49           44.325889    41.649304   0.02040816 
+  36           44.226012    41.637694   0.02777778 
+  35           44.161195    41.626092   0.02857143 
+  50           44.126133    41.614496   0.02      
+  51           44.116934    41.602908   0.01960784 
+  46           44.132079    41.591326   0.02173913 
+  38           44.169431    41.579751   0.02631579 
+  49           44.222864    41.568183   0.02040816 
+  36           44.277945    41.556623   0.02777778 
+  58           44.3134      41.545069   0.01724138 
+  43           44.317574    41.533524   0.02325581 
+  51           44.303267    41.521985   0.01960784 
+  41           44.294789    41.510454   0.02439024 
+  50           44.310396    41.498931   0.02      
+  36           44.355834    41.487416   0.02777778 
+  46           44.425875    41.475908   0.02173913 
+  42           44.503105    41.464408   0.02380952 
+  57           44.563403    41.452916   0.01754386 
+  38           44.596566    41.441432   0.02631579 
+  36           44.618422    41.429956   0.02777778 
+  51           44.654174    41.418488   0.01960784 
+  55           44.720471    41.407029   0.01818182 
+  39           44.822355    41.395578   0.02564103 
+  45           44.958589    41.384135   0.02222222 
+  40           45.128646    41.372701   0.025     
+  41           45.342839    41.361276   0.02439024 
+  39           45.624755    41.349859   0.02564103 
+  38           46.00658     41.338451   0.02631579 
+  41           46.528665    41.327052   0.02439024 
+  46           47.252714    41.315662   0.02173913 
+  62           48.250441    41.304281   0.01612903 
+  50           49.608596    41.292909   0.02      
+  44           51.413877    41.281547   0.02272727 
+  47           53.727842    41.270193   0.0212766 
+  51           56.527282    41.25885    0.01960784 
+  60           59.568515    41.247515   0.01666667 
+  55           62.248462    41.23619    0.01818182 
+  59           63.782371    41.224875   0.01694915 
+  60           63.746218    41.21357    0.01666667 
+  54           62.295398    41.202274   0.01851852 
+  44           59.963146    41.190988   0.02272727 
+  47           57.429502    41.179713   0.0212766 
+  49           55.209956    41.168447   0.02040816 
+  40           53.510417    41.157192   0.025     
+  45           52.320806    41.145947   0.02222222 
+  45           51.58773     41.134712   0.02222222 
+  55           51.308703    41.123488   0.01818182 
+  46           51.51573     41.112274   0.02173913 
+  52           52.231036    41.101071   0.01923077 
+  52           53.4495      41.089879   0.01923077 
+  50           55.119331    41.078698   0.02      
+  41           57.076721    41.067527   0.02439024 
+  53           58.964168    41.056368   0.01886792 
+  61           60.304264    41.045219   0.01639344 
+  58           60.706775    41.034082   0.01724138 
+  53           59.987907    41.022956   0.01886792 
+  60           58.338229    41.011842   0.01666667 
+  57           56.305178    41.000739   0.01754386 
+  52           54.381534    40.989647   0.01923077 
+  71           52.758516    40.978567   0.01408451 
+  61           51.427306    40.967499   0.01639344 
+  58           50.362066    40.956443   0.01724138 
+  53           49.574487    40.945399   0.01886792 
+  54           49.071869    40.934367   0.01851852 
+  46           48.837595    40.923347   0.02173913 
+  49           48.847386    40.912339   0.02040816 
+  41           49.092547    40.901343   0.02439024 
+  60           49.585785    40.89036    0.01666667 
+  40           50.338032    40.87939    0.025     
+  42           51.318521    40.868432   0.02380952 
+  55           52.427613    40.857486   0.01818182 
+  61           53.54835     40.846554   0.01639344 
+  57           54.660598    40.835634   0.01754386 
+  67           55.798383    40.824728   0.01492537 
+  52           56.817916    40.813834   0.01923077 
+  54           57.333221    40.802954   0.01851852 
+  39           57.070443    40.792087   0.02564103 
+  54           56.236398    40.781233   0.01851852 
+  56           55.297018    40.770393   0.01785714 
+  64           54.550969    40.759566   0.015625  
+  50           54.015789    40.748753   0.02      
+  50           53.554286    40.737954   0.02      
+  55           53.093873    40.727169   0.01818182 
+  50           52.728316    40.716397   0.02      
+  58           52.596636    40.70564    0.01724138 
+  48           52.803033    40.694897   0.02083333 
+  48           53.405817    40.684168   0.02083333 
+  55           54.452406    40.673454   0.01818182 
+  57           55.996783    40.662754   0.01754386 
+  51           58.056184    40.652068   0.01960784 
+  57           60.744687    40.641397   0.01754386 
+  49           64.086513    40.630741   0.02040816 
+  70           68.337259    40.6201     0.01428571 
+  60           74.038888    40.609474   0.01666667 
+  82           81.761721    40.598863   0.01219512 
+  64           91.637213    40.588267   0.015625  
+  94           102.712669   40.577686   0.0106383 
+  92           112.112797   40.567121   0.01086957 
+  115          115.537632   40.556571   0.00869565 
+  87           111.06811    40.546037   0.01149425 
+  92           101.632378   40.535519   0.01086957 
+  95           91.565501    40.525016   0.01052632 
+  89           83.403482    40.514529   0.01123596 
+  82           77.931253    40.504058   0.01219512 
+  89           75.154912    40.493604   0.01123596 
+  92           74.637399    40.483165   0.01086957 
+  97           75.657534    40.472743   0.01030928 
+  70           77.215987    40.462337   0.01428571 
+  94           78.473173    40.451948   0.0106383 
+  79           79.482078    40.441575   0.01265823 
+  72           81.057541    40.431219   0.01388889 
+  100          83.83787     40.42088    0.01      
+  64           87.599288    40.410558   0.015625  
+  99           90.912572    40.400253   0.01010101 
+  76           91.576633    40.389965   0.01315789 
+  96           88.658971    40.379694   0.01041667 
+  88           83.651898    40.369441   0.01136364 
+  82           78.634132    40.359205   0.01219512 
+  67           74.684859    40.348986   0.01492537 
+  59           72.104995    40.338786   0.01694915 
+  71           70.970878    40.328603   0.01408451 
+  88           71.229353    40.318438   0.01136364 
+  75           72.534534    40.308291   0.01333333 
+  88           74.130342    40.298162   0.01136364 
+  70           75.018397    40.288052   0.01428571 
+  87           74.573481    40.27796    0.01149425 
+  76           73.064449    40.267886   0.01315789 
+  70           71.377302    40.257831   0.01428571 
+  82           70.34502     40.247794   0.01219512 
+  70           70.507317    40.237776   0.01428571 
+  64           72.273284    40.227777   0.015625  
+  79           76.097546    40.217797   0.01265823 
+  82           82.466792    40.207837   0.01219512 
+  85           91.727195    40.197895   0.01176471 
+  91           103.759418   40.187973   0.01098901 
+  89           117.355662   40.17807    0.01123596 
+  92           129.176215   40.168187   0.01086957 
+  107          134.14112    40.158323   0.00934579 
+  118          129.809304   40.14848    0.00847458 
+  116          119.355298   40.138656   0.00862069 
+  104          107.546185   40.128852   0.00961538 
+  93           97.065257    40.119068   0.01075269 
+  96           88.904361    40.109305   0.01041667 
+  73           83.466324    40.099561   0.01369863 
+  79           80.900868    40.089839   0.01265823 
+  79           81.201634    40.080136   0.01265823 
+  84           84.316031    40.070455   0.01190476 
+  67           90.113351    40.060794   0.01492537 
+  93           98.290493    40.051155   0.01075269 
+  111          108.500463   40.041536   0.00900901 
+  103          120.512751   40.031938   0.00970874 
+  111          133.251985   40.022362   0.00900901 
+  124          143.020195   40.012807   0.00806452 
+  134          144.36216    40.003274   0.00746269 
+  110          135.453711   39.993762   0.00909091 
+  148          120.488396   39.984272   0.00675676 
+  92           104.825173   39.974803   0.01086957 
+  102          91.383832    39.965357   0.00980392 
+  88           81.03224     39.955933   0.01136364 
+  75           73.713939    39.946531   0.01333333 
+  98           69.018509    39.937151   0.01020408 
+  55           66.470225    39.927794   0.01818182 
+  75           65.648566    39.918459   0.01333333 
+  51           66.183067    39.909147   0.01960784 
+  85           67.6821      39.899858   0.01176471 
+  64           69.773154    39.890592   0.015625  
+  62           72.255341    39.881348   0.01612903 
+  66           74.884137    39.872128   0.01515152 
+  79           76.72037     39.862931   0.01265823 
+  84           76.250666    39.853758   0.01190476 
+  78           72.983083    39.844608   0.01282051 
+  75           68.160134    39.835481   0.01333333 
+  80           63.301172    39.826379   0.0125    
+  67           59.176435    39.8173     0.01492537 
+  63           55.966199    39.808245   0.01587302 
+  64           53.569629    39.799214   0.015625  
+  68           51.778773    39.790208   0.01470588 
+  60           50.399949    39.781226   0.01666667 
+  64           49.321147    39.772268   0.015625  
+  65           48.486279    39.763335   0.01538462 
+  51           47.857211    39.754427   0.01960784 
+  63           47.402841    39.745544   0.01587302 
+  44           47.101847    39.736686   0.02272727 
+  47           46.943733    39.727852   0.0212766 
+  45           46.928895    39.719044   0.02222222 
+  56           47.062703    39.710261   0.01785714 
+  55           47.356955    39.701504   0.01818182 
+  54           47.820208    39.692773   0.01851852 
+  47           48.443479    39.684067   0.0212766 
+  59           49.168318    39.675387   0.01694915 
+  61           49.838727    39.666732   0.01639344 
+  41           50.21684     39.658104   0.02439024 
+  57           50.151076    39.649503   0.01754386 
+  56           49.740934    39.640927   0.01785714 
+  55           49.234018    39.632378   0.01818182 
+  49           48.838595    39.623856   0.02040816 
+  39           48.671973    39.61536    0.02564103 
+  46           48.798779    39.606892   0.02173913 
+  71           49.270856    39.59845    0.01408451 
+  42           50.142539    39.590035   0.02380952 
+  56           51.477005    39.581648   0.01785714 
+  52           53.320781    39.573288   0.01923077 
+  56           55.663718    39.564956   0.01785714 
+  64           58.319951    39.556651   0.015625  
+  54           60.789392    39.548374   0.01851852 
+  53           62.298958    39.540125   0.01886792 
+  61           62.362112    39.531904   0.01639344 
+  53           61.246658    39.523711   0.01886792 
+  63           59.632062    39.515546   0.01587302 
+  69           58.079699    39.50741    0.01449275 
+  71           56.909149    39.499302   0.01408451 
+  55           56.218474    39.491223   0.01818182 
+  66           55.956311    39.483173   0.01515152 
+  61           55.98337     39.475151   0.01639344 
+  56           56.136413    39.467159   0.01785714 
+  66           56.28989     39.459196   0.01515152 
+  68           56.411153    39.451263   0.01470588 
+  57           56.561764    39.443358   0.01754386 
+  62           56.849066    39.435484   0.01612903 
+  60           57.327257    39.427639   0.01666667 
+  54           57.898606    39.419824   0.01851852 
+  60           58.27332     39.412039   0.01666667 
+  58           58.166347    39.404284   0.01724138 
+  43           57.631542    39.39656    0.02325581 
+  61           57.024306    39.388866   0.01639344 
+  52           56.663765    39.381202   0.01923077 
+  61           56.622632    39.37357    0.01639344 
+  54           56.73937     39.365968   0.01851852 
+  58           56.747497    39.358397   0.01724138 
+  72           56.502817    39.350857   0.01388889 
+  56           56.083416    39.343348   0.01785714 
+  55           55.62943     39.335871   0.01818182 
+  56           55.229521    39.328425   0.01785714 
+  54           54.931024    39.321011   0.01851852 
+  64           54.781225    39.313628   0.015625  
+  68           54.821409    39.306278   0.01470588 
+  64           55.078671    39.298959   0.015625  
+  57           55.558433    39.291673   0.01754386 
+  50           56.271604    39.284419   0.02      
+  61           57.286658    39.277198   0.01639344 
+  71           58.761963    39.270009   0.01408451 
+  62           60.910028    39.262853   0.01612903 
+  70           63.99839     39.25573    0.01428571 
+  80           68.388496    39.24864    0.0125    
+  75           74.592653    39.241583   0.01333333 
+  67           83.445429    39.234559   0.01492537 
+  96           96.140898    39.227569   0.01041667 
+  113          113.703528   39.220613   0.00884956 
+  139          135.324451   39.21369    0.00719424 
+  154          155.73418    39.206801   0.00649351 
+  150          164.084708   39.199946   0.00666667 
+  156          153.927027   39.193126   0.00641026 
+  116          132.736473   39.186339   0.00862069 
+  119          111.138139   39.179587   0.00840336 
+  128          94.175266    39.17287    0.0078125 
+  109          82.799548    39.166188   0.00917431 
+  90           76.34252     39.15954    0.01111111 
+  72           73.769091    39.152927   0.01388889 
+  73           74.166527    39.14635    0.01369863 
+  80           76.964348    39.139808   0.0125    
+  59           81.788074    39.133301   0.01694915 
+  69           88.248046    39.12683    0.01449275 
+  78           95.858723    39.120395   0.01282051 
+  82           104.546225   39.113996   0.01219512 
+  104          114.671291   39.107632   0.00961538 
+  117          125.583271   39.101305   0.00854701 
+  128          133.386796   39.095014   0.0078125 
+  130          132.229533   39.08876    0.00769231 
+  112          121.37782    39.082543   0.00892857 
+  94           106.312015   39.076362   0.0106383 
+  78           92.050138    39.070218   0.01282051 
+  64           80.832886    39.064111   0.015625  
+  79           73.039004    39.058042   0.01265823 
+  57           68.265287    39.052009   0.01754386 
+  46           65.904177    39.046015   0.02173913 
+  56           65.452982    39.040058   0.01785714 
+  63           66.537448    39.034139   0.01587302 
+  62           68.809948    39.028258   0.01612903 
+  72           71.774931    39.022415   0.01388889 
+  58           74.788915    39.01661    0.01724138 
+  64           77.252191    39.010844   0.015625  
+  50           78.634702    39.005116   0.02      
+  53           78.481197    38.999427   0.01886792 
+  79           76.804093    38.993777   0.01265823 
+  65           74.022248    38.988166   0.01538462 
+  42           70.58636     38.982594   0.02380952 
+  71           67.001564    38.977062   0.01408451 
+  57           63.718236    38.971569   0.01754386 
+  53           60.940625    38.966116   0.01886792 
+  61           58.669719    38.960702   0.01639344 
+  63           56.867463    38.955329   0.01587302 
+  63           55.511811    38.949995   0.01587302 
+  48           54.600309    38.944702   0.02083333 
+  59           54.13301     38.93945    0.01694915 
+  68           54.105706    38.934238   0.01470588 
+  61           54.48061     38.929066   0.01639344 
+  54           55.141467    38.923936   0.01851852 
+  63           55.812312    38.918847   0.01587302 
+  70           56.08717     38.913798   0.01428571 
+  58           55.710695    38.908792   0.01724138 
+  45           54.855008    38.903826   0.02222222 
+  69           53.923495    38.898903   0.01449275 
+  62           53.223448    38.894021   0.01612903 
+  69           52.880713    38.889181   0.01449275 
+  62           52.923721    38.884384   0.01612903 
+  72           53.362445    38.879628   0.01388889 
+  56           54.255539    38.874916   0.01785714 
+  79           55.711336    38.870245   0.01265823 
+  72           57.861782    38.865618   0.01388889 
+  67           60.780369    38.861034   0.01492537 
+  76           64.374761    38.856492   0.01315789 
+  71           68.143486    38.851994   0.01408451 
+  59           71.004054    38.84754    0.01694915 
+  61           71.632222    38.843129   0.01639344 
+  50           69.60781     38.838761   0.02      
+  55           65.887139    38.834438   0.01818182 
+  52           61.812198    38.830159   0.01923077 
+  59           58.19668     38.825924   0.01694915 
+  41           55.313976    38.821733   0.02439024 
+  59           53.151041    38.817587   0.01694915 
+  46           51.622766    38.813486   0.02173913 
+  52           50.644474    38.80943    0.01923077 
+  53           50.158697    38.805418   0.01886792 
+  47           50.123796    38.801452   0.0212766 
+  38           50.53525     38.797531   0.02631579 
+  48           51.397345    38.793656   0.02083333 
+  47           52.700413    38.789827   0.0212766 
+  57           54.338863    38.786043   0.01754386 
+  64           55.998705    38.782305   0.015625  
+  55           57.075028    38.778614   0.01818182 
+  58           56.947073    38.774969   0.01724138 
+  56           55.549405    38.771371   0.01785714 
+  60           53.447968    38.767819   0.01666667 
+  66           51.27926     38.764314   0.01515152 
+  51           49.381436    38.760856   0.01960784 
+  44           47.845261    38.757446   0.02272727 
+  41           46.64355     38.754083   0.02439024 
+  57           45.715935    38.750767   0.01754386 
+  45           45.005745    38.747499   0.02222222 
+  52           44.4591      38.744279   0.01923077 
+  44           44.031245    38.741107   0.02272727 
+  57           43.687689    38.737984   0.01754386 
+  44           43.34935     38.734908   0.02272727 
+  61           43.106342    38.731881   0.01639344 
+  43           42.896209    38.728903   0.02325581 
+  53           42.713186    38.725974   0.01886792 
+  57           42.554578    38.723094   0.01754386 
+  53           42.418317    38.720264   0.01886792 
+  50           42.302983    38.717482   0.02      
+  50           42.207257    38.71475    0.02      
+  46           42.129939    38.712068   0.02173913 
+  48           42.070269    38.709436   0.02083333 
+  43           42.027798    38.706855   0.02325581 
+  37           42.00276     38.704323   0.02702703 
+  40           41.996047    38.701842   0.025     
+  53           42.009677    38.699411   0.01886792 
+  38           42.046788    38.697031   0.02631579 
+  51           42.085735    38.694703   0.01960784 
+  36           42.184892    38.692425   0.02777778 
+  46           42.324881    38.690199   0.02173913 
+  43           42.512171    38.688024   0.02325581 
+  55           42.750583    38.685901   0.01818182 
+  45           43.034407    38.68383    0.02222222 
+  48           43.339277    38.681811   0.02083333 
+  62           43.624051    38.679844   0.01612903 
+  38           43.862636    38.67793    0.02631579 
+  61           44.080627    38.676068   0.01639344 
+  50           44.335263    38.674258   0.02      
+  41           44.664481    38.672502   0.02439024 
+  57           45.047941    38.670799   0.01754386 
+  63           45.392066    38.669149   0.01587302 
+  49           45.5574      38.667553   0.02040816 
+  53           45.475862    38.66601    0.01886792 
+  61           45.227768    38.664521   0.01639344 
+  57           44.959437    38.663086   0.01754386 
+  52           44.776623    38.661706   0.01923077 
+  54           44.73395     38.660379   0.01851852 
+  43           44.858055    38.659107   0.02325581 
+  48           45.170318    38.65789    0.02083333 
+  53           45.690437    38.656728   0.01886792 
+  49           46.436809    38.655621   0.02040816 
+  46           47.420354    38.654569   0.02173913 
+  48           48.647773    38.653573   0.02083333 
+  61           50.107366    38.652632   0.01639344 
+  46           51.68497     38.651747   0.02173913 
+  50           53.083111    38.650919   0.02      
+  46           53.9087      38.650146   0.02173913 
+  57           54.020974    38.64943    0.01754386 
+  37           53.657184    38.64877    0.02702703 
+  50           53.151401    38.648167   0.02      
+  51           52.682348    38.647621   0.01960784 
+  58           52.228209    38.647132   0.01724138 
+  49           51.707208    38.6467     0.02040816 
+  60           51.154966    38.646326   0.01666667 
+  47           50.729361    38.64601    0.0212766 
+  34           50.598765    38.645751   0.02941176 
+  55           50.876924    38.645551   0.01818182 
+  47           51.628822    38.645408   0.0212766 
+  47           52.888368    38.645325   0.0212766 
+  44           54.676842    38.645299   0.02272727 
+  51           57.024969    38.645333   0.01960784 
+  59           59.92448     38.645426   0.01694915 
+  48           63.187886    38.645577   0.02083333 
+  69           66.300523    38.645788   0.01449275 
+  71           68.480633    38.646059   0.01408451 
+  64           69.036491    38.64639    0.015625  
+  57           67.972569    38.64678    0.01754386 
+  59           66.021598    38.64723    0.01694915 
+  68           63.926446    38.647741   0.01470588 
+  79           62.015699    38.648313   0.01265823 
+  67           60.384875    38.648945   0.01492537 
+  58           59.09949     38.649638   0.01724138 
+  58           58.207853    38.650392   0.01724138 
+  58           57.692629    38.651207   0.01724138 
+  60           57.489717    38.652084   0.01666667 
+  51           57.521891    38.653023   0.01960784 
+  56           57.733996    38.654023   0.01785714 
+  50           58.11261     38.655085   0.02      
+  65           58.688385    38.65621    0.01538462 
+  60           59.471489    38.657397   0.01666667 
+  60           60.358587    38.658647   0.01666667 
+  66           61.045105    38.65996    0.01515152 
+  61           61.124753    38.661335   0.01639344 
+  68           60.449645    38.662774   0.01470588 
+  75           59.30697     38.664277   0.01333333 
+  66           58.110869    38.665843   0.01515152 
+  56           57.101049    38.667473   0.01785714 
+  46           56.345421    38.669166   0.02173913 
+  56           55.853094    38.670925   0.01785714 
+  50           55.616927    38.672747   0.02      
+  47           55.615557    38.674634   0.0212766 
+  46           55.815413    38.676586   0.02173913 
+  66           56.186936    38.678603   0.01515152 
+  62           56.708113    38.680685   0.01612903 
+  62           57.365174    38.682833   0.01612903 
+  56           58.127667    38.685046   0.01785714 
+  60           58.916714    38.687325   0.01666667 
+  73           59.575871    38.68967    0.01369863 
+  68           59.960837    38.692082   0.01470588 
+  76           60.100908    38.694559   0.01315789 
+  70           60.204645    38.697104   0.01428571 
+  77           60.482232    38.699715   0.01298701 
+  70           61.054308    38.702393   0.01428571 
+  69           61.94947     38.705139   0.01449275 
+  51           63.133246    38.707952   0.01960784 
+  49           64.522553    38.710832   0.02040816 
+  66           66.031514    38.713781   0.01515152 
+  52           67.594796    38.716797   0.01923077 
+  69           69.114689    38.719882   0.01449275 
+  73           70.468334    38.723035   0.01369863 
+  61           71.597842    38.726257   0.01639344 
+  66           72.50868     38.729547   0.01515152 
+  69           73.129792    38.732907   0.01449275 
+  62           73.26982     38.736336   0.01612903 
+  72           72.781872    38.739835   0.01388889 
+  62           71.695408    38.743403   0.01612903 
+  68           70.248377    38.747041   0.01470588 
+  63           68.810736    38.75075    0.01587302 
+  62           67.6957      38.754528   0.01612903 
+  58           67.078704    38.758378   0.01724138 
+  80           67.023631    38.762298   0.0125    
+  64           67.537302    38.766288   0.015625  
+  63           68.590637    38.770351   0.01587302 
+  71           70.138811    38.774484   0.01408451 
+  87           72.110976    38.778689   0.01149425 
+  74           74.351432    38.782966   0.01351351 
+  77           76.570435    38.787315   0.01298701 
+  83           78.465784    38.791736   0.01204819 
+  81           79.879895    38.796229   0.01234568 
+  79           80.735795    38.800795   0.01265823 
+  80           80.974888    38.805434   0.0125    
+  77           80.699456    38.810146   0.01298701 
+  81           80.170822    38.814932   0.01234568 
+  89           79.634798    38.81979    0.01123596 
+  89           79.252041    38.824723   0.01123596 
+  86           79.086049    38.829729   0.01162791 
+  89           79.133439    38.83481    0.01123596 
+  80           79.359825    38.839965   0.0125    
+  67           79.737088    38.845194   0.01492537 
+  85           80.279592    38.850499   0.01176471 
+  75           81.068818    38.855878   0.01333333 
+  75           82.298879    38.861333   0.01333333 
+  82           84.318147    38.866863   0.01219512 
+  87           87.662478    38.872468   0.01149425 
+  102          93.052657    38.87815    0.00980392 
+  126          101.282872   38.883907   0.00793651 
+  117          112.882536   38.889741   0.00854701 
+  132          127.183961   38.895652   0.00757576 
+  127          140.739795   38.901639   0.00787402 
+  143          146.33873    38.907703   0.00699301 
+  132          139.169522   38.913844   0.00757576 
+  117          123.805967   38.920063   0.00854701 
+  109          107.629605   38.926359   0.00917431 
+  90           94.347471    38.932734   0.01111111 
+  96           84.647138    38.939186   0.01041667 
+  102          78.030673    38.945716   0.00980392 
+  71           73.648811    38.952325   0.01408451 
+  64           70.749698    38.959013   0.015625  
+  81           68.832591    38.96578    0.01234568 
+  74           67.680913    38.972626   0.01351351 
+  53           67.34555     38.979551   0.01886792 
+  72           68.083644    38.986556   0.01388889 
+  78           70.288431    38.993641   0.01282051 
+  80           74.309913    39.000806   0.0125    
+  77           80.179792    39.008051   0.01298701 
+  89           86.958026    39.015377   0.01123596 
+  90           91.814684    39.022783   0.01111111 
+  95           91.043694    39.030271   0.01052632 
+  97           84.544129    39.037839   0.01030928 
+  83           75.959918    39.04549    0.01204819 
+  65           68.182277    39.053221   0.01538462 
+  62           62.168728    39.061035   0.01612903 
+  53           57.903312    39.068931   0.01886792 
+  64           55.009959    39.076909   0.015625  
+  52           53.072836    39.084969   0.01923077 
+  56           51.751423    39.093113   0.01785714 
+  53           50.824554    39.101339   0.01886792 
+  45           50.166395    39.109649   0.02222222 
+  56           49.716308    39.118042   0.01785714 
+  48           49.447106    39.126519   0.02083333 
+  46           49.343668    39.13508    0.02173913 
+  45           49.391942    39.143725   0.02222222 
+  56           49.586472    39.152455   0.01785714 
+  53           49.946925    39.161269   0.01886792 
+  41           50.501745    39.170168   0.02439024 
+  32           51.222079    39.179152   0.03125   
+  53           51.949964    39.188222   0.01886792 
+  44           52.375317    39.197377   0.02272727 
+  45           52.212704    39.206617   0.02222222 
+  55           51.479297    39.215944   0.01818182 
+  40           50.469736    39.225357   0.025     
+  42           49.474434    39.234857   0.02380952 
+  52           48.64019     39.244444   0.01923077 
+  48           48.002261    39.254117   0.02083333 
+  47           47.548838    39.263878   0.0212766 
+  53           47.250912    39.273726   0.01886792 
+  52           47.080061    39.283662   0.01923077 
+  53           47.01092     39.293685   0.01886792 
+  42           47.023109    39.303797   0.02380952 
+  53           47.099269    39.313997   0.01886792 
+  43           47.235584    39.324286   0.02325581 
+  54           47.443025    39.334664   0.01851852 
+  52           47.730861    39.345131   0.01923077 
+  40           48.066073    39.355687   0.025     
+  47           48.341848    39.366333   0.0212766 
+  51           48.39117     39.377069   0.01960784 
+  54           48.111906    39.387895   0.01851852 
+  45           47.574677    39.398811   0.02222222 
+  42           46.94511     39.409818   0.02380952 
+  51           46.350289    39.420915   0.01960784 
+  51           45.84913     39.432104   0.01960784 
+  56           45.455273    39.443384   0.01785714 
+  45           45.164318    39.454755   0.02222222 
+  47           44.964167    39.466218   0.0212766 
+  51           44.843138    39.477773   0.01960784 
+  41           44.793456    39.489421   0.02439024 
+  47           44.811285    39.501161   0.0212766 
+  32           44.896511    39.512993   0.03125   
+  36           45.049853    39.524919   0.02777778 
+  62           45.266307    39.536938   0.01612903 
+  36           45.53404     39.549051   0.02777778 
+  49           45.851995    39.561257   0.02040816 
+  33           46.249492    39.573557   0.03030303 
+  51           46.767766    39.585951   0.01960784 
+  46           47.402919    39.59844    0.02173913 
+  42           48.054727    39.611024   0.02380952 
+  52           48.503571    39.623702   0.01923077 
+  47           48.527425    39.636476   0.0212766 
+  53           48.103411    39.649345   0.01886792 
+  44           47.409393    39.66231    0.02272727 
+  51           46.631135    39.675371   0.01960784 
+  56           45.881021    39.688528   0.01785714 
+  44           45.229074    39.701782   0.02272727 
+  56           44.716858    39.715132   0.01785714 
+  49           44.353468    39.72858    0.02040816 
+  39           44.128445    39.742124   0.02564103 
+  40           44.021964    39.755766   0.025     
+  43           44.011473    39.769506   0.02325581 
+  57           44.07391     39.783344   0.01754386 
+  41           44.199287    39.79728    0.02439024 
+  44           44.395457    39.811314   0.02272727 
+  54           44.674414    39.825447   0.01851852 
+  35           45.021623    39.83968    0.02857143 
+  38           45.369352    39.854011   0.02631579 
+  46           45.596644    39.868442   0.02173913 
+  48           45.599037    39.882973   0.02083333 
+  39           45.385053    39.897603   0.02564103 
+  52           45.048498    39.912334   0.01923077 
+  39           44.671292    39.927166   0.02564103 
+  45           44.302066    39.942098   0.02222222 
+  42           43.971269    39.957132   0.02380952 
+  53           43.695898    39.972266   0.01886792 
+  54           43.477805    39.987503   0.01851852 
+  45           43.310908    40.002841   0.02222222 
+  38           43.188317    40.018281   0.02631579 
+  53           43.102545    40.033823   0.01886792 
+  38           43.048807    40.049468   0.02631579 
+  44           43.024333    40.065216   0.02272727 
+  41           43.028054    40.081068   0.02439024 
+  59           43.06125     40.097022   0.01694915 
+  37           43.125633    40.11308    0.02702703 
+  38           43.222951    40.129242   0.02631579 
+  45           43.353319    40.145508   0.02222222 
+  45           43.511619    40.161879   0.02222222 
+  44           43.679427    40.178354   0.02272727 
+  34           43.818339    40.194934   0.02941176 
+  49           43.880398    40.21162    0.02040816 
+  52           43.846898    40.228411   0.01923077 
+  36           43.746929    40.245308   0.02777778 
+  51           43.626271    40.26231    0.01960784 
+  40           43.515218    40.279419   0.025     
+  59           43.426471    40.296635   0.01694915 
+  42           43.363994    40.313957   0.02380952 
+  52           43.328979    40.331387   0.01923077 
+  40           43.32208     40.348924   0.025     
+  43           43.345838    40.366568   0.02325581 
+  53           43.402874    40.38432    0.01886792 
+  48           43.496805    40.402181   0.02083333 
+  58           43.629982    40.42015    0.01724138 
+  44           43.799994    40.438227   0.02272727 
+  51           43.994226    40.456414   0.01960784 
+  56           44.183316    40.47471    0.01785714 
+  38           44.331542    40.493115   0.02631579 
+  33           44.418761    40.51163    0.03030303 
+  53           44.44895     40.530255   0.01886792 
+  50           44.443641    40.548991   0.02      
+  42           44.435875    40.567837   0.02380952 
+  53           44.454736    40.586793   0.01886792 
+  54           44.516488    40.605861   0.01851852 
+  47           44.62449     40.625041   0.0212766 
+  39           44.775478    40.644332   0.02564103 
+  46           44.962444    40.663735   0.02173913 
+  39           45.179926    40.68325    0.02564103 
+  45           45.423781    40.702878   0.02222222 
+  59           45.687308    40.722618   0.01694915 
+  37           45.963139    40.742472   0.02702703 
+  39           46.251229    40.762439   0.02564103 
+  50           46.556998    40.782519   0.02      
+  49           46.880175    40.802714   0.02040816 
+  52           47.209851    40.823022   0.01923077 
+  39           47.531966    40.843445   0.02564103 
+  41           47.846673    40.863983   0.02439024 
+  45           48.170826    40.884636   0.02222222 
+  50           48.528958    40.905404   0.02      
+  39           48.945646    40.926287   0.02564103 
+  42           49.4503      40.947286   0.02380952 
+  54           50.085114    40.968402   0.01851852 
+  49           50.910512    40.989634   0.02040816 
+  61           52.012697    41.010982   0.01639344 
+  48           53.498237    41.032448   0.02083333 
+  63           55.484506    41.05403    0.01587302 
+  68           58.071442    41.075731   0.01470588 
+  81           61.340198    41.097549   0.01234568 
+  90           65.304804    41.119485   0.01111111 
+  98           69.720902    41.141539   0.01020408 
+  95           73.673415    41.163713   0.01052632 
+  129          75.576368    41.186005   0.00775194 
+  109          74.40841     41.208416   0.00917431 
+  96           70.933676    41.230947   0.01041667 
+  109          66.792927    41.253597   0.00917431 
+  87           63.122628    41.276368   0.01149425 
+  78           60.338053    41.299259   0.01282051 
+  70           58.491904    41.322271   0.01428571 
+  82           57.493114    41.345404   0.01219512 
+  64           57.235042    41.368657   0.015625  
+  58           57.625129    41.392033   0.01724138 
+  65           58.605703    41.41553    0.01538462 
+  66           60.1144      41.439149   0.01515152 
+  58           62.016265    41.462891   0.01724138 
+  65           64.020702    41.486755   0.01538462 
+  82           65.781121    41.510743   0.01219512 
+  67           67.213094    41.534853   0.01492537 
+  64           68.523947    41.559087   0.015625  
+  96           69.726467    41.583445   0.01041667 
+  98           70.270217    41.607927   0.01020408 
+  95           69.501765    41.632534   0.01052632 
+  104          67.446081    41.657265   0.00961538 
+  96           64.706303    41.682121   0.01041667 
+  82           61.905177    41.707103   0.01219512 
+  88           59.486906    41.73221    0.01136364 
+  71           57.678747    41.757443   0.01408451 
+  63           56.539775    41.782802   0.01587302 
+  67           56.025281    41.808288   0.01492537 
+  79           56.049622    41.8339     0.01265823 
+  55           56.476262    41.85964    0.01818182 
+  73           57.100571    41.885507   0.01369863 
+  66           57.651929    41.911501   0.01515152 
+  60           57.896864    41.937624   0.01666667 
+  56           57.730188    41.963875   0.01785714 
+  55           57.208956    41.990254   0.01818182 
+  51           56.546979    42.016762   0.01960784 
+  58           55.988984    42.0434     0.01724138 
+  68           55.672727    42.070166   0.01470588 
+  60           55.603972    42.097063   0.01666667 
+  53           55.686326    42.12409    0.01886792 
+  59           55.79526     42.151247   0.01694915 
+  65           55.883629    42.178534   0.01538462 
+  60           56.007877    42.205953   0.01666667 
+  66           56.221303    42.233503   0.01515152 
+  65           56.500828    42.261184   0.01538462 
+  59           56.785887    42.288997   0.01694915 
+  59           57.103002    42.316943   0.01694915 
+  67           57.580467    42.345021   0.01492537 
+  61           58.347353    42.373232   0.01639344 
+  51           59.461247    42.401576   0.01960784 
+  58           60.965737    42.430053   0.01724138 
+  62           62.926385    42.458664   0.01612903 
+  44           65.347219    42.487409   0.02272727 
+  63           67.952409    42.516288   0.01587302 
+  56           70.087564    42.545302   0.01785714 
+  68           70.981116    42.574451   0.01470588 
+  53           70.38951     42.603735   0.01886792 
+  48           68.713008    42.633154   0.02083333 
+  73           66.524875    42.66271    0.01369863 
+  54           64.307517    42.692401   0.01851852 
+  56           62.439167    42.722229   0.01785714 
+  44           61.123391    42.752194   0.02272727 
+  60           60.407118    42.782296   0.01666667 
+  56           60.263877    42.812535   0.01785714 
+  54           60.726657    42.842912   0.01851852 
+  67           61.981263    42.873427   0.01492537 
+  64           64.365212    42.904081   0.015625  
+  66           68.314054    42.934873   0.01515152 
+  68           74.248989    42.965804   0.01470588 
+  63           82.403972    42.996874   0.01587302 
+  92           92.453754    43.028084   0.01086957 
+  104          102.492331   43.059434   0.00961538 
+  92           108.284451   43.090924   0.01086957 
+  97           106.301172   43.122554   0.01030928 
+  107          98.43095     43.154326   0.00934579 
+  92           89.145657    43.186238   0.01086957 
+  79           81.079221    43.218292   0.01265823 
+  86           74.9272      43.250488   0.01162791 
+  60           70.397782    43.282826   0.01666667 
+  56           66.948885    43.315307   0.01785714 
+  60           64.184493    43.34793    0.01666667 
+  53           61.928272    43.380696   0.01886792 
+  61           60.149459    43.413606   0.01639344 
+  59           58.921589    43.446659   0.01694915 
+  56           58.393473    43.479856   0.01785714 
+  60           58.728753    43.513198   0.01666667 
+  66           60.092909    43.546685   0.01515152 
+  58           62.597976    43.580316   0.01724138 
+  59           66.199852    43.614093   0.01694915 
+  77           70.399117    43.648015   0.01298701 
+  67           73.666694    43.682084   0.01492537 
+  60           73.868064    43.716298   0.01666667 
+  71           70.737779    43.75066    0.01408451 
+  85           66.303098    43.785168   0.01176471 
+  69           62.330961    43.819823   0.01449275 
+  64           59.4139      43.854626   0.015625  
+  53           57.463043    43.889577   0.01886792 
+  56           56.115456    43.924676   0.01785714 
+  69           55.042925    43.959924   0.01449275 
+  52           54.081375    43.995321   0.01923077 
+  51           53.203754    44.030867   0.01960784 
+  50           52.449934    44.066562   0.02      
+  62           51.882167    44.102408   0.01612903 
+  56           51.544787    44.138403   0.01785714 
+  52           51.454511    44.174549   0.01923077 
+  67           51.606394    44.210846   0.01492537 
+  46           51.97248     44.247294   0.02173913 
+  57           52.485266    44.283894   0.01754386 
+  63           53.025962    44.320645   0.01587302 
+  68           53.47831     44.357549   0.01470588 
+  52           53.825974    44.394605   0.01923077 
+  78           54.153295    44.431814   0.01282051 
+  82           54.521058    44.469177   0.01219512 
+  50           54.878551    44.506692   0.02      
+  60           55.114866    44.544362   0.01666667 
+  69           55.218146    44.582186   0.01449275 
+  75           55.345922    44.620164   0.01333333 
+  78           55.71939     44.658298   0.01282051 
+  50           56.517569    44.696586   0.02      
+  73           57.873806    44.73503    0.01369863 
+  59           59.862752    44.77363    0.01694915 
+  57           62.469898    44.812386   0.01754386 
+  46           65.471618    44.851298   0.02173913 
+  61           68.325694    44.890368   0.01639344 
+  61           70.29568     44.929595   0.01639344 
+  51           71.050566    44.968979   0.01960784 
+  56           71.024373    45.008521   0.01785714 
+  58           70.901725    45.048221   0.01724138 
+  55           70.993818    45.08808    0.01818182 
+  65           71.134493    45.128098   0.01538462 
+  63           70.929271    45.168275   0.01587302 
+  80           70.059603    45.208612   0.0125    
+  57           68.42148     45.249109   0.01754386 
+  72           66.21045     45.289766   0.01388889 
+  91           63.898761    45.330583   0.01098901 
+  69           61.950162    45.371562   0.01449275 
+  58           60.616794    45.412702   0.01724138 
+  49           59.932067    45.454003   0.02040816 
+  60           59.80777     45.495467   0.01666667 
+  64           60.129318    45.537093   0.015625  
+  50           60.795972    45.578882   0.02      
+  56           61.628422    45.620833   0.01785714 
+  60           62.292377    45.662948   0.01666667 
+  61           62.449215    45.705227   0.01639344 
+  64           62.079132    45.74767    0.015625  
+  53           61.522673    45.790277   0.01886792 
+  51           61.129764    45.833049   0.01960784 
+  39           60.975998    45.875987   0.02564103 
+  63           60.87849     45.91909    0.01587302 
+  47           60.576203    45.962358   0.0212766 
+  66           59.907875    46.005793   0.01515152 
+  51           58.87515     46.049394   0.01960784 
+  49           57.652913    46.093162   0.02040816 
+  54           56.49536     46.137098   0.01851852 
+  51           55.570993    46.181201   0.01960784 
+  58           54.914949    46.225472   0.01724138 
+  52           54.455283    46.269911   0.01923077 
+#--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--#
+
+# start Validation Reply Form
+_vrf_PLAT741_QPAPBMXGreaseSuspendedSamplePrep_phase_1 # for all atoms in 1_quartz
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT741_QPAPBMXGreaseSuspendedSamplePrep_phase_3 # for all atoms in 3_pyrrhotite
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT741_QPAPBMXGreaseSuspendedSamplePrep_phase_4 # for all atoms in 4_rutile
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT741_QPAPBMXGreaseSuspendedSamplePrep_phase_2 # for all atoms in 2_albite
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT155_QPAPBMXGreaseSuspendedSamplePrep_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+; 
+_vrf_PLAT141_QPAPBMXGreaseSuspendedSamplePrep_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT142_QPAPBMXGreaseSuspendedSamplePrep_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT143_QPAPBMXGreaseSuspendedSamplePrep_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT144_QPAPBMXGreaseSuspendedSamplePrep_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT145_QPAPBMXGreaseSuspendedSamplePrep_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT146_QPAPBMXGreaseSuspendedSamplePrep_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT151_QPAPBMXGreaseSuspendedSamplePrep_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+# end Validation Reply Form

--- a/data/hamish/fixed/vb5042sup2.cif
+++ b/data/hamish/fixed/vb5042sup2.cif
@@ -1,0 +1,8052 @@
+
+data_QPAPBMXHandGrindSamplePrep_publ
+_audit_creation_method  "created in GSAS-II"
+_audit_creation_date  2021-08-04T17:23
+_audit_author_name  "McDougall, Hamish"
+_audit_update_record
+   "2021-08-04T17:23  Initial software-generated CIF"
+_pd_block_id
+   2021-08-04T17:23|QPAPBMXHandGrindSamplePrep|McDougallHamish|Overall
+# GSAS-II edited template follows Publication_Template
+#=============================================================================
+# this information describes the project, paper etc. for the CIF             #
+# Acta Cryst. Section C papers and editorial correspondence is generated     #
+# from the information in this section                                       #
+#                                                                            #
+#   (from)   CIF submission form for Rietveld refinements (Acta Cryst. C)    #
+#                                                 Version 14 December 1998   #
+#=============================================================================
+# 1. SUBMISSION DETAILS
+
+_publ_contact_author_name            "Suzanne Neville; Vanessa Peterson; Christophe Didier"   # Name of author for correspondence
+_publ_contact_author_address             # Address of author for correspondence
+; ?
+;
+_publ_contact_author_email           "s.neville@unsw.edu.au; vanessa.peterson@ansto.gov.au; drchristophedidier@gmail.com"
+_publ_contact_author_fax             ?
+_publ_contact_author_phone           ?
+
+_publ_contact_letter
+; ?
+;
+   
+_publ_requested_journal              ?
+_publ_requested_coeditor_name        ?
+_publ_requested_category             ?   # Acta C: one of CI/CM/CO/FI/FM/FO
+
+#==============================================================================
+
+# 2. PROCESSING SUMMARY (IUCr Office Use Only)
+
+_journal_data_validation_number      ?
+
+_journal_date_recd_electronic        ?
+_journal_date_to_coeditor            ?
+_journal_date_from_coeditor          ?
+_journal_date_accepted               ?
+_journal_date_printers_first         ?
+_journal_date_printers_final         ?
+_journal_date_proofs_out             ?
+_journal_date_proofs_in              ?
+_journal_coeditor_name               ?
+_journal_coeditor_code               ?
+_journal_coeditor_notes
+; ?
+;
+_journal_techeditor_code             ?
+_journal_techeditor_notes
+; ?
+;
+_journal_coden_ASTM                  ?
+_journal_name_full                   ?
+_journal_year                        ?
+_journal_volume                      ?
+_journal_issue                       ?
+_journal_page_first                  ?
+_journal_page_last                   ?
+_journal_paper_category              ?
+_journal_suppl_publ_number           ?
+_journal_suppl_publ_pages            ?
+
+#==============================================================================
+
+# 3. TITLE AND AUTHOR LIST
+
+_publ_section_title
+; ?
+;
+_publ_section_title_footnote
+; ?
+;         
+ 
+# The loop structure below should contain the names and addresses of all 
+# authors, in the required order of publication. Repeat as necessary.
+
+loop_
+	_publ_author_name
+        _publ_author_footnote
+	_publ_author_address
+ ?                                   #<--'Last name, first name' 
+; ?
+;
+; ?
+;
+
+#==============================================================================
+
+# 4. TEXT
+
+_publ_section_synopsis
+;  ?
+;
+_publ_section_abstract                         
+; ?
+;          
+_publ_section_comment                          
+; ?
+;
+_publ_section_exptl_prep      # Details of the preparation of the sample(s)
+                              # should be given here. 
+; ?
+;
+_publ_section_exptl_refinement                  
+; ?
+;
+_publ_section_references
+; ?
+;
+_publ_section_figure_captions
+; ?
+;
+_publ_section_acknowledgements
+; ?
+;
+
+#=============================================================================
+# 5. OVERALL REFINEMENT & COMPUTING DETAILS
+
+_refine_special_details
+; ?
+;
+_pd_proc_ls_special_details
+; ?
+;
+
+# The following items are used to identify the programs used.
+_computing_molecular_graphics     ?
+_computing_publication_material   ?
+
+_refine_ls_weighting_scheme       ?        
+_refine_ls_weighting_details      ?
+_refine_ls_hydrogen_treatment     ?        
+_refine_ls_extinction_method      ?        
+_refine_ls_extinction_coef        ?         
+_refine_ls_number_constraints     ?        
+
+_refine_ls_restrained_S_all       ?        
+_refine_ls_restrained_S_obs       ?
+
+#==============================================================================
+# 6. SAMPLE PREPARATION DATA
+
+# (In the unusual case where multiple samples are used in a single
+#  Rietveld study, this information should be moved into the phase
+#  blocks)
+
+# The following three fields describe the preparation of the material.
+# The cooling rate is in K/min.  The pressure at which the sample was  
+# prepared is in kPa.  The temperature of preparation is in K.
+               
+_pd_prep_cool_rate                N/A        
+_pd_prep_pressure                 101.3        
+_pd_prep_temperature              298         
+
+_pd_char_colour                   ?       # use ICDD colour descriptions
+
+data_QPAPBMXHandGrindSamplePrep_overall
+_pd_proc_info_datetime  2021-08-04T17:23
+_pd_calc_method  "Rietveld Refinement"
+_computing_structure_refinement
+   "GSAS-II (Toby & Von Dreele, J. Appl. Cryst. 46, 544-549, 2013)"
+_refine_ls_number_parameters  29
+_refine_ls_goodness_of_fit_all  2.482
+_refine_ls_shift/su_max  4.9301
+
+# OVERALL WEIGHTED R-FACTOR
+_refine_ls_wR_factor_obs  0.14998
+_refine_ls_matrix_type  full
+# POINTERS TO PHASE AND HISTOGRAM BLOCKS
+loop_   _pd_phase_block_id
+
+   2021-08-04T17:23|QPAPBMXHandGrindSamplePrep|phase_2|McDougallHamish
+
+   2021-08-04T17:23|QPAPBMXHandGrindSamplePrep|phase_0|McDougallHamish
+
+   2021-08-04T17:23|QPAPBMXHandGrindSamplePrep|phase_3|McDougallHamish
+
+   2021-08-04T17:23|QPAPBMXHandGrindSamplePrep|phase_4|McDougallHamish
+
+   2021-08-04T17:23|QPAPBMXHandGrindSamplePrep|phase_1|McDougallHamish
+_pd_block_diffractogram_id
+;
+2021-08-04T17:23|QPAPBMXHandGrindSamplePrep|McDougallHamish|PANalytical,Co-EmpyreanII_hist_0
+;
+
+data_QPAPBMXHandGrindSamplePrep_phase_2
+# Information for phase 2
+_pd_block_id
+   2021-08-04T17:23|QPAPBMXHandGrindSamplePrep|phase_2|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Albite NaAlSi3O8 follows
+_pd_phase_name  "Albite NaAlSi3O8"
+_cell_length_a  8.141789
+_cell_length_b  12.787902
+_cell_length_c  7.158828
+_cell_angle_alpha  94.2429
+_cell_angle_beta   116.5972
+_cell_angle_gamma  87.7872
+_cell_volume  664.636
+_exptl_crystal_density_diffrn  2.6206
+_symmetry_cell_setting  triclinic
+_symmetry_space_group_name_H-M  "C -1"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -x,-y,-z
+     3  1/2+x,1/2+y,z
+     4  1/2-x,1/2-y,-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Al1    Al3+ 0.00887     0.16846     0.20805     1.000      Uani 0.007      4   
+Si1    Si4+ 0.00375     0.82051     0.23737     1.000      Uani 0.006      4   
+Si2    Si4+ 0.69162     0.11021     0.31466     1.000      Uani 0.006      4   
+Si3    Si4+ 0.68129     0.88190     0.36076     1.000      Uani 0.006      4   
+Na1    Na1+ 0.26799     0.98865     0.14650     1.000      Uani 0.031      4   
+O1     O2-  0.00490     0.13103     0.96660     1.000      Uani 0.012      4   
+O2     O2-  0.59176     0.99756     0.28040     1.000      Uani 0.008      4   
+O3     O2-  0.81230     0.10966     0.19010     1.000      Uani 0.014      4   
+O4     O2-  0.82000     0.85101     0.25870     1.000      Uani 0.018      4   
+O5     O2-  0.01288     0.30238     0.27060     1.000      Uani 0.011      4   
+O6     O2-  0.02329     0.69368     0.22910     1.000      Uani 0.011      4   
+O7     O2-  0.20780     0.10896     0.38900     1.000      Uani 0.011      4   
+O8     O2-  0.18400     0.86817     0.43620     1.000      Uani 0.012      4   
+
+loop_
+   _atom_site_aniso_label
+   _atom_site_aniso_U_11
+   _atom_site_aniso_U_22
+   _atom_site_aniso_U_33
+   _atom_site_aniso_U_12
+   _atom_site_aniso_U_13
+   _atom_site_aniso_U_23
+Al1    0.0074      0.0068      0.0061      -0.0009     0.0031      0.0004      
+Si1    0.0068      0.0065      0.0055      0.0011      0.0030      0.0008      
+Si2    0.0061      0.0055      0.0073      -0.0002     0.0025      0.0004      
+Si3    0.0060      0.0055      0.0074      0.0006      0.0028      0.0009      
+Na1    0.0136      0.0471      0.0315      -0.0050     0.0084      -0.0219     
+O1     0.0164      0.0122      0.0074      -0.0002     0.0067      0.0014      
+O2     0.0074      0.0056      0.0119      0.0003      0.0033      0.0020      
+O3     0.0117      0.0130      0.0162      -0.0040     0.0093      -0.0017     
+O4     0.0134      0.0179      0.0216      0.0046      0.0129      0.0020      
+O5     0.0103      0.0076      0.0150      -0.0020     0.0052      -0.0009     
+O6     0.0101      0.0071      0.0145      0.0022      0.0034      0.0012      
+O7     0.0120      0.0129      0.0080      0.0024      0.0013      0.0015      
+O8     0.0140      0.0140      0.0084      -0.0026     -0.0002     -0.0006     
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Al   4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Na   4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  O    32     ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si   12     ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Al Na O8 Si3"
+_chemical_formula_weight  262.22
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Al1    O1     1.74545      1_555    1_554 yes
+  Al1    O3     1.74292      1_555    1_455 yes
+  Al1    O5     1.73556      1_555    1_555 yes
+  Al1    O7     1.74706      1_555    1_555 yes
+  Si1    O1     1.59987      1_555    2_566 yes
+  Si1    O4     1.60134      1_555    1_455 yes
+  Si1    O6     1.62285      1_555    1_555 yes
+  Si1    O8     1.61909      1_555    1_555 yes
+  Si2    O2     1.62972      1_555    1_545 yes
+  Si2    O3     1.59488      1_555    1_555 yes
+  Si2    O6     1.62016      1_555    3_545 yes
+  Si2    O8     1.6169       1_555    2_666 yes
+  Si3    O2     1.64834      1_555    1_555 yes
+  Si3    O4     1.6208       1_555    1_555 yes
+  Si3    O5     1.59651      1_555    3_555 yes
+  Si3    O7     1.60217      1_555    2_666 yes
+  Na1    O1     2.67163      1_555    1_564 yes
+  Na1    O1     2.53036      1_555    2_566 yes
+  Na1    O2     2.37173      1_555    1_555 yes
+  Na1    O3     2.45337      1_555    2_665 yes
+  Na1    O7     2.43501      1_555    1_565 yes
+  O1     Al1    1.74545      1_555    1_556 yes
+  O1     Si1    1.59987      1_555    2_566 yes
+  O1     Na1    2.67163      1_555    1_546 yes
+  O1     Na1    2.53036      1_555    2_566 yes
+  O2     Si2    1.62972      1_555    1_565 yes
+  O2     Si3    1.64834      1_555    1_555 yes
+  O2     Na1    2.37173      1_555    1_555 yes
+  O3     Al1    1.74292      1_555    1_655 yes
+  O3     Si2    1.59488      1_555    1_555 yes
+  O3     Na1    2.45337      1_555    2_665 yes
+  O4     Si1    1.60134      1_555    1_655 yes
+  O4     Si3    1.6208       1_555    1_555 yes
+  O5     Al1    1.73556      1_555    1_555 yes
+  O5     Si3    1.59651      1_555    3_445 yes
+  O6     Si1    1.62285      1_555    1_555 yes
+  O6     Si2    1.62016      1_555    3_455 yes
+  O7     Al1    1.74706      1_555    1_555 yes
+  O7     Si3    1.60217      1_555    2_666 yes
+  O7     Na1    2.43501      1_555    1_545 yes
+  O8     Si1    1.61909      1_555    1_555 yes
+  O8     Si2    1.6169       1_555    2_666 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Al1    O3     102.855       1_554  1_555    1_455 yes
+  O1     Al1    O5     116.061       1_554  1_555    1_555 yes
+  O3     Al1    O5     112.147       1_455  1_555    1_555 yes
+  O1     Al1    O7     103.957       1_554  1_555    1_555 yes
+  O3     Al1    O7     111.182       1_455  1_555    1_555 yes
+  O5     Al1    O7     110.191       1_555  1_555    1_555 yes
+  O1     Si1    O4     109.397       2_566  1_555    1_455 yes
+  O1     Si1    O6     112.462       2_566  1_555    1_555 yes
+  O4     Si1    O6     108.255       1_455  1_555    1_555 yes
+  O1     Si1    O8     107.195       2_566  1_555    1_555 yes
+  O4     Si1    O8     111.458       1_455  1_555    1_555 yes
+  O6     Si1    O8     108.103       1_555  1_555    1_555 yes
+  O2     Si2    O3     111.114       1_545  1_555    1_555 yes
+  O2     Si2    O6     104.247       1_545  1_555    3_545 yes
+  O3     Si2    O6     112.16        1_555  1_555    3_545 yes
+  O2     Si2    O8     106.957       1_545  1_555    2_666 yes
+  O3     Si2    O8     111.575       1_555  1_555    2_666 yes
+  O6     Si2    O8     110.428       3_545  1_555    2_666 yes
+  O2     Si3    O4     107.334       1_555  1_555    1_555 yes
+  O2     Si3    O5     105.864       1_555  1_555    3_555 yes
+  O4     Si3    O5     110.228       1_555  1_555    3_555 yes
+  O2     Si3    O7     108.58        1_555  1_555    2_666 yes
+  O4     Si3    O7     110.176       1_555  1_555    2_666 yes
+  O5     Si3    O7     114.331       3_555  1_555    2_666 yes
+  Al1    O1     Si1    141.388       1_556  1_555    2_566 yes
+  Si2    O2     Si3    129.999       1_565  1_555    1_555 yes
+  Si2    O2     Na1    120.298       1_565  1_555    1_555 yes
+  Si3    O2     Na1    108.885       1_555  1_555    1_555 yes
+  Al1    O3     Si2    139.47        1_655  1_555    1_555 yes
+  Si1    O4     Si3    161.161       1_655  1_555    1_555 yes
+  Al1    O5     Si3    129.633       1_555  1_555    3_445 yes
+  Si1    O6     Si2    135.712       1_555  1_555    3_455 yes
+  Al1    O7     Si3    133.928       1_555  1_555    2_666 yes
+  Si1    O8     Si2    151.749       1_555  1_555    2_666 yes
+_pd_proc_ls_pref_orient_corr  none
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    1.000, 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_QPAPBMXHandGrindSamplePrep_phase_0
+# Information for phase 0
+_pd_block_id
+   2021-08-04T17:23|QPAPBMXHandGrindSamplePrep|phase_0|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Pyrite FeS2 - 3191 follows
+_pd_phase_name  "Pyrite FeS2 - 3191"
+_cell_length_a  5.41900(5)
+_cell_length_b  5.41900(5)
+_cell_length_c  5.41900(5)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  90
+_cell_volume  159.132(5)
+_exptl_crystal_density_diffrn  5.0074
+_symmetry_cell_setting  cubic
+_symmetry_space_group_name_H-M  "P a -3"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  z,x,y
+     3  y,z,x
+     4  1/2+x,y,1/2-z
+     5  1/2-z,1/2+x,y
+     6  y,1/2-z,1/2+x
+     7  -z,1/2+x,1/2-y
+     8  1/2-y,-z,1/2+x
+     9  1/2+y,1/2-z,-x
+    10  -x,1/2+y,1/2-z
+    11  1/2-z,-x,1/2+y
+    12  1/2+x,1/2-y,-z
+    13  -x,-y,-z
+    14  -z,-x,-y
+    15  -y,-z,-x
+    16  1/2-x,-y,1/2+z
+    17  1/2+z,1/2-x,-y
+    18  -y,1/2+z,1/2-x
+    19  z,1/2-x,1/2+y
+    20  1/2+y,z,1/2-x
+    21  1/2-y,1/2+z,x
+    22  x,1/2-y,1/2+z
+    23  1/2+z,x,1/2-y
+    24  1/2-x,1/2+y,z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Fe1    Fe   0.00000     0.00000     0.00000     1.000      Uiso 0.0281(10) 4   
+S2     S    0.38871(17) 0.38871     0.38871     1.000      Uiso 0.0310(8)  8   
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Fe   4      11.7695    7.3573     3.5222     2.3045     4.7611     0.3072     15.3535    76.8805    1.0369     0.945
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S    8      6.9053     5.2034     1.4379     1.5863     1.4679     22.2151    0.2536     56.172     0.8669     0.2847
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Fe S2"
+_chemical_formula_weight  119.97
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Fe1    S2     2.27253(24)   1_555    4_455 yes
+  Fe1    S2     2.27253(24)   1_555    5_545 yes
+  Fe1    S2     2.27253(24)   1_555    6_554 yes
+  Fe1    S2     2.27253(24)   1_555    7_545 yes
+  Fe1    S2     2.27253(24)   1_555    8_554 yes
+  Fe1    S2     2.2725(8)    1_555    9_455 yes
+  S2     Fe1    2.27253(24)   1_555    4_555 yes
+  S2     Fe1    2.27253(24)   1_555    5_555 yes
+  S2     Fe1    2.2725(8)    1_555    6_555 yes
+  S2     S2     2.0892(10)   1_555   13_666 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.389(5), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_QPAPBMXHandGrindSamplePrep_phase_3
+# Information for phase 3
+_pd_block_id
+   2021-08-04T17:23|QPAPBMXHandGrindSamplePrep|phase_3|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Pyrrhotite 4M Fe7S8 follows
+_pd_phase_name  "Pyrrhotite 4M Fe7S8"
+_cell_length_a  11.93(4)
+_cell_length_b  6.860(5)
+_cell_length_c  12.89(4)
+_cell_angle_alpha  90
+_cell_angle_beta   117.08(7)
+_cell_angle_gamma  90
+_cell_volume  939.0(4)
+_exptl_crystal_density_diffrn  4.5794
+_symmetry_cell_setting  monoclinic
+_symmetry_space_group_name_H-M  "C 2/c"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -x,y,1/2-z
+     3  -x,-y,-z
+     4  x,-y,1/2+z
+     5  1/2+x,1/2+y,z
+     6  1/2-x,1/2+y,1/2-z
+     7  1/2-x,1/2-y,-z
+     8  1/2+x,1/2-y,1/2+z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+S1     S    0.01800     0.38330     0.11960     1.000      Uiso 0.010      8   
+S2     S    0.02910     0.11420     0.63900     1.000      Uiso 0.010      8   
+Fe3    Fe   0.10860     0.10250     0.49980     1.000      Uiso 0.010      8   
+S4     S    0.23410     0.13550     0.38260     1.000      Uiso 0.010      8   
+Fe5    Fe   0.24180     0.36600     0.24680     1.000      Uiso 0.010      8   
+S6     S    0.26790     0.13400     0.12360     1.000      Uiso 0.010      8   
+Fe7    Fe   0.38720     0.15000     0.01260     1.000      Uiso 0.010      8   
+Fe8    Fe   0.00000     0.14720     0.25000     1.000      Uiso 0.010      4   
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Fe   28     11.7695    7.3573     3.5222     2.3045     4.7611     0.3072     15.3535    76.8805    1.0369     0.945
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S    32     6.9053     5.2034     1.4379     1.5863     1.4679     22.2151    0.2536     56.172     0.8669     0.2847
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Fe7 S8"
+_chemical_formula_weight  647.41
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  S1     Fe3    2.49857      1_555    2_555 yes
+  S1     Fe5    2.4174       1_555    1_555 yes
+  S1     Fe7    2.39247      1_555    5_455 yes
+  S1     Fe7    2.4473       1_555    7_555 yes
+  S1     Fe8    2.413        1_555    1_555 yes
+  S2     Fe3    2.3821       1_555    1_555 yes
+  S2     Fe3    2.33075      1_555    3_556 yes
+  S2     Fe5    2.44766      1_555    7_556 yes
+  S2     Fe7    2.37162      1_555    8_456 yes
+  S2     Fe8    2.41553      1_555    3_556 yes
+  Fe3    S1     2.49857      1_555    2_555 yes
+  Fe3    S2     2.3821       1_555    1_555 yes
+  Fe3    S2     2.33075      1_555    3_556 yes
+  Fe3    S6     2.45518      1_555    4_556 yes
+  S4     Fe5    2.39134      1_555    1_555 yes
+  Fe5    S1     2.4174       1_555    1_555 yes
+  Fe5    S2     2.44766      1_555    7_556 yes
+  Fe5    S4     2.39134      1_555    1_555 yes
+  Fe5    S6     2.36671      1_555    1_555 yes
+  S6     Fe3    2.45518      1_555    4_555 yes
+  S6     Fe5    2.36671      1_555    1_555 yes
+  S6     Fe7    2.43689      1_555    1_555 yes
+  S6     Fe7    2.39639      1_555    7_555 yes
+  Fe7    S1     2.39247      1_555    5_545 yes
+  Fe7    S1     2.4473       1_555    7_555 yes
+  Fe7    S2     2.37162      1_555    8_555 yes
+  Fe7    S6     2.43689      1_555    1_555 yes
+  Fe7    S6     2.39639      1_555    7_555 yes
+  Fe8    S1     2.413        1_555    1_555 yes
+  Fe8    S1     2.413        1_555    2_555 yes
+  Fe8    S2     2.41553      1_555    3_556 yes
+  Fe8    S2     2.41553      1_555    4_555 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.0230(14), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_QPAPBMXHandGrindSamplePrep_phase_4
+# Information for phase 4
+_pd_block_id
+   2021-08-04T17:23|QPAPBMXHandGrindSamplePrep|phase_4|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Rutile TiO2 follows
+_pd_phase_name  "Rutile TiO2"
+_cell_length_a  4.5962(7)
+_cell_length_b  4.5962(7)
+_cell_length_c  2.9622(7)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  90
+_cell_volume  62.576(15)
+_exptl_crystal_density_diffrn  4.2404
+_symmetry_cell_setting  tetragonal
+_symmetry_space_group_name_H-M  "P 42/m n m"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  1/2-y,1/2+x,1/2+z
+     3  -x,-y,z
+     4  1/2+y,1/2-x,1/2+z
+     5  1/2-x,1/2+y,1/2+z
+     6  -y,-x,z
+     7  1/2+x,1/2-y,1/2+z
+     8  y,x,z
+     9  -x,-y,-z
+    10  1/2+y,1/2-x,1/2-z
+    11  x,y,-z
+    12  1/2-y,1/2+x,1/2-z
+    13  1/2+x,1/2-y,1/2-z
+    14  y,x,-z
+    15  1/2-x,1/2+y,1/2-z
+    16  -y,-x,-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Ti1    Ti4+ 0.00000     0.00000     0.00000     1.000      Uani 0.006      2   
+O1     O2-  0.30493     0.30493     0.00000     1.000      Uani 0.006      4   
+
+loop_
+   _atom_site_aniso_label
+   _atom_site_aniso_U_11
+   _atom_site_aniso_U_22
+   _atom_site_aniso_U_33
+   _atom_site_aniso_U_12
+   _atom_site_aniso_U_13
+   _atom_site_aniso_U_23
+Ti1    0.0070      0.0070      0.0047      -0.0002     0.0000      0.0000      
+O1     0.0060      0.0060      0.0045      -0.0019     0.0000      0.0000      
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  O    4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Ti   2      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  2
+_chemical_formula_sum  "O2 Ti"
+_chemical_formula_weight  79.9
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Ti1    O1     1.98205      1_555    1_555 yes
+  Ti1    O1     1.9497       1_555    2_544 yes
+  Ti1    O1     1.9497       1_555    2_545 yes
+  Ti1    O1     1.98205      1_555    3_555 yes
+  Ti1    O1     1.9497       1_555    4_454 yes
+  Ti1    O1     1.9497       1_555    4_455 yes
+  O1     Ti1    1.98205      1_555    1_555 yes
+  O1     Ti1    1.9497       1_555    2_554 yes
+  O1     Ti1    1.9497       1_555    2_555 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Ti1    O1     90            1_555  1_555    2_544 yes
+  O1     Ti1    O1     90            1_555  1_555    2_545 yes
+  O1     Ti1    O1     98.866        2_544  1_555    2_545 yes
+  O1     Ti1    O1     180           1_555  1_555    3_555 yes
+  O1     Ti1    O1     90            2_544  1_555    3_555 yes
+  O1     Ti1    O1     90            2_545  1_555    3_555 yes
+  O1     Ti1    O1     90            1_555  1_555    4_454 yes
+  O1     Ti1    O1     81.134        2_544  1_555    4_454 yes
+  O1     Ti1    O1     180           2_545  1_555    4_454 yes
+  O1     Ti1    O1     90            3_555  1_555    4_454 yes
+  O1     Ti1    O1     90            1_555  1_555    4_455 yes
+  O1     Ti1    O1     180           2_544  1_555    4_455 yes
+  O1     Ti1    O1     81.134        2_545  1_555    4_455 yes
+  O1     Ti1    O1     90            3_555  1_555    4_455 yes
+  O1     Ti1    O1     98.866        4_454  1_555    4_455 yes
+  Ti1    O1     Ti1    130.567       1_555  1_555    2_554 yes
+  Ti1    O1     Ti1    130.567       1_555  1_555    2_555 yes
+  Ti1    O1     Ti1    98.866        2_554  1_555    2_555 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    1.000, 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_QPAPBMXHandGrindSamplePrep_phase_1
+# Information for phase 1
+_pd_block_id
+   2021-08-04T17:23|QPAPBMXHandGrindSamplePrep|phase_1|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Silica SiO2 follows
+_pd_phase_name  "Silica SiO2"
+_cell_length_a  4.9135(3)
+_cell_length_b  4.9135(3)
+_cell_length_c  5.40577(30)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  120
+_cell_volume  113.026(7)
+_exptl_crystal_density_diffrn  2.6482
+_symmetry_cell_setting  trigonal
+_symmetry_space_group_name_H-M  "P 32 2 1"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -y,x-y,2/3+z
+     3  y-x,-x,1/3+z
+     4  y,x,-z
+     5  -x,y-x,2/3-z
+     6  x-y,-y,1/3-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Si1    Si4+ 0.47000     0.00000     0.66670     1.000      Uani 0.006      3   
+O1     O2-  0.41460     0.26780     0.78543     1.000      Uani 0.011      6   
+
+loop_
+   _atom_site_aniso_label
+   _atom_site_aniso_U_11
+   _atom_site_aniso_U_22
+   _atom_site_aniso_U_33
+   _atom_site_aniso_U_12
+   _atom_site_aniso_U_13
+   _atom_site_aniso_U_23
+Si1    0.0073      0.0059      0.0053      0.0029      0.0003      0.0006      
+O1     0.0120      0.0105      0.0118      0.0065      -0.0029     -0.0040     
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  O    6      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si   3      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  3
+_chemical_formula_sum  "O2 Si"
+_chemical_formula_weight  60.08
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Si1    O1     1.60489      1_555    1_555 yes
+  Si1    O1     1.6114       1_555    2_654 yes
+  Si1    O1     1.61114      1_555    5_656 yes
+  Si1    O1     1.60504      1_555    6_556 yes
+  O1     Si1    1.60489      1_555    1_555 yes
+  O1     Si1    1.6114       1_555    3_665 yes
+  O1     Si1    1.61114      1_555    5_666 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Si1    O1     110.262       1_555  1_555    2_654 yes
+  O1     Si1    O1     108.732       1_555  1_555    5_656 yes
+  O1     Si1    O1     109.697       2_654  1_555    5_656 yes
+  O1     Si1    O1     109.164       1_555  1_555    6_556 yes
+  O1     Si1    O1     108.712       2_654  1_555    6_556 yes
+  O1     Si1    O1     110.268       5_656  1_555    6_556 yes
+  Si1    O1     Si1    143.832       1_555  1_555    3_665 yes
+  Si1    O1     Si1    143.836       1_555  1_555    5_666 yes
+  Si1    O1     Si1    0.009         3_665  1_555    5_666 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.263(14), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_QPAPBMXHandGrindSamplePrep_pwd_0
+_pd_proc_ls_profile_function
+;
+Finger-Cox-Jephcoat function parameters U, V, W, X, Y, SH/L:
+  peak variance(Gauss) = Utan(Th)^2^+Vtan(Th)+W:
+  peak HW(Lorentz) = X/cos(Th)+Ytan(Th); SH/L = S/L+H/L
+  U, V, W in (centideg)^2^, X & Y in centideg
+    0.000, 0.000, 3.345, 2.239, -0.670, 0.034, 
+;
+# Information for histogram 0: PWDR 201103PBHMR1_PyriteHandGrind.xrdml Scan 1
+_pd_block_id
+
+2021-08-04T17:23|QPAPBMXHandGrindSamplePrep|McDougallHamish|PANalytical,Co-EmpyreanII_hist_0
+
+# GSAS-II edited template follows Instrument_Template
+#==============================================================================
+# 9. INSTRUMENT CHARACTERIZATION
+
+_exptl_special_details
+; ?
+;
+
+# if regions of the data are excluded, the reason(s) are supplied here:
+_pd_proc_info_excluded_regions
+; ?
+;
+
+# The following item is used to identify the equipment used to record 
+# the powder pattern when the diffractogram was measured at a laboratory 
+# other than the authors' home institution, e.g. when neutron or synchrotron
+# radiation is used.
+
+_pd_instr_location
+; ?
+;
+_pd_calibration_special_details           # description of the method used
+                                          # to calibrate the instrument
+; ?
+;
+
+_diffrn_source                    Co-Ka       
+_diffrn_source_target             Co
+_diffrn_source_type               Graded_Flat
+_diffrn_measurement_device_type   Panalytical_Reflection_Transmission       
+_diffrn_detector                  PIXcel1D       
+_diffrn_detector_type             Empyrean_II       # make or model of detector
+
+_pd_meas_scan_method              ?       # options are 'step', 'cont',
+                                          # 'tof', 'fixed' or
+                                          # 'disp' (= dispersive)
+_pd_meas_special_details
+;  ?
+;
+
+# The following two items identify the program(s) used (if appropriate).
+_computing_data_collection        ?        
+_computing_data_reduction         ?                   
+
+# Describe any processing performed on the data, prior to refinement.
+# For example: a manual Lp correction or a precomputed absorption correction
+_pd_proc_info_data_reduction      ?
+
+# The following item is used for angular dispersive measurements only.
+
+_diffrn_radiation_monochromator   ?        
+
+# The following items are used to define the size of the instrument.
+# Not all distances are appropriate for all instrument types.
+
+_pd_instr_dist_src/mono           ?
+_pd_instr_dist_mono/spec          ?
+_pd_instr_dist_src/spec           ?
+_pd_instr_dist_spec/anal          ?
+_pd_instr_dist_anal/detc          ?
+_pd_instr_dist_spec/detc          ?
+
+# 10. Specimen size and mounting information
+
+# The next three fields give the specimen dimensions in mm.  The equatorial 
+# plane contains the incident and diffracted beam.
+
+_pd_spec_size_axial               ?       # perpendicular to 
+                                          # equatorial plane
+
+_pd_spec_size_equat               ?       # parallel to 
+                                          # scattering vector 
+                                          # in transmission
+
+_pd_spec_size_thick               ?       # parallel to 
+                                          # scattering vector 
+                                          # in reflection
+
+_pd_spec_mounting                         # This field should be
+                                          # used to give details of the 
+                                          # container.
+; ?
+;
+
+_pd_spec_mount_mode               ?       # options are 'reflection' 
+                                          # or 'transmission'
+    
+_pd_spec_shape                    ?       # options are 'cylinder' 
+                                          # 'flat_sheet' or 'irregular'
+
+
+loop_
+     _atom_type_symbol
+     _atom_type_scat_dispersion_real
+     _atom_type_scat_dispersion_imag
+     _atom_type_scat_dispersion_source
+  Al        0.255   0.328   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Fe       -3.332   0.490   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Na        0.167   0.167   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  O         0.063   0.044   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S         0.371   0.733   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si        0.298   0.438   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Ti       -0.063   2.321   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+_diffrn_radiation_type  K\a~1,2~
+loop_
+   _diffrn_radiation_wavelength
+   _diffrn_radiation_wavelength_wt
+   _diffrn_radiation_wavelength_id
+  1.78892         1.0             1     
+  1.79278         0.5000          2     
+
+# PHASE TABLE
+loop_
+   _pd_phase_id
+   _pd_phase_block_id
+   _pd_phase_mass_%
+  2  2021-08-04T17:23|QPAPBMXHandGrindSamplePrep|phase_2|McDougallHamish  0.0929(20)
+  0  2021-08-04T17:23|QPAPBMXHandGrindSamplePrep|phase_0|McDougallHamish  0.752(3)
+  3  2021-08-04T17:23|QPAPBMXHandGrindSamplePrep|phase_3|McDougallHamish  0.0708(20)
+  4  2021-08-04T17:23|QPAPBMXHandGrindSamplePrep|phase_4|McDougallHamish  0.0041(4)
+  1  2021-08-04T17:23|QPAPBMXHandGrindSamplePrep|phase_1|McDougallHamish  0.0802(11)
+loop_
+   _gsas_proc_phase_R_F_factor
+   _gsas_proc_phase_R_Fsqd_factor
+   _gsas_proc_phase_id
+   _gsas_proc_phase_block_id
+    0.15957  0.44825  2  2021-08-04T17:23|QPAPBMXHandGrindSamplePrep|phase_2|McDougallHamish
+    0.05236  0.07424  0  2021-08-04T17:23|QPAPBMXHandGrindSamplePrep|phase_0|McDougallHamish
+    0.08966  0.20282  3  2021-08-04T17:23|QPAPBMXHandGrindSamplePrep|phase_3|McDougallHamish
+    0.10514  0.25185  4  2021-08-04T17:23|QPAPBMXHandGrindSamplePrep|phase_4|McDougallHamish
+    0.12224  0.27272  1  2021-08-04T17:23|QPAPBMXHandGrindSamplePrep|phase_1|McDougallHamish
+_pd_proc_ls_prof_R_factor     0.10502
+_pd_proc_ls_prof_wR_factor    0.14998
+_gsas_proc_ls_prof_R_B_factor   0.12461
+_gsas_proc_ls_prof_wR_B_factor  0.16565
+_pd_proc_ls_prof_wR_expected  0.06059
+_diffrn_radiation_probe  x-ray
+_diffrn_radiation_polarisn_ratio  0.7000
+_pd_proc_ls_background_function
+;
+Background function: "chebyschev-1" function with 7 terms:
+    188.5(8), -242.5(13), 149.2(12), -71.5(10), 28.4(10), -6.6(8), 
+    3.0(7), 
+;
+_diffrn_ambient_temperature  300
+_diffrn_ambient_pressure  100
+
+# STRUCTURE FACTOR TABLE
+loop_
+   _pd_refln_phase_id
+   _refln_index_h
+   _refln_index_k
+   _refln_index_l
+   _refln_F_squared_meas
+   _refln_F_squared_calc
+   _refln_phase_calc
+   _refln_d_spacing
+   _gsas_i100_meas
+  0  1    1    1    757.0510   672.7758   0.0     3.12866  20.31  
+  0  2    0    0    6721.4934  6248.9158  -0.0    2.70950  100.00 
+  0  2    1    0    2521.8354  2684.7009  0.0     2.42345  59.27  
+  0  2    1    1    1412.9392  1381.6310  -180.0  2.21230  54.75  
+  0  2    2    0    2584.4971  2755.3249  -0.0    1.91591  36.97  
+  0  2    2    1    53.7371    50.0462    -0.0    1.80633  1.36   
+  0  3    1    1    3747.4061  3661.9697  -0.0    1.63389  77.51  
+  0  2    2    2    1710.5925  1693.8210  0.0     1.56433  10.85  
+  0  3    0    2    2050.6608  2176.9056  -0.0    1.50296  18.12  
+  0  3    1    2    322.3112   282.9653   0.0     1.44829  5.34   
+  0  3    2    1    1345.8224  1181.5323  180.0   1.44829  22.30  
+  0  4    0    0    513.5634   161.3838   -180.0  1.35475  1.92   
+  0  3    2    2    37.6323    47.8745    -0.0    1.31430  0.54   
+  0  4    1    0    83.4776    106.1973   -0.0    1.31430  0.60   
+  0  4    1    1    63.0337    58.1413    180.0   1.27727  0.87   
+  1  1    0    0    159.8976   242.4765   180.0   4.25525  0.69   
+  1  1    0    -1   2032.3431  1509.1214  -120.0  3.34362  5.34   
+  1  1    0    1    854.3184   634.3762   120.0   3.34362  2.24   
+  1  1    1    0    275.5435   343.6538   -155.6  2.45677  0.38   
+  1  1    0    -2   72.4226    86.1201    -60.0   2.28153  0.09   
+  1  1    0    2    251.3070   298.8374   -120.0  2.28153  0.30   
+  1  1    1    1    80.3155    96.0078    82.9    2.23662  0.18   
+  1  2    0    0    348.9038   308.9373   0.0     2.12763  0.35   
+  1  2    0    -1   83.3855    77.1778    60.0    1.97980  0.07   
+  1  2    0    1    199.6907   184.8246   -60.0   1.97980  0.17   
+  1  1    1    2    564.7279   602.6435   9.8     1.81800  0.82   
+  1  0    0    3    99.8428    94.4664    0.0     1.80192  0.02   
+  1  2    0    -2   611.5467   364.0082   120.0   1.67181  0.38   
+  1  2    0    2    137.8345   82.0426    60.0    1.67181  0.08   
+  1  1    0    -3   148.9813   203.8147   180.0   1.65928  0.09   
+  1  1    0    3    1.8869     2.5814     0.0     1.65928  0.00   
+  1  2    1    0    13.0265    14.6199    -38.9   1.60833  0.01   
+  1  2    1    -1   267.7199   356.0952   95.9    1.54155  0.28   
+  1  2    1    1    230.5283   306.6265   -109.6  1.54155  0.24   
+  1  1    1    3    172.9621   142.5308   117.5   1.45300  0.16   
+  1  3    0    0    82.1286    76.2961    180.0   1.41842  0.04   
+  1  2    1    -2   373.4253   413.6199   -123.3  1.38215  0.33   
+  1  2    1    2    115.9199   128.3973   143.4   1.38215  0.10   
+  1  2    0    -3   229.1502   292.6199   -0.0    1.37505  0.10   
+  1  2    0    3    806.6028   1030.0148  0.0     1.37505  0.35   
+  1  3    0    -1   564.1005   815.3070   -120.0  1.37197  0.24   
+  1  3    0    1    0.6985     1.0096     -60.0   1.37197  0.00   
+  1  1    0    -4   92.6785    120.2775   -120.0  1.28804  0.04   
+  1  1    0    4    305.4179   396.3690   120.0   1.28804  0.12   
+  2  0    0    1    1132.4208  685.7647   180.0   6.38835  0.21   
+  2  0    2    0    642.5380   396.4120   180.0   6.37631  0.00   
+  2  1    1    0    345.4458   238.2377   -0.0    6.33920  0.00   
+  2  1    -1   0    512.3787   287.5556   -0.0    6.30570  0.00   
+  2  1    1    -1   789.4884   406.2236   180.0   5.90977  0.01   
+  2  1    -1   -1   302.4063   415.7013   -180.0  5.58902  0.00   
+  2  0    2    -1   19.7937    16.5801    0.0     4.66336  0.00   
+  2  0    2    1    2.3022     1.8366     180.0   4.37627  0.00   
+  2  2    0    -1   53089.9501 21043.8193 -0.0    4.02974  0.13   
+  2  1    -1   1    9376.0722  3768.5551  -0.0    3.85493  0.06   
+  2  1    1    1    10791.6372 10390.7983 0.0     3.77579  0.14   
+  2  1    3    0    15323.6802 5886.5192  180.0   3.68077  0.04   
+  2  1    3    -1   12048.3803 4505.2577  0.0     3.66511  0.02   
+  2  1    -3   0    26286.8632 11680.2050 180.0   3.66110  0.05   
+  2  2    0    0    2.9185     2.5832     0.0     3.64003  0.00   
+  2  1    1    -2   6160.2173  4328.6309  0.0     3.50528  0.05   
+  2  2    2    -1   3313.1549  1650.0335  180.0   3.48090  0.01   
+  2  1    -3   -1   59.9698    12.1173    0.0     3.43836  0.00   
+  2  1    -1   -2   4449.9394  5251.8386  0.0     3.37324  0.06   
+  2  2    -2   -1   474.6157   365.3694   0.0     3.33662  0.00   
+  2  2    0    -2   29754.3180 26661.3008 -180.0  3.21586  0.08   
+  2  0    0    2    42022.7302 37073.7643 -180.0  3.19418  1.92   
+  2  0    4    0    32992.7950 25367.4849 180.0   3.18815  0.05   
+  2  2    2    0    21216.0457 13873.9510 180.0   3.16960  0.05   
+  2  2    -2   0    21254.5061 14956.5420 -180.0  3.15285  0.03   
+  2  1    -3   1    11740.7455 11180.6996 -180.0  2.96651  0.02   
+  2  2    2    -2   5785.6845  7187.5807  0.0     2.95488  0.01   
+  2  0    2    -2   13475.7326 5311.3929  0.0     2.93134  0.06   
+  2  0    4    -1   18608.9451 8588.0866  0.0     2.92784  0.03   
+  2  1    3    1    7075.1568  6896.7891  180.0   2.86082  0.03   
+  2  1    3    -2   2819.7057  1923.1952  -0.0    2.83887  0.01   
+  2  2    -2   -2   189.5101   183.4864   -0.0    2.79451  0.00   
+  2  0    2    2    121.6317   191.6420   0.0     2.78596  0.00   
+  2  0    4    1    223.6842   387.5366   -0.0    2.78296  0.00   
+  2  2    0    1    108.1675   109.7875   -0.0    2.68830  0.00   
+  2  3    1    -1   222.8414   431.0564   -180.0  2.66389  0.00   
+  2  1    -3   -2   6123.3101  6172.5327  -0.0    2.63917  0.02   
+  2  3    -1   -1   28.7115    33.5494    -180.0  2.62768  0.00   
+  2  2    4    -1   16450.4604 12549.4355 -180.0  2.55929  0.02   
+  2  3    1    -2   2200.3700  1812.0601  180.0   2.53773  0.00   
+  2  1    -1   2    1067.4526  666.9371   180.0   2.51226  0.01   
+  2  2    -2   1    1896.3802  1688.6024  -180.0  2.49702  0.00   
+  2  3    -1   -2   585.6458   449.9332   180.0   2.48219  0.00   
+  2  1    1    2    124.4022   110.2132   180.0   2.46626  0.00   
+  2  2    2    1    1059.5602  1367.0996  -180.0  2.45772  0.00   
+  2  2    -4   -1   9949.5121  10458.4667 -180.0  2.44517  0.01   
+  2  1    5    -1   4337.5148  4093.4339  -0.0    2.42932  0.00   
+  2  1    5    0    58.4124    63.9704    180.0   2.41171  0.00   
+  2  2    4    0    4102.5031  3942.6705  -0.0    2.40566  0.00   
+  2  1    -5   0    2430.0064  2235.9855  180.0   2.40247  0.00   
+  2  2    -4   0    2227.4639  2082.2215  -0.0    2.39103  0.00   
+  2  3    1    0    1928.8180  1564.7419  -0.0    2.38661  0.00   
+  2  3    -1   0    2934.0859  2088.1418  -0.0    2.38122  0.00   
+  2  2    0    -3   10.7028    7.3573     180.0   2.35170  0.00   
+  2  2    4    -2   4.7066     2.9337     0.0     2.34690  0.00   
+  2  1    1    -3   185.9498   110.8614   -0.0    2.33668  0.00   
+  2  0    4    -2   1664.9878  885.2704   -180.0  2.33168  0.00   
+  2  3    3    -1   34063.7193 9809.4418  180.0   2.31746  0.03   
+  2  1    -5   -1   3713.8596  1044.3756  0.0     2.31652  0.00   
+  2  1    -1   -3   1533.2044  2291.8461  -0.0    2.27768  0.02   
+  2  2    2    -3   173.2617   155.7072   -0.0    2.26145  0.00   
+  2  3    3    -2   21.5110    15.9276    0.0     2.25050  0.00   
+  2  3    -3   -1   3294.0135  2706.2986  -180.0  2.24772  0.00   
+  2  1    -3   2    797.5116   823.6349   -0.0    2.22680  0.00   
+  2  2    -4   -2   1279.2789  1432.3442  0.0     2.18948  0.00   
+  2  0    4    2    1841.4441  2085.0733  0.0     2.18813  0.01   
+  2  1    -5   1    3671.0340  4195.9129  180.0   2.18652  0.00   
+  2  2    -2   -3   1292.9067  1852.6924  0.0     2.15521  0.00   
+  2  1    5    -2   207.4640   312.5636   -180.0  2.15181  0.00   
+  2  3    -3   -2   392.9352   514.4958   180.0   2.13920  0.00   
+  2  3    1    -3   164.2781   204.6552   0.0     2.13861  0.00   
+  2  1    3    2    147.2534   174.3368   -180.0  2.13411  0.00   
+  2  0    0    3    479.9260   454.6694   -0.0    2.12945  0.01   
+  2  0    6    0    18390.2194 11046.7060 -0.0    2.12544  0.01   
+  2  1    3    -3   916.4124   674.5582   -180.0  2.11891  0.00   
+  2  1    5    1    4521.3943  4734.7861  180.0   2.11563  0.01   
+  2  3    3    0    1539.7385  1496.7653  -180.0  2.11307  0.00   
+  2  3    -3   0    175.5466   181.3393   -180.0  2.10190  0.00   
+  2  3    -1   -3   2899.6564  2417.9444  0.0     2.09067  0.00   
+  2  2    -4   1    13236.4244 8387.1524  180.0   2.07800  0.01   
+  2  0    2    -3   294.6493   286.9831   -180.0  2.05944  0.00   
+  2  0    6    -1   95.2160    83.9146    -0.0    2.05621  0.00   
+  2  2    4    1    3776.8667  2722.4107  180.0   2.03310  0.01   
+  2  4    0    -2   1804.3412  1675.9000  -0.0    2.01487  0.00   
+  2  1    -5   -2   1216.7208  978.1835   -0.0    2.00623  0.00   
+  2  4    0    -1   4140.1369  3213.2483  -0.0    2.00158  0.00   
+  2  2    0    2    954.6674   915.2009   0.0     1.99890  0.00   
+  2  1    -3   -3   2085.2020  2006.9959  -0.0    1.99378  0.01   
+  2  0    2    3    1154.1817  1320.4867  0.0     1.98235  0.02   
+  2  0    6    1    5238.8521  4761.0232  0.0     1.97947  0.00   
+  2  3    -1   1    1582.0882  1781.9764  0.0     1.97296  0.00   
+  2  3    3    -3   731.0263   747.3311   -180.0  1.96992  0.00   
+  2  3    1    1    1133.3991  1050.9711  0.0     1.96411  0.00   
+  2  2    4    -3   190.6037   210.4912   -180.0  1.96325  0.00   
+  2  4    2    -2   1430.0906  1505.4469  0.0     1.94762  0.00   
+  2  2    -2   2    4633.7749  4437.2487  -0.0    1.92746  0.01   
+  2  4    2    -1   196.7045   195.4576   0.0     1.92441  0.00   
+  2  2    6    -1   24.4565    25.6550    -0.0    1.91739  0.00   
+  2  4    -2   -2   14966.2422 14631.1918 -0.0    1.89589  0.01   
+  2  4    -2   -1   88.4079    83.9565    180.0   1.89533  0.00   
+  2  2    2    2    9019.8939  11148.7231 -0.0    1.88789  0.03   
+  2  3    5    -1   2655.3059  3251.7822  -180.0  1.88756  0.00   
+  2  3    -3   -3   288.4281   242.0551   -0.0    1.86301  0.00   
+  2  3    5    -2   180.0231   151.8892   -180.0  1.86081  0.00   
+  2  4    0    -3   45170.8803 17240.5285 -180.0  1.85042  0.03   
+  2  2    -6   -1   1580.9218  630.6748   -180.0  1.84465  0.00   
+  2  1    -5   2    74.3309    32.7394    -180.0  1.84401  0.00   
+  2  2    6    0    10236.2683 5972.5447  -0.0    1.84039  0.01   
+  2  2    6    -2   4060.5257  2234.2310  -180.0  1.83255  0.00   
+  2  2    -6   0    14347.8493 11181.5242 0.0     1.83055  0.01   
+  2  1    -1   3    2904.8635  2404.9621  -180.0  1.83002  0.01   
+  2  2    -4   -3   489.9467   351.0141   -0.0    1.82893  0.00   
+  2  0    4    -3   8382.3923  6601.7381  180.0   1.82508  0.01   
+  2  3    -5   -1   696.6278   548.8976   -180.0  1.82505  0.00   
+  2  0    6    -2   11816.0018 9381.3005  -180.0  1.82367  0.01   
+  2  4    0    0    17215.4512 16559.4268 -0.0    1.82001  0.01   
+  2  3    -3   1    1522.5170  1388.1866  -0.0    1.81438  0.00   
+  2  4    2    -3   1846.6913  1698.6376  -0.0    1.80705  0.00   
+  2  1    1    3    10469.5943 13206.5125 -180.0  1.80281  0.11   
+  2  3    3    1    1606.0277  659.8969   -0.0    1.79394  0.00   
+  2  1    5    -3   90.5381    36.9259    180.0   1.79173  0.00   
+  2  1    7    -1   360.4221   370.2194   -180.0  1.78560  0.00   
+  2  2    0    -4   24322.8239 29308.4798 0.0     1.78474  0.08   
+  2  1    7    0    2393.0923  1186.8843  -0.0    1.76987  0.00   
+  2  1    -7   0    5664.1134  1864.1693  0.0     1.76475  0.00   
+  2  3    5    0    691.9013   192.4465   -180.0  1.76350  0.00   
+  2  1    5    2    5940.5958  1478.0487  -180.0  1.75705  0.01   
+  2  3    -5   -2   1169.3282  293.8707   -180.0  1.75701  0.00   
+  2  4    2    0    6505.4327  3241.7093  180.0   1.75297  0.00   
+  2  3    -5   0    1.2250     0.6701     -180.0  1.75270  0.00   
+  2  2    2    -4   9657.5433  5374.5367  180.0   1.75264  0.02   
+  2  4    -2   -3   1781.7852  1501.3542  -180.0  1.74860  0.00   
+  2  4    -2   0    1595.9335  1480.3538  -180.0  1.74728  0.00   
+  2  4    4    -2   9726.5924  11156.6958 -180.0  1.74045  0.00   
+  2  3    1    -4   8.5290     11.6952    0.0     1.73811  0.00   
+  2  1    1    -4   403.9072   931.7255   180.0   1.73054  0.00   
+  2  2    -4   2    4667.2816  5117.1459  -180.0  1.72195  0.00   
+  2  1    -7   -1   499.3939   545.0225   -0.0    1.72182  0.00   
+  2  0    4    3    1587.3506  1649.4526  180.0   1.72106  0.01   
+  2  0    6    2    4373.8026  4043.5236  180.0   1.71988  0.00   
+  2  2    -6   -2   6380.0623  5848.5073  180.0   1.71918  0.00   
+  2  1    -3   3    3937.7656  3892.2158  0.0     1.71826  0.01   
+  2  4    4    -1   3209.5575  3425.5582  -0.0    1.71591  0.00   
+  2  3    -1   -4   13.6526    26.3186    -0.0    1.70431  0.00   
+  2  3    5    -3   992.5166   1781.6481  180.0   1.70021  0.00   
+  2  1    -1   -4   619.1825   1087.4011  180.0   1.69848  0.01   
+  2  2    -2   -4   5653.4161  6608.9731  -0.0    1.68662  0.02   
+  2  2    -6   1    101.7376   111.9394   180.0   1.68555  0.00   
+  2  1    -7   1    1480.5687  1038.6759  0.0     1.68099  0.00   
+  2  4    -4   -1   5889.0107  3117.2039  -0.0    1.67520  0.00   
+  2  1    7    -2   5195.8299  3014.8201  0.0     1.67354  0.00   
+  2  4    -4   -2   4198.3997  3003.2514  -180.0  1.66831  0.00   
+  2  1    -5   -3   417.4916   322.9253   -180.0  1.66769  0.00   
+  2  2    4    2    7689.3215  6979.3358  -180.0  1.66653  0.01   
+  2  1    3    3    575.5586   605.5004   0.0     1.65306  0.00   
+  2  3    3    -4   479.1649   474.6538   180.0   1.65081  0.00   
+  2  2    6    1    14.1636    15.0367    180.0   1.64960  0.00   
+  2  4    4    -3   90.2504    81.4955    0.0     1.64484  0.00   
+  2  1    3    -4   1469.6772  1267.2150  -180.0  1.64315  0.00   
+  2  2    6    -3   442.1147   438.4626   0.0     1.63836  0.00   
+  2  1    7    1    1049.0036  959.5955   0.0     1.63551  0.00   
+  2  5    1    -2   53.0673    62.4140    -180.0  1.62197  0.00   
+  2  2    4    -4   6.1927     6.6339     0.0     1.60884  0.00   
+  2  3    -1   2    217.3057   237.2790   -180.0  1.60863  0.00   
+  2  4    0    -4   21.8066    25.6125    0.0     1.60793  0.00   
+  2  5    -1   -2   89.5826    104.9300   -0.0    1.60609  0.00   
+  2  3    1    2    4.9998     3.3551     -180.0  1.59744  0.00   
+  2  0    0    4    2568.3679  1719.8128  -0.0    1.59709  0.03   
+  2  0    8    0    8447.5653  4107.3731  -0.0    1.59408  0.00   
+  2  3    -5   -3   6084.4300  7051.8599  -180.0  1.58781  0.00   
+  2  4    2    -4   4235.5013  5769.4576  -180.0  1.58539  0.00   
+  2  4    4    0    58.0469    80.5808    180.0   1.58480  0.00   
+  2  3    -5   1    3308.3567  3544.9333  0.0     1.58147  0.00   
+  2  4    -4   0    761.2732   974.4663   180.0   1.57643  0.00   
+  2  1    -7   -2   86.5577    106.0891   180.0   1.57618  0.00   
+  2  4    0    1    1319.7864  1313.3069  0.0     1.57488  0.00   
+  2  5    1    -1   1367.4823  1840.0940  0.0     1.57300  0.00   
+  2  0    2    -4   5079.0117  6838.2135  -180.0  1.57293  0.02   
+  2  5    1    -3   5.2738     4.5439     0.0     1.57119  0.00   
+  2  0    8    -1   5622.1198  5108.4047  -180.0  1.57024  0.00   
+  2  3    -3   -4   234.3951   221.8879   -180.0  1.56802  0.00   
+  2  1    -3   -4   1170.7114  1168.3569  -180.0  1.56449  0.01   
+  2  5    -1   -1   3530.7003  3534.7232  -0.0    1.56443  0.00   
+  2  2    0    3    1670.1964  1763.7846  -180.0  1.55948  0.00   
+  2  4    -4   -3   627.1652   668.8022   0.0     1.55937  0.00   
+  2  3    5    1    6160.4717  6629.8139  -0.0    1.55901  0.00   
+  2  0    6    -3   45.8721    50.4743    180.0   1.55445  0.00   
+  2  5    -1   -3   2205.6108  3178.4708  180.0   1.55089  0.00   
+  2  5    3    -2   1264.7700  1684.4282  0.0     1.53983  0.00   
+  2  3    7    -1   284.7945   254.9952   -0.0    1.53513  0.00   
+  2  4    -2   -4   5763.2382  4568.5821  180.0   1.53411  0.00   
+  2  4    -2   1    390.0974   360.8410   -0.0    1.53262  0.00   
+  2  2    -2   3    2961.7133  3887.2133  0.0     1.53039  0.00   
+  2  1    -5   3    91.9210    114.2935   180.0   1.52853  0.00   
+  2  0    2    4    914.2310   1999.3181  180.0   1.52657  0.01   
+  2  3    7    -2   761.6230   1417.6635  180.0   1.52614  0.00   
+  2  4    2    1    48.7587    55.0449    -0.0    1.52528  0.00   
+  2  3    -3   2    762.1923   712.8094   0.0     1.52463  0.00   
+  2  0    8    1    56.4292    53.5251    0.0     1.52410  0.00   
+  2  2    -6   -3   1060.9512  973.4366   180.0   1.52179  0.00   
+  2  1    -7   2    2774.6440  2094.6801  180.0   1.51499  0.00   
+  2  2    -4   -4   4394.0859  3476.1609  -180.0  1.51046  0.01   
+  2  2    8    -1   9976.3412  8931.5081  0.0     1.50665  0.00   
+  2  5    3    -3   10772.6453 11219.2542 -0.0    1.50142  0.00   
+  2  5    -3   -2   1235.7868  1283.3353  0.0     1.50004  0.00   
+  2  2    2    3    244.0772   261.5188   0.0     1.49974  0.00   
+  2  4    6    -2   1602.9695  1643.3830  -180.0  1.49770  0.00   
+  2  3    3    2    2933.3596  2828.5069  0.0     1.49653  0.00   
+  2  5    3    -1   1865.1792  1376.0279  180.0   1.49254  0.00   
+  2  1    7    -3   1229.5806  964.3274   -0.0    1.49160  0.00   
+  2  3    -7   -1   4.7478     4.1999     -180.0  1.48788  0.00   
+  2  3    5    -4   1111.6897  976.8667   0.0     1.48729  0.00   
+  2  2    -6   2    1807.6277  2226.8314  -180.0  1.48326  0.00   
+  2  1    5    -4   400.9935   569.1069   -0.0    1.48082  0.00   
+  2  4    4    -4   922.8719   936.7134   -0.0    1.47744  0.00   
+  2  4    6    -1   2415.1375  2424.8622  -0.0    1.47693  0.00   
+  2  5    -3   -1   3293.7024  2253.8519  180.0   1.47087  0.00   
+  2  2    8    -2   3608.4472  2036.6636  -0.0    1.46934  0.00   
+  2  0    4    -4   3407.8441  1799.7706  0.0     1.46567  0.00   
+  2  0    8    -2   5161.0264  2671.9714  0.0     1.46392  0.00   
+  2  2    8    0    33247.8044 17370.7343 180.0   1.46351  0.01   
+  2  3    7    0    2173.9188  1344.1131  -0.0    1.46125  0.00   
+  2  2    -8   -1   390.2022   277.7262   0.0     1.45912  0.00   
+  2  0    6    3    12391.1487 9727.7514  -180.0  1.45876  0.02   
+  2  2    -8   0    24447.3424 14988.7252 -180.0  1.45690  0.01   
+  2  1    5    3    103.9002   84.4671    0.0     1.45338  0.00   
+  2  3    -7   0    2184.6275  1877.7552  -0.0    1.45264  0.00   
+  2  5    -3   -3   4844.1317  3977.9159  -0.0    1.45001  0.00   
+  2  5    1    0    543.8388   469.7462   0.0     1.44762  0.00   
+  2  1    7    2    412.0002   339.7406   180.0   1.44722  0.00   
+  2  5    -1   0    331.9030   283.8520   0.0     1.44561  0.00   
+  2  3    -7   -2   476.3340   408.0009   -180.0  1.44559  0.00   
+  2  5    1    -4   434.0471   376.3042   -0.0    1.44479  0.00   
+  2  4    6    -3   4998.5816  4798.5294  180.0   1.44009  0.00   
+  2  3    7    -3   1998.4605  2066.7908  0.0     1.43834  0.00   
+  2  4    -6   -1   14007.2040 13999.2250 -0.0    1.43815  0.00   
+  2  1    -1   4    1818.1846  1748.3144  -0.0    1.43185  0.01   
+  2  2    6    2    14479.8273 14125.2857 -180.0  1.43041  0.01   
+  2  4    -6   -2   14122.3206 11512.2174 -180.0  1.42921  0.00   
+  2  2    -4   3    13619.0605 9314.3328  -0.0    1.42576  0.01   
+  2  3    1    -5   104.3459   54.5613    0.0     1.42510  0.00   
+  2  5    -1   -4   12973.3505 6194.5216  0.0     1.42444  0.01   
+  2  2    0    -5   781.5911   530.7241   -0.0    1.41979  0.00   
+  2  2    6    -4   5296.9358  4109.5441  -0.0    1.41943  0.00   
+  2  4    -4   1    2048.0122  2331.0537  -180.0  1.41782  0.00   
+  2  1    1    4    6493.1127  9766.5845  -0.0    1.41427  0.05   
+  2  2    2    -5   338.2455   102.1717   180.0   1.40780  0.00   
+  2  4    4    1    19850.8489 4251.4610  -180.0  1.40625  0.01   
+  2  1    9    -1   1187.1398  313.3291   180.0   1.40438  0.00   
+  2  3    -1   -5   1771.2408  559.5402   180.0   1.40198  0.00   
+  2  4    -4   -4   716.1354   334.4149   -180.0  1.39725  0.00   
+  2  5    5    -2   232.3880   121.8382   180.0   1.39676  0.00   
+  2  5    3    -4   15626.1607 10292.8662 -180.0  1.39419  0.01   
+  2  0    4    4    696.9643   603.2748   180.0   1.39298  0.00   
+  2  1    9    0    7793.1352  6061.6196  -180.0  1.39246  0.00   
+  2  0    8    2    949.9134   842.1064   -0.0    1.39148  0.00   
+  2  1    -7   -3   9.0784     8.6388     0.0     1.39111  0.00   
+  2  2    -8   -2   451.1602   389.2731   0.0     1.39040  0.00   
+  2  1    -9   0    6266.7660  5036.1864  -180.0  1.38925  0.00   
+  2  3    -5   -4   924.9234   714.2717   180.0   1.38894  0.00   
+  2  1    -5   -4   11.2602    12.2639    -0.0    1.38719  0.00   
+  2  4    6    0    6460.1210  6881.3324  0.0     1.38665  0.00   
+  2  2    -8   1    3122.3602  2589.0744  -0.0    1.38467  0.00   
+  2  3    -5   2    102.5244   107.3821   180.0   1.38257  0.00   
+  2  1    -3   4    9377.0267  11503.5261 180.0   1.38045  0.01   
+  2  5    3    0    1739.7195  2065.5040  180.0   1.38006  0.00   
+  2  3    3    -5   524.8514   601.4217   -0.0    1.37985  0.00   
+  2  4    -6   0    2457.7663  2933.5616  0.0     1.37825  0.00   
+  2  2    4    3    5809.4471  7682.8626  -0.0    1.37724  0.01   
+  2  5    -3   0    1344.2518  1849.8117  -180.0  1.37486  0.00   
+  2  4    0    -5   7415.0508  9855.5152  -0.0    1.37293  0.01   
+  2  5    5    -3   621.7409   1000.1579  -0.0    1.37191  0.00   
+  2  1    1    -5   53.8389    51.8485    180.0   1.36885  0.00   
+  2  2    8    -3   1226.9308  897.3178   0.0     1.36737  0.00   
+  2  2    -2   -5   1158.8934  891.2006   -180.0  1.36490  0.00   
+  2  1    -9   -1   3371.5834  2521.6117  180.0   1.36405  0.00   
+  2  4    2    -5   12263.9728 11337.4504 180.0   1.36275  0.01   
+  2  2    8    1    6761.0856  3611.4778  -180.0  1.35801  0.00   
+  2  5    5    -1   2111.3437  870.3877   -180.0  1.35726  0.00   
+  2  4    -6   -3   12514.6815 4131.6380  180.0   1.35503  0.00   
+  2  3    -7   1    2009.1796  578.8574   0.0     1.35446  0.00   
+  2  6    0    -2   37113.7999 16999.9716 180.0   1.35222  0.01   
+  2  1    9    -2   36437.3896 16151.5223 0.0     1.35170  0.01   
+  2  1    -9   1    8621.9295  3743.5555  -0.0    1.35110  0.00   
+  2  1    -1   -5   12590.8808 10684.6947 -0.0    1.34898  0.10   
+  2  3    5    2    310.0462   209.3105   0.0     1.34800  0.00   
+  2  5    -5   -2   842.8519   569.3229   180.0   1.34796  0.00   
+  2  4    0    2    16426.2962 20281.5496 180.0   1.34415  0.01   
+  2  6    0    -3   441.3645   425.5759   0.0     1.34325  0.00   
+  2  3    -7   -3   1093.5930  987.4854   180.0   1.34309  0.00   
+  2  5    -3   -4   21.0852    19.5836    -0.0    1.34131  0.00   
+  2  3    7    1    644.5188   545.0817   0.0     1.33472  0.00   
+  2  1    3    4    358.1658   303.9149   180.0   1.33470  0.00   
+  2  2    4    -5   1821.2798  2138.3293  -0.0    1.33364  0.00   
+  2  6    2    -2   9114.4669  7476.5144  0.0     1.33195  0.00   
+  2  3    -1   3    375.2301   551.8654   -0.0    1.33039  0.00   
+  2  5    -5   -1   2043.9657  3083.6461  -180.0  1.33032  0.00   
+  2  1    -7   3    676.8842   846.7620   -180.0  1.32861  0.00   
+  2  1    3    -5   9204.2305  12958.6368 180.0   1.32799  0.02   
+  2  4    6    -4   865.3950   1218.9271  0.0     1.32736  0.00   
+  2  6    2    -3   4.3092     5.9956     -0.0    1.32699  0.00   
+  2  4    -2   -5   2878.3781  3148.2794  0.0     1.32250  0.00   
+  2  4    -2   2    2066.3529  2257.9872  0.0     1.32117  0.00   
+  2  1    9    1    886.0498   1105.0576  -0.0    1.32053  0.00   
+  2  3    1    3    2551.5295  3239.2591  0.0     1.32043  0.00   
+  2  2    -6   -4   86.0398    114.1536   0.0     1.31958  0.00   
+  2  3    -3   -5   1640.7370  2180.4261  180.0   1.31953  0.00   
+  2  0    6    -4   2552.1037  3687.4603  0.0     1.31759  0.00   
+  2  0    8    -3   3050.2114  4548.2663  -0.0    1.31684  0.00   
+  2  6    -2   -2   260.4007   331.0134   180.0   1.31384  0.00   
+  2  4    2    2    395.0582   505.6991   0.0     1.30940  0.00   
+  2  5    -5   -3   7368.3848  6219.1169  0.0     1.30780  0.00   
+  2  3    7    -4   13.9789    11.5411    -180.0  1.30589  0.00   
+  2  6    0    -1   769.0810   635.8821   -0.0    1.30347  0.00   
+  2  6    -2   -3   4577.7713  4805.7953  0.0     1.30215  0.00   
+  2  1    7    -4   781.8406   817.0588   180.0   1.30092  0.00   
+  2  4    4    -5   739.2286   839.8610   -180.0  1.29572  0.00   
+  2  5    -1   1    528.3451   561.7539   -180.0  1.29375  0.00   
+  2  5    5    -4   104.6435   102.0613   -0.0    1.29201  0.00   
+  2  5    1    1    217.2031   213.3445   180.0   1.29181  0.00   
+  2  5    1    -5   993.8050   1297.9127  -180.0  1.28880  0.00   
+  2  3    -3   3    5165.2563  3825.8482  180.0   1.28498  0.00   
+  2  1    -9   -2   10692.9074 7597.1469  0.0     1.28482  0.00   
+  2  2    -6   3    155.7959   98.1026    -0.0    1.28448  0.00   
+  2  3    5    -5   5572.6112  3037.7152  -0.0    1.28329  0.00   
+  2  6    2    -1   4452.9071  2449.2829  180.0   1.28198  0.00   
+  2  6    0    -4   5965.4513  4647.3829  0.0     1.27977  0.00   
+  2  4    8    -2   20414.1004 16039.4631 -0.0    1.27964  0.01   
+  2  1    -5   4    0.3502     0.2752     -0.0    1.27938  0.00   
+  2  0    0    5    1521.9374  1505.0398  0.0     1.27767  0.01   
+  2  2    -8   -3   1387.5254  971.0655   0.0     1.27634  0.00   
+  2  1    -3   -5   2393.8492  1649.2139  -180.0  1.27560  0.01   
+  2  0    10   0    7945.8506  5615.7294  -0.0    1.27526  0.00   
+  2  3    9    -1   1116.5334  567.6078   180.0   1.27289  0.00   
+  2  6    -2   -1   1167.5292  606.3424   -180.0  1.27218  0.00   
+  2  4    -6   1    3960.7155  2160.8901  180.0   1.27166  0.00   
+  2  5    -1   -5   6394.1756  3289.9147  -0.0    1.27108  0.00   
+  2  3    9    -2   437.2607   209.2136   0.0     1.27094  0.00   
+  2  2    -8   2    18049.1961 15688.9183 0.0     1.26897  0.01   
+  2  2    0    4    6462.6138  5973.6167  -0.0    1.26887  0.02   
+  2  6    2    -4   2852.8339  2644.4850  -180.0  1.26887  0.00   
+  2  0    2    -5   4316.6296  4142.0269  180.0   1.26837  0.01   
+  2  5    5    0    2389.8561  1539.1598  -0.0    1.26784  0.00   
+  2  0    10   -1   886.2829   722.6067   -180.0  1.26611  0.00   
+  3  1    1    0    8634.8388  5229.9408  0.0     5.76223  0.02   
+  3  1    1    -1   2282.4830  1404.4642  0.0     5.75058  0.01   
+  3  0    0    2    10675.6272 6648.0829  0.0     5.73783  0.01   
+  3  2    0    0    1117.8860  777.9553   180.0   5.31049  0.00   
+  3  2    0    -2   15085.1049 11512.6160 0.0     5.27425  0.02   
+  3  1    1    1    7975.6159  5916.0442  -180.0  4.70453  0.01   
+  3  1    1    -2   657.2293   471.3091   -180.0  4.68555  0.00   
+  3  1    1    2    3465.4149  1811.9004  -180.0  3.64096  0.00   
+  3  1    1    -3   11487.2954 6224.7494  180.0   3.62630  0.01   
+  3  0    2    0    4149.9810  1737.0665  180.0   3.42976  0.00   
+  3  3    1    -1   1735.8861  1015.3644  -0.0    3.40570  0.00   
+  3  3    1    -2   5001.6175  3188.4694  180.0   3.39848  0.00   
+  3  0    2    1    5516.6436  5005.7893  -0.0    3.28613  0.00   
+  3  2    0    2    14511.1155 11618.0014 -0.0    3.23222  0.01   
+  3  2    0    -4   6368.5852  5013.3058  180.0   3.20774  0.00   
+  3  3    1    0    2727.0215  2138.8026  0.0     3.14602  0.00   
+  3  3    1    -3   3029.9507  2677.5527  180.0   3.12903  0.00   
+  3  4    0    -2   82201.9181 80922.8191 -180.0  2.98220  0.03   
+  3  2    2    -1   80840.5124 75006.4942 -0.0    2.97323  0.05   
+  3  0    2    2    1039.1932  793.4329   0.0     2.94392  0.00   
+  3  2    2    0    1760.5358  1808.9163  0.0     2.88112  0.00   
+  3  1    1    3    2497.5766  2492.8532  -0.0    2.87630  0.00   
+  3  2    2    -2   533.8131   529.3047   -0.0    2.87529  0.00   
+  3  0    0    4    10843.7711 10346.8898 -0.0    2.86891  0.00   
+  3  1    1    -4   6178.6778  5819.5912  -0.0    2.86618  0.00   
+  3  3    1    1    3082.4691  3759.3145  -180.0  2.76244  0.00   
+  3  3    1    -4   2647.4432  3268.9679  -0.0    2.74331  0.00   
+  3  4    0    0    57521.7832 71136.5042 0.0     2.65525  0.01   
+  3  2    2    1    115247.4364 133079.6522 0.0     2.64437  0.06   
+  3  4    0    -4   123196.9435 140762.5963 180.0   2.63712  0.03   
+  3  2    2    -3   57875.0190 66325.7874 -180.0  2.63538  0.03   
+  3  0    2    3    16628.0154 14209.8323 180.0   2.55361  0.01   
+  3  3    1    2    12312.5450 9802.7498  -180.0  2.38205  0.00   
+  3  3    1    -5   7616.2936  5880.0373  -0.0    2.36488  0.00   
+  3  2    2    2    214.4773   144.0770   -180.0  2.35226  0.00   
+  3  1    1    4    4788.6944  2979.7862  -0.0    2.34727  0.00   
+  3  2    2    -4   1514.8489  883.3747   180.0   2.34277  0.00   
+  3  1    1    -5   535.9594   301.3334   -0.0    2.34018  0.00   
+  3  4    2    -2   1582.4317  1407.3210  -0.0    2.25045  0.00   
+  3  5    1    -2   2292.3922  2123.4244  180.0   2.24430  0.00   
+  3  5    1    -3   565.1692   539.2561   180.0   2.24086  0.00   
+  3  1    3    0    53.1031    52.4259    0.0     2.23529  0.00   
+  3  1    3    -1   4224.9661  4180.3508  -0.0    2.23461  0.00   
+  3  4    2    -1   906.4816   918.1952   0.0     2.21103  0.00   
+  3  4    2    -3   12762.0605 13296.5582 -0.0    2.20576  0.00   
+  3  0    2    4    914.3141   970.4662   180.0   2.20056  0.00   
+  3  5    1    -1   9894.7170  11525.6216 -0.0    2.16619  0.00   
+  3  5    1    -4   572.9887   710.3618   -180.0  2.15694  0.00   
+  3  1    3    1    829.3711   1031.4626  -0.0    2.15564  0.00   
+  3  1    3    -2   8799.1126  10966.5101 0.0     2.15380  0.00   
+  3  2    0    4    1332.9284  1641.1119  0.0     2.14805  0.00   
+  3  2    0    -6   6821.0291  7250.4262  0.0     2.13603  0.00   
+  3  4    2    0    825.6703   728.7537   -180.0  2.09958  0.00   
+  3  4    2    -4   687.2972   549.0412   -180.0  2.09059  0.00   
+  3  4    0    2    388889.1717 286836.0728 180.0   2.07622  0.06   
+  3  2    2    3    388299.1037 293751.3685 0.0     2.06884  0.11   
+  3  2    2    -5   383513.0065 298115.3825 0.0     2.06023  0.11   
+  3  4    0    -6   390453.5433 303411.3942 -180.0  2.05893  0.06   
+  3  3    1    3    1410.9357  1086.0204  -180.0  2.05577  0.00   
+  3  3    1    -6   207.5413   155.3313   -0.0    2.04158  0.00   
+  3  5    1    0    976.4955   771.9891   180.0   2.02913  0.00   
+  3  1    3    2    16287.8435 14029.5270 -0.0    2.01843  0.00   
+  3  5    1    -5   16319.0522 14178.8649 -0.0    2.01648  0.00   
+  3  1    3    -3   1424.0830  1239.6149  -0.0    2.01592  0.00   
+  3  3    3    -1   7104.5759  7019.4194  -0.0    1.97551  0.00   
+  3  3    3    -2   189.3066   188.0566   0.0     1.97410  0.00   
+  3  1    1    5    4629.2370  4644.9116  180.0   1.97138  0.00   
+  3  1    1    -6   1533.2876  1571.2732  -0.0    1.96624  0.00   
+  3  6    0    -2   922.7573   971.0780   180.0   1.96172  0.00   
+  3  6    0    -4   16237.5898 17269.6602 -180.0  1.95620  0.00   
+  3  4    2    1    20883.4630 20996.6238 -0.0    1.94504  0.01   
+  3  4    2    -5   71.2788    71.0915    180.0   1.93434  0.00   
+  3  3    3    0    9850.2791  9835.0988  180.0   1.92074  0.00   
+  3  3    3    -3   2759.0676  2769.3680  -0.0    1.91686  0.00   
+  3  0    0    6    1710.9080  1720.5415  -0.0    1.91261  0.00   
+  3  0    2    5    90.9484    90.4715    -180.0  1.90745  0.00   
+  3  5    1    1    3820.9633  2507.7680  -180.0  1.86396  0.00   
+  3  1    3    3    6423.6975  3431.0335  0.0     1.85410  0.00   
+  3  1    3    -4   1012.4147  510.0263   -180.0  1.85138  0.00   
+  3  5    1    -6   5857.6956  2907.0512  -180.0  1.85026  0.00   
+  3  3    3    1    4542.6019  3298.3860  -0.0    1.82251  0.00   
+  3  2    2    4    2697.6132  2013.9090  180.0   1.82048  0.00   
+  3  3    3    -4   19717.8266 15089.5976 -180.0  1.81699  0.00   
+  3  2    2    -6   147.2626   111.5713   -0.0    1.81315  0.00   
+  3  3    1    4    1923.6175  1178.4243  -0.0    1.78975  0.00   
+  3  3    1    -7   1082.0490  725.9349   -180.0  1.77829  0.00   
+  3  4    2    2    901.0285   571.7609   -0.0    1.77613  0.00   
+  3  6    0    0    66203.9286 33181.4274 180.0   1.77016  0.01   
+  3  4    2    -6   2965.9396  1202.5389  -0.0    1.76527  0.00   
+  3  6    0    -6   5.6070     2.0490     0.0     1.75808  0.00   
+  3  6    2    -3   337084.2537 369938.5795 -180.0  1.72004  0.07   
+  3  0    4    0    302821.3137 348479.5467 -180.0  1.71488  0.03   
+  3  6    2    -2   305.0335   389.5943   -0.0    1.70285  0.00   
+  3  3    3    2    3005.7829  3606.5174  -0.0    1.69941  0.00   
+  3  6    2    -4   1305.5878  1559.9063  180.0   1.69924  0.00   
+  3  0    4    1    2969.3586  3255.7850  -0.0    1.69605  0.00   
+  3  5    1    2    2400.9524  2577.0016  -180.0  1.69525  0.00   
+  3  1    1    6    710.6412   746.2082   -0.0    1.69440  0.00   
+  3  3    3    -5   10348.1911 10555.5299 0.0     1.69315  0.00   
+  3  1    1    -7   12904.1660 12532.2843 -180.0  1.69054  0.00   
+  3  1    3    4    49.9101    45.2175    -0.0    1.68665  0.00   
+  3  1    3    -5   5529.3686  4696.9172  0.0     1.68402  0.00   
+  3  5    1    -7   331.8202   266.7848   -180.0  1.68201  0.00   
+  3  0    2    6    1340.2897  1010.9792  0.0     1.67043  0.00   
+  3  6    2    -1   883.7245   866.1805   -180.0  1.65090  0.00   
+  3  7    1    -3   36.2760    35.4940    180.0   1.65053  0.00   
+  3  7    1    -4   576.1953   557.7399   -0.0    1.64861  0.00   
+  3  2    4    -1   2943.2727  2839.6979  180.0   1.64811  0.00   
+  3  5    3    -2   351.0392   336.5571   -180.0  1.64721  0.00   
+  3  5    3    -3   1297.8946  1232.3026  -180.0  1.64584  0.00   
+  3  6    2    -5   537.6106   505.7360   -180.0  1.64434  0.00   
+  3  0    4    2    653.1297   611.2974   -180.0  1.64307  0.00   
+  3  2    4    0    772.6394   752.6479   -0.0    1.63190  0.00   
+  3  2    4    -2   4545.0530  4457.0559  180.0   1.63084  0.00   
+  3  7    1    -2   3306.5993  3573.3164  180.0   1.61922  0.00   
+  3  4    0    4    59364.0486 64734.1102 180.0   1.61611  0.01   
+  3  5    3    -1   886.5164   966.5143   0.0     1.61557  0.00   
+  3  7    1    -5   845.7205   917.7423   -0.0    1.61380  0.00   
+  3  4    2    3    25.4204    27.2643    180.0   1.61197  0.00   
+  3  5    3    -4   3583.6647  3835.3161  -180.0  1.61172  0.00   
+  3  2    2    5    34898.6341 37309.7254 -180.0  1.61160  0.01   
+  3  2    2    -7   68356.9088 66901.8211 0.0     1.60550  0.01   
+  3  4    0    -8   39405.8732 37138.8177 0.0     1.60387  0.00   
+  3  4    2    -7   2919.5593  2596.5146  -0.0    1.60183  0.00   
+  3  2    4    1    2011.5860  1923.8493  0.0     1.58503  0.00   
+  3  2    0    6    29903.1552 29168.2638 -0.0    1.58415  0.00   
+  3  2    4    -3   1890.1972  1875.8650  0.0     1.58309  0.00   
+  3  2    0    -8   4919.1674  5028.2109  -180.0  1.57739  0.00   
+  3  3    1    5    1723.4259  1753.8851  180.0   1.57535  0.00   
+  3  6    2    0    316.0895   317.6799   -0.0    1.57301  0.00   
+  3  3    3    3    497.7348   487.1948   0.0     1.56818  0.00   
+  3  3    1    -8   1918.9621  1875.6642  0.0     1.56611  0.00   
+  3  0    4    3    2973.8130  2916.6965  -0.0    1.56482  0.00   
+  3  6    2    -6   1272.0799  1249.2285  -180.0  1.56452  0.00   
+  3  3    3    -6   1500.6536  1497.2639  -180.0  1.56185  0.00   
+  3  7    1    -1   2019.3808  2044.6251  -0.0    1.55998  0.00   
+  3  5    3    0    3591.5904  3765.1112  180.0   1.55625  0.00   
+  3  7    1    -6   3441.0838  3792.3266  -180.0  1.55192  0.00   
+  3  5    3    -5   1258.8569  1408.4097  0.0     1.55053  0.00   
+  3  5    1    3    752.2052   793.3049   0.0     1.53703  0.00   
+  3  1    3    5    6.9969     7.3229     -180.0  1.52974  0.00   
+  3  1    3    -6   1114.4657  1163.6125  0.0     1.52733  0.00   
+  3  5    1    -8   5.2873     5.2918     0.0     1.52497  0.00   
+  3  2    4    2    5080.7823  4257.8935  180.0   1.51487  0.00   
+  3  2    4    -4   2960.4623  2489.4645  -0.0    1.51233  0.00   
+  3  6    0    2    10452.3762 8969.7388  -180.0  1.50899  0.00   
+  3  6    0    -8   4917.0982  4411.8311  -180.0  1.49655  0.00   
+  3  8    0    -4   23723.8541 20108.3695 0.0     1.49110  0.00   
+  3  4    4    -2   23154.3050 20463.8926 -0.0    1.48662  0.00   
+  3  1    1    7    9908.2738  9171.7752  -0.0    1.48331  0.00   
+  3  7    1    0    567.7183   523.6927   0.0     1.48147  0.00   
+  3  1    1    -8   8240.5615  7477.8736  0.0     1.48033  0.00   
+  3  6    2    1    567.7415   511.3441   180.0   1.47995  0.00   
+  3  0    2    7    2868.8316  2531.9941  180.0   1.47910  0.00   
+  3  5    3    1    1727.3254  1472.7063  180.0   1.47789  0.00   
+  3  4    4    -1   232.0581   180.4329   180.0   1.47508  0.00   
+  3  4    4    -3   2255.5681  1668.7785  180.0   1.47351  0.00   
+  3  0    4    4    831.5101   588.3828   180.0   1.47196  0.00   
+  3  7    1    -7   330.1229   232.7897   -180.0  1.47183  0.00   
+  3  5    3    -6   0.2582     0.1783     -180.0  1.47103  0.00   
+  3  6    2    -7   1602.5194  1093.6180  180.0   1.47053  0.00   
+  3  4    2    4    483.0766   311.3563   -180.0  1.46194  0.00   
+  3  4    2    -8   400.9093   304.9106   -180.0  1.45286  0.00   
+  3  8    0    -2   64263.3731 52333.9892 0.0     1.44612  0.00   
+  3  4    4    0    47503.3127 40400.3932 -180.0  1.44056  0.01   
+  3  8    0    -6   46379.7375 39537.2697 -180.0  1.44024  0.00   
+  3  3    3    4    5440.0857  4643.0050  -180.0  1.44007  0.00   
+  3  2    2    6    0.9699     0.8356     -180.0  1.43815  0.00   
+  3  4    4    -4   62755.1013 54118.1487 0.0     1.43764  0.01   
+  3  0    0    8    317480.4267 269542.3856 -0.0    1.43446  0.02   
+  3  3    3    -7   1725.7681  1457.5261  0.0     1.43408  0.00   
+  3  2    2    -8   2210.2212  1833.8366  -0.0    1.43309  0.00   
+  3  2    4    3    3499.4456  2703.6576  180.0   1.43051  0.00   
+  3  2    4    -5   2393.6717  1676.0081  180.0   1.42766  0.00   
+  3  3    1    6    2450.2131  953.3228   180.0   1.40181  0.00   
+  3  5    1    4    1411.2307  769.3977   0.0     1.39510  0.00   
+  3  3    1    -9   1258.0407  719.7991   -0.0    1.39429  0.00   
+  3  7    1    1    80.4385    50.2578    -180.0  1.39276  0.00   
+  3  5    3    2    614.2080   444.3953   -180.0  1.38945  0.00   
+  3  1    3    6    4319.3705  3177.0263  0.0     1.38898  0.00   
+  3  4    4    1    4717.2640  3624.9875  -0.0    1.38761  0.00   
+  3  1    3    -7   620.1723   487.0361   -180.0  1.38685  0.00   
+  3  5    1    -9   3822.6738  3195.9143  -0.0    1.38443  0.00   
+  3  4    4    -5   1437.7701  1225.1211  0.0     1.38370  0.00   
+  3  7    1    -8   263.5750   232.0851   0.0     1.38247  0.00   
+  3  5    3    -7   1214.4312  1078.8823  180.0   1.38213  0.00   
+  3  6    2    2    281.9211   256.0783   -180.0  1.38122  0.00   
+  3  0    4    5    373.9332   361.4245   -180.0  1.37376  0.00   
+  3  6    2    -8   3.0332     2.8092     0.0     1.37165  0.00   
+  3  8    2    -4   944.3182   738.8453   180.0   1.36746  0.00   
+  3  7    3    -3   4458.6543  3196.5118  -180.0  1.36450  0.00   
+  3  7    3    -4   662.3173   462.3097   -180.0  1.36342  0.00   
+  3  1    5    0    6976.1958  4364.1111  -180.0  1.36060  0.00   
+  3  1    5    -1   92.3049    57.2778    -0.0    1.36045  0.00   
+  3  8    2    -3   3347.5404  1922.4893  180.0   1.35908  0.00   
+  3  8    2    -5   27967.9399 14154.5714 180.0   1.35663  0.00   
+  3  7    3    -2   10199.8495 6970.2714  0.0     1.34665  0.00   
+  3  7    3    -5   3220.8180  2391.0016  180.0   1.34353  0.00   
+  3  1    5    1    9933.2919  7427.3532  0.0     1.34202  0.00   
+  3  1    5    -2   3744.2030  2798.0482  180.0   1.34157  0.00   
+  3  2    4    4    275.6908   205.2037   -180.0  1.34018  0.00   
+  3  2    4    -6   5625.3901  4289.0376  180.0   1.33725  0.00   
+  3  8    2    -2   211.8792   192.3295   0.0     1.33251  0.00   
+  3  4    2    5    12535.3719 12924.4778 0.0     1.32907  0.00   
+  3  8    2    -6   110.3879   116.8075   0.0     1.32791  0.00   
+  3  8    0    0    119457.2449 126985.7272 0.0     1.32762  0.01   
+  3  0    2    8    344.7308   372.5808   180.0   1.32337  0.00   
+  3  4    4    2    105088.5368 114041.8510 0.0     1.32219  0.01   
+  3  4    2    -9   5089.1987  5567.4086  180.0   1.32111  0.00   
+  3  3    3    5    1146.8526  1254.7052  -0.0    1.32110  0.00   
+  3  8    0    -8   125032.9439 139622.3566 -0.0    1.31856  0.01   
+  3  1    1    8    140.4453   157.1123   180.0   1.31776  0.00   
+  3  4    4    -6   108077.5267 120901.7616 0.0     1.31769  0.01   
+  3  3    3    -8   6472.7327  7156.4686  180.0   1.31564  0.00   
+  3  1    1    -9   655.1238   722.4364   180.0   1.31539  0.00   
+  3  7    3    -1   986.4989   1032.7373  180.0   1.31200  0.00   
+  3  7    3    -6   8093.6834  7548.7798  -0.0    1.30719  0.00   
+  3  1    5    2    1873.0715  1737.2292  180.0   1.30689  0.00   
+  3  1    5    -3   7973.1570  7318.6861  -0.0    1.30620  0.00   
+  3  7    1    2    4483.8185  3990.0856  -180.0  1.30123  0.00   
+  3  9    1    -4   949.9704   841.0437   0.0     1.29987  0.00   
+  3  9    1    -5   288.9237   256.8743   0.0     1.29866  0.00   
+  3  6    4    -3   2646.6661  2355.2525  -0.0    1.29855  0.00   
+  3  5    3    3    376.4117   335.9562   180.0   1.29826  0.00   
+  3  4    0    6    20586.0027 18741.5605 180.0   1.29693  0.00   
+  3  3    5    -1   659.8790   622.0208   0.0     1.29502  0.00   
+  3  3    5    -2   2308.5507  2189.0430  -0.0    1.29462  0.00   
+  3  2    2    7    17160.5151 16386.2542 -0.0    1.29407  0.00   
+  3  6    4    -2   26.4117    25.5642    0.0     1.29111  0.00   
+  3  7    1    -9   137.8837   133.3647   180.0   1.29098  0.00   
+  3  5    3    -8   3621.2041  3502.1832  180.0   1.29096  0.00   
+  3  8    2    -1   9246.3714  8931.9049  180.0   1.29080  0.00   
+  3  2    2    -9   21057.1216 20077.2594 0.0     1.28985  0.00   
+  3  6    4    -4   7539.3565  7137.8005  -0.0    1.28953  0.00   
+  3  4    0    -10  22931.2300 20993.9087 -180.0  1.28848  0.00   
+  3  9    1    -3   7397.1385  5509.0756  180.0   1.28467  0.00   
+  3  8    2    -7   581.7233   430.2999   -180.0  1.28453  0.00   
+  3  6    2    3    0.5528     0.3928     180.0   1.28356  0.00   
+  3  9    1    -6   269.9660   186.6299   -0.0    1.28119  0.00   
+  3  3    5    0    1019.0386  721.1811   -0.0    1.27922  0.00   
+  3  3    5    -3   8501.9860  6042.2846  -0.0    1.27807  0.00   
+  3  0    4    6    170.8067   119.4400   180.0   1.27681  0.00   
+  3  6    2    -9   722.5386   468.2664   180.0   1.27435  0.00   
+  3  5    1    5    7790.9299  4654.3749  180.0   1.27052  0.00   
+  3  6    0    4    12258.0849 7336.9163  180.0   1.27006  0.00   
+  3  6    4    -1   784.1399   481.6983   -180.0  1.26802  0.00   
+  3  1    3    7    13289.3449 8492.7416  -0.0    1.26540  0.00   
+  3  6    4    -5   906.1071   581.7489   -180.0  1.26504  0.00   
+  4  1    1    0    1676.5995  1271.7368  -0.0    3.25001  0.02   
+  4  1    0    1    572.2579   492.3378   -0.0    2.48987  0.01   
+  4  2    0    0    200.8487   149.3356   -0.0    2.29811  0.00   
+  4  1    1    1    333.4284   375.0134   180.0   2.18927  0.00   
+  4  2    1    0    177.2084   152.6586   0.0     2.05549  0.00   
+  4  2    1    1    784.0731   880.1039   -0.0    1.68873  0.01   
+  4  2    2    0    1057.3902  1142.2908  -0.0    1.62501  0.00   
+  4  0    0    2    927.7371   1419.6113  -0.0    1.48108  0.00   
+  4  3    1    0    442.0807   356.5837   -0.0    1.45345  0.00   
+  4  2    2    1    58.8136    28.2210    180.0   1.42470  0.00   
+  4  3    0    1    1070.8999  1054.8092  -0.0    1.36083  0.00   
+  4  1    1    2    780.9770   541.9815   -0.0    1.34773  0.00   
+  4  3    1    1    36.4823    32.7302    0.0     1.30484  0.00   
+  4  3    2    0    21.7664    15.0074    180.0   1.27476  0.00   
+_reflns_number_total  650
+_reflns_d_resolution_low    6.388
+_reflns_d_resolution_high   1.265
+
+# POWDER DATA TABLE
+_pd_meas_2theta_range_min  10.01687
+_pd_meas_2theta_range_max  89.99342
+_pd_meas_2theta_range_inc  0.01313
+_pd_meas_number_of_points  6092
+
+loop_
+   _pd_meas_intensity_total
+   _pd_calc_intensity_total
+   _pd_proc_intensity_bkg_calc
+   _pd_proc_ls_weight
+  1125         0            0           0         
+  1129         0            0           0         
+  1150         0            0           0         
+  1109         0            0           0         
+  1050         0            0           0         
+  1113         0            0           0         
+  1099         0            0           0         
+  1125         0            0           0         
+  1065         0            0           0         
+  1084         0            0           0         
+  1096         0            0           0         
+  1074         0            0           0         
+  1142         0            0           0         
+  1044         0            0           0         
+  1141         0            0           0         
+  1155         0            0           0         
+  1090         0            0           0         
+  1109         0            0           0         
+  1058         0            0           0         
+  1136         0            0           0         
+  1039         0            0           0         
+  1095         0            0           0         
+  1126         0            0           0         
+  1138         0            0           0         
+  1116         0            0           0         
+  1084         0            0           0         
+  1065         0            0           0         
+  1080         0            0           0         
+  1063         0            0           0         
+  1093         0            0           0         
+  1079         0            0           0         
+  1105         0            0           0         
+  1105         0            0           0         
+  1074         0            0           0         
+  1080         0            0           0         
+  1105         0            0           0         
+  1060         0            0           0         
+  1061         0            0           0         
+  1081         0            0           0         
+  1077         0            0           0         
+  1079         0            0           0         
+  1095         0            0           0         
+  1051         0            0           0         
+  1126         0            0           0         
+  1036         0            0           0         
+  1056         0            0           0         
+  1058         0            0           0         
+  1064         0            0           0         
+  1056         0            0           0         
+  1050         0            0           0         
+  1019         0            0           0         
+  1014         0            0           0         
+  1099         0            0           0         
+  1081         0            0           0         
+  1078         0            0           0         
+  1068         0            0           0         
+  1077         0            0           0         
+  990          0            0           0         
+  1075         0            0           0         
+  1021         0            0           0         
+  1041         0            0           0         
+  1020         0            0           0         
+  982          0            0           0         
+  1049         0            0           0         
+  1063         0            0           0         
+  1060         0            0           0         
+  1030         0            0           0         
+  1043         0            0           0         
+  1072         0            0           0         
+  1064         0            0           0         
+  1012         0            0           0         
+  1049         0            0           0         
+  982          0            0           0         
+  1077         0            0           0         
+  1037         0            0           0         
+  1036         0            0           0         
+  985          0            0           0         
+  1033         0            0           0         
+  1066         0            0           0         
+  1009         0            0           0         
+  1075         0            0           0         
+  1000         0            0           0         
+  1019         0            0           0         
+  1040         0            0           0         
+  1065         0            0           0         
+  1007         0            0           0         
+  982          0            0           0         
+  985          0            0           0         
+  999          0            0           0         
+  1034         0            0           0         
+  956          0            0           0         
+  1025         0            0           0         
+  973          0            0           0         
+  991          0            0           0         
+  995          0            0           0         
+  989          0            0           0         
+  1024         0            0           0         
+  971          0            0           0         
+  964          0            0           0         
+  968          0            0           0         
+  1038         0            0           0         
+  987          0            0           0         
+  942          0            0           0         
+  1007         0            0           0         
+  947          0            0           0         
+  987          0            0           0         
+  946          0            0           0         
+  989          0            0           0         
+  1046         0            0           0         
+  1006         0            0           0         
+  1035         0            0           0         
+  959          0            0           0         
+  946          0            0           0         
+  995          0            0           0         
+  1003         0            0           0         
+  994          0            0           0         
+  926          0            0           0         
+  1015         0            0           0         
+  987          0            0           0         
+  995          0            0           0         
+  960          0            0           0         
+  919          0            0           0         
+  990          0            0           0         
+  981          0            0           0         
+  987          0            0           0         
+  947          0            0           0         
+  997          0            0           0         
+  1004         0            0           0         
+  931          0            0           0         
+  926          0            0           0         
+  988          0            0           0         
+  989          0            0           0         
+  996          0            0           0         
+  938          0            0           0         
+  965          0            0           0         
+  993          0            0           0         
+  928          0            0           0         
+  976          0            0           0         
+  959          0            0           0         
+  902          0            0           0         
+  924          0            0           0         
+  930          0            0           0         
+  940          0            0           0         
+  966          0            0           0         
+  961          0            0           0         
+  959          0            0           0         
+  968          0            0           0         
+  957          0            0           0         
+  942          0            0           0         
+  929          0            0           0         
+  930          0            0           0         
+  989          0            0           0         
+  937          0            0           0         
+  917          0            0           0         
+  915          0            0           0         
+  941          0            0           0         
+  907          0            0           0         
+  939          0            0           0         
+  979          0            0           0         
+  979          0            0           0         
+  998          0            0           0         
+  952          0            0           0         
+  936          0            0           0         
+  917          0            0           0         
+  878          0            0           0         
+  896          0            0           0         
+  929          0            0           0         
+  949          0            0           0         
+  944          0            0           0         
+  927          0            0           0         
+  982          0            0           0         
+  958          0            0           0         
+  899          0            0           0         
+  909          0            0           0         
+  923          0            0           0         
+  894          0            0           0         
+  882          0            0           0         
+  895          0            0           0         
+  916          0            0           0         
+  879          0            0           0         
+  924          0            0           0         
+  911          0            0           0         
+  900          0            0           0         
+  887          0            0           0         
+  904          0            0           0         
+  887          0            0           0         
+  888          0            0           0         
+  908          0            0           0         
+  884          0            0           0         
+  964          0            0           0         
+  917          0            0           0         
+  879          0            0           0         
+  891          0            0           0         
+  913          0            0           0         
+  908          0            0           0         
+  907          0            0           0         
+  928          0            0           0         
+  891          0            0           0         
+  886          0            0           0         
+  881          0            0           0         
+  845          0            0           0         
+  913          0            0           0         
+  900          0            0           0         
+  900          0            0           0         
+  878          0            0           0         
+  902          0            0           0         
+  914          0            0           0         
+  869          0            0           0         
+  877          0            0           0         
+  912          0            0           0         
+  838          0            0           0         
+  895          0            0           0         
+  862          0            0           0         
+  820          0            0           0         
+  925          0            0           0         
+  836          0            0           0         
+  860          0            0           0         
+  907          0            0           0         
+  814          0            0           0         
+  892          0            0           0         
+  859          0            0           0         
+  844          0            0           0         
+  876          0            0           0         
+  825          0            0           0         
+  832          0            0           0         
+  816          0            0           0         
+  860          0            0           0         
+  903          0            0           0         
+  870          0            0           0         
+  850          0            0           0         
+  852          0            0           0         
+  874          0            0           0         
+  811          0            0           0         
+  870          0            0           0         
+  823          0            0           0         
+  894          0            0           0         
+  855          0            0           0         
+  814          0            0           0         
+  839          0            0           0         
+  838          0            0           0         
+  862          0            0           0         
+  855          0            0           0         
+  870          0            0           0         
+  825          0            0           0         
+  878          0            0           0         
+  842          0            0           0         
+  807          0            0           0         
+  818          0            0           0         
+  841          0            0           0         
+  872          0            0           0         
+  819          0            0           0         
+  872          0            0           0         
+  804          0            0           0         
+  817          0            0           0         
+  871          0            0           0         
+  794          0            0           0         
+  834          0            0           0         
+  837          0            0           0         
+  811          0            0           0         
+  776          0            0           0         
+  836          0            0           0         
+  852          0            0           0         
+  849          0            0           0         
+  776          0            0           0         
+  765          0            0           0         
+  831          0            0           0         
+  785          0            0           0         
+  822          0            0           0         
+  786          0            0           0         
+  778          0            0           0         
+  846          0            0           0         
+  816          0            0           0         
+  837          0            0           0         
+  846          0            0           0         
+  786          0            0           0         
+  748          0            0           0         
+  801          0            0           0         
+  835          0            0           0         
+  753          0            0           0         
+  830          0            0           0         
+  814          0            0           0         
+  765          0            0           0         
+  835          0            0           0         
+  805          0            0           0         
+  789          0            0           0         
+  832          0            0           0         
+  859          0            0           0         
+  778          0            0           0         
+  797          0            0           0         
+  830          0            0           0         
+  791          0            0           0         
+  785          0            0           0         
+  765          0            0           0         
+  805          0            0           0         
+  787          0            0           0         
+  811          0            0           0         
+  807          0            0           0         
+  807          0            0           0         
+  781          0            0           0         
+  784          0            0           0         
+  811          0            0           0         
+  794          0            0           0         
+  791          0            0           0         
+  768          0            0           0         
+  774          0            0           0         
+  773          0            0           0         
+  798          0            0           0         
+  797          0            0           0         
+  780          0            0           0         
+  798          0            0           0         
+  767          0            0           0         
+  799          0            0           0         
+  776          0            0           0         
+  781          0            0           0         
+  768          0            0           0         
+  750          0            0           0         
+  743          0            0           0         
+  724          0            0           0         
+  757          0            0           0         
+  765          0            0           0         
+  799          0            0           0         
+  729          0            0           0         
+  785          0            0           0         
+  748          0            0           0         
+  736          0            0           0         
+  794          0            0           0         
+  785          0            0           0         
+  767          0            0           0         
+  737          0            0           0         
+  734          0            0           0         
+  713          0            0           0         
+  789          0            0           0         
+  779          0            0           0         
+  762          0            0           0         
+  792          0            0           0         
+  788          0            0           0         
+  768          0            0           0         
+  765          0            0           0         
+  751          0            0           0         
+  758          0            0           0         
+  811          0            0           0         
+  821          0            0           0         
+  763          0            0           0         
+  745          0            0           0         
+  724          0            0           0         
+  742          0            0           0         
+  738          0            0           0         
+  766          0            0           0         
+  735          0            0           0         
+  768          0            0           0         
+  763          0            0           0         
+  762          0            0           0         
+  751          0            0           0         
+  723          0            0           0         
+  711          0            0           0         
+  729          0            0           0         
+  735          0            0           0         
+  780          0            0           0         
+  742          0            0           0         
+  793          0            0           0         
+  722          0            0           0         
+  717          0            0           0         
+  714          0            0           0         
+  730          0            0           0         
+  724          0            0           0         
+  724          0            0           0         
+  749          0            0           0         
+  677          0            0           0         
+  748          0            0           0         
+  746          0            0           0         
+  703          0            0           0         
+  706          0            0           0         
+  706          0            0           0         
+  749          0            0           0         
+  789          0            0           0         
+  711          0            0           0         
+  767          0            0           0         
+  755          0            0           0         
+  751          0            0           0         
+  715          0            0           0         
+  731          0            0           0         
+  723          0            0           0         
+  733          0            0           0         
+  726          0            0           0         
+  729          0            0           0         
+  672          0            0           0         
+  694          690.30742    689.73057   0.00144092 
+  720          689.54188    688.95633   0.00138889 
+  685          688.7775     688.18298   0.00145985 
+  688          688.01429    687.4105    0.00145349 
+  706          687.25226    686.6389    0.00141643 
+  638          686.49142    685.86817   0.0015674 
+  735          685.73179    685.09833   0.00136054 
+  716          684.9734     684.32935   0.00139665 
+  701          684.21625    683.56125   0.00142653 
+  703          683.46037    682.79402   0.00142248 
+  712          682.70577    682.02767   0.00140449 
+  668          681.95248    681.26218   0.00149701 
+  689          681.20053    680.49757   0.00145138 
+  726          680.44994    679.73382   0.00137741 
+  707          679.70073    678.97095   0.00141443 
+  692          678.95295    678.20894   0.00144509 
+  682          678.20661    677.4478    0.00146628 
+  654          677.46177    676.68752   0.00152905 
+  693          676.71845    675.92811   0.001443  
+  699          675.9767     675.16956   0.00143062 
+  674          675.23656    674.41187   0.00148368 
+  705          674.49809    673.65505   0.00141844 
+  663          673.76134    672.89909   0.0015083 
+  705          673.02637    672.14399   0.00141844 
+  729          672.29325    671.38975   0.00137174 
+  698          671.56204    670.63637   0.00143266 
+  692          670.83282    669.88384   0.00144509 
+  662          670.10569    669.13217   0.00151057 
+  692          669.38074    668.38136   0.00144509 
+  689          668.65806    667.63141   0.00145138 
+  679          667.93779    666.8823    0.00147275 
+  658          667.22005    666.13406   0.00151976 
+  681          666.50497    665.38666   0.00146843 
+  706          665.79273    664.64012   0.00141643 
+  700          665.0835     663.89442   0.00142857 
+  695          664.37748    663.14958   0.00143885 
+  696          663.67489    662.40559   0.00143678 
+  645          662.97598    661.66244   0.00155039 
+  700          662.28104    660.92014   0.00142857 
+  686          661.5904     660.17869   0.00145773 
+  680          660.9044     659.43808   0.00147059 
+  693          660.22349    658.69832   0.001443  
+  687          659.54811    657.9594    0.0014556 
+  689          658.87882    657.22133   0.00145138 
+  655          658.21626    656.4841    0.00152672 
+  676          657.56139    655.74771   0.00147929 
+  668          656.91456    655.01216   0.00149701 
+  737          656.27702    654.27745   0.00135685 
+  669          655.64991    653.54357   0.00149477 
+  704          655.0346     652.81054   0.00142045 
+  623          654.43273    652.07834   0.00160514 
+  717          653.84621    651.34698   0.0013947 
+  723          653.2774     650.61646   0.00138313 
+  632          652.72926    649.88677   0.00158228 
+  684          652.20498    649.15791   0.00146199 
+  673          651.70896    648.42988   0.00148588 
+  667          651.24653    647.70269   0.00149925 
+  678          650.82435    646.97633   0.00147493 
+  684          650.45096    646.2508    0.00146199 
+  639          650.13739    645.5261    0.00156495 
+  698          649.898      644.80222   0.00143266 
+  662          649.75209    644.07918   0.00151057 
+  620          649.72601    643.35696   0.0016129 
+  753          649.857      642.63556   0.00132802 
+  708          650.2027     641.91499   0.00141243 
+  674          650.86413    641.19525   0.00148368 
+  720          652.03772    640.47633   0.00138889 
+  671          654.104      639.75823   0.00149031 
+  663          657.72206    639.04096   0.0015083 
+  713          663.87671    638.3245    0.00140252 
+  709          673.80319    637.60887   0.00141044 
+  735          688.64522    636.89405   0.00136054 
+  722          709.98011    636.18005   0.00138504 
+  784          740.73049    635.46687   0.00127551 
+  780          781.92833    634.75451   0.00128205 
+  844          834.93234    634.04296   0.00118483 
+  896          896.58794    633.33223   0.00111607 
+  990          951.97305    632.62231   0.0010101 
+  1067         979.55029    631.9132    0.00093721 
+  1071         961.66917    631.20491   0.00093371 
+  950          911.51888    630.49743   0.00105263 
+  914          848.7341     629.79076   0.00109409 
+  880          783.37955    629.0849    0.00113636 
+  767          728.85262    628.37984   0.00130378 
+  691          691.7168     627.6756    0.00144718 
+  676          669.70491    626.97217   0.00147929 
+  662          657.74443    626.26954   0.00151057 
+  657          651.15516    625.56771   0.00152207 
+  641          646.79885    624.86669   0.00156006 
+  604          643.23569    624.16648   0.00165563 
+  650          640.23167    623.46707   0.00153846 
+  640          637.74689    622.76846   0.0015625 
+  654          635.78842    622.07065   0.00152905 
+  657          634.26237    621.37365   0.00152207 
+  589          632.83615    620.67744   0.00169779 
+  656          631.09931    619.98203   0.00152439 
+  618          629.05915    619.28742   0.00161812 
+  611          626.95903    618.59361   0.00163666 
+  623          624.89705    617.9006    0.00160514 
+  641          623.02585    617.20838   0.00156006 
+  638          621.45625    616.51696   0.0015674 
+  598          620.16107    615.82633   0.00167224 
+  631          619.05999    615.13649   0.00158479 
+  616          618.07789    614.44745   0.00162338 
+  606          617.16504    613.75919   0.00165017 
+  637          616.29497    613.07173   0.00156986 
+  649          615.45485    612.38506   0.00154083 
+  607          614.63795    611.69918   0.00164745 
+  621          613.84006    611.01409   0.00161031 
+  632          613.05815    610.32978   0.00158228 
+  640          612.28992    609.64626   0.0015625 
+  580          611.53356    608.96353   0.00172414 
+  600          610.78763    608.28158   0.00166667 
+  633          610.05093    607.60042   0.00157978 
+  609          609.3225     606.92004   0.00164204 
+  632          608.60153    606.24044   0.00158228 
+  617          607.88734    605.56163   0.00162075 
+  601          607.17934    604.88359   0.00166389 
+  653          606.47707    604.20634   0.00153139 
+  574          605.78009    603.52987   0.00174216 
+  591          605.08807    602.85417   0.00169205 
+  618          604.40068    602.17925   0.00161812 
+  584          603.71767    601.50511   0.00171233 
+  604          603.03882    600.83175   0.00165563 
+  629          602.36393    600.15916   0.00158983 
+  589          601.69285    599.48735   0.00169779 
+  623          601.02542    598.81631   0.00160514 
+  655          600.36153    598.14604   0.00152672 
+  629          599.70109    597.47655   0.00158983 
+  618          599.044      596.80782   0.00161812 
+  606          598.39022    596.13987   0.00165017 
+  561          597.73968    595.47269   0.00178253 
+  588          597.09235    594.80628   0.00170068 
+  631          596.4482     594.14063   0.00158479 
+  610          595.80721    593.47575   0.00163934 
+  608          595.1694     592.81164   0.00164474 
+  609          594.53475    592.1483    0.00164204 
+  544          593.90329    591.48572   0.00183824 
+  615          593.27505    590.8239    0.00162602 
+  596          592.65007    590.16285   0.00167785 
+  602          592.0284     589.50256   0.00166113 
+  637          591.41008    588.84303   0.00156986 
+  629          590.7952     588.18426   0.00158983 
+  553          590.18383    587.52626   0.00180832 
+  566          589.57605    586.86901   0.00176678 
+  593          588.97198    586.21252   0.00168634 
+  649          588.37173    585.55679   0.00154083 
+  581          587.77542    584.90182   0.00172117 
+  628          587.1832     584.2476    0.00159236 
+  581          586.59522    583.59414   0.00172117 
+  610          586.01166    582.94143   0.00163934 
+  570          585.43272    582.28948   0.00175439 
+  644          584.85861    581.63828   0.0015528 
+  576          584.28957    580.98783   0.00173611 
+  640          583.72587    580.33814   0.0015625 
+  543          583.16782    579.68919   0.00184162 
+  601          582.61577    579.041     0.00166389 
+  578          582.07009    578.39355   0.0017301 
+  539          581.53124    577.74685   0.00185529 
+  561          580.99974    577.10091   0.00178253 
+  574          580.47621    576.4557    0.00174216 
+  576          579.96137    575.81125   0.00173611 
+  565          579.45614    575.16754   0.00176991 
+  570          578.96165    574.52457   0.00175439 
+  586          578.4794     573.88235   0.00170648 
+  588          578.01159    573.24087   0.00170068 
+  554          577.56187    572.60013   0.00180505 
+  592          577.137      571.96013   0.00168919 
+  628          576.7494     571.32088   0.00159236 
+  593          576.41972    570.68236   0.00168634 
+  570          576.17812    570.04459   0.00175439 
+  605          576.06134    569.40755   0.00165289 
+  552          576.1069     568.77125   0.00181159 
+  586          576.37769    568.13568   0.00170648 
+  561          576.93523    567.50086   0.00178253 
+  594          577.78358    566.86676   0.0016835 
+  591          578.86163    566.23341   0.00169205 
+  590          579.84445    565.60078   0.00169492 
+  586          580.2058     564.96889   0.00170648 
+  603          579.55498    564.33773   0.00165837 
+  590          578.20435    563.70731   0.00169492 
+  589          576.63737    563.07761   0.00169779 
+  596          575.00529    562.44864   0.00167785 
+  582          573.55159    561.8204    0.00171821 
+  584          572.48391    561.19289   0.00171233 
+  565          571.80485    560.56611   0.00176991 
+  544          571.39388    559.94006   0.00183824 
+  574          571.15845    559.31473   0.00174216 
+  576          571.03015    558.69012   0.00173611 
+  584          570.97979    558.06625   0.00171233 
+  527          570.984      557.44309   0.00189753 
+  577          571.04269    556.82066   0.0017331 
+  590          571.15397    556.19895   0.00169492 
+  566          571.31705    555.57796   0.00176678 
+  528          571.53121    554.95769   0.00189394 
+  593          571.7954     554.33814   0.00168634 
+  552          572.10807    553.71931   0.00181159 
+  558          572.46662    553.1012    0.00179211 
+  560          572.86712    552.48381   0.00178571 
+  539          573.30424    551.86713   0.00185529 
+  584          573.77065    551.25117   0.00171233 
+  601          574.2569     550.63593   0.00166389 
+  555          574.75142    550.0214    0.0018018 
+  574          575.24021    549.40758   0.00174216 
+  553          575.70698    548.79448   0.00180832 
+  600          576.13367    548.18209   0.00166667 
+  570          576.50065    547.57041   0.00175439 
+  564          576.78742    546.95945   0.00177305 
+  579          576.97374    546.34919   0.00172712 
+  555          577.04036    545.73964   0.0018018 
+  552          576.96999    545.1308    0.00181159 
+  618          576.74854    544.52267   0.00161812 
+  545          576.36575    543.91525   0.00183486 
+  547          575.81574    543.30853   0.00182815 
+  585          575.09748    542.70252   0.0017094 
+  581          574.21474    542.09721   0.00172117 
+  568          573.17574    541.49261   0.00176056 
+  530          571.99271    540.88871   0.00188679 
+  522          570.68114    540.28551   0.00191571 
+  559          569.25884    539.68302   0.00178891 
+  549          567.74509    539.08122   0.00182149 
+  560          566.15957    538.48013   0.00178571 
+  597          564.52186    537.87974   0.00167504 
+  574          562.85036    537.28004   0.00174216 
+  549          561.16188    536.68105   0.00182149 
+  551          559.47148    536.08275   0.00181488 
+  572          557.79194    535.48515   0.00174825 
+  521          556.13381    534.88824   0.00191939 
+  572          554.5057     534.29203   0.00174825 
+  555          552.91411    533.69651   0.0018018 
+  577          551.36374    533.10169   0.0017331 
+  550          549.85789    532.50756   0.00181818 
+  567          548.39852    531.91413   0.00176367 
+  540          546.98649    531.32138   0.00185185 
+  536          545.62196    530.72933   0.00186567 
+  521          544.30447    530.13796   0.00191939 
+  518          543.03302    529.54729   0.0019305 
+  535          541.8065     528.9573    0.00186916 
+  564          540.62363    528.36801   0.00177305 
+  551          539.48314    527.77939   0.00181488 
+  492          538.38395    527.19147   0.00203252 
+  511          537.32544    526.60423   0.00195695 
+  573          536.30776    526.01768   0.0017452 
+  535          535.33291    525.43181   0.00186916 
+  487          534.40681    524.84662   0.00205339 
+  512          533.5428     524.26212   0.00195312 
+  520          532.76594    523.6783    0.00192308 
+  507          532.11619    523.09516   0.00197239 
+  589          531.64683    522.51271   0.00169779 
+  558          531.41604    521.93093   0.00179211 
+  552          531.50894    521.34983   0.00181159 
+  548          532.00991    520.76941   0.00182482 
+  509          532.90455    520.18967   0.00196464 
+  527          534.03254    519.6106    0.00189753 
+  511          534.88249    519.03221   0.00195695 
+  522          534.7099     518.4545    0.00191571 
+  512          533.2043     517.87746   0.00195312 
+  512          530.99637    517.3011    0.00195312 
+  524          528.59914    516.7254    0.0019084 
+  503          526.10559    516.15039   0.00198807 
+  516          523.81873    515.57604   0.00193798 
+  473          521.99202    515.00237   0.00211416 
+  509          520.6098     514.42936   0.00196464 
+  528          519.54186    513.85703   0.00189394 
+  545          518.65613    513.28536   0.00183486 
+  522          517.86436    512.71437   0.00191571 
+  483          517.12163    512.14404   0.00207039 
+  515          516.40843    511.57438   0.00194175 
+  494          515.71616    511.00538   0.00202429 
+  501          515.04032    510.43705   0.00199601 
+  531          514.37806    509.86939   0.00188324 
+  496          513.72744    509.30239   0.00201613 
+  525          513.08708    508.73605   0.00190476 
+  507          512.45584    508.17038   0.00197239 
+  519          511.83298    507.60537   0.00192678 
+  523          511.21788    507.04102   0.00191205 
+  507          510.61007    506.47733   0.00197239 
+  472          510.00918    505.9143    0.00211864 
+  513          509.41491    505.35193   0.00194932 
+  511          508.82705    504.79021   0.00195695 
+  516          508.24544    504.22916   0.00193798 
+  482          507.66993    503.66876   0.00207469 
+  536          507.10046    503.10902   0.00186567 
+  504          506.53697    502.54994   0.00198413 
+  519          505.97945    501.99151   0.00192678 
+  454          505.42791    501.43373   0.00220264 
+  467          504.88239    500.87661   0.00214133 
+  536          504.34298    500.32014   0.00186567 
+  502          503.80976    499.76433   0.00199203 
+  519          503.28288    499.20916   0.00192678 
+  563          502.76247    498.65465   0.0017762 
+  510          502.24872    498.10079   0.00196078 
+  535          501.74186    497.54757   0.00186916 
+  492          501.24211    496.99501   0.00203252 
+  509          500.74975    496.44309   0.00196464 
+  543          500.26511    495.89182   0.00184162 
+  485          499.7885     495.3412    0.00206186 
+  537          499.32032    494.79122   0.0018622 
+  469          498.86099    494.24189   0.0021322 
+  511          498.41096    493.6932    0.00195695 
+  489          497.97073    493.14516   0.00204499 
+  502          497.54088    492.59776   0.00199203 
+  480          497.12194    492.051     0.00208333 
+  453          496.71459    491.50488   0.00220751 
+  502          496.3195     490.95941   0.00199203 
+  508          495.93741    490.41458   0.0019685 
+  529          495.5691     489.87038   0.00189036 
+  489          495.21542    489.32683   0.00204499 
+  530          494.8772     488.78391   0.00188679 
+  485          494.55538    488.24163   0.00206186 
+  472          494.25118    487.69999   0.00211864 
+  465          493.96494    487.15898   0.00215054 
+  483          493.69794    486.61861   0.00207039 
+  442          493.4511     486.07888   0.00226244 
+  493          493.22528    485.53978   0.0020284 
+  503          493.02131    485.00131   0.00198807 
+  512          492.83989    484.46348   0.00195312 
+  500          492.68149    483.92628   0.002     
+  486          492.54663    483.38971   0.00205761 
+  492          492.43497    482.85377   0.00203252 
+  471          492.34629    482.31846   0.00212314 
+  492          492.27985    481.78378   0.00203252 
+  518          492.23432    481.24973   0.0019305 
+  463          492.20769    480.71631   0.00215983 
+  473          492.19734    480.18351   0.00211416 
+  480          492.19974    479.65134   0.00208333 
+  485          492.21037    479.1198    0.00206186 
+  478          492.22379    478.58889   0.00209205 
+  515          492.23333    478.0586    0.00194175 
+  467          492.23133    477.52893   0.00214133 
+  438          492.20893    476.99988   0.00228311 
+  451          492.15643    476.47146   0.00221729 
+  498          492.06344    475.94366   0.00200803 
+  470          491.91924    475.41649   0.00212766 
+  485          491.71342    474.88993   0.00206186 
+  460          491.43636    474.36399   0.00217391 
+  506          491.07987    473.83868   0.00197628 
+  508          490.63789    473.31398   0.0019685 
+  506          490.10685    472.7899    0.00197628 
+  470          489.48607    472.26644   0.00212766 
+  458          488.77781    471.74359   0.00218341 
+  498          487.98706    471.22136   0.00200803 
+  466          487.12135    470.69975   0.00214592 
+  498          486.18998    470.17875   0.00200803 
+  463          485.20357    469.65836   0.00215983 
+  482          484.17339    469.13859   0.00207469 
+  464          483.11066    468.61943   0.00215517 
+  447          482.02612    468.10089   0.00223714 
+  483          480.92968    467.58295   0.00207039 
+  481          479.83001    467.06563   0.002079  
+  482          478.73456    466.54891   0.00207469 
+  477          477.64949    466.03281   0.00209644 
+  471          476.57961    465.51731   0.00212314 
+  460          475.52862    465.00242   0.00217391 
+  436          474.4992     464.48814   0.00229358 
+  456          473.49309    463.97447   0.00219298 
+  472          472.51133    463.4614    0.00211864 
+  460          471.55439    462.94894   0.00217391 
+  414          470.6222     462.43708   0.00241546 
+  452          469.71439    461.92583   0.00221239 
+  484          468.83033    461.41518   0.00206612 
+  460          467.96914    460.90514   0.00217391 
+  488          467.12986    460.39569   0.00204918 
+  457          466.31147    459.88685   0.00218818 
+  418          465.51286    459.37861   0.00239234 
+  452          464.73292    458.87097   0.00221239 
+  455          463.9706     458.36393   0.0021978 
+  457          463.22481    457.85748   0.00218818 
+  482          462.49453    457.35164   0.00207469 
+  450          461.7788     456.84639   0.00222222 
+  450          461.07667    456.34174   0.00222222 
+  442          460.38728    455.83769   0.00226244 
+  428          459.7098     455.33423   0.00233645 
+  449          459.04344    454.83137   0.00222717 
+  432          458.3875     454.32911   0.00231481 
+  479          457.74154    453.82743   0.00208768 
+  424          457.10446    453.32635   0.00235849 
+  434          456.4759     452.82586   0.00230415 
+  418          455.85534    452.32597   0.00239234 
+  450          455.24227    451.82666   0.00222222 
+  405          454.63622    451.32795   0.00246914 
+  467          454.03679    450.82983   0.00214133 
+  471          453.44355    450.33229   0.00212314 
+  444          452.85614    449.83534   0.00225225 
+  430          452.27436    449.33899   0.00232558 
+  411          451.69764    448.84322   0.00243309 
+  438          451.12581    448.34803   0.00228311 
+  469          450.5586     447.85343   0.0021322 
+  414          449.99577    447.35942   0.00241546 
+  437          449.43709    446.86599   0.00228833 
+  436          448.88233    446.37315   0.00229358 
+  458          448.33133    445.88089   0.00218341 
+  446          447.78387    445.38922   0.00224215 
+  426          447.23981    444.89812   0.00234742 
+  403          446.69895    444.40761   0.00248139 
+  465          446.16118    443.91768   0.00215054 
+  451          445.62657    443.42833   0.00221729 
+  452          445.09456    442.93955   0.00221239 
+  462          444.56526    442.45136   0.0021645 
+  422          444.03855    441.96375   0.00236967 
+  417          443.51434    441.47671   0.00239808 
+  416          442.99252    440.99025   0.00240385 
+  416          442.47302    440.50437   0.00240385 
+  415          441.95575    440.01906   0.00240964 
+  432          441.44288    439.53433   0.00231481 
+  440          440.92996    439.05018   0.00227273 
+  419          440.41898    438.5666    0.00238663 
+  429          439.90993    438.08359   0.002331  
+  438          439.40391    437.60115   0.00228311 
+  409          438.89862    437.11929   0.00244499 
+  472          438.39513    436.638     0.00211864 
+  424          437.89339    436.15728   0.00235849 
+  446          437.39336    435.67712   0.00224215 
+  404          436.895      435.19754   0.00247525 
+  416          436.39827    434.71853   0.00240385 
+  384          435.90316    434.24009   0.00260417 
+  384          435.4096     433.76221   0.00260417 
+  437          434.91758    433.28491   0.00228833 
+  402          434.42707    432.80816   0.00248756 
+  412          433.93804    432.33199   0.00242718 
+  433          433.45048    431.85638   0.00230947 
+  417          432.96437    431.38133   0.00239808 
+  443          432.47968    430.90685   0.00225734 
+  437          431.99639    430.43293   0.00228833 
+  420          431.5145     429.95958   0.00238095 
+  409          431.03399    429.48679   0.00244499 
+  431          430.55484    429.01456   0.00232019 
+  433          430.07713    428.54289   0.00230947 
+  418          429.60069    428.07178   0.00239234 
+  419          429.1256     427.60123   0.00238663 
+  433          428.65184    427.13124   0.00230947 
+  424          428.17941    426.6618    0.00235849 
+  418          427.70832    426.19293   0.00239234 
+  410          427.23856    425.72461   0.00243902 
+  416          426.77012    425.25685   0.00240385 
+  442          426.30303    424.78965   0.00226244 
+  431          425.8373     424.323     0.00232019 
+  412          425.37288    423.85691   0.00242718 
+  438          424.90982    423.39137   0.00228311 
+  421          424.44811    422.92638   0.0023753 
+  421          423.98777    422.46195   0.0023753 
+  402          423.52882    421.99807   0.00248756 
+  424          423.07126    421.53475   0.00235849 
+  406          422.61512    421.07197   0.00246305 
+  424          422.1604     420.60974   0.00235849 
+  406          421.70714    420.14807   0.00246305 
+  415          421.25535    419.68694   0.00240964 
+  442          420.80505    419.22636   0.00226244 
+  422          420.35628    418.76633   0.00236967 
+  407          419.90907    418.30685   0.002457  
+  381          419.46344    417.84792   0.00262467 
+  412          419.01943    417.38953   0.00242718 
+  428          418.57708    416.93169   0.00233645 
+  389          418.13642    416.47439   0.00257069 
+  396          417.69751    416.01764   0.00252525 
+  443          417.26039    415.56143   0.00225734 
+  443          416.82512    415.10577   0.00225734 
+  440          416.39174    414.65064   0.00227273 
+  381          415.96032    414.19606   0.00262467 
+  426          415.53093    413.74203   0.00234742 
+  409          415.10363    413.28853   0.00244499 
+  393          414.6785     412.83557   0.00254453 
+  404          414.25562    412.38316   0.00247525 
+  437          413.83509    411.93128   0.00228833 
+  435          413.41698    411.47994   0.00229885 
+  397          413.00142    411.02914   0.00251889 
+  404          412.58851    410.57888   0.00247525 
+  414          412.17836    410.12915   0.00241546 
+  429          411.77111    409.67996   0.002331  
+  373          411.36691    409.23131   0.00268097 
+  434          410.96589    408.78319   0.00230415 
+  401          410.56823    408.3356    0.00249377 
+  405          410.1741     407.88855   0.00246914 
+  388          409.78369    407.44203   0.00257732 
+  404          409.3972     406.99605   0.00247525 
+  429          409.01488    406.5506    0.002331  
+  414          408.63695    406.10567   0.00241546 
+  407          408.26367    405.66128   0.002457  
+  402          407.89533    405.21742   0.00248756 
+  390          407.53225    404.77409   0.0025641 
+  395          407.17474    404.33129   0.00253165 
+  384          406.82318    403.88902   0.00260417 
+  416          406.47794    403.44728   0.00240385 
+  378          406.13945    403.00606   0.0026455 
+  398          405.80815    402.56537   0.00251256 
+  382          405.48454    402.12521   0.0026178 
+  372          405.16913    401.68557   0.00268817 
+  413          404.86251    401.24646   0.00242131 
+  396          404.56525    400.80787   0.00252525 
+  372          404.27801    400.36981   0.00268817 
+  374          404.00147    399.93227   0.0026738 
+  345          403.73639    399.49525   0.00289855 
+  384          403.48349    399.05875   0.00260417 
+  410          403.24363    398.62278   0.00243902 
+  365          403.0176     398.18733   0.00273973 
+  380          402.80741    397.75239   0.00263158 
+  418          402.61172    397.31798   0.00239234 
+  383          402.43253    396.88409   0.00261097 
+  385          402.27072    396.45071   0.0025974 
+  457          402.12709    396.01786   0.00218818 
+  397          402.00298    395.58552   0.00251889 
+  420          401.89784    395.1537    0.00238095 
+  395          401.81268    394.72239   0.00253165 
+  400          401.74769    394.2916    0.0025    
+  417          401.70277    393.86133   0.00239808 
+  403          401.6773     393.43157   0.00248139 
+  380          401.67026    393.00233   0.00263158 
+  354          401.67979    392.5736    0.00282486 
+  380          401.69858    392.14538   0.00263158 
+  374          401.7329     391.71767   0.0026738 
+  400          401.77342    391.29048   0.0025    
+  373          401.8124     390.8638    0.00268097 
+  368          401.84811    390.43762   0.00271739 
+  380          401.87044    390.01196   0.00263158 
+  367          401.87115    389.58681   0.0027248 
+  392          401.84121    389.16217   0.00255102 
+  370          401.77144    388.73803   0.0027027 
+  382          401.65283    388.31441   0.0026178 
+  369          401.47709    387.89129   0.00271003 
+  377          401.23736    387.46868   0.00265252 
+  399          400.92828    387.04657   0.00250627 
+  406          400.54672    386.62497   0.00246305 
+  402          400.09174    386.20387   0.00248756 
+  406          399.56476    385.78328   0.00246305 
+  379          398.96928    385.3632    0.00263852 
+  374          398.31107    384.94361   0.0026738 
+  379          397.59712    384.52453   0.00263852 
+  365          396.8357     384.10595   0.00273973 
+  387          396.03601    383.68788   0.00258398 
+  403          395.20775    383.2703    0.00248139 
+  416          394.36097    382.85323   0.00240385 
+  406          393.50595    382.43665   0.00246305 
+  399          392.65216    382.02058   0.00250627 
+  362          391.80812    381.605     0.00276243 
+  356          390.98122    381.18992   0.00280899 
+  400          390.16241    380.77534   0.0025    
+  386          389.34283    380.36126   0.00259067 
+  392          388.50803    379.94768   0.00255102 
+  352          387.66343    379.53459   0.00284091 
+  390          386.83711    379.12199   0.0025641 
+  395          386.02478    378.70989   0.00253165 
+  375          385.22771    378.29829   0.00266667 
+  403          384.44907    377.88718   0.00248139 
+  390          383.69817    377.47656   0.0025641 
+  407          382.97718    377.06644   0.002457  
+  378          382.27898    376.6568    0.0026455 
+  374          381.60285    376.24766   0.0026738 
+  362          380.94571    375.83901   0.00276243 
+  357          380.31088    375.43086   0.00280112 
+  389          379.68603    375.02319   0.00257069 
+  334          379.07554    374.61601   0.00299401 
+  353          378.47847    374.20932   0.00283286 
+  374          377.89392    373.80312   0.0026738 
+  365          377.32112    373.3974    0.00273973 
+  336          376.75928    372.99218   0.00297619 
+  368          376.20771    372.58744   0.00271739 
+  368          375.66572    372.18318   0.00271739 
+  371          375.13544    371.77942   0.00269542 
+  372          374.61079    371.37613   0.00268817 
+  352          374.09397    370.97334   0.00284091 
+  360          373.58448    370.57102   0.00277778 
+  325          373.08185    370.16919   0.00307692 
+  379          372.58566    369.76785   0.00263852 
+  371          372.09549    369.36698   0.00269542 
+  350          371.6165     368.9666    0.00285714 
+  385          371.1373     368.5667    0.0025974 
+  372          370.66589    368.16728   0.00268817 
+  388          370.19638    367.76834   0.00257732 
+  336          369.7313     367.36988   0.00297619 
+  357          369.2704     366.9719    0.00280112 
+  375          368.81343    366.57439   0.00266667 
+  361          368.36019    366.17737   0.00277008 
+  384          367.91049    365.78082   0.00260417 
+  355          367.46687    365.38475   0.0028169 
+  370          367.02367    364.98916   0.0027027 
+  354          366.58488    364.59404   0.00282486 
+  336          366.14757    364.1994    0.00297619 
+  363          365.71298    363.80523   0.00275482 
+  350          365.281      363.41154   0.00285714 
+  388          364.85151    363.01832   0.00257732 
+  362          364.42441    362.62558   0.00276243 
+  351          363.9996     362.23331   0.002849  
+  365          363.57697    361.84151   0.00273973 
+  391          363.15644    361.45018   0.00255754 
+  367          362.73794    361.05932   0.0027248 
+  343          362.32139    360.66894   0.00291545 
+  344          361.90672    360.27902   0.00290698 
+  359          361.49388    359.88957   0.00278552 
+  329          361.08279    359.50059   0.00303951 
+  385          360.6734     359.11209   0.0025974 
+  384          360.26567    358.72405   0.00260417 
+  321          359.85954    358.33647   0.00311526 
+  333          359.45498    357.94937   0.003003  
+  352          359.05193    357.56273   0.00284091 
+  344          358.65037    357.17655   0.00290698 
+  364          358.25093    356.79084   0.00274725 
+  316          357.85224    356.4056    0.00316456 
+  377          357.45493    356.02082   0.00265252 
+  342          357.05899    355.6365    0.00292398 
+  352          356.66439    355.25265   0.00284091 
+  356          356.27143    354.86926   0.00280899 
+  328          355.87943    354.48634   0.00304878 
+  353          355.48871    354.10387   0.00283286 
+  364          355.09924    353.72187   0.00274725 
+  359          354.71103    353.34032   0.00278552 
+  352          354.32444    352.95924   0.00284091 
+  319          353.93868    352.57862   0.0031348 
+  345          353.55513    352.19845   0.00289855 
+  372          353.17168    351.81875   0.00268817 
+  375          352.78974    351.4395    0.00266667 
+  339          352.4088     351.06071   0.00294985 
+  379          352.02899    350.68237   0.00263852 
+  352          351.65093    350.3045    0.00284091 
+  338          351.27357    349.92708   0.00295858 
+  390          350.8974     349.55011   0.0025641 
+  352          350.52243    349.1736    0.00284091 
+  344          350.14867    348.79755   0.00290698 
+  373          349.77613    348.42195   0.00268097 
+  349          349.4048     348.0468    0.00286533 
+  301          349.03472    347.6721    0.00332226 
+  365          348.66589    347.29786   0.00273973 
+  340          348.29832    346.92407   0.00294118 
+  319          347.93204    346.55073   0.0031348 
+  368          347.56707    346.17784   0.00271739 
+  357          347.20342    345.8054    0.00280112 
+  315          346.84113    345.43342   0.0031746 
+  334          346.48021    345.06188   0.00299401 
+  351          346.12071    344.69079   0.002849  
+  316          345.76266    344.32015   0.00316456 
+  340          345.40609    343.94995   0.00294118 
+  298          345.05105    343.58021   0.0033557 
+  346          344.69758    343.21091   0.00289017 
+  341          344.34574    342.84205   0.00293255 
+  355          343.99557    342.47365   0.0028169 
+  330          343.64715    342.10568   0.0030303 
+  321          343.30053    341.73817   0.00311526 
+  333          342.9558     341.37109   0.003003  
+  332          342.61305    341.00446   0.00301205 
+  328          342.27239    340.63828   0.00304878 
+  317          341.93395    340.27254   0.00315457 
+  341          341.59796    339.90723   0.00293255 
+  333          341.26476    339.54238   0.003003  
+  329          340.93488    339.17796   0.00303951 
+  351          340.60908    338.81398   0.002849  
+  303          340.28848    338.45044   0.00330033 
+  344          339.97334    338.08735   0.00290698 
+  349          339.664      337.72469   0.00286533 
+  340          339.35855    337.36247   0.00294118 
+  319          339.05332    337.00069   0.0031348 
+  327          338.74319    336.63935   0.0030581 
+  328          338.42946    336.27844   0.00304878 
+  315          338.11839    335.91797   0.0031746 
+  338          337.81256    335.55794   0.00295858 
+  336          337.51056    335.19835   0.00297619 
+  313          337.21214    334.83918   0.00319489 
+  334          336.92019    334.48046   0.00299401 
+  351          336.63649    334.12217   0.002849  
+  356          336.36146    333.76431   0.00280899 
+  334          336.09467    333.40688   0.00299401 
+  350          335.83614    333.04989   0.00285714 
+  331          335.58615    332.69333   0.00302115 
+  331          335.34528    332.3372    0.00302115 
+  339          335.11433    331.98151   0.00294985 
+  325          334.89423    331.62624   0.00307692 
+  324          334.68611    331.27141   0.00308642 
+  309          334.49128    330.917     0.00323625 
+  331          334.31117    330.56303   0.00302115 
+  312          334.14751    330.20948   0.00320513 
+  320          334.0023     329.85636   0.003125  
+  313          333.87777    329.50367   0.00319489 
+  328          333.7766     329.15141   0.00304878 
+  323          333.70196    328.79957   0.00309598 
+  312          333.65748    328.44816   0.00320513 
+  308          333.64755    328.09718   0.00324675 
+  360          333.67742    327.74662   0.00277778 
+  325          333.75321    327.39648   0.00307692 
+  312          333.88248    327.04678   0.00320513 
+  311          334.0744     326.69749   0.00321543 
+  363          334.34011    326.34863   0.00275482 
+  321          334.69346    326.00019   0.00311526 
+  312          335.15184    325.65218   0.00320513 
+  306          335.73676    325.30458   0.00326797 
+  347          336.47604    324.95741   0.00288184 
+  346          337.40549    324.61066   0.00289017 
+  299          338.57183    324.26433   0.00334448 
+  322          340.03744    323.91842   0.00310559 
+  325          341.88881    323.57293   0.00307692 
+  349          344.24852    323.22786   0.00286533 
+  352          347.30542    322.88321   0.00284091 
+  340          351.36738    322.53897   0.00294118 
+  395          356.95565    322.19516   0.00253165 
+  341          364.94593    321.85176   0.00293255 
+  405          376.73898    321.50878   0.00246914 
+  400          394.40002    321.16621   0.0025    
+  427          420.6075     320.82406   0.00234192 
+  428          458.09802    320.48233   0.00233645 
+  484          507.85111    320.14101   0.00206612 
+  478          566.5854     319.8001    0.00209205 
+  493          628.29638    319.45961   0.0020284 
+  529          685.84707    319.11953   0.00189036 
+  560          721.53586    318.77987   0.00178571 
+  501          717.40425    318.44062   0.00199601 
+  478          683.69106    318.10178   0.00209205 
+  450          642.78468    317.76335   0.00222222 
+  412          599.9948     317.42533   0.00242718 
+  382          549.56896    317.08773   0.0026178 
+  394          495.75796    316.75053   0.00253807 
+  368          448.55222    316.41374   0.00271739 
+  359          412.36186    316.07736   0.00278552 
+  309          386.54461    315.7414    0.00323625 
+  297          368.80371    315.40584   0.003367  
+  320          356.76831    315.07068   0.003125  
+  328          348.42016    314.73594   0.00304878 
+  286          342.4033     314.4016    0.0034965 
+  294          337.84972    314.06767   0.00340136 
+  297          334.25293    313.73414   0.003367  
+  312          331.31889    313.40102   0.00320513 
+  330          328.8694     313.06831   0.0030303 
+  332          326.78844    312.736     0.00301205 
+  322          324.99443    312.40409   0.00310559 
+  325          323.42778    312.07259   0.00307692 
+  305          322.04403    311.74149   0.00327869 
+  303          320.80887    311.41079   0.00330033 
+  322          319.69584    311.0805    0.00310559 
+  286          318.684      310.7506    0.0034965 
+  322          317.75683    310.42111   0.00310559 
+  328          316.90101    310.09202   0.00304878 
+  356          316.10586    309.76333   0.00280899 
+  301          315.36262    309.43504   0.00332226 
+  319          314.66388    309.10715   0.0031348 
+  292          314.0039     308.77966   0.00342466 
+  338          313.37739    308.45256   0.00295858 
+  336          312.78024    308.12587   0.00297619 
+  320          312.20893    307.79957   0.003125  
+  319          311.66041    307.47367   0.0031348 
+  316          311.13208    307.14817   0.00316456 
+  309          310.62176    306.82306   0.00323625 
+  327          310.12753    306.49835   0.0030581 
+  318          309.6478     306.17403   0.00314465 
+  335          309.18106    305.85011   0.00298507 
+  301          308.726      305.52659   0.00332226 
+  326          308.28159    305.20345   0.00306748 
+  273          307.84686    304.88071   0.003663  
+  308          307.42098    304.55837   0.00324675 
+  309          307.00319    304.23641   0.00323625 
+  285          306.59285    303.91485   0.00350877 
+  272          306.18935    303.59368   0.00367647 
+  293          305.79219    303.27291   0.00341297 
+  308          305.40094    302.95252   0.00324675 
+  292          305.01514    302.63252   0.00342466 
+  316          304.63441    302.31291   0.00316456 
+  300          304.25845    301.9937    0.00333333 
+  262          303.88698    301.67487   0.00381679 
+  300          303.51974    301.35643   0.00333333 
+  288          303.15649    301.03838   0.00347222 
+  332          302.79704    300.72071   0.00301205 
+  312          302.44121    300.40343   0.00320513 
+  312          302.08885    300.08654   0.00320513 
+  287          301.73984    299.77004   0.00348432 
+  292          301.39403    299.45392   0.00342466 
+  293          301.05133    299.13819   0.00341297 
+  305          300.71169    298.82284   0.00327869 
+  286          300.37503    298.50788   0.0034965 
+  301          300.04131    298.1933    0.00332226 
+  313          299.71052    297.87911   0.00319489 
+  302          299.38264    297.56529   0.00331126 
+  311          299.05769    297.25187   0.00321543 
+  271          298.73571    296.93882   0.00369004 
+  279          298.41675    296.62615   0.00358423 
+  309          298.10102    296.31387   0.00323625 
+  293          297.78837    296.00197   0.00341297 
+  298          297.47905    295.69045   0.0033557 
+  308          297.17324    295.3793    0.00324675 
+  314          296.87116    295.06854   0.00318471 
+  309          296.57305    294.75816   0.00323625 
+  315          296.27923    294.44816   0.0031746 
+  315          295.99006    294.13853   0.0031746 
+  271          295.70601    293.82928   0.00369004 
+  272          295.42759    293.52041   0.00367647 
+  304          295.15553    293.21192   0.00328947 
+  292          294.8905     292.9038    0.00342466 
+  275          294.63351    292.59606   0.00363636 
+  330          294.38574    292.2887    0.0030303 
+  265          294.14866    291.98171   0.00377358 
+  291          293.92404    291.6751    0.00343643 
+  289          293.71414    291.36886   0.00346021 
+  292          293.52182    291.06299   0.00342466 
+  292          293.3507     290.7575    0.00342466 
+  289          293.20549    290.45238   0.00346021 
+  304          293.0924     290.14763   0.00328947 
+  275          293.01958    289.84326   0.00363636 
+  316          292.9982     289.53926   0.00316456 
+  280          293.04371    289.23562   0.00357143 
+  304          293.1784     288.93236   0.00328947 
+  311          293.43464    288.62948   0.00321543 
+  314          293.86821    288.32696   0.00318471 
+  337          294.58676    288.02481   0.00296736 
+  328          295.82287    287.72303   0.00304878 
+  369          298.06736    287.42162   0.00271003 
+  367          302.22764    287.12057   0.0027248 
+  379          309.78454    286.8199    0.00263852 
+  379          322.62397    286.51959   0.00263852 
+  415          341.98776    286.21965   0.00240964 
+  435          367.52659    285.92008   0.00229885 
+  537          395.32985    285.62087   0.0018622 
+  596          414.47206    285.32203   0.00167785 
+  559          414.82452    285.02355   0.00178891 
+  554          399.25338    284.72544   0.00180505 
+  492          382.80816    284.42769   0.00203252 
+  479          370.50105    284.13031   0.00208768 
+  497          357.18184    283.83329   0.00201207 
+  390          339.0838     283.53664   0.0025641 
+  379          320.63822    283.24034   0.00263852 
+  378          306.60497    282.94441   0.0026455 
+  297          297.7237     282.64885   0.003367  
+  291          292.681      282.35364   0.00343643 
+  274          289.83825    282.05879   0.00364964 
+  310          288.06261    281.76431   0.00322581 
+  281          286.7899     281.47018   0.00355872 
+  300          285.78419    281.17642   0.00333333 
+  256          284.94578    280.88302   0.00390625 
+  259          284.22373    280.58997   0.003861  
+  288          283.58683    280.29728   0.00347222 
+  276          283.01401    280.00495   0.00362319 
+  319          282.49051    279.71298   0.0031348 
+  307          282.00554    279.42137   0.00325733 
+  332          281.55124    279.13011   0.00301205 
+  301          281.12167    278.83921   0.00332226 
+  284          280.71228    278.54867   0.00352113 
+  282          280.31957    278.25848   0.0035461 
+  281          279.94081    277.96865   0.00355872 
+  268          279.57379    277.67917   0.00373134 
+  257          279.21676    277.39005   0.00389105 
+  270          278.86832    277.10128   0.0037037 
+  276          278.52731    276.81286   0.00362319 
+  290          278.19278    276.5248    0.00344828 
+  258          277.86395    276.23709   0.00387597 
+  296          277.54016    275.94973   0.00337838 
+  258          277.22085    275.66273   0.00387597 
+  302          276.90558    275.37607   0.00331126 
+  277          276.59396    275.08977   0.00361011 
+  290          276.28564    274.80382   0.00344828 
+  265          275.98035    274.51822   0.00377358 
+  248          275.67785    274.23297   0.00403226 
+  310          275.37794    273.94807   0.00322581 
+  272          275.0806     273.66352   0.00367647 
+  262          274.78537    273.37931   0.00381679 
+  277          274.49228    273.09546   0.00361011 
+  278          274.20122    272.81195   0.00359712 
+  268          273.9121     272.52879   0.00373134 
+  267          273.62487    272.24598   0.00374532 
+  274          273.33945    271.96351   0.00364964 
+  258          273.05581    271.68139   0.00387597 
+  283          272.77395    271.39962   0.00353357 
+  274          272.49377    271.11819   0.00364964 
+  272          272.21539    270.83711   0.00367647 
+  266          271.93865    270.55637   0.0037594 
+  278          271.66365    270.27597   0.00359712 
+  239          271.39042    269.99592   0.0041841 
+  268          271.119      269.71622   0.00373134 
+  277          270.84944    269.43685   0.00361011 
+  272          270.58181    269.15783   0.00367647 
+  295          270.31621    268.87915   0.00338983 
+  280          270.05276    268.60081   0.00357143 
+  265          269.79159    268.32282   0.00377358 
+  259          269.53282    268.04516   0.003861  
+  269          269.27665    267.76785   0.00371747 
+  235          269.02333    267.49088   0.00425532 
+  271          268.77311    267.21424   0.00369004 
+  272          268.52632    266.93795   0.00367647 
+  263          268.28334    266.66199   0.00380228 
+  280          268.04465    266.38638   0.00357143 
+  278          267.81081    266.1111    0.00359712 
+  266          267.58252    265.83616   0.0037594 
+  270          267.36063    265.56156   0.0037037 
+  264          267.1462     265.28729   0.00378788 
+  285          266.94059    265.01336   0.00350877 
+  281          266.74546    264.73977   0.00355872 
+  258          266.56301    264.46651   0.00387597 
+  259          266.39606    264.19359   0.003861  
+  277          266.24837    263.921     0.00361011 
+  282          266.12497    263.64875   0.0035461 
+  261          266.0328     263.37683   0.00383142 
+  276          265.98155    263.10525   0.00362319 
+  276          265.98547    262.834     0.00362319 
+  299          266.0672     262.56308   0.00334448 
+  297          266.26822    262.2925    0.003367  
+  271          266.67592    262.02225   0.00369004 
+  297          267.48075    261.75233   0.003367  
+  257          269.06483    261.48274   0.00389105 
+  299          272.10087    261.21348   0.00334448 
+  310          277.54833    260.94456   0.00322581 
+  293          286.273      260.67596   0.00341297 
+  350          298.26466    260.4077    0.00285714 
+  340          312.05044    260.13976   0.00294118 
+  401          322.84949    259.87215   0.00249377 
+  470          324.87644    259.60488   0.00212766 
+  403          317.88446    259.33793   0.00248139 
+  357          309.19169    259.0713    0.00280112 
+  368          303.28913    258.80501   0.00271739 
+  366          298.18317    258.53904   0.00273224 
+  361          290.65392    258.2734    0.00277008 
+  324          281.37467    258.00809   0.00308642 
+  275          273.39811    257.74311   0.00363636 
+  268          267.95788    257.47844   0.00373134 
+  235          264.7404     257.21411   0.00425532 
+  282          262.93525    256.9501    0.0035461 
+  272          261.85723    256.68641   0.00367647 
+  262          261.12237    256.42305   0.00381679 
+  277          260.56232    256.16001   0.00361011 
+  272          260.10911    255.8973    0.00367647 
+  299          259.73195    255.63491   0.00334448 
+  257          259.41401    255.37284   0.00389105 
+  266          259.1451     255.11109   0.0037594 
+  270          258.91909    254.84967   0.0037037 
+  243          258.73267    254.58856   0.00411523 
+  249          258.58463    254.32778   0.00401606 
+  258          258.47899    254.06732   0.00387597 
+  280          258.4114     253.80718   0.00357143 
+  261          258.3893     253.54736   0.00383142 
+  274          258.41881    253.28786   0.00364964 
+  263          258.50846    253.02868   0.00380228 
+  242          258.66966    252.76982   0.00413223 
+  298          258.91975    252.51127   0.0033557 
+  271          259.27641    252.25305   0.00369004 
+  275          259.81951    251.99514   0.00363636 
+  301          260.49092    251.73755   0.00332226 
+  292          261.39731    251.48027   0.00342466 
+  296          262.62399    251.22332   0.00337838 
+  309          264.31198    250.96668   0.00323625 
+  269          266.75471    250.71035   0.00371747 
+  288          270.48394    250.45434   0.00347222 
+  310          276.78338    250.19865   0.00322581 
+  291          288.13549    249.94327   0.00343643 
+  345          308.73976    249.6882    0.00289855 
+  374          344.23901    249.43345   0.0026738 
+  416          398.26754    249.17902   0.00240385 
+  501          468.62525    248.92489   0.00199601 
+  507          542.2806     248.67108   0.00197239 
+  521          588.23922    248.41758   0.00191939 
+  491          580.83039    248.1644    0.00203666 
+  481          535.47368    247.91152   0.002079  
+  413          494.02469    247.65896   0.00242131 
+  439          468.68562    247.40671   0.0022779 
+  391          442.44557    247.15477   0.00255754 
+  345          400.47888    246.90314   0.00289855 
+  342          352.28743    246.65182   0.00292398 
+  309          313.39952    246.40081   0.00323625 
+  287          288.1572     246.1501    0.00348432 
+  240          273.88251    245.89971   0.00416667 
+  278          266.17543    245.64963   0.00359712 
+  261          261.71505    245.39985   0.00383142 
+  236          258.76491    245.15038   0.00423729 
+  235          256.58847    244.90122   0.00425532 
+  284          254.88217    244.65237   0.00352113 
+  240          253.49914    244.40382   0.00416667 
+  249          252.34879    244.15558   0.00401606 
+  240          251.37388    243.90764   0.00416667 
+  285          250.53364    243.66001   0.00350877 
+  262          249.7986     243.41269   0.00381679 
+  263          249.14797    243.16567   0.00380228 
+  261          248.56429    242.91896   0.00383142 
+  239          248.03604    242.67255   0.0041841 
+  235          247.55383    242.42644   0.00425532 
+  272          247.11044    242.18063   0.00367647 
+  272          246.70015    241.93513   0.00367647 
+  234          246.31853    241.68994   0.0042735 
+  264          245.96203    241.44504   0.00378788 
+  245          245.62895    241.20045   0.00408163 
+  244          245.31499    240.95616   0.00409836 
+  244          245.01957    240.71217   0.00409836 
+  273          244.74148    240.46848   0.003663  
+  263          244.47991    240.22509   0.00380228 
+  230          244.23435    239.982     0.00434783 
+  271          244.00525    239.73921   0.00369004 
+  279          243.79179    239.49672   0.00358423 
+  256          243.59518    239.25453   0.00390625 
+  239          243.41654    239.01264   0.0041841 
+  234          243.25761    238.77105   0.0042735 
+  246          243.12086    238.52975   0.00406504 
+  234          243.00974    238.28875   0.0042735 
+  232          242.92914    238.04805   0.00431034 
+  241          242.88599    237.80765   0.00414938 
+  265          242.89054    237.56754   0.00377358 
+  243          242.95904    237.32773   0.00411523 
+  268          243.12169    237.08822   0.00373134 
+  269          243.44197    236.849     0.00371747 
+  235          244.05777    236.61008   0.00425532 
+  287          245.24461    236.37145   0.00348432 
+  284          247.47834    236.13312   0.00352113 
+  281          251.40316    235.89508   0.00355872 
+  293          257.48214    235.65733   0.00341297 
+  317          265.44412    235.41988   0.00315457 
+  339          273.78863    235.18272   0.00294985 
+  320          279.04434    234.94585   0.003125  
+  325          278.38985    234.70928   0.00307692 
+  323          273.82638    234.473     0.00309598 
+  326          270.25983    234.23701   0.00306748 
+  313          269.48001    234.00131   0.00319489 
+  341          270.15916    233.7659    0.00293255 
+  345          271.21104    233.53078   0.00289855 
+  414          274.27486    233.29595   0.00241546 
+  437          281.60462    233.06142   0.00228833 
+  443          292.58616    232.82717   0.00225734 
+  437          304.01232    232.59321   0.00228833 
+  438          312.33544    232.35954   0.00228311 
+  386          314.25039    232.12616   0.00259067 
+  390          308.29114    231.89307   0.0025641 
+  395          298.61031    231.66027   0.00253165 
+  326          290.26869    231.42775   0.00306748 
+  316          283.71431    231.19552   0.00316456 
+  341          276.61155    230.96358   0.00293255 
+  279          267.4319     230.73192   0.00358423 
+  284          258.26751    230.50056   0.00352113 
+  237          251.38195    230.26947   0.00421941 
+  242          247.08339    230.03867   0.00413223 
+  257          244.69488    229.80816   0.00389105 
+  262          243.40058    229.57793   0.00381679 
+  220          242.63532    229.34799   0.00454545 
+  247          242.11144    229.11833   0.00404858 
+  243          241.70444    228.88895   0.00411523 
+  221          241.36028    228.65986   0.00452489 
+  235          241.04947    228.43105   0.00425532 
+  222          240.7513     228.20253   0.0045045 
+  265          240.44998    227.97428   0.00377358 
+  232          240.1345     227.74632   0.00431034 
+  263          239.79801    227.51864   0.00380228 
+  226          239.4361     227.29124   0.00442478 
+  232          239.04591    227.06413   0.00431034 
+  222          238.62632    226.83729   0.0045045 
+  229          238.17773    226.61074   0.00436681 
+  222          237.70198    226.38446   0.0045045 
+  230          237.20208    226.15846   0.00434783 
+  235          236.68182    225.93275   0.00425532 
+  247          236.14546    225.70731   0.00404858 
+  278          235.5975     225.48215   0.00359712 
+  260          235.04241    225.25727   0.00384615 
+  231          234.48442    225.03267   0.004329  
+  196          233.92741    224.80835   0.00510204 
+  259          233.37483    224.5843    0.003861  
+  242          232.82954    224.36053   0.00413223 
+  231          232.29388    224.13704   0.004329  
+  241          231.7697     223.91382   0.00414938 
+  241          231.25833    223.69088   0.00414938 
+  234          230.76073    223.46822   0.0042735 
+  242          230.27748    223.24583   0.00413223 
+  210          229.80883    223.02371   0.0047619 
+  248          229.35478    222.80187   0.00403226 
+  221          228.91516    222.58031   0.00452489 
+  228          228.48964    222.35902   0.00438596 
+  234          228.07774    222.138     0.0042735 
+  223          227.67903    221.91726   0.0044843 
+  214          227.29292    221.69679   0.0046729 
+  272          226.91881    221.47659   0.00367647 
+  207          226.55613    221.25667   0.00483092 
+  258          226.20428    221.03701   0.00387597 
+  237          225.86268    220.81763   0.00421941 
+  216          225.53081    220.59852   0.00462963 
+  221          225.20813    220.37969   0.00452489 
+  229          224.89415    220.16112   0.00436681 
+  213          224.5884     219.94282   0.00469484 
+  266          224.29045    219.7248    0.0037594 
+  226          223.99989    219.50704   0.00442478 
+  227          223.71641    219.28955   0.00440529 
+  221          223.43964    219.07234   0.00452489 
+  224          223.16931    218.85539   0.00446429 
+  227          222.90515    218.63871   0.00440529 
+  235          222.64695    218.42229   0.00425532 
+  231          222.3945     218.20615   0.004329  
+  209          222.14768    217.99027   0.00478469 
+  232          221.90639    217.77467   0.00431034 
+  218          221.67048    217.55932   0.00458716 
+  192          221.43994    217.34425   0.00520833 
+  209          221.21479    217.12944   0.00478469 
+  231          220.99507    216.9149    0.004329  
+  239          220.78093    216.70062   0.0041841 
+  235          220.57246    216.48661   0.00425532 
+  211          220.36994    216.27286   0.00473934 
+  206          220.17367    216.05938   0.00485437 
+  243          219.98408    215.84616   0.00411523 
+  212          219.8017     215.63321   0.00471698 
+  215          219.62725    215.42052   0.00465116 
+  249          219.46153    215.20809   0.00401606 
+  222          219.30588    214.99593   0.0045045 
+  215          219.16128    214.78403   0.00465116 
+  232          219.02973    214.57239   0.00431034 
+  223          218.91358    214.36102   0.0044843 
+  224          218.81583    214.1499    0.00446429 
+  203          218.74045    213.93905   0.00492611 
+  208          218.69283    213.72846   0.00480769 
+  230          218.68024    213.51813   0.00434783 
+  238          218.71285    213.30806   0.00420168 
+  247          218.80515    213.09825   0.00404858 
+  234          218.97902    212.8887    0.0042735 
+  246          219.27064    212.67942   0.00406504 
+  247          219.75012    212.47039   0.00404858 
+  249          220.57222    212.26162   0.00401606 
+  234          222.07944    212.0531    0.0042735 
+  248          224.95879    211.84485   0.00403226 
+  238          230.37138    211.63686   0.00420168 
+  262          239.753      211.42912   0.00381679 
+  314          253.77747    211.22164   0.00318471 
+  308          271.03051    211.01442   0.00324675 
+  325          286.72391    210.80745   0.00307692 
+  277          292.69544    210.60074   0.00361011 
+  313          285.625      210.39429   0.00319489 
+  268          273.65887    210.18809   0.00373134 
+  294          265.60071    209.98215   0.00340136 
+  228          261.98477    209.77646   0.00438596 
+  291          257.60512    209.57103   0.00343643 
+  242          248.65992    209.36586   0.00413223 
+  228          237.7081     209.16094   0.00438596 
+  210          228.71962    208.95627   0.0047619 
+  228          222.90693    208.75185   0.00438596 
+  221          219.76163    208.54769   0.00452489 
+  244          218.36656    208.34379   0.00409836 
+  185          218.07895    208.14013   0.00540541 
+  235          218.5754     207.93673   0.00425532 
+  242          219.5853     207.73358   0.00413223 
+  242          220.64877    207.53068   0.00413223 
+  239          220.98863    207.32804   0.0041841 
+  245          220.15062    207.12565   0.00408163 
+  241          218.75582    206.9235    0.00414938 
+  218          217.69026    206.72161   0.00458716 
+  200          217.11212    206.51997   0.005     
+  217          216.57775    206.31858   0.00460829 
+  233          215.65332    206.11743   0.00429185 
+  216          214.47916    205.91654   0.00462963 
+  198          213.44867    205.7159    0.00505051 
+  204          212.71562    205.5155    0.00490196 
+  228          212.24582    205.31536   0.00438596 
+  218          211.94522    205.11546   0.00458716 
+  216          211.73526    204.91581   0.00462963 
+  240          211.57242    204.71641   0.00416667 
+  217          211.43868    204.51726   0.00460829 
+  225          211.32447    204.31835   0.00444444 
+  226          211.22714    204.11969   0.00442478 
+  217          211.14464    203.92128   0.00460829 
+  207          211.07572    203.72311   0.00483092 
+  235          211.01954    203.52519   0.00425532 
+  232          210.97609    203.32751   0.00431034 
+  226          210.94422    203.13008   0.00442478 
+  258          210.92453    202.9329    0.00387597 
+  240          210.91754    202.73596   0.00416667 
+  225          210.92435    202.53926   0.00444444 
+  237          210.94686    202.34281   0.00421941 
+  242          210.98436    202.1466    0.00413223 
+  240          211.03552    201.95064   0.00416667 
+  270          211.09486    201.75492   0.0037037 
+  279          211.15404    201.55944   0.00358423 
+  262          211.21122    201.36421   0.00381679 
+  258          211.27611    201.16921   0.00387597 
+  266          211.35626    200.97446   0.0037594 
+  233          211.45193    200.77995   0.00429185 
+  237          211.55803    200.58569   0.00421941 
+  269          211.67142    200.39166   0.00371747 
+  229          211.79565    200.19788   0.00436681 
+  225          211.93551    200.00433   0.00444444 
+  237          212.0931     199.81103   0.00421941 
+  233          212.26889    199.61796   0.00429185 
+  209          212.463      199.42514   0.00478469 
+  248          212.67571    199.23256   0.00403226 
+  232          212.90771    199.04021   0.00431034 
+  215          213.15976    198.8481    0.00465116 
+  204          213.43268    198.65624   0.00490196 
+  230          213.72721    198.46461   0.00434783 
+  215          214.04405    198.27321   0.00465116 
+  197          214.38489    198.08206   0.00507614 
+  204          214.74811    197.89114   0.00490196 
+  213          215.13565    197.70047   0.00469484 
+  205          215.54861    197.51002   0.00487805 
+  204          215.98913    197.31982   0.00490196 
+  218          216.45852    197.12985   0.00458716 
+  229          216.96105    196.94011   0.00436681 
+  210          217.50021    196.75062   0.0047619 
+  194          218.08267    196.56135   0.00515464 
+  228          218.71662    196.37233   0.00438596 
+  230          219.41296    196.18354   0.00434783 
+  201          220.185      195.99498   0.00497512 
+  226          221.05033    195.80666   0.00442478 
+  216          222.03173    195.61857   0.00462963 
+  237          223.15853    195.43071   0.00421941 
+  248          224.46951    195.24309   0.00403226 
+  224          226.01801    195.0557    0.00446429 
+  232          227.88243    194.86854   0.00431034 
+  221          230.19496    194.68162   0.00452489 
+  228          233.21905    194.49493   0.00438596 
+  240          237.53282    194.30847   0.00416667 
+  235          244.35236    194.12224   0.00425532 
+  297          255.91198    193.93625   0.003367  
+  279          275.42766    193.75048   0.00358423 
+  277          305.51144    193.56495   0.00361011 
+  302          344.76043    193.37965   0.00331126 
+  342          385.12724    193.19458   0.00292398 
+  342          409.69671    193.00973   0.00292398 
+  353          405.24235    192.82512   0.00283286 
+  346          383.54166    192.64074   0.00289017 
+  314          367.82535    192.45658   0.00318471 
+  330          365.68818    192.27266   0.0030303 
+  328          369.10525    192.08896   0.00304878 
+  316          365.77308    191.90549   0.00316456 
+  334          354.92197    191.72226   0.00299401 
+  328          346.80472    191.53924   0.00304878 
+  357          348.22111    191.35646   0.00280112 
+  376          360.86482    191.1739    0.00265957 
+  432          385.0582     190.99157   0.00231481 
+  456          422.89867    190.80947   0.00219298 
+  531          480.56739    190.62759   0.00188324 
+  627          569.82884    190.44594   0.0015949 
+  734          708.24574    190.26452   0.0013624 
+  956          916.41947    190.08332   0.00104603 
+  1197         1210.80974   189.90234   0.00083542 
+  1518         1588.03321   189.7216    0.00065876 
+  2258         1991.08827   189.54107   0.00044287 
+  2867         2273.2431    189.36077   0.0003488 
+  3596         2291.92492   189.1807    0.00027809 
+  3831         2109.01402   189.00085   0.00026103 
+  3274         1904.53052   188.82122   0.00030544 
+  2452         1768.44958   188.64182   0.00040783 
+  2008         1665.3464    188.46264   0.00049801 
+  2028         1502.54704   188.28368   0.0004931 
+  2074         1260.17802   188.10494   0.00048216 
+  1637         1004.95237   187.92643   0.00061087 
+  1097         789.85268    187.74814   0.00091158 
+  687          628.55864    187.57007   0.0014556 
+  478          515.36687    187.39223   0.00209205 
+  355          438.72512    187.2146    0.0028169 
+  329          387.04113    187.0372    0.00303951 
+  297          351.2918     186.86001   0.003367  
+  281          325.46403    186.68305   0.00355872 
+  318          305.93959    186.5063    0.00314465 
+  300          290.62539    186.32978   0.00333333 
+  300          278.29504    186.15348   0.00333333 
+  228          268.18216    185.97739   0.00438596 
+  272          259.77504    185.80153   0.00367647 
+  274          252.70568    185.62588   0.00364964 
+  293          246.71037    185.45045   0.00341297 
+  224          241.584      185.27525   0.00446429 
+  243          237.16754    185.10025   0.00411523 
+  230          233.33894    184.92548   0.00434783 
+  249          230.00324    184.75092   0.00401606 
+  223          227.08262    184.57659   0.0044843 
+  193          224.51492    184.40246   0.00518135 
+  209          222.24891    184.22856   0.00478469 
+  202          220.24318    184.05487   0.0049505 
+  223          218.46149    183.8814    0.0044843 
+  189          216.87468    183.70814   0.00529101 
+  190          215.45771    183.5351    0.00526316 
+  191          214.18886    183.36228   0.0052356 
+  220          213.04891    183.18967   0.00454545 
+  191          212.02104    183.01727   0.0052356 
+  202          211.09028    182.84509   0.0049505 
+  246          210.24307    182.67313   0.00406504 
+  191          209.46765    182.50137   0.0052356 
+  190          208.75317    182.32984   0.00526316 
+  199          208.09038    182.15851   0.00502513 
+  218          207.4712     181.9874    0.00458716 
+  213          206.88893    181.8165    0.00469484 
+  224          206.33822    181.64582   0.00446429 
+  208          205.81529    181.47534   0.00480769 
+  211          205.31766    181.30508   0.00473934 
+  218          204.84381    181.13504   0.00458716 
+  194          204.39386    180.9652    0.00515464 
+  190          203.96892    180.79557   0.00526316 
+  227          203.57107    180.62616   0.00440529 
+  175          203.20346    180.45696   0.00571429 
+  217          202.87005    180.28797   0.00460829 
+  209          202.5754     180.11918   0.00478469 
+  181          202.32527    179.95061   0.00552486 
+  181          202.12643    179.78225   0.00552486 
+  184          201.98705    179.6141    0.00543478 
+  191          201.91745    179.44616   0.0052356 
+  186          201.93084    179.27842   0.00537634 
+  240          202.04473    179.1109    0.00416667 
+  174          202.28382    178.94358   0.00574713 
+  192          202.68519    178.77648   0.00520833 
+  201          203.31205    178.60958   0.00497512 
+  236          204.29277    178.44289   0.00423729 
+  193          205.91867    178.27641   0.00518135 
+  228          208.83645    178.11013   0.00438596 
+  210          214.31099    177.94406   0.0047619 
+  248          224.31182    177.7782    0.00403226 
+  242          240.76519    177.61254   0.00413223 
+  284          263.39948    177.4471    0.00352113 
+  303          287.74255    177.28185   0.00330033 
+  311          303.69089    177.11682   0.00321543 
+  328          301.29697    176.95199   0.00304878 
+  350          285.48398    176.78736   0.00285714 
+  340          271.36284    176.62294   0.00294118 
+  314          265.12537    176.45872   0.00318471 
+  294          263.66742    176.29471   0.00340136 
+  274          258.93965    176.13091   0.00364964 
+  274          246.84912    175.9673    0.00364964 
+  282          233.29169    175.80391   0.0035461 
+  248          223.15098    175.64071   0.00403226 
+  262          217.29341    175.47772   0.00381679 
+  264          214.6705     175.31493   0.00378788 
+  231          213.92694    175.15235   0.004329  
+  213          214.15381    174.98996   0.00469484 
+  202          214.95517    174.82778   0.0049505 
+  197          216.19131    174.6658    0.00507614 
+  207          217.85453    174.50403   0.00483092 
+  219          220.0047     174.34245   0.00456621 
+  226          222.80685    174.18108   0.00442478 
+  236          226.62485    174.01991   0.00423729 
+  268          232.31818    173.85894   0.00373134 
+  260          241.6841     173.69817   0.00384615 
+  322          257.78105    173.5376    0.00310559 
+  283          284.3755     173.37723   0.00353357 
+  333          323.09083    173.21706   0.003003  
+  348          368.33339    173.05709   0.00287356 
+  385          408.02869    172.89732   0.0025974 
+  418          424.26654    172.73774   0.00239234 
+  384          408.23432    172.57837   0.00260417 
+  395          384.97042    172.4192    0.00253165 
+  390          376.10616    172.26022   0.0025641 
+  401          382.81991    172.10144   0.00249377 
+  480          395.17312    171.94286   0.00208333 
+  453          399.71106    171.78448   0.00220751 
+  487          399.1533     171.6263    0.00205339 
+  564          408.71498    171.46831   0.00177305 
+  621          440.91738    171.31052   0.00161031 
+  773          511.7793     171.15293   0.00129366 
+  961          654.16227    170.99553   0.00104058 
+  1325         928.81787    170.83833   0.00075472 
+  1801         1417.88281   170.68133   0.00055525 
+  2398         2172.37744   170.52452   0.00041701 
+  2977         3098.00904   170.36791   0.00033591 
+  3891         3935.65401   170.21149   0.000257  
+  4258         4303.82886   170.05527   0.00023485 
+  3869         3907.51793   169.89924   0.00025846 
+  3152         3213.71355   169.74341   0.00031726 
+  2772         2767.88877   169.58777   0.00036075 
+  2875         2644.5312    169.43232   0.00034783 
+  3259         2626.81946   169.27707   0.00030684 
+  3099         2375.30009   169.12202   0.00032268 
+  2142         1833.56839   168.96715   0.00046685 
+  1386         1278.89534   168.81248   0.0007215 
+  1042         875.86282    168.65801   0.00095969 
+  883          634.32335    168.50372   0.0011325 
+  905          499.07338    168.34963   0.00110497 
+  746          418.70236    168.19573   0.00134048 
+  505          367.57661    168.04202   0.0019802 
+  378          334.81495    167.88851   0.0026455 
+  370          315.42114    167.73518   0.0027027 
+  317          307.21711    167.58205   0.00315457 
+  316          308.16411    167.4291    0.00316456 
+  386          314.22118    167.27635   0.00259067 
+  381          319.40079    167.12379   0.00262467 
+  407          315.8131     166.97142   0.002457  
+  415          300.74289    166.81924   0.00240964 
+  365          284.42958    166.66725   0.00273973 
+  335          274.49839    166.51545   0.00298507 
+  349          270.65855    166.36384   0.00286533 
+  316          268.45515    166.21242   0.00316456 
+  299          262.30262    166.06118   0.00334448 
+  305          253.02821    165.91014   0.00327869 
+  339          246.14273    165.75928   0.00294985 
+  319          244.98985    165.60861   0.0031348 
+  327          250.59407    165.45814   0.0030581 
+  343          261.76191    165.30784   0.00291545 
+  347          274.6903     165.15774   0.00288184 
+  328          284.15347    165.00782   0.00304878 
+  333          284.01925    164.85809   0.003003  
+  304          276.57026    164.70855   0.00328947 
+  291          271.11807    164.55919   0.00343643 
+  285          271.63825    164.41002   0.00350877 
+  318          276.63226    164.26104   0.00314465 
+  299          282.03364    164.11224   0.00334448 
+  312          284.56414    163.96363   0.00320513 
+  325          287.10595    163.8152    0.00307692 
+  319          293.92884    163.66696   0.0031348 
+  417          307.35044    163.5189    0.00239808 
+  442          329.23472    163.37103   0.00226244 
+  510          363.14795    163.22335   0.00196078 
+  577          416.86449    163.07584   0.0017331 
+  714          504.86255    162.92852   0.00140056 
+  921          649.26608    162.78139   0.00108578 
+  1142         876.00686    162.63444   0.00087566 
+  1528         1200.04069   162.48767   0.00065445 
+  1989         1595.53464   162.34109   0.00050277 
+  2404         1977.72906   162.19469   0.00041597 
+  2852         2219.31889   162.04847   0.00035063 
+  2601         2189.19102   161.90243   0.00038447 
+  2157         1949.21385   161.75658   0.00046361 
+  1548         1708.8851    161.61091   0.00064599 
+  1508         1566.75695   161.46542   0.00066313 
+  1534         1493.42937   161.32011   0.00065189 
+  1522         1395.85059   161.17498   0.00065703 
+  1233         1197.5193    161.03004   0.00081103 
+  842          944.11036    160.88528   0.00118765 
+  549          717.15588    160.74069   0.00182149 
+  395          548.37869    160.59629   0.00253165 
+  325          435.59042    160.45207   0.00307692 
+  275          364.60613    160.30802   0.00363636 
+  247          320.23797    160.16416   0.00404858 
+  227          291.19828    160.02048   0.00440529 
+  209          270.75132    159.87698   0.00478469 
+  216          255.38852    159.73365   0.00462963 
+  239          243.33261    159.59051   0.0041841 
+  222          233.61227    159.44754   0.0045045 
+  204          225.62953    159.30475   0.00490196 
+  191          218.97954    159.16214   0.0052356 
+  211          213.37084    159.01971   0.00473934 
+  199          208.58928    158.87746   0.00502513 
+  164          204.47383    158.73538   0.00609756 
+  188          200.90104    158.59348   0.00531915 
+  183          197.77594    158.45176   0.00546448 
+  162          195.02307    158.31022   0.00617284 
+  190          192.58298    158.16885   0.00526316 
+  192          190.40757    158.02766   0.00520833 
+  196          188.45793    157.88665   0.00510204 
+  177          186.70211    157.74581   0.00564972 
+  185          185.11404    157.60515   0.00540541 
+  169          183.67167    157.46466   0.00591716 
+  211          182.35688    157.32435   0.00473934 
+  180          181.15431    157.18421   0.00555556 
+  173          180.05061    157.04425   0.00578035 
+  169          179.03469    156.90447   0.00591716 
+  155          178.09719    156.76486   0.00645161 
+  171          177.22984    156.62542   0.00584795 
+  158          176.42554    156.48616   0.00632911 
+  161          175.67814    156.34707   0.00621118 
+  175          174.9823     156.20816   0.00571429 
+  165          174.3327     156.06941   0.00606061 
+  182          173.72652    155.93085   0.00549451 
+  192          173.15946    155.79245   0.00520833 
+  175          172.62844    155.65423   0.00571429 
+  164          172.1307     155.51618   0.00609756 
+  179          171.66331    155.37831   0.00558659 
+  157          171.22475    155.2406    0.00636943 
+  159          170.81273    155.10307   0.00628931 
+  147          170.42557    154.96571   0.00680272 
+  156          170.0614     154.82852   0.00641026 
+  164          169.71959    154.6915    0.00609756 
+  169          169.39847    154.55466   0.00591716 
+  167          169.09615    154.41798   0.00598802 
+  172          168.81341    154.28148   0.00581395 
+  161          168.54836    154.14515   0.00621118 
+  148          168.30065    154.00898   0.00675676 
+  182          168.06945    153.87299   0.00549451 
+  153          167.85375    153.73717   0.00653595 
+  174          167.65396    153.60152   0.00574713 
+  174          167.4692     153.46603   0.00574713 
+  149          167.29916    153.33072   0.00671141 
+  159          167.14356    153.19557   0.00628931 
+  161          167.00222    153.0606    0.00621118 
+  162          166.87492    152.92579   0.00617284 
+  180          166.76161    152.79115   0.00555556 
+  161          166.66221    152.65668   0.00621118 
+  175          166.57673    152.52238   0.00571429 
+  151          166.50526    152.38824   0.00662252 
+  159          166.44789    152.25428   0.00628931 
+  167          166.4048     152.12048   0.00598802 
+  184          166.37623    151.98685   0.00543478 
+  159          166.36238    151.85338   0.00628931 
+  154          166.36364    151.72008   0.00649351 
+  169          166.38034    151.58695   0.00591716 
+  169          166.41297    151.45399   0.00591716 
+  150          166.46201    151.32119   0.00666667 
+  139          166.52805    151.18856   0.00719424 
+  178          166.61172    151.05609   0.00561798 
+  161          166.71367    150.92379   0.00621118 
+  158          166.83473    150.79165   0.00632911 
+  172          166.97575    150.65968   0.00581395 
+  159          167.13768    150.52787   0.00628931 
+  157          167.32158    150.39623   0.00636943 
+  148          167.52853    150.26476   0.00675676 
+  160          167.75981    150.13345   0.00625   
+  165          168.01673    150.0023    0.00606061 
+  141          168.30077    149.87132   0.0070922 
+  135          168.61354    149.7405    0.00740741 
+  147          168.9568     149.60984   0.00680272 
+  149          169.33236    149.47935   0.00671141 
+  164          169.7423     149.34902   0.00609756 
+  162          170.18875    149.21885   0.00617284 
+  155          170.67412    149.08885   0.00645161 
+  165          171.20097    148.95901   0.00606061 
+  182          171.7721     148.82933   0.00549451 
+  143          172.39037    148.69981   0.00699301 
+  148          173.05904    148.57046   0.00675676 
+  175          173.78138    148.44126   0.00571429 
+  161          174.56108    148.31223   0.00621118 
+  159          175.40194    148.18336   0.00628931 
+  154          176.30922    148.05465   0.00649351 
+  173          177.28484    147.92611   0.00578035 
+  173          178.33444    147.79772   0.00578035 
+  168          179.46249    147.66949   0.00595238 
+  170          180.67376    147.54143   0.00588235 
+  176          181.97303    147.41352   0.00568182 
+  163          183.36499    147.28577   0.00613497 
+  152          184.85497    147.15819   0.00657895 
+  154          186.44591    147.03076   0.00649351 
+  157          188.1421     146.9035    0.00636943 
+  185          189.94678    146.77639   0.00540541 
+  156          191.86215    146.64944   0.00641026 
+  161          193.88912    146.52265   0.00621118 
+  183          196.02733    146.39602   0.00546448 
+  177          198.27385    146.26955   0.00564972 
+  194          200.62358    146.14323   0.00515464 
+  207          203.069      146.01708   0.00483092 
+  194          205.59932    145.89108   0.00515464 
+  187          208.20034    145.76524   0.00534759 
+  181          210.85462    145.63955   0.00552486 
+  214          213.5405     145.51403   0.0046729 
+  203          216.23298    145.38866   0.00492611 
+  176          218.90439    145.26344   0.00568182 
+  243          221.52422    145.13839   0.00411523 
+  206          224.06005    145.01349   0.00485437 
+  222          226.4786     144.88875   0.0045045 
+  209          228.74649    144.76416   0.00478469 
+  246          230.83107    144.63973   0.00406504 
+  261          232.70316    144.51546   0.00383142 
+  245          234.33781    144.39134   0.00408163 
+  275          235.71699    144.26737   0.00363636 
+  291          236.83367    144.14356   0.00343643 
+  297          237.70049    144.01991   0.003367  
+  298          238.37309    143.89641   0.0033557 
+  309          239.01147    143.77306   0.00323625 
+  297          239.99771    143.64987   0.003367  
+  291          242.07315    143.52684   0.00343643 
+  275          246.31387    143.40396   0.00363636 
+  318          253.58487    143.28123   0.00314465 
+  295          263.13466    143.15865   0.00338983 
+  290          271.63595    143.03623   0.00344828 
+  260          274.0876     142.91396   0.00384615 
+  274          266.62009    142.79185   0.00364964 
+  244          254.58428    142.66989   0.00409836 
+  245          245.46552    142.54808   0.00408163 
+  259          241.42156    142.42642   0.003861  
+  231          240.57672    142.30491   0.004329  
+  223          239.5058     142.18356   0.0044843 
+  224          235.8193     142.06236   0.00446429 
+  209          231.97733    141.94131   0.00478469 
+  195          230.51159    141.82041   0.00512821 
+  186          230.25031    141.69967   0.00537634 
+  227          227.70673    141.57907   0.00440529 
+  162          220.36022    141.45863   0.00617284 
+  180          211.59213    141.33834   0.00555556 
+  200          205.33008    141.21819   0.005     
+  203          202.28459    141.0982    0.00492611 
+  210          200.867      140.97836   0.0047619 
+  163          198.57481    140.85867   0.00613497 
+  209          193.76918    140.73913   0.00478469 
+  170          187.95423    140.61973   0.00588235 
+  182          182.9805     140.50049   0.00549451 
+  174          179.38087    140.3814    0.00574713 
+  163          176.9474     140.26245   0.00613497 
+  169          175.28779    140.14366   0.00591716 
+  164          174.12724    140.02501   0.00609756 
+  176          173.38297    139.90651   0.00568182 
+  187          173.17295    139.78816   0.00534759 
+  228          173.89967    139.66996   0.00438596 
+  230          176.41429    139.55191   0.00434783 
+  292          182.05773    139.434     0.00342466 
+  338          192.1618     139.31625   0.00295858 
+  401          206.51166    139.19864   0.00249377 
+  417          221.81024    139.08117   0.00239808 
+  430          232.48671    138.96386   0.00232558 
+  356          232.87402    138.84669   0.00280899 
+  336          226.71664    138.72967   0.00297619 
+  358          221.38617    138.61279   0.0027933 
+  334          217.42594    138.49606   0.00299401 
+  334          213.04267    138.37948   0.00299401 
+  280          208.12686    138.26304   0.00357143 
+  273          200.85162    138.14675   0.003663  
+  248          192.1662     138.0306    0.00403226 
+  216          184.56021    137.9146    0.00462963 
+  196          177.6064     137.79875   0.00510204 
+  190          170.63669    137.68304   0.00526316 
+  196          164.77126    137.56748   0.00510204 
+  164          160.60713    137.45206   0.00609756 
+  172          157.92857    137.33678   0.00581395 
+  156          156.2504     137.22165   0.00641026 
+  136          155.13299    137.10666   0.00735294 
+  175          154.3047     136.99182   0.00571429 
+  166          153.63501    136.87712   0.0060241 
+  168          153.06732    136.76257   0.00595238 
+  162          152.57457    136.64816   0.00617284 
+  139          152.14117    136.53389   0.00719424 
+  139          151.75675    136.41976   0.00719424 
+  129          151.41402    136.30578   0.00775194 
+  176          151.10763    136.19194   0.00568182 
+  134          150.83372    136.07825   0.00746269 
+  154          150.58994    135.96469   0.00649351 
+  151          150.37295    135.85128   0.00662252 
+  144          150.18166    135.73801   0.00694444 
+  148          150.01483    135.62488   0.00675676 
+  147          149.87151    135.5119    0.00680272 
+  135          149.75104    135.39905   0.00740741 
+  132          149.6529     135.28635   0.00757576 
+  128          149.57705    135.17379   0.0078125 
+  155          149.52256    135.06137   0.00645161 
+  143          149.48953    134.94909   0.00699301 
+  139          149.47771    134.83695   0.00719424 
+  123          149.48688    134.72495   0.00813008 
+  135          149.51674    134.6131    0.00740741 
+  133          149.5669     134.50138   0.0075188 
+  138          149.63683    134.3898    0.00724638 
+  144          149.72588    134.27836   0.00694444 
+  130          149.83315    134.16706   0.00769231 
+  157          149.95762    134.05591   0.00636943 
+  116          150.09806    133.94489   0.00862069 
+  165          150.25302    133.83401   0.00606061 
+  148          150.42091    133.72327   0.00675676 
+  139          150.60479    133.61266   0.00719424 
+  140          150.79317    133.5022    0.00714286 
+  156          150.989      133.39187   0.00641026 
+  126          151.19048    133.28169   0.00793651 
+  134          151.39598    133.17164   0.00746269 
+  166          151.60413    133.06173   0.0060241 
+  138          151.81417    132.95196   0.00724638 
+  149          152.02858    132.84232   0.00671141 
+  149          152.24366    132.73282   0.00671141 
+  159          152.4651     132.62346   0.00628931 
+  133          152.69902    132.51424   0.0075188 
+  144          152.95599    132.40515   0.00694444 
+  156          153.2543     132.2962    0.00641026 
+  150          153.62745    132.18739   0.00666667 
+  180          154.14665    132.07871   0.00555556 
+  179          154.98373    131.97017   0.00558659 
+  176          156.54903    131.86177   0.00568182 
+  178          159.68198    131.7535    0.00561798 
+  201          165.70689    131.64537   0.00497512 
+  196          175.91043    131.53737   0.00510204 
+  204          189.9358     131.42951   0.00490196 
+  183          203.93887    131.32178   0.00546448 
+  197          211.41767    131.21419   0.00507614 
+  205          206.2533     131.10674   0.00487805 
+  195          193.23452    130.99942   0.00512821 
+  191          182.65112    130.89223   0.0052356 
+  166          178.69713    130.78518   0.0060241 
+  198          179.699      130.67826   0.00505051 
+  175          180.955      130.57148   0.00571429 
+  139          177.41711    130.46483   0.00719424 
+  145          169.02507    130.35831   0.00689655 
+  178          160.35014    130.25193   0.00561798 
+  180          153.93889    130.14568   0.00555556 
+  159          149.99105    130.03956   0.00628931 
+  150          147.7575     129.93358   0.00666667 
+  150          146.44982    129.82773   0.00666667 
+  139          145.59131    129.72201   0.00719424 
+  121          144.98263    129.61643   0.00826446 
+  147          144.58518    129.51098   0.00680272 
+  150          144.46491    129.40566   0.00666667 
+  186          144.77727    129.30047   0.00537634 
+  146          145.70992    129.19542   0.00684932 
+  176          147.28606    129.09049   0.00568182 
+  141          149.06924    128.9857    0.0070922 
+  159          150.18277    128.88104   0.00628931 
+  172          149.62841    128.77651   0.00581395 
+  152          147.65832    128.67211   0.00657895 
+  152          145.77252    128.56785   0.00657895 
+  154          144.80598    128.46371   0.00649351 
+  152          144.69015    128.3597    0.00657895 
+  168          144.82047    128.25583   0.00595238 
+  147          144.43842    128.15209   0.00680272 
+  156          143.26162    128.04847   0.00641026 
+  144          141.87417    127.94499   0.00694444 
+  123          140.75941    127.84163   0.00813008 
+  140          140.01674    127.73841   0.00714286 
+  135          139.55953    127.63531   0.00740741 
+  150          139.26731    127.53235   0.00666667 
+  130          139.05708    127.42951   0.00769231 
+  118          138.88877    127.3268    0.00847458 
+  122          138.74554    127.22422   0.00819672 
+  125          138.62086    127.12178   0.008     
+  133          138.51095    127.01945   0.0075188 
+  151          138.41372    126.91726   0.00662252 
+  137          138.32764    126.8152    0.00729927 
+  148          138.25235    126.71326   0.00675676 
+  110          138.1856     126.61145   0.00909091 
+  124          138.12752    126.50977   0.00806452 
+  111          138.07767    126.40822   0.00900901 
+  110          138.03581    126.30679   0.00909091 
+  119          138.00178    126.2055    0.00840336 
+  140          137.976      126.10433   0.00714286 
+  136          137.95677    126.00328   0.00735294 
+  140          137.94497    125.90236   0.00714286 
+  130          137.94062    125.80157   0.00769231 
+  118          137.94383    125.70091   0.00847458 
+  159          137.95473    125.60037   0.00628931 
+  138          137.9736     125.49996   0.00724638 
+  159          138.00102    125.39968   0.00628931 
+  123          138.03718    125.29952   0.00813008 
+  133          138.0821     125.19949   0.0075188 
+  122          138.13708    125.09958   0.00819672 
+  124          138.20346    124.9998    0.00806452 
+  116          138.28395    124.90014   0.00862069 
+  163          138.38404    124.80061   0.00613497 
+  151          138.5157     124.7012    0.00662252 
+  123          138.69906    124.60192   0.00813008 
+  140          138.95816    124.50276   0.00714286 
+  121          139.30083    124.40373   0.00826446 
+  156          139.68583    124.30482   0.00641026 
+  157          140.02151    124.20604   0.00636943 
+  137          140.20451    124.10738   0.00729927 
+  143          140.27296    124.00884   0.00699301 
+  145          140.43525    123.91043   0.00689655 
+  127          140.88514    123.81214   0.00787402 
+  144          141.79166    123.71398   0.00694444 
+  147          143.30195    123.61594   0.00680272 
+  133          145.41915    123.51802   0.0075188 
+  149          147.76975    123.42022   0.00671141 
+  129          149.80026    123.32255   0.00775194 
+  145          150.22585    123.225     0.00689655 
+  135          149.26792    123.12757   0.00740741 
+  129          148.188      123.03027   0.00775194 
+  138          147.65187    122.93309   0.00724638 
+  147          147.63035    122.83603   0.00680272 
+  144          147.90065    122.73909   0.00694444 
+  130          147.98004    122.64227   0.00769231 
+  134          147.55957    122.54558   0.00746269 
+  133          146.80648    122.449     0.0075188 
+  123          146.20333    122.35255   0.00813008 
+  138          145.78142    122.25622   0.00724638 
+  140          145.55652    122.16001   0.00714286 
+  120          145.5543     122.06392   0.00833333 
+  129          145.74033    121.96795   0.00775194 
+  145          146.06119    121.87211   0.00689655 
+  170          146.47074    121.77638   0.00588235 
+  152          146.93753    121.68077   0.00657895 
+  112          147.44654    121.58529   0.00892857 
+  142          147.98973    121.48992   0.00704225 
+  159          148.56376    121.39467   0.00628931 
+  133          149.16675    121.29955   0.0075188 
+  152          149.79792    121.20454   0.00657895 
+  133          150.45694    121.10965   0.0075188 
+  130          151.14421    121.01488   0.00769231 
+  150          151.86036    120.92023   0.00666667 
+  162          152.60687    120.8257    0.00617284 
+  161          153.38578    120.73129   0.00621118 
+  178          154.19948    120.637     0.00561798 
+  124          155.05109    120.54283   0.00806452 
+  139          155.94432    120.44877   0.00719424 
+  142          156.8834     120.35483   0.00704225 
+  144          157.87304    120.26101   0.00694444 
+  154          158.91853    120.16731   0.00649351 
+  155          160.02529    120.07373   0.00645161 
+  142          161.20002    119.98026   0.00704225 
+  181          162.44802    119.88691   0.00552486 
+  128          163.7767     119.79368   0.0078125 
+  158          165.1907     119.70057   0.00632911 
+  158          166.70368    119.60757   0.00632911 
+  148          168.32109    119.51469   0.00675676 
+  152          170.05227    119.42193   0.00657895 
+  162          171.90784    119.32928   0.00617284 
+  167          173.89739    119.23676   0.00598802 
+  165          176.03694    119.14434   0.00606061 
+  169          178.34013    119.05205   0.00591716 
+  163          180.8232     118.95986   0.00613497 
+  153          183.50556    118.8678    0.00653595 
+  155          186.40958    118.77585   0.00645161 
+  148          189.56068    118.68402   0.00675676 
+  172          192.98846    118.5923    0.00581395 
+  176          196.72763    118.5007    0.00568182 
+  171          200.81682    118.40921   0.00584795 
+  141          205.30212    118.31784   0.0070922 
+  175          210.23714    118.22658   0.00571429 
+  170          215.62124    118.13544   0.00588235 
+  190          221.65439    118.04441   0.00526316 
+  187          228.36086    117.9535    0.00534759 
+  183          235.84169    117.8627    0.00546448 
+  177          244.22077    117.77202   0.00564972 
+  205          253.64411    117.68145   0.00487805 
+  207          264.26299    117.59099   0.00483092 
+  225          276.35849    117.50065   0.00444444 
+  245          290.17198    117.41042   0.00408163 
+  241          306.03653    117.32031   0.00414938 
+  277          324.37921    117.2303    0.00361011 
+  317          345.7382     117.14042   0.00315457 
+  299          370.81163    117.05064   0.00334448 
+  386          400.50765    116.96098   0.00259067 
+  399          436.03689    116.87143   0.00250627 
+  485          479.01135    116.78199   0.00206186 
+  529          531.66813    116.69267   0.00189036 
+  678          597.15793    116.60346   0.00147493 
+  687          680.16971    116.51436   0.0014556 
+  897          788.35298    116.42537   0.00111483 
+  1054         935.94139    116.3365    0.00094877 
+  1297         1151.91861   116.24773   0.00077101 
+  1668         1495.07313   116.15908   0.00059952 
+  2126         2070.80316   116.07054   0.00047037 
+  2882         3031.26608   115.98212   0.00034698 
+  4036         4530.30444   115.8938    0.00024777 
+  5731         6611.74908   115.80559   0.00017449 
+  7731         8990.97364   115.7175    0.00012935 
+  10341        10723.70648  115.62952   0.0000967 
+  12238        10642.97956  115.54164   0.00008171 
+  13010        9056.19868   115.45388   0.00007686 
+  10828        7331.52934   115.36623   0.00009235 
+  7559         6294.95183   115.27869   0.00013229 
+  5904         6090.58326   115.19126   0.00016938 
+  5815         6368.84913   115.10394   0.00017197 
+  6362         6362.315     115.01673   0.00015718 
+  6572         5537.16622   114.92963   0.00015216 
+  6131         4249.96179   114.84264   0.00016311 
+  4287         3040.63437   114.75576   0.00023326 
+  2447         2126.00279   114.66898   0.00040866 
+  1430         1513.50158   114.58232   0.0006993 
+  1078         1131.63347   114.49577   0.00092764 
+  730          897.02507    114.40932   0.00136986 
+  621          746.50078    114.32299   0.00161031 
+  549          642.40568    114.23676   0.00182149 
+  504          565.29145    114.15064   0.00198413 
+  445          505.47816    114.06464   0.00224719 
+  448          457.78902    113.97873   0.00223214 
+  401          419.07132    113.89294   0.00249377 
+  403          387.22139    113.80726   0.00248139 
+  348          360.74835    113.72168   0.00287356 
+  333          338.54317    113.63621   0.003003  
+  321          319.7331     113.55085   0.00311526 
+  308          303.6025     113.4656    0.00324675 
+  326          289.58036    113.38045   0.00306748 
+  297          277.33897    113.29541   0.003367  
+  261          266.70707    113.21048   0.00383142 
+  264          257.46592    113.12566   0.00378788 
+  266          249.49345    113.04094   0.0037594 
+  259          242.54022    112.95633   0.003861  
+  212          236.41163    112.87183   0.00471698 
+  212          230.96371    112.78743   0.00471698 
+  210          226.13208    112.70314   0.0047619 
+  169          221.93206    112.61896   0.00591716 
+  180          218.29872    112.53488   0.00555556 
+  188          215.17469    112.45091   0.00531915 
+  169          212.5073     112.36704   0.00591716 
+  186          210.25192    112.28328   0.00537634 
+  213          208.37451    112.19962   0.00469484 
+  184          206.84789    112.11608   0.00543478 
+  197          205.65118    112.03263   0.00507614 
+  176          204.76646    111.94929   0.00568182 
+  162          204.17998    111.86606   0.00617284 
+  158          203.88026    111.78293   0.00632911 
+  172          203.85966    111.69991   0.00581395 
+  157          204.1146     111.61699   0.00636943 
+  155          204.65049    111.53417   0.00645161 
+  138          205.48215    111.45146   0.00724638 
+  163          206.63019    111.36886   0.00613497 
+  184          208.09849    111.28636   0.00543478 
+  164          209.83609    111.20396   0.00609756 
+  180          211.72599    111.12167   0.00555556 
+  132          213.63422    111.03948   0.00757576 
+  146          215.57497    110.95739   0.00684932 
+  168          217.72248    110.87541   0.00595238 
+  149          220.18016    110.79353   0.00671141 
+  177          222.94993    110.71176   0.00564972 
+  154          225.96283    110.63009   0.00649351 
+  155          229.11656    110.54852   0.00645161 
+  167          232.32479    110.46705   0.00598802 
+  201          235.60457    110.38569   0.00497512 
+  182          239.02054    110.30443   0.00549451 
+  194          242.59052    110.22327   0.00515464 
+  181          246.29399    110.14221   0.00552486 
+  179          250.09663    110.06126   0.00558659 
+  196          253.96288    109.98041   0.00510204 
+  206          257.86001    109.89966   0.00485437 
+  229          261.7567     109.81902   0.00436681 
+  225          265.62108    109.73847   0.00444444 
+  230          269.42136    109.65803   0.00434783 
+  240          273.12825    109.57769   0.00416667 
+  274          276.71883    109.49745   0.00364964 
+  261          280.18853    109.41731   0.00383142 
+  281          283.58424    109.33727   0.00355872 
+  321          287.09029    109.25733   0.00311526 
+  349          291.19524    109.1775    0.00286533 
+  390          296.8618     109.09777   0.0025641 
+  372          305.39765    109.01813   0.00268817 
+  365          317.53168    108.9386    0.00273973 
+  355          331.4788     108.85917   0.0028169 
+  332          341.87625    108.77983   0.00301205 
+  323          341.77503    108.7006    0.00309598 
+  298          330.26597    108.62147   0.0033557 
+  336          316.29233    108.54244   0.00297619 
+  337          306.70142    108.46351   0.00296736 
+  302          302.96179    108.38467   0.00331126 
+  276          302.75522    108.30594   0.00362319 
+  307          301.64757    108.22731   0.00325733 
+  245          295.30797    108.14877   0.00408163 
+  286          283.93935    108.07034   0.0034965 
+  260          271.84866    107.992     0.00384615 
+  236          261.51158    107.91377   0.00423729 
+  277          253.21303    107.83563   0.00361011 
+  221          246.34477    107.75759   0.00452489 
+  235          240.23172    107.67965   0.00425532 
+  248          234.46871    107.60181   0.00403226 
+  240          228.89974    107.52407   0.00416667 
+  220          223.49604    107.44642   0.00454545 
+  189          218.26424    107.36888   0.00529101 
+  189          213.21384    107.29143   0.00529101 
+  192          208.35089    107.21408   0.00520833 
+  161          203.67729    107.13682   0.00621118 
+  149          199.19384    107.05967   0.00671141 
+  163          194.90611    106.98261   0.00613497 
+  157          190.82157    106.90565   0.00636943 
+  126          186.94154    106.82879   0.00793651 
+  150          183.26259    106.75202   0.00666667 
+  139          179.77863    106.67536   0.00719424 
+  112          176.48247    106.59878   0.00892857 
+  147          173.36614    106.52231   0.00680272 
+  125          170.42197    106.44593   0.008     
+  149          167.64165    106.36965   0.00671141 
+  147          165.0168     106.29347   0.00680272 
+  173          162.53886    106.21738   0.00578035 
+  154          160.19957    106.14139   0.00649351 
+  138          157.99067    106.06549   0.00724638 
+  142          155.9046     105.98969   0.00704225 
+  118          153.93384    105.91399   0.00847458 
+  141          152.07126    105.83838   0.0070922 
+  129          150.31007    105.76287   0.00775194 
+  128          148.60686    105.68745   0.0078125 
+  151          147.02969    105.61213   0.00662252 
+  116          145.53594    105.53691   0.00862069 
+  133          144.12033    105.46178   0.0075188 
+  142          142.77797    105.38674   0.00704225 
+  132          141.48563    105.3118    0.00757576 
+  130          140.27631    105.23695   0.00769231 
+  127          139.12732    105.1622    0.00787402 
+  131          138.03505    105.08755   0.00763359 
+  109          136.99608    105.01299   0.00917431 
+  119          136.00727    104.93852   0.00840336 
+  118          135.06562    104.86415   0.00847458 
+  125          134.16844    104.78987   0.008     
+  121          133.31315    104.71568   0.00826446 
+  96           132.49746    104.64159   0.01041667 
+  112          131.71926    104.5676    0.00892857 
+  137          130.97654    104.49369   0.00729927 
+  130          130.26745    104.41989   0.00769231 
+  134          129.59029    104.34617   0.00746269 
+  112          128.94349    104.27255   0.00892857 
+  140          128.32564    104.19902   0.00714286 
+  123          127.73543    104.12558   0.00813008 
+  126          127.17171    104.05224   0.00793651 
+  119          126.63369    103.97899   0.00840336 
+  132          126.11965    103.90583   0.00757576 
+  143          125.62911    103.83277   0.00699301 
+  123          125.16115    103.7598    0.00813008 
+  123          124.71516    103.68692   0.00813008 
+  130          124.29049    103.61413   0.00769231 
+  150          123.88659    103.54144   0.00666667 
+  108          123.50301    103.46884   0.00925926 
+  132          123.13955    103.39633   0.00757576 
+  96           122.79554    103.32391   0.01041667 
+  121          122.471      103.25158   0.00826446 
+  98           122.1658     103.17935   0.01020408 
+  118          121.87991    103.1072    0.00847458 
+  112          121.61341    103.03515   0.00892857 
+  106          121.3665     102.96319   0.00943396 
+  116          121.14172    102.89132   0.00862069 
+  111          120.93506    102.81954   0.00900901 
+  117          120.7494     102.74786   0.00854701 
+  135          120.58553    102.67626   0.00740741 
+  134          120.44453    102.60476   0.00746269 
+  94           120.32781    102.53334   0.0106383 
+  140          120.23717    102.46202   0.00714286 
+  125          120.17507    102.39079   0.008     
+  120          120.14482    102.31964   0.00833333 
+  97           120.1513     102.24859   0.01030928 
+  114          120.20029    102.17763   0.00877193 
+  106          120.30204    102.10676   0.00943396 
+  116          120.47317    102.03598   0.00862069 
+  104          120.74799    101.96528   0.00961538 
+  119          121.2096     101.89468   0.00840336 
+  122          122.06012    101.82417   0.00819672 
+  144          123.72243    101.75374   0.00694444 
+  145          126.85691    101.68341   0.00689655 
+  145          132.06186    101.61317   0.00689655 
+  157          139.03604    101.54301   0.00636943 
+  169          145.60656    101.47294   0.00591716 
+  150          148.14032    101.40297   0.00666667 
+  139          144.42733    101.33308   0.00719424 
+  141          137.87629    101.26328   0.0070922 
+  147          132.89375    101.19357   0.00680272 
+  160          131.13429    101.12394   0.00625   
+  156          132.17845    101.05441   0.00641026 
+  129          134.19495    100.98496   0.00775194 
+  162          134.74183    100.91561   0.00617284 
+  142          132.28408    100.84634   0.00704225 
+  125          128.22882    100.77716   0.008     
+  148          124.59845    100.70806   0.00675676 
+  136          122.08483    100.63906   0.00735294 
+  127          120.54907    100.57014   0.00787402 
+  127          119.60544    100.50131   0.00787402 
+  131          118.9424     100.43256   0.00763359 
+  139          118.39626    100.36391   0.00719424 
+  122          117.90147    100.29534   0.00819672 
+  107          117.43534    100.22686   0.00934579 
+  117          116.99091    100.15847   0.00854701 
+  115          116.56796    100.09016   0.00869565 
+  106          116.17243    100.02194   0.00943396 
+  130          115.82101    99.9538     0.00769231 
+  108          115.55779    99.88576    0.00925926 
+  135          115.46277    99.8178     0.00740741 
+  108          115.64679    99.74992    0.00925926 
+  123          116.17977    99.68214    0.00813008 
+  105          116.93098    99.61443    0.00952381 
+  107          117.45948    99.54682    0.00934579 
+  125          117.18194    99.47929    0.008     
+  120          116.01724    99.41185    0.00833333 
+  129          114.68183    99.34449    0.00775194 
+  124          113.73788    99.27722    0.00806452 
+  113          113.32777    99.21003    0.00884956 
+  138          113.3124     99.14293    0.00724638 
+  98           113.36414    99.07592    0.01020408 
+  116          113.10329    99.00899    0.00862069 
+  132          112.39763    98.94214    0.00757576 
+  130          111.55461    98.87538    0.00769231 
+  105          110.84161    98.80871    0.00952381 
+  102          110.3228     98.74212    0.00980392 
+  114          109.95825    98.67561    0.00877193 
+  100          109.68639    98.60919    0.01      
+  126          109.46358    98.54286    0.00793651 
+  116          109.26818    98.4766     0.00862069 
+  114          109.09155    98.41044    0.00877193 
+  96           108.93028    98.34436    0.01041667 
+  112          108.78297    98.27836    0.00892857 
+  114          108.64905    98.21244    0.00877193 
+  98           108.52868    98.14661    0.01020408 
+  109          108.42267    98.08087    0.00917431 
+  117          108.33265    98.0152     0.00854701 
+  100          108.26154    97.94962    0.01      
+  102          108.21455    97.88413    0.00980392 
+  113          108.20269    97.81872    0.00884956 
+  110          108.25276    97.75339    0.00909091 
+  132          108.4306     97.68814    0.00757576 
+  109          108.87535    97.62298    0.00917431 
+  102          109.80909    97.5579     0.00980392 
+  114          111.44036    97.4929     0.00877193 
+  125          113.69025    97.42799    0.008     
+  143          115.84801    97.36316    0.00699301 
+  131          116.67741    97.29841    0.00763359 
+  109          115.39652    97.23375    0.00917431 
+  125          113.11343    97.16916    0.008     
+  132          111.32373    97.10466    0.00757576 
+  121          110.61663    97.04024    0.00826446 
+  125          110.90488    96.97591    0.008     
+  115          111.63892    96.91165    0.00869565 
+  124          112.01614    96.84748    0.00806452 
+  117          111.41632    96.78339    0.00854701 
+  111          110.1621     96.71938    0.00900901 
+  127          108.98753    96.65546    0.00787402 
+  137          108.20532    96.59161    0.00729927 
+  105          107.80778    96.52785    0.00952381 
+  131          107.84476    96.46417    0.00763359 
+  102          107.91889    96.40056    0.00980392 
+  112          108.20595    96.33704    0.00892857 
+  106          108.81901    96.27361    0.00943396 
+  103          109.91169    96.21025    0.00970874 
+  121          111.52132    96.14697    0.00826446 
+  107          113.31665    96.08377    0.00934579 
+  114          114.53811    96.02066    0.00877193 
+  125          114.45345    95.95762    0.008     
+  121          113.56597    95.89467    0.00826446 
+  115          112.9609     95.8318     0.00869565 
+  132          113.63764    95.769      0.00757576 
+  104          116.34965    95.70629    0.00961538 
+  126          121.89475    95.64366    0.00793651 
+  133          130.73083    95.5811     0.0075188 
+  122          141.82634    95.51863    0.00819672 
+  137          151.5323     95.45624    0.00729927 
+  138          154.34579    95.39392    0.00724638 
+  155          147.31219    95.33169    0.00645161 
+  159          136.25517    95.26953    0.00628931 
+  151          127.99492    95.20746    0.00662252 
+  144          125.01198    95.14546    0.00694444 
+  158          126.75991    95.08355    0.00632911 
+  126          130.62842    95.02171    0.00793651 
+  134          132.82211    94.95995    0.00746269 
+  155          130.37959    94.89827    0.00645161 
+  145          124.75601    94.83667    0.00689655 
+  119          119.31717    94.77515    0.00840336 
+  126          115.41331    94.71371    0.00793651 
+  124          113.04469    94.65234    0.00806452 
+  128          111.80869    94.59106    0.0078125 
+  116          111.26908    94.52985    0.00862069 
+  96           111.13214    94.46872    0.01041667 
+  124          111.22011    94.40767    0.00806452 
+  116          111.39501    94.3467     0.00862069 
+  105          111.54215    94.2858     0.00952381 
+  120          111.63752    94.22498    0.00833333 
+  105          111.76329    94.16424    0.00952381 
+  127          111.97976    94.10358    0.00787402 
+  110          112.29975    94.043      0.00909091 
+  117          112.71544    93.98249    0.00854701 
+  106          113.21929    93.92207    0.00943396 
+  120          113.81596    93.86171    0.00833333 
+  106          114.53031    93.80144    0.00943396 
+  113          115.41843    93.74124    0.00884956 
+  101          116.57191    93.68112    0.00990099 
+  121          118.09115    93.62108    0.00826446 
+  123          119.99495    93.56112    0.00813008 
+  146          122.09029    93.50123    0.00684932 
+  130          123.97907    93.44141    0.00769231 
+  139          125.38608    93.38168    0.00719424 
+  141          126.74177    93.32202    0.0070922 
+  123          128.78403    93.26244    0.00813008 
+  138          132.06835    93.20293    0.00724638 
+  141          137.14646    93.1435     0.0070922 
+  152          144.79662    93.08415    0.00657895 
+  150          156.17807    93.02487    0.00666667 
+  155          172.80924    92.96567    0.00645161 
+  178          196.29717    92.90654    0.00561798 
+  187          227.00809    92.84749    0.00534759 
+  228          261.14       92.78852    0.00438596 
+  211          287.42344    92.72962    0.00473934 
+  246          291.48978    92.6708     0.00406504 
+  223          273.55655    92.61205    0.0044843 
+  175          248.99898    92.55338    0.00571429 
+  175          230.5103     92.49478    0.00571429 
+  191          222.60769    92.43626    0.0052356 
+  171          224.1922     92.37781    0.00584795 
+  208          229.56196    92.31944    0.00480769 
+  207          229.51548    92.26115    0.00483092 
+  200          218.98639    92.20292    0.005     
+  176          202.58986    92.14478    0.00568182 
+  177          187.05906    92.0867     0.00564972 
+  168          175.67448    92.02871    0.00595238 
+  148          169.28033    91.97078    0.00675676 
+  154          167.82421    91.91293    0.00649351 
+  186          170.67707    91.85516    0.00537634 
+  170          176.08825    91.79746    0.00588235 
+  171          180.84341    91.73983    0.00584795 
+  196          181.62322    91.68228    0.00510204 
+  171          178.91333    91.6248     0.00584795 
+  162          176.62723    91.5674     0.00617284 
+  191          177.17342    91.51007    0.0052356 
+  166          181.04561    91.45281    0.0060241 
+  177          187.56677    91.39563    0.00564972 
+  182          195.19665    91.33852    0.00549451 
+  186          202.05525    91.28148    0.00537634 
+  217          207.41242    91.22452    0.00460829 
+  199          212.94633    91.16763    0.00502513 
+  196          220.39291    91.11081    0.00510204 
+  229          230.44077    91.05407    0.00436681 
+  227          243.25856    90.99739    0.00440529 
+  240          258.97117    90.9408     0.00416667 
+  292          277.92772    90.88427    0.00342466 
+  328          300.80688    90.82782    0.00304878 
+  314          328.63885    90.77144    0.00318471 
+  375          362.95448    90.71513    0.00266667 
+  374          405.93143    90.6589     0.0026738 
+  428          460.65694    90.60274    0.00233645 
+  571          531.69603    90.54665    0.00175131 
+  715          626.86989    90.49063    0.0013986 
+  930          762.30125    90.43468    0.00107527 
+  1176         972.64192    90.37881    0.00085034 
+  1580         1323.422     90.32301    0.00063291 
+  2082         1912.4421    90.26728    0.00048031 
+  2733         2845.38974   90.21162    0.0003659 
+  3925         4171.42891   90.15603    0.00025478 
+  5339         5751.9653    90.10052    0.0001873 
+  6736         7041.38994   90.04507    0.00014846 
+  7141         7198.49105   89.9897     0.00014004 
+  6241         6179.46617   89.9344     0.00016023 
+  4469         4855.17919   89.87917    0.00022376 
+  3413         3885.30972   89.82401    0.000293  
+  2762         3486.18038   89.76892    0.00036206 
+  2931         3610.14081   89.71391    0.00034118 
+  3418         3994.04827   89.65896    0.00029257 
+  3789         4146.40202   89.60409    0.00026392 
+  3523         3700.85128   89.54929    0.00028385 
+  2677         2881.08115   89.49455    0.00037355 
+  1730         2075.24137   89.43989    0.00057803 
+  1012         1453.46806   89.3853     0.00098814 
+  744          1032.34204   89.33078    0.00134409 
+  548          768.41259    89.27633    0.00182482 
+  494          606.68587    89.22194    0.00202429 
+  359          503.83262    89.16763    0.00278552 
+  390          433.46242    89.11339    0.0025641 
+  361          381.70323    89.05922    0.00277008 
+  280          341.69173    89.00512    0.00357143 
+  295          309.85891    88.95109    0.00338983 
+  282          284.15357    88.89713    0.0035461 
+  256          263.32384    88.84324    0.00390625 
+  256          246.61769    88.78942    0.00390625 
+  239          233.52354    88.73566    0.0041841 
+  245          223.34405    88.68198    0.00408163 
+  202          214.7824     88.62837    0.0049505 
+  198          206.11935    88.57482    0.00505051 
+  181          196.58471    88.52135    0.00552486 
+  203          187.52854    88.46794    0.00492611 
+  189          180.17182    88.4146     0.00529101 
+  181          174.43844    88.36134    0.00552486 
+  174          169.53986    88.30814    0.00574713 
+  187          164.92662    88.25501    0.00534759 
+  184          160.42542    88.20194    0.00543478 
+  160          155.65979    88.14895    0.00625   
+  144          150.81852    88.09603    0.00694444 
+  150          146.60864    88.04317    0.00666667 
+  146          143.19196    87.99038    0.00684932 
+  137          140.21286    87.93766    0.00729927 
+  142          137.27706    87.88501    0.00704225 
+  142          134.44628    87.83243    0.00704225 
+  136          131.96581    87.77991    0.00735294 
+  120          129.94989    87.72746    0.00833333 
+  163          128.44034    87.67508    0.00613497 
+  151          127.46187    87.62277    0.00662252 
+  114          126.97333    87.57053    0.00877193 
+  123          126.71857    87.51835    0.00813008 
+  122          126.17278    87.46624    0.00819672 
+  124          124.87721    87.4142     0.00806452 
+  130          123.16846    87.36223    0.00769231 
+  114          121.83893    87.31032    0.00877193 
+  109          121.31891    87.25848    0.00917431 
+  122          121.57461    87.20671    0.00819672 
+  144          122.08209    87.155      0.00694444 
+  146          121.97187    87.10336    0.00684932 
+  123          120.71519    87.05179    0.00813008 
+  118          118.82363    87.00029    0.00847458 
+  113          117.22433    86.94885    0.00884956 
+  104          116.50111    86.89748    0.00961538 
+  127          116.77772    86.84618    0.00787402 
+  119          117.71722    86.79494    0.00840336 
+  114          118.46347    86.74377    0.00877193 
+  131          117.95462    86.69266    0.00763359 
+  139          116.01051    86.64162    0.00719424 
+  150          113.71271    86.59065    0.00666667 
+  136          111.91998    86.53974    0.00735294 
+  131          110.86693    86.4889     0.00763359 
+  121          110.44464    86.43813    0.00826446 
+  113          110.35483    86.38742    0.00884956 
+  121          110.1715     86.33677    0.00826446 
+  130          109.5072     86.2862     0.00769231 
+  108          108.41983    86.23569    0.00925926 
+  127          107.31004    86.18524    0.00787402 
+  125          106.39431    86.13486    0.008     
+  117          105.69229    86.08454    0.00854701 
+  118          105.14308    86.03429    0.00847458 
+  105          104.68193    85.98411    0.00952381 
+  110          104.26905    85.93399    0.00909091 
+  105          103.88584    85.88394    0.00952381 
+  109          103.52426    85.83395    0.00917431 
+  105          103.18022    85.78402    0.00952381 
+  105          102.85074    85.73416    0.00952381 
+  88           102.5335     85.68437    0.01136364 
+  88           102.2258     85.63464    0.01136364 
+  96           101.92594    85.58497    0.01041667 
+  111          101.6321     85.53537    0.00900901 
+  105          101.34282    85.48584    0.00952381 
+  97           101.05688    85.43637    0.01030928 
+  104          100.77339    85.38696    0.00961538 
+  94           100.49187    85.33762    0.0106383 
+  107          100.21204    85.28834    0.00934579 
+  101          99.9339      85.23912    0.00990099 
+  97           99.65776     85.18997    0.01030928 
+  103          99.38407     85.14089    0.00970874 
+  95           99.11345     85.09186    0.01052632 
+  106          98.84659     85.0429     0.00943396 
+  82           98.58436     84.99401    0.01219512 
+  104          98.32765     84.94518    0.00961538 
+  91           98.07704     84.89641    0.01098901 
+  87           97.83346     84.8477     0.01149425 
+  111          97.5977      84.79906    0.00900901 
+  90           97.37094     84.75049    0.01111111 
+  95           97.1546      84.70197    0.01052632 
+  102          96.95011     84.65352    0.00980392 
+  90           96.75786     84.60513    0.01111111 
+  98           96.57394     84.55681    0.01020408 
+  101          96.39082     84.50855    0.00990099 
+  109          96.20163     84.46035    0.00917431 
+  115          96.00988     84.41221    0.00869565 
+  109          95.82401     84.36414    0.00917431 
+  96           95.64783     84.31613    0.01041667 
+  113          95.48118     84.26818    0.00884956 
+  94           95.32183     84.22029    0.0106383 
+  94           95.16409     84.17247    0.0106383 
+  95           95.00234     84.12471    0.01052632 
+  95           94.83399     84.07701    0.01052632 
+  100          94.662       84.02937    0.01      
+  108          94.49143     83.9818     0.00925926 
+  96           94.32393     83.93429    0.01041667 
+  112          94.15979     83.88684    0.00892857 
+  111          93.99905     83.83945    0.00900901 
+  111          93.84185     83.79212    0.00900901 
+  106          93.69121     83.74486    0.00943396 
+  100          93.55626     83.69766    0.01      
+  91           93.45727     83.65052    0.01098901 
+  106          93.42998     83.60344    0.00943396 
+  100          93.51708     83.55642    0.01      
+  112          93.73217     83.50946    0.00892857 
+  93           93.99633     83.46257    0.01075269 
+  120          94.10575     83.41574    0.00833333 
+  97           93.86817     83.36896    0.01030928 
+  90           93.39835     83.32225    0.01111111 
+  93           93.01125     83.2756     0.01075269 
+  91           92.91581     83.22901    0.01098901 
+  95           93.20207     83.18249    0.01052632 
+  114          93.8224      83.13602    0.00877193 
+  101          94.49754     83.08961    0.00990099 
+  98           94.72425     83.04327    0.01020408 
+  88           94.1569      82.99698    0.01136364 
+  92           93.1606      82.95076    0.01086957 
+  99           92.28803     82.90459    0.01010101 
+  108          91.76816     82.85849    0.00925926 
+  106          91.60655     82.81245    0.00943396 
+  103          91.69471     82.76647    0.00970874 
+  97           91.84293     82.72054    0.01030928 
+  89           91.81631     82.67468    0.01123596 
+  132          91.50907     82.62888    0.00757576 
+  119          91.09428     82.58314    0.00840336 
+  97           90.75756     82.53745    0.01030928 
+  110          90.55715     82.49183    0.00909091 
+  102          90.48282     82.44627    0.00980392 
+  109          90.51595     82.40077    0.00917431 
+  119          90.66531     82.35532    0.00840336 
+  113          91.01112     82.30994    0.00884956 
+  137          91.76691     82.26462    0.00729927 
+  110          93.33762     82.21935    0.00909091 
+  148          96.23876     82.17415    0.00675676 
+  140          100.69123    82.129      0.00714286 
+  168          105.85804    82.08391    0.00595238 
+  154          109.38634    82.03889    0.00649351 
+  152          108.71903    81.99392    0.00657895 
+  146          104.4992     81.94901    0.00684932 
+  150          99.77002     81.90416    0.00666667 
+  153          96.59691     81.85937    0.00653595 
+  159          95.63996     81.81463    0.00628931 
+  134          96.59528     81.76996    0.00746269 
+  128          98.26397     81.72535    0.0078125 
+  159          99.43301     81.68079    0.00628931 
+  158          98.54631     81.63629    0.00632911 
+  160          96.06042     81.59185    0.00625   
+  113          93.40162     81.54747    0.00884956 
+  115          91.39006     81.50315    0.00869565 
+  117          90.06072     81.45888    0.00854701 
+  120          89.39219     81.41468    0.00833333 
+  114          89.0405      81.37053    0.00877193 
+  127          88.84387     81.32644    0.00787402 
+  106          88.72406     81.28241    0.00943396 
+  104          88.64887     81.23843    0.00961538 
+  112          88.60555     81.19452    0.00892857 
+  101          88.58891     81.15066    0.00990099 
+  95           88.59731     81.10686    0.01052632 
+  92           88.63208     81.06312    0.01086957 
+  97           88.69903     81.01943    0.01030928 
+  91           88.8154      80.9758     0.01098901 
+  107          89.0278      80.93223    0.00934579 
+  102          89.43988     80.88872    0.00980392 
+  97           90.21583     80.84526    0.01030928 
+  73           91.49347     80.80186    0.01369863 
+  92           93.17801     80.75852    0.01086957 
+  87           94.63986     80.71524    0.01149425 
+  104          94.79601     80.67201    0.00961538 
+  92           93.64878     80.62884    0.01086957 
+  97           92.31273     80.58573    0.01030928 
+  108          91.4829      80.54267    0.00925926 
+  96           91.34609     80.49967    0.01041667 
+  95           91.83759     80.45673    0.01052632 
+  99           92.74449     80.41384    0.01010101 
+  109          93.64173     80.37102    0.00917431 
+  99           93.95049     80.32824    0.01010101 
+  101          93.69012     80.28553    0.00990099 
+  100          93.4139      80.24287    0.01      
+  91           93.44546     80.20026    0.01098901 
+  98           93.85202     80.15771    0.01020408 
+  81           94.59692     80.11522    0.01234568 
+  98           95.64573     80.07279    0.01020408 
+  97           97.0163      80.03041    0.01030928 
+  91           98.79387     79.98809    0.01098901 
+  103          101.15384    79.94582    0.00970874 
+  100          104.42169    79.90361    0.01      
+  93           109.17411    79.86145    0.01075269 
+  114          116.3504     79.81935    0.00877193 
+  124          127.26348    79.77731    0.00806452 
+  129          143.41719    79.73532    0.00775194 
+  149          165.95074    79.69339    0.00671141 
+  172          194.46676    79.65151    0.00581395 
+  210          224.51423    79.60969    0.0047619 
+  227          244.94621    79.56792    0.00440529 
+  244          244.78108    79.52621    0.00409836 
+  212          228.78805    79.48455    0.00471698 
+  198          212.9231     79.44295    0.00505051 
+  173          208.64427    79.40141    0.00578035 
+  145          218.56278    79.35991    0.00689655 
+  151          235.66434    79.31848    0.00662252 
+  179          243.67261    79.2771     0.00558659 
+  153          233.2464     79.23577    0.00653595 
+  176          209.86545    79.1945     0.00568182 
+  163          183.00647    79.15328    0.00613497 
+  149          161.5242     79.11212    0.00671141 
+  130          149.2411     79.07101    0.00769231 
+  112          145.24785    79.02996    0.00892857 
+  111          144.94941    78.98896    0.00900901 
+  108          140.66647    78.94802    0.00925926 
+  117          129.76095    78.90713    0.00854701 
+  111          117.60909    78.86629    0.00900901 
+  84           108.1429     78.82551    0.01190476 
+  112          102.05468    78.78478    0.00892857 
+  86           98.51924     78.74411    0.01162791 
+  100          96.45401     78.70349    0.01      
+  108          95.1265      78.66292    0.00925926 
+  84           94.17819     78.62241    0.01190476 
+  83           93.45732     78.58195    0.01204819 
+  94           92.89533     78.54155    0.0106383 
+  95           92.45459     78.5012     0.01052632 
+  84           92.11202     78.4609     0.01190476 
+  87           91.85545     78.42066    0.01149425 
+  116          91.6844      78.38047    0.00862069 
+  87           91.60783     78.34033    0.01149425 
+  108          91.63185     78.30025    0.00925926 
+  105          91.73471     78.26022    0.00952381 
+  97           91.83113     78.22024    0.01030928 
+  100          91.79966     78.18032    0.01      
+  73           91.66013     78.14045    0.01369863 
+  78           91.53602     78.10063    0.01282051 
+  99           91.49445     78.06087    0.01010101 
+  102          91.55003     78.02116    0.00980392 
+  85           91.69301     77.9815     0.01176471 
+  99           91.89916     77.94189    0.01010101 
+  72           92.12203     77.90234    0.01388889 
+  88           92.29545     77.86284    0.01136364 
+  94           92.41758     77.82339    0.0106383 
+  81           92.54962     77.784      0.01234568 
+  94           92.72835     77.74466    0.0106383 
+  96           92.96042     77.70537    0.01041667 
+  98           93.24094     77.66613    0.01020408 
+  98           93.56513     77.62694    0.01020408 
+  116          93.93509     77.58781    0.00862069 
+  115          94.36548     77.54873    0.00869565 
+  94           94.8963      77.5097     0.0106383 
+  91           95.61339     77.47073    0.01098901 
+  119          96.65039     77.4318     0.00840336 
+  98           98.10974     77.39293    0.01020408 
+  97           99.87825     77.35411    0.01030928 
+  104          101.38519    77.31534    0.00961538 
+  114          101.80321    77.27662    0.00877193 
+  125          101.32338    77.23796    0.008     
+  106          100.83493    77.19934    0.00943396 
+  121          100.82046    77.16078    0.00826446 
+  89           101.39754    77.12227    0.01123596 
+  119          102.5242     77.08381    0.00840336 
+  118          104.06859    77.0454     0.00847458 
+  109          105.75087    77.00705    0.00917431 
+  98           107.16128    76.96874    0.01020408 
+  102          108.3553     76.93049    0.00980392 
+  100          109.92857    76.89228    0.01      
+  111          112.44236    76.85413    0.00900901 
+  121          116.41577    76.81603    0.00826446 
+  104          122.44552    76.77798    0.00961538 
+  121          131.16488    76.73998    0.00826446 
+  126          142.99612    76.70203    0.00793651 
+  138          157.50722    76.66414    0.00724638 
+  161          172.07652    76.62629    0.00621118 
+  155          180.89016    76.58849    0.00645161 
+  147          179.20472    76.55075    0.00680272 
+  177          169.98172    76.51305    0.00564972 
+  139          159.93212    76.47541    0.00719424 
+  155          153.15162    76.43782    0.00645161 
+  131          150.90349    76.40027    0.00763359 
+  145          152.87168    76.36278    0.00689655 
+  123          157.41007    76.32534    0.00813008 
+  130          161.23404    76.28794    0.00769231 
+  132          160.92016    76.2506     0.00757576 
+  141          156.62149    76.21331    0.0070922 
+  123          151.34129    76.17607    0.00813008 
+  126          147.29926    76.13888    0.00793651 
+  155          145.26786    76.10173    0.00645161 
+  133          145.31165    76.06464    0.0075188 
+  110          147.17107    76.0276     0.00909091 
+  148          150.33768    75.99061    0.00675676 
+  143          154.00204    75.95366    0.00699301 
+  146          157.61518    75.91677    0.00684932 
+  176          161.61567    75.87992    0.00568182 
+  160          166.61236    75.84313    0.00625   
+  193          172.91529    75.80638    0.00518135 
+  219          180.68043    75.76969    0.00456621 
+  219          190.02271    75.73304    0.00456621 
+  222          201.04856    75.69644    0.0045045 
+  217          213.79813    75.6599     0.00460829 
+  233          228.38621    75.6234     0.00429185 
+  276          245.48461    75.58695    0.00362319 
+  260          266.14852    75.55055    0.00384615 
+  268          291.50202    75.5142     0.00373134 
+  309          322.94464    75.47789    0.00323625 
+  367          362.42413    75.44164    0.0027248 
+  407          412.94293    75.40543    0.002457  
+  492          479.66176    75.36928    0.00203252 
+  687          572.55989    75.33317    0.0014556 
+  833          712.08835    75.29711    0.00120048 
+  1155         938.1128     75.2611     0.0008658 
+  1484         1317.44844   75.22514    0.00067385 
+  2243         1937.66185   75.18923    0.00044583 
+  3104         2872.62066   75.15336    0.00032216 
+  4354         4108.60501   75.11754    0.00022967 
+  5637         5395.65308   75.08178    0.0001774 
+  6810         6100.08365   75.04606    0.00014684 
+  6332         5694.81445   75.01038    0.00015793 
+  4808         4582.89      74.97476    0.00020799 
+  3319         3483.51438   74.93918    0.0003013 
+  2635         2759.93342   74.90366    0.00037951 
+  2307         2501.12571   74.86818    0.00043346 
+  2547         2656.8095    74.83274    0.00039262 
+  3090         3063.73113   74.79736    0.00032362 
+  3444         3393.80221   74.76202    0.00029036 
+  3462         3258.89367   74.72674    0.00028885 
+  2708         2671.67414   74.69149    0.00036928 
+  1863         1976.48562   74.6563     0.00053677 
+  1127         1395.35483   74.62116    0.00088731 
+  789          982.71279    74.58606    0.00126743 
+  517          717.05661    74.55101    0.00193424 
+  418          553.90971    74.516      0.00239234 
+  368          452.47421    74.48105    0.00271739 
+  310          385.34711    74.44614    0.00322581 
+  264          337.36521    74.41128    0.00378788 
+  266          300.92499    74.37646    0.0037594 
+  232          272.16912    74.3417     0.00431034 
+  191          248.92175    74.30698    0.0052356 
+  178          229.81603    74.2723     0.00561798 
+  204          213.89314    74.23768    0.00490196 
+  201          200.47255    74.2031     0.00497512 
+  151          189.04645    74.16856    0.00662252 
+  149          179.23482    74.13408    0.00671141 
+  179          170.74803    74.09964    0.00558659 
+  161          163.36305    74.06525    0.00621118 
+  147          156.90716    74.0309     0.00680272 
+  146          151.24689    73.9966     0.00684932 
+  152          146.28083    73.96235    0.00657895 
+  138          141.93685    73.92814    0.00724638 
+  117          138.17669    73.89398    0.00854701 
+  130          135.02763    73.85987    0.00769231 
+  118          132.66101    73.8258     0.00847458 
+  141          131.5494     73.79178    0.0070922 
+  146          132.55904    73.75781    0.00684932 
+  126          136.67735    73.72388    0.00793651 
+  139          144.10143    73.69       0.00719424 
+  153          152.61285    73.65616    0.00653595 
+  133          156.76909    73.62237    0.0075188 
+  155          153.96771    73.58863    0.00645161 
+  147          146.91881    73.55493    0.00680272 
+  139          138.55772    73.52128    0.00719424 
+  128          132.02365    73.48767    0.0078125 
+  115          127.99185    73.45411    0.00869565 
+  128          126.17343    73.42059    0.0078125 
+  118          126.58988    73.38712    0.00847458 
+  107          127.3289     73.3537     0.00934579 
+  126          125.68637    73.32032    0.00793651 
+  100          121.84438    73.28698    0.01      
+  104          116.92488    73.2537     0.00961538 
+  98           112.23051    73.22045    0.01020408 
+  113          108.41474    73.18725    0.00884956 
+  99           105.04112    73.1541     0.01010101 
+  100          102.12578    73.12099    0.01      
+  84           99.88833     73.08793    0.01190476 
+  100          98.28264     73.05491    0.01      
+  100          97.14109     73.02194    0.01      
+  81           96.29209     72.98902    0.01234568 
+  96           95.61427     72.95613    0.01041667 
+  83           95.0409      72.9233     0.01204819 
+  77           94.54162     72.8905     0.01298701 
+  108          94.10136     72.85775    0.00925926 
+  106          93.7113      72.82505    0.00943396 
+  98           93.36536     72.79239    0.01020408 
+  90           93.05887     72.75978    0.01111111 
+  93           92.78812     72.72721    0.01075269 
+  90           92.54951     72.69468    0.01111111 
+  78           92.341       72.6622     0.01282051 
+  84           92.1598      72.62977    0.01190476 
+  86           92.003       72.59737    0.01162791 
+  93           91.86829     72.56503    0.01075269 
+  95           91.75315     72.53272    0.01052632 
+  85           91.655       72.50046    0.01176471 
+  89           91.57105     72.46825    0.01123596 
+  106          91.49902     72.43608    0.00943396 
+  96           91.43612     72.40395    0.01041667 
+  96           91.37985     72.37187    0.01041667 
+  78           91.32793     72.33983    0.01282051 
+  89           91.2783      72.30783    0.01123596 
+  94           91.22921     72.27588    0.0106383 
+  83           91.1795      72.24397    0.01204819 
+  99           91.1283      72.21211    0.01010101 
+  92           91.07542     72.18029    0.01086957 
+  95           91.021       72.14851    0.01052632 
+  89           90.96695     72.11678    0.01123596 
+  90           90.912       72.08509    0.01111111 
+  89           90.85901     72.05344    0.01123596 
+  76           90.81019     72.02184    0.01315789 
+  60           90.76817     71.99028    0.01666667 
+  90           90.73698     71.95876    0.01111111 
+  78           90.72145     71.92729    0.01282051 
+  79           90.7296      71.89586    0.01265823 
+  90           90.7754      71.86447    0.01111111 
+  77           90.89355     71.83312    0.01298701 
+  73           91.17431     71.80182    0.01369863 
+  81           91.81772     71.77056    0.01234568 
+  88           93.15347     71.73935    0.01136364 
+  74           95.48155     71.70818    0.01351351 
+  87           98.67021     71.67705    0.01149425 
+  103          101.54498    71.64596    0.00970874 
+  91           101.85524    71.61492    0.01098901 
+  104          99.26896     71.58392    0.00961538 
+  77           96.02155     71.55296    0.01298701 
+  95           93.64816     71.52204    0.01052632 
+  95           92.5663      71.49117    0.01052632 
+  90           92.65965     71.46034    0.01111111 
+  90           93.57798     71.42955    0.01111111 
+  78           94.79775     71.3988     0.01282051 
+  89           95.43238     71.3681     0.01123596 
+  98           94.549       71.33743    0.01020408 
+  73           92.67425     71.30681    0.01369863 
+  67           90.88683     71.27624    0.01492537 
+  94           89.63009     71.2457     0.0106383 
+  79           88.88601     71.21521    0.01265823 
+  71           88.45137     71.18476    0.01408451 
+  73           88.11657     71.15435    0.01369863 
+  91           87.7947      71.12398    0.01098901 
+  72           87.50327     71.09365    0.01388889 
+  84           87.26091     71.06337    0.01190476 
+  90           87.06822     71.03313    0.01111111 
+  80           86.91724     71.00293    0.0125    
+  81           86.80019     70.97277    0.01234568 
+  85           86.71362     70.94265    0.01176471 
+  78           86.65976     70.91258    0.01282051 
+  80           86.64883     70.88254    0.0125    
+  70           86.70435     70.85255    0.01428571 
+  71           86.86496     70.8226     0.01408451 
+  80           87.16791     70.79269    0.0125    
+  78           87.60556     70.76282    0.01282051 
+  74           88.05502     70.73299    0.01351351 
+  84           88.28394     70.70321    0.01190476 
+  92           88.22523     70.67346    0.01086957 
+  83           88.07123     70.64376    0.01204819 
+  96           88.04211     70.6141     0.01041667 
+  75           88.25737     70.58448    0.01333333 
+  98           88.78327     70.55489    0.01020408 
+  98           89.66989     70.52536    0.01020408 
+  96           90.90512     70.49586    0.01041667 
+  111          92.29889     70.4664     0.00900901 
+  70           93.43769     70.43698    0.01428571 
+  87           94.13114     70.4076     0.01149425 
+  80           94.88133     70.37827    0.0125    
+  101          96.37067     70.34897    0.00990099 
+  95           99.27881     70.31972    0.01052632 
+  103          104.5374     70.29051    0.00970874 
+  93           113.32435    70.26133    0.01075269 
+  105          126.49184    70.2322     0.00952381 
+  118          143.40077    70.20311    0.00847458 
+  134          160.86714    70.17405    0.00746269 
+  144          176.59711    70.14504    0.00694444 
+  148          191.06051    70.11607    0.00675676 
+  131          200.02917    70.08714    0.00763359 
+  142          197.43196    70.05825    0.00704225 
+  180          186.32895    70.02939    0.00555556 
+  205          175.4636     70.00058    0.00487805 
+  268          168.65572    69.97181    0.00373134 
+  279          163.5632     69.94308    0.00358423 
+  291          158.39673    69.91439    0.00343643 
+  221          154.96691    69.88574    0.00452489 
+  161          153.95666    69.85713    0.00621118 
+  176          151.8302     69.82855    0.00568182 
+  172          145.22427    69.80002    0.00581395 
+  128          135.9107     69.77153    0.0078125 
+  161          127.26498    69.74307    0.00621118 
+  192          119.99581    69.71466    0.00520833 
+  183          113.05827    69.68629    0.00546448 
+  163          106.87839    69.65795    0.00613497 
+  134          102.37723    69.62966    0.00746269 
+  105          99.29747     69.6014     0.00952381 
+  99           97.07236     69.57319    0.01010101 
+  113          95.9321      69.54501    0.00884956 
+  95           96.5159      69.51687    0.01052632 
+  88           98.77409     69.48877    0.01136364 
+  98           102.24046    69.46071    0.01020408 
+  96           104.86347    69.43269    0.01041667 
+  101          104.19876    69.40471    0.00990099 
+  110          101.2153     69.37677    0.00909091 
+  90           98.31088     69.34886    0.01111111 
+  92           96.49332     69.321      0.01086957 
+  110          95.73911     69.29317    0.00909091 
+  100          95.53677     69.26539    0.01      
+  90           95.91224     69.23764    0.01111111 
+  91           96.89069     69.20993    0.01098901 
+  90           97.31526     69.18226    0.01111111 
+  97           96.23818     69.15463    0.01030928 
+  91           94.46445     69.12703    0.01098901 
+  97           93.11106     69.09948    0.01030928 
+  78           92.46007     69.07196    0.01282051 
+  94           92.16811     69.04448    0.0106383 
+  103          91.81357     69.01704    0.00970874 
+  95           91.43278     68.98964    0.01052632 
+  93           91.19536     68.96228    0.01075269 
+  89           91.1511      68.93496    0.01123596 
+  88           91.27032     68.90767    0.01136364 
+  94           91.50016     68.88042    0.0106383 
+  77           91.80059     68.85321    0.01298701 
+  89           92.02422     68.82604    0.01123596 
+  76           92.42764     68.7989     0.01315789 
+  89           92.8854      68.77181    0.01123596 
+  75           93.39686     68.74475    0.01333333 
+  94           93.94092     68.71773    0.0106383 
+  89           94.46603     68.69075    0.01123596 
+  100          94.94296     68.6638     0.01      
+  97           95.35304     68.6369     0.01030928 
+  84           95.87221     68.61003    0.01190476 
+  84           96.45198     68.58319    0.01190476 
+  108          97.09364     68.5564     0.00925926 
+  102          97.7942      68.52964    0.00980392 
+  110          98.54857     68.50293    0.00909091 
+  101          99.34354     68.47624    0.00990099 
+  108          100.15327    68.4496     0.00925926 
+  113          100.97094    68.42299    0.00884956 
+  103          101.82494    68.39642    0.00970874 
+  109          102.7403     68.36989    0.00917431 
+  95           103.72721    68.3434     0.01052632 
+  121          104.79261    68.31694    0.00826446 
+  102          105.94993    68.29052    0.00980392 
+  129          107.2378     68.26414    0.00775194 
+  130          108.75007    68.23779    0.00769231 
+  107          110.65942    68.21148    0.00934579 
+  132          113.16652    68.18521    0.00757576 
+  128          116.31381    68.15897    0.0078125 
+  113          119.66674    68.13278    0.00884956 
+  142          122.04449    68.10661    0.00704225 
+  118          122.65956    68.08049    0.00847458 
+  119          122.52502    68.0544     0.00840336 
+  107          122.75737    68.02835    0.00934579 
+  149          123.7632     68.00234    0.00671141 
+  132          125.55535    67.97636    0.00757576 
+  151          128.03604    67.95042    0.00662252 
+  166          131.06016    67.92451    0.0060241 
+  151          134.30596    67.89864    0.00662252 
+  142          137.13243    67.87281    0.00704225 
+  167          139.19891    67.84702    0.00598802 
+  171          141.05507    67.82126    0.00584795 
+  217          143.22006    67.79553    0.00460829 
+  161          145.84856    67.76985    0.00621118 
+  220          148.89663    67.7442     0.00454545 
+  195          152.27006    67.71858    0.00512821 
+  208          155.9001     67.693      0.00480769 
+  234          159.75943    67.66746    0.0042735 
+  240          163.85657    67.64196    0.00416667 
+  240          168.25018    67.61649    0.00416667 
+  258          173.10493    67.59105    0.00387597 
+  272          178.75459    67.56565    0.00367647 
+  322          185.64184    67.54029    0.00310559 
+  293          193.96462    67.51496    0.00341297 
+  308          203.02127    67.48967    0.00324675 
+  318          210.44525    67.46442    0.00314465 
+  313          213.79288    67.4392     0.00319489 
+  300          214.60323    67.41402    0.00333333 
+  285          215.6591     67.38887    0.00350877 
+  334          218.13312    67.36376    0.00299401 
+  320          222.14951    67.33868    0.003125  
+  324          227.48753    67.31364    0.00308642 
+  312          233.8449     67.28863    0.00320513 
+  321          240.64009    67.26366    0.00311526 
+  285          246.57991    67.23872    0.00350877 
+  320          250.41468    67.21382    0.003125  
+  325          252.90443    67.18896    0.00307692 
+  283          255.39711    67.16413    0.00353357 
+  247          258.40782    67.13934    0.00404858 
+  295          261.88889    67.11458    0.00338983 
+  305          265.59811    67.08985    0.00327869 
+  282          269.31889    67.06516    0.0035461 
+  304          272.92522    67.04051    0.00328947 
+  319          276.35783    67.01589    0.0031348 
+  371          279.58919    66.9913     0.00269542 
+  379          282.60822    66.96675    0.00263852 
+  387          285.41115    66.94224    0.00258398 
+  433          287.99898    66.91776    0.00230947 
+  414          290.37562    66.89331    0.00241546 
+  447          292.54429    66.8689     0.00223714 
+  496          294.50976    66.84453    0.00201613 
+  448          296.27121    66.82019    0.00223214 
+  373          297.82478    66.79588    0.00268097 
+  361          299.16135    66.77161    0.00277008 
+  371          300.26691    66.74737    0.00269542 
+  405          301.12265    66.72317    0.00246914 
+  401          301.70794    66.699      0.00249377 
+  384          302.01119    66.67486    0.00260417 
+  431          302.04235    66.65076    0.00232019 
+  400          301.83679    66.6267     0.0025    
+  322          301.43852    66.60266    0.00310559 
+  292          300.80792    66.57867    0.00342466 
+  275          299.70253    66.5547     0.00363636 
+  264          297.6285     66.53077    0.00378788 
+  241          294.44663    66.50688    0.00414938 
+  278          290.68728    66.48302    0.00359712 
+  287          286.86705    66.45919    0.00348432 
+  268          283.35294    66.4354     0.00373134 
+  279          280.41036    66.41164    0.00358423 
+  271          278.01519    66.38791    0.00369004 
+  263          275.4262     66.36422    0.00380228 
+  241          270.89709    66.34056    0.00414938 
+  262          263.47519    66.31693    0.00381679 
+  263          254.63508    66.29334    0.00380228 
+  294          246.00607    66.26979    0.00340136 
+  275          238.25002    66.24626    0.00363636 
+  317          231.4368     66.22277    0.00315457 
+  290          225.44904    66.19932    0.00344828 
+  264          220.10804    66.17589    0.00378788 
+  286          215.0106     66.1525     0.0034965 
+  255          209.33985    66.12915    0.00392157 
+  235          202.60385    66.10582    0.00425532 
+  267          195.50648    66.08253    0.00374532 
+  244          188.78424    66.05928    0.00409836 
+  329          182.6692     66.03605    0.00303951 
+  272          177.11462    66.01286    0.00367647 
+  290          171.98881    65.9897     0.00344828 
+  243          167.18796    65.96658    0.00411523 
+  215          162.65842    65.94349    0.00465116 
+  204          158.37108    65.92043    0.00490196 
+  215          154.31379    65.89741    0.00465116 
+  176          150.47597    65.87441    0.00568182 
+  179          146.84809    65.85145    0.00558659 
+  182          143.4211     65.82853    0.00549451 
+  198          140.18446    65.80563    0.00505051 
+  177          137.12883    65.78277    0.00564972 
+  171          134.24445    65.75994    0.00584795 
+  164          131.52265    65.73715    0.00609756 
+  142          128.95486    65.71439    0.00704225 
+  158          126.5319     65.69166    0.00632911 
+  141          124.24593    65.66896    0.0070922 
+  135          122.08947    65.64629    0.00740741 
+  144          120.05548    65.62366    0.00694444 
+  133          118.13739    65.60106    0.0075188 
+  144          116.32955    65.57849    0.00694444 
+  145          114.62711    65.55595    0.00689655 
+  128          113.02521    65.53345    0.0078125 
+  112          111.52199    65.51098    0.00892857 
+  127          110.11543    65.48854    0.00787402 
+  111          108.8074     65.46613    0.00900901 
+  126          107.60734    65.44376    0.00793651 
+  109          106.5458     65.42141    0.00917431 
+  133          105.70735    65.3991     0.0075188 
+  120          105.27158    65.37682    0.00833333 
+  146          105.49768    65.35458    0.00684932 
+  121          106.55303    65.33236    0.00826446 
+  127          108.16126    65.31018    0.00787402 
+  124          109.12939    65.28803    0.00806452 
+  130          107.85301    65.26591    0.00769231 
+  113          104.81745    65.24382    0.00884956 
+  111          101.72428    65.22177    0.00900901 
+  95           99.41474     65.19974    0.01052632 
+  114          98.02553     65.17775    0.00877193 
+  121          97.44584     65.15579    0.00826446 
+  116          97.53985     65.13386    0.00862069 
+  95           98.09572     65.11196    0.01052632 
+  94           98.57619     65.09009    0.0106383 
+  135          98.10364     65.06826    0.00740741 
+  116          96.60268     65.04645    0.00862069 
+  101          94.90924     65.02468    0.00990099 
+  110          93.5436      65.00294    0.00909091 
+  107          92.5965      64.98123    0.00934579 
+  94           91.96613     64.95955    0.0106383 
+  124          91.52194     64.93791    0.00806452 
+  93           91.17809     64.91629    0.01075269 
+  94           90.89372     64.8947     0.0106383 
+  100          90.65183     64.87315    0.01      
+  119          90.44454     64.85163    0.00840336 
+  94           90.26678     64.83014    0.0106383 
+  62           90.11443     64.80867    0.01612903 
+  102          89.98364     64.78724    0.00980392 
+  100          89.87055     64.76585    0.01      
+  97           89.77136     64.74448    0.01030928 
+  92           89.68206     64.72314    0.01086957 
+  93           89.59859     64.70183    0.01075269 
+  83           89.51689     64.68056    0.01204819 
+  75           89.43315     64.65931    0.01333333 
+  81           89.35402     64.6381     0.01234568 
+  96           89.25728     64.61691    0.01041667 
+  88           89.15343     64.59576    0.01136364 
+  92           89.05029     64.57463    0.01086957 
+  84           88.97252     64.55354    0.01190476 
+  96           88.97064     64.53248    0.01041667 
+  98           89.10939     64.51145    0.01020408 
+  88           89.41304     64.49045    0.01136364 
+  109          89.76646     64.46947    0.00917431 
+  83           89.80849     64.44853    0.01204819 
+  88           89.2146      64.42762    0.01136364 
+  77           88.25888     64.40674    0.01298701 
+  87           87.32854     64.38589    0.01149425 
+  84           86.58547     64.36507    0.01190476 
+  82           86.04209     64.34428    0.01219512 
+  95           85.66969     64.32352    0.01052632 
+  74           85.43997     64.30279    0.01351351 
+  91           85.29906     64.28209    0.01098901 
+  83           85.1004      64.26142    0.01204819 
+  85           84.635       64.24078    0.01176471 
+  98           83.93905     64.22017    0.01020408 
+  99           83.23617     64.19959    0.01010101 
+  86           82.66092     64.17904    0.01162791 
+  87           82.27432     64.15851    0.01149425 
+  79           82.12799     64.13802    0.01265823 
+  82           82.26916     64.11756    0.01219512 
+  75           82.66469     64.09713    0.01333333 
+  103          83.05531     64.07673    0.00970874 
+  81           82.89891     64.05635    0.01234568 
+  86           82.02586     64.03601    0.01162791 
+  85           80.95413     64.01569    0.01176471 
+  101          80.09269     63.99541    0.00990099 
+  62           79.58101     63.97515    0.01612903 
+  67           79.46508     63.95493    0.01492537 
+  80           79.81747     63.93473    0.0125    
+  75           80.71828     63.91456    0.01333333 
+  87           82.07169     63.89442    0.01149425 
+  106          83.32048     63.87431    0.00943396 
+  97           83.5025      63.85423    0.01030928 
+  86           82.52222     63.83418    0.01162791 
+  102          81.5292      63.81416    0.00980392 
+  76           81.42323     63.79417    0.01315789 
+  75           82.33877     63.7742     0.01333333 
+  92           83.62133     63.75427    0.01086957 
+  59           83.97071     63.73436    0.01694915 
+  86           83.03117     63.71448    0.01162791 
+  89           81.83673     63.69464    0.01123596 
+  74           80.91628     63.67482    0.01351351 
+  87           80.17027     63.65503    0.01149425 
+  77           79.85555     63.63526    0.01298701 
+  95           80.58735     63.61553    0.01052632 
+  97           83.00893     63.59582    0.01030928 
+  99           87.53432     63.57615    0.01010101 
+  97           93.6403      63.5565     0.01030928 
+  95           99.2354      63.53688    0.01052632 
+  84           100.67252    63.51729    0.01190476 
+  96           96.16834     63.49773    0.01041667 
+  106          89.40415     63.47819    0.00943396 
+  82           83.86432     63.45869    0.01219512 
+  103          80.59953     63.43921    0.00970874 
+  82           79.46726     63.41976    0.01219512 
+  85           80.09497     63.40034    0.01176471 
+  75           82.17784     63.38095    0.01333333 
+  93           85.12624     63.36158    0.01075269 
+  87           87.37614     63.34225    0.01149425 
+  72           86.87152     63.32294    0.01388889 
+  75           84.13788     63.30366    0.01333333 
+  86           81.28709     63.28441    0.01162791 
+  70           79.3567      63.26518    0.01428571 
+  91           78.4465      63.24599    0.01098901 
+  74           78.28783     63.22682    0.01351351 
+  79           78.6097      63.20768    0.01265823 
+  75           79.28558     63.18857    0.01333333 
+  89           80.34838     63.16948    0.01123596 
+  80           82.03974     63.15043    0.0125    
+  88           84.99606     63.1314     0.01136364 
+  94           90.47513     63.11239    0.0106383 
+  87           100.1675     63.09342    0.01149425 
+  96           115.03898    63.07447    0.01041667 
+  103          133.13039    63.05556    0.00970874 
+  104          146.92565    63.03666    0.00961538 
+  122          148.67864    63.0178     0.00819672 
+  137          144.42933    62.99897    0.00729927 
+  171          144.35787    62.98016    0.00584795 
+  205          151.73733    62.96138    0.00487805 
+  195          163.00143    62.94262    0.00512821 
+  181          170.03369    62.92389    0.00552486 
+  182          167.73457    62.90519    0.00549451 
+  165          159.94704    62.88652    0.00606061 
+  126          151.84543    62.86788    0.00793651 
+  130          142.46038    62.84926    0.00769231 
+  116          131.4242     62.83067    0.00862069 
+  140          123.23568    62.81211    0.00714286 
+  140          120.51185    62.79357    0.00714286 
+  131          122.24999    62.77506    0.00763359 
+  141          124.50402    62.75658    0.0070922 
+  139          122.56617    62.73812    0.00719424 
+  114          115.57916    62.71969    0.00877193 
+  117          106.96062    62.70129    0.00854701 
+  107          99.71954     62.68292    0.00934579 
+  77           94.66298     62.66457    0.01298701 
+  88           91.06496     62.64625    0.01136364 
+  73           87.77946     62.62795    0.01369863 
+  93           84.74938     62.60968    0.01075269 
+  77           82.4249      62.59144    0.01298701 
+  59           80.93985     62.57323    0.01694915 
+  80           80.19645     62.55504    0.0125    
+  75           79.9812      62.53688    0.01333333 
+  87           79.9868      62.51874    0.01149425 
+  85           79.94165     62.50063    0.01176471 
+  67           79.78593     62.48255    0.01492537 
+  78           79.31431     62.46449    0.01282051 
+  81           78.44005     62.44646    0.01234568 
+  79           77.52984     62.42846    0.01265823 
+  84           76.86841     62.41048    0.01190476 
+  78           76.52832     62.39253    0.01282051 
+  71           76.48167     62.37461    0.01408451 
+  64           76.66433     62.35671    0.015625  
+  86           76.99971     62.33884    0.01162791 
+  82           77.49409     62.32099    0.01219512 
+  95           78.13995     62.30317    0.01052632 
+  84           78.56149     62.28538    0.01190476 
+  76           78.24991     62.26761    0.01315789 
+  81           77.40117     62.24986    0.01234568 
+  74           76.50269     62.23215    0.01351351 
+  72           75.8242      62.21446    0.01388889 
+  67           75.45554     62.19679    0.01492537 
+  62           75.37896     62.17915    0.01612903 
+  91           75.55783     62.16154    0.01098901 
+  75           75.94004     62.14395    0.01333333 
+  68           76.38455     62.12639    0.01470588 
+  79           76.59534     62.10886    0.01265823 
+  80           76.41057     62.09134    0.0125    
+  77           76.03823     62.07386    0.01298701 
+  60           75.68913     62.0564     0.01666667 
+  57           75.46096     62.03897    0.01754386 
+  61           75.35942     62.02156    0.01639344 
+  67           75.34586     62.00418    0.01492537 
+  66           75.38202     61.98682    0.01515152 
+  78           75.44397     61.96949    0.01282051 
+  75           75.51982     61.95218    0.01333333 
+  54           75.60444     61.9349     0.01851852 
+  85           75.69581     61.91764    0.01176471 
+  77           75.79314     61.90041    0.01298701 
+  68           75.89633     61.8832     0.01470588 
+  86           76.00564     61.86602    0.01162791 
+  73           76.12162     61.84887    0.01369863 
+  72           76.24496     61.83174    0.01388889 
+  65           76.37656     61.81463    0.01538462 
+  77           76.5175      61.79755    0.01298701 
+  71           76.66914     61.78049    0.01408451 
+  80           76.83344     61.76346    0.0125    
+  74           77.0141      61.74646    0.01351351 
+  68           77.22038     61.72948    0.01470588 
+  89           77.47471     61.71252    0.01123596 
+  84           77.81964     61.69559    0.01190476 
+  63           78.30773     61.67868    0.01587302 
+  75           78.95621     61.6618     0.01333333 
+  90           79.66645     61.64494    0.01111111 
+  80           80.13865     61.62811    0.0125    
+  73           80.11171     61.6113     0.01369863 
+  88           79.80765     61.59452    0.01136364 
+  75           79.43203     61.57776    0.01333333 
+  89           79.32305     61.56102    0.01123596 
+  74           79.37137     61.54431    0.01351351 
+  71           79.54682     61.52763    0.01408451 
+  78           79.8292      61.51097    0.01282051 
+  64           80.19242     61.49433    0.015625  
+  68           80.56232     61.47772    0.01470588 
+  79           80.75178     61.46113    0.01265823 
+  79           80.692       61.44456    0.01265823 
+  96           80.48206     61.42802    0.01041667 
+  88           80.36624     61.41151    0.01136364 
+  80           80.32735     61.39502    0.0125    
+  87           80.35348     61.37855    0.01149425 
+  75           80.42012     61.36211    0.01333333 
+  83           80.51007     61.34569    0.01204819 
+  105          80.61647     61.32929    0.00952381 
+  85           80.7382      61.31292    0.01176471 
+  89           80.88084     61.29657    0.01123596 
+  79           81.03933     61.28025    0.01265823 
+  85           81.22043     61.26395    0.01176471 
+  104          81.42737     61.24767    0.00961538 
+  84           81.66335     61.23142    0.01190476 
+  74           81.93172     61.21519    0.01351351 
+  76           82.23593     61.19899    0.01315789 
+  72           82.57945     61.18281    0.01388889 
+  78           82.96595     61.16665    0.01282051 
+  84           83.39917     61.15052    0.01190476 
+  60           83.88348     61.13441    0.01666667 
+  86           84.4229      61.11832    0.01162791 
+  74           85.0225      61.10226    0.01351351 
+  81           85.68794     61.08622    0.01234568 
+  74           86.42543     61.0702     0.01351351 
+  87           87.24256     61.05421    0.01149425 
+  96           88.14837     61.03824    0.01041667 
+  82           89.15404     61.02229    0.01219512 
+  91           90.27414     61.00637    0.01098901 
+  87           91.52917     60.99047    0.01149425 
+  80           92.95274     60.97459    0.0125    
+  103          94.62348     60.95874    0.00970874 
+  105          96.71589     60.94291    0.00952381 
+  97           99.57785     60.9271     0.01030928 
+  107          103.70057    60.91132    0.00934579 
+  93           109.40485    60.89556    0.01075269 
+  118          116.20606    60.87982    0.00847458 
+  120          121.96076    60.86411    0.00833333 
+  138          123.80896    60.84842    0.00724638 
+  148          122.70099    60.83275    0.00675676 
+  128          121.75666    60.8171     0.0078125 
+  147          122.52678    60.80148    0.00680272 
+  136          125.2803     60.78588    0.00735294 
+  141          129.84855    60.7703     0.0070922 
+  148          136.10583    60.75474    0.00675676 
+  132          143.9824     60.73921    0.00757576 
+  159          153.17698    60.7237     0.00628931 
+  173          162.682      60.70822    0.00578035 
+  158          171.4333     60.69275    0.00632911 
+  175          180.48386    60.67731    0.00571429 
+  159          191.73209    60.66189    0.00628931 
+  165          206.36614    60.64649    0.00606061 
+  208          225.15272    60.63112    0.00480769 
+  208          248.95828    60.61577    0.00480769 
+  236          279.14103    60.60044    0.00423729 
+  303          318.03381    60.58513    0.00330033 
+  365          369.95091    60.56985    0.00273973 
+  428          443.36421    60.55458    0.00233645 
+  582          555.46217    60.53934    0.00171821 
+  803          738.37527    60.52413    0.00124533 
+  1077         1042.8984    60.50893    0.00092851 
+  1438         1530.56444   60.49376    0.00069541 
+  2089         2245.11443   60.4786     0.0004787 
+  2914         3153.71064   60.46347    0.00034317 
+  3801         4032.01635   60.44837    0.00026309 
+  4189         4396.3131    60.43328    0.00023872 
+  3742         3964.11064   60.41822    0.00026724 
+  2880         3104.31146   60.40318    0.00034722 
+  1942         2283.00882   60.38816    0.00051493 
+  1537         1703.11667   60.37316    0.00065062 
+  1232         1406.98848   60.35818    0.00081169 
+  1320         1376.0429    60.34323    0.00075758 
+  1444         1569.98617   60.3283     0.00069252 
+  1779         1921.05896   60.31339    0.00056211 
+  2254         2280.66302   60.2985     0.00044366 
+  2276         2387.07207   60.28363    0.00043937 
+  2019         2105.80455   60.26878    0.00049529 
+  1442         1626.94355   60.25396    0.00069348 
+  1050         1171.1808    60.23916    0.00095238 
+  744          824.2428     60.22438    0.00134409 
+  502          590.54071    60.20962    0.00199203 
+  433          444.09754    60.19488    0.00230947 
+  309          354.07347    60.18016    0.00323625 
+  268          296.6004     60.16547    0.00373134 
+  223          257.14768    60.15079    0.0044843 
+  204          228.07664    60.13614    0.00490196 
+  151          205.55853    60.12151    0.00662252 
+  170          187.58131    60.1069     0.00588235 
+  147          172.93135    60.09231    0.00680272 
+  124          160.80971    60.07774    0.00806452 
+  146          150.6525     60.0632     0.00684932 
+  117          142.04777    60.04867    0.00854701 
+  127          134.68787    60.03417    0.00787402 
+  142          128.33826    60.01969    0.00704225 
+  114          122.82033    60.00522    0.00877193 
+  102          117.99231    59.99078    0.00980392 
+  113          113.74289    59.97636    0.00884956 
+  118          109.98314    59.96196    0.00847458 
+  101          106.64082    59.94758    0.00990099 
+  120          103.65938    59.93323    0.00833333 
+  92           100.99091    59.91889    0.01086957 
+  76           98.59718     59.90457    0.01315789 
+  99           96.44748     59.89028    0.01010101 
+  95           94.51784     59.87601    0.01052632 
+  106          92.79079     59.86175    0.00943396 
+  86           91.25637     59.84752    0.01162791 
+  78           89.91862     59.83331    0.01282051 
+  79           88.81282     59.81911    0.01265823 
+  88           88.05674     59.80494    0.01136364 
+  98           87.93204     59.79079    0.01020408 
+  102          88.91089     59.77666    0.00980392 
+  82           91.43896     59.76255    0.01219512 
+  98           95.36424     59.74846    0.01020408 
+  88           99.04223     59.73439    0.01136364 
+  109          99.13618     59.72034    0.00917431 
+  90           94.81754     59.70632    0.01111111 
+  78           89.27088     59.69231    0.01282051 
+  93           84.81847     59.67832    0.01075269 
+  89           82.0485      59.66435    0.01123596 
+  83           80.76804     59.6504     0.01204819 
+  95           80.70519     59.63648    0.01052632 
+  75           81.74578     59.62257    0.01333333 
+  85           83.69492     59.60868    0.01176471 
+  86           85.764       59.59482    0.01162791 
+  79           86.31587     59.58097    0.01265823 
+  93           84.77168     59.56714    0.01075269 
+  90           82.75138     59.55333    0.01111111 
+  89           81.76736     59.53955    0.01123596 
+  103          82.85971     59.52578    0.00970874 
+  77           87.42104     59.51203    0.01298701 
+  109          97.53411     59.4983     0.00917431 
+  112          114.84268    59.4846     0.00892857 
+  114          137.61243    59.47091    0.00877193 
+  112          156.37701    59.45724    0.00892857 
+  95           155.78897    59.44359    0.01052632 
+  97           136.44199    59.42996    0.01030928 
+  93           113.65364    59.41635    0.01075269 
+  112          96.57835     59.40276    0.00892857 
+  111          87.02806     59.38919    0.00900901 
+  93           83.83875     59.37564    0.01075269 
+  100          85.83049     59.36211    0.01      
+  81           92.51638     59.3486     0.01234568 
+  95           102.72817    59.33511    0.01052632 
+  88           112.13171    59.32163    0.01136364 
+  101          112.86916    59.30818    0.00990099 
+  83           103.52937    59.29474    0.01204819 
+  86           91.48019     59.28133    0.01162791 
+  81           81.86401     59.26793    0.01234568 
+  77           75.80518     59.25456    0.01298701 
+  76           72.48875     59.2412     0.01315789 
+  77           70.725       59.22786    0.01298701 
+  69           69.69015     59.21454    0.01449275 
+  61           68.98382     59.20124    0.01639344 
+  74           68.44525     59.18796    0.01351351 
+  76           68.00952     59.1747     0.01315789 
+  69           67.64545     59.16145    0.01449275 
+  63           67.33418     59.14823    0.01587302 
+  71           67.0634      59.13502    0.01408451 
+  70           66.82405     59.12184    0.01428571 
+  69           66.61003     59.10867    0.01449275 
+  65           66.41683     59.09552    0.01538462 
+  71           66.241       59.08239    0.01408451 
+  71           66.07995     59.06928    0.01408451 
+  75           65.93156     59.05619    0.01333333 
+  72           65.79428     59.04311    0.01388889 
+  71           65.66682     59.03006    0.01408451 
+  65           65.54815     59.01702    0.01538462 
+  70           65.43745     59.004      0.01428571 
+  69           65.33402     58.99101    0.01449275 
+  62           65.23731     58.97802    0.01612903 
+  66           65.14682     58.96506    0.01515152 
+  67           65.06216     58.95212    0.01492537 
+  64           64.98299     58.93919    0.015625  
+  73           64.90906     58.92629    0.01369863 
+  69           64.84008     58.9134     0.01449275 
+  90           64.77585     58.90053    0.01111111 
+  59           64.71619     58.88768    0.01694915 
+  70           64.66092     58.87484    0.01428571 
+  59           64.60988     58.86203    0.01694915 
+  74           64.56294     58.84923    0.01351351 
+  86           64.51994     58.83645    0.01162791 
+  61           64.48074     58.82369    0.01639344 
+  60           64.44519     58.81095    0.01666667 
+  58           64.41339     58.79822    0.01724138 
+  67           64.38474     58.78551    0.01492537 
+  53           64.35933     58.77283    0.01886792 
+  64           64.33709     58.76016    0.015625  
+  56           64.31798     58.7475     0.01785714 
+  77           64.30213     58.73487    0.01298701 
+  71           64.29012     58.72225    0.01408451 
+  76           64.28382     58.70965    0.01315789 
+  67           64.28812     58.69707    0.01492537 
+  72           64.3139      58.68451    0.01388889 
+  67           64.37616     58.67196    0.01492537 
+  79           64.48457     58.65943    0.01265823 
+  67           64.62279     58.64692    0.01492537 
+  58           64.72224     58.63443    0.01724138 
+  62           64.69248     58.62195    0.01612903 
+  61           64.56665     58.6095     0.01639344 
+  65           64.44807     58.59706    0.01538462 
+  53           64.38539     58.58463    0.01886792 
+  69           64.37413     58.57223    0.01449275 
+  54           64.37672     58.55984    0.01851852 
+  79           64.36632     58.54747    0.01265823 
+  67           64.365       58.53512    0.01492537 
+  72           64.39392     58.52278    0.01388889 
+  74           64.43582     58.51046    0.01351351 
+  61           64.44028     58.49816    0.01639344 
+  61           64.39484     58.48588    0.01639344 
+  54           64.34603     58.47361    0.01851852 
+  69           64.32647     58.46137    0.01449275 
+  62           64.33987     58.44913    0.01612903 
+  55           64.3699      58.43692    0.01818182 
+  59           64.39539     58.42472    0.01694915 
+  52           64.41706     58.41254    0.01923077 
+  69           64.44991     58.40038    0.01449275 
+  66           64.50251     58.38823    0.01515152 
+  71           64.57835     58.3761     0.01408451 
+  73           64.68018     58.36399    0.01369863 
+  55           64.81353     58.35189    0.01818182 
+  63           64.9899      58.33981    0.01587302 
+  89           65.23336     58.32775    0.01123596 
+  89           65.6024      58.31571    0.01123596 
+  83           66.2499      58.30368    0.01204819 
+  84           67.53071     58.29167    0.01190476 
+  82           70.06535     58.27967    0.01219512 
+  90           74.51584     58.26769    0.01111111 
+  100          80.89167     58.25573    0.01      
+  115          87.38816     58.24379    0.00869565 
+  99           89.64655     58.23186    0.01010101 
+  137          85.45862     58.21995    0.00729927 
+  143          78.72561     58.20805    0.00699301 
+  135          73.06804     58.19617    0.00740741 
+  126          69.5619      58.18431    0.00793651 
+  91           67.99872     58.17247    0.01098901 
+  93           67.93725     58.16064    0.01075269 
+  93           69.19539     58.14882    0.01075269 
+  86           71.69524     58.13703    0.01162791 
+  109          74.88234     58.12525    0.00917431 
+  97           77.00769     58.11348    0.01030928 
+  101          76.02751     58.10174    0.00990099 
+  108          72.86979     58.09       0.00925926 
+  105          69.75811     58.07829    0.00952381 
+  90           67.62165     58.06659    0.01111111 
+  88           66.36275     58.05491    0.01136364 
+  91           65.56877     58.04324    0.01098901 
+  66           65.02448     58.03159    0.01515152 
+  63           64.66827     58.01995    0.01587302 
+  78           64.4825      58.00833    0.01282051 
+  72           64.47708     57.99673    0.01388889 
+  69           64.72121     57.98514    0.01449275 
+  62           65.38613     57.97357    0.01612903 
+  76           66.70498     57.96202    0.01315789 
+  79           68.76786     57.95048    0.01265823 
+  71           71.15511     57.93895    0.01408451 
+  67           72.53977     57.92745    0.01492537 
+  86           71.63627     57.91595    0.01162791 
+  76           69.33079     57.90448    0.01315789 
+  73           67.14197     57.89302    0.01369863 
+  76           65.68184     57.88157    0.01315789 
+  86           64.96168     57.87014    0.01162791 
+  78           64.81436     57.85873    0.01282051 
+  67           65.1365      57.84733    0.01492537 
+  62           65.90863     57.83595    0.01612903 
+  77           67.03614     57.82458    0.01298701 
+  81           68.10033     57.81323    0.01234568 
+  78           68.31509     57.80189    0.01282051 
+  69           67.53213     57.79057    0.01449275 
+  74           66.50838     57.77927    0.01351351 
+  81           65.76963     57.76797    0.01234568 
+  77           65.44461     57.7567     0.01298701 
+  92           65.49292     57.74544    0.01086957 
+  76           65.86872     57.7342     0.01315789 
+  81           66.57805     57.72297    0.01234568 
+  90           67.63041     57.71175    0.01111111 
+  71           68.92364     57.70055    0.01408451 
+  88           70.23056     57.68937    0.01136364 
+  75           71.72683     57.6782     0.01333333 
+  94           74.55646     57.66705    0.0106383 
+  71           80.0101      57.65591    0.01408451 
+  102          88.45674     57.64478    0.00980392 
+  105          98.01427     57.63368    0.00952381 
+  93           104.21267    57.62258    0.01075269 
+  88           102.99284    57.6115     0.01136364 
+  82           95.37423     57.60044    0.01219512 
+  99           86.92377     57.58939    0.01010101 
+  91           80.76177     57.57835    0.01098901 
+  107          77.23062     57.56734    0.00934579 
+  92           76.07576     57.55633    0.01086957 
+  102          77.2214      57.54534    0.00980392 
+  100          80.70895     57.53436    0.01      
+  98           86.26638     57.5234     0.01020408 
+  95           92.62896     57.51246    0.01052632 
+  109          97.88403     57.50153    0.00917431 
+  105          100.95705    57.49061    0.00952381 
+  106          102.70656    57.47971    0.00943396 
+  95           102.74495    57.46882    0.01052632 
+  119          100.13218    57.45794    0.00840336 
+  100          97.47492     57.44709    0.01      
+  126          96.34714     57.43624    0.00793651 
+  94           95.15513     57.42541    0.0106383 
+  119          92.91876     57.41459    0.00840336 
+  89           91.37519     57.40379    0.01123596 
+  112          92.10008     57.393      0.00892857 
+  134          95.8021      57.38223    0.00746269 
+  129          102.70574    57.37147    0.00775194 
+  130          112.57741    57.36073    0.00769231 
+  150          124.86022    57.35       0.00666667 
+  177          140.43604    57.33928    0.00564972 
+  159          160.36861    57.32858    0.00628931 
+  186          182.98617    57.31789    0.00537634 
+  216          209.3409     57.30722    0.00462963 
+  227          245.09313    57.29656    0.00440529 
+  257          291.2901     57.28591    0.00389105 
+  309          337.1531     57.27528    0.00323625 
+  279          359.33417    57.26466    0.00358423 
+  246          341.96376    57.25405    0.00406504 
+  214          298.20545    57.24346    0.0046729 
+  180          251.94046    57.23289    0.00555556 
+  171          216.22043    57.22232    0.00584795 
+  169          193.61893    57.21177    0.00591716 
+  147          182.47339    57.20124    0.00680272 
+  181          182.47447    57.19072    0.00552486 
+  204          193.42042    57.18021    0.00490196 
+  174          211.56445    57.16971    0.00574713 
+  175          227.15225    57.15923    0.00571429 
+  206          226.97319    57.14876    0.00485437 
+  181          207.6223     57.13831    0.00552486 
+  155          179.19543    57.12787    0.00645161 
+  147          152.01626    57.11744    0.00680272 
+  131          130.3497     57.10703    0.00763359 
+  99           114.69341    57.09663    0.01010101 
+  133          104.11833    57.08624    0.0075188 
+  131          97.34164     57.07587    0.00763359 
+  95           93.1762      57.06551    0.01052632 
+  108          90.66553     57.05516    0.00925926 
+  109          89.09405     57.04483    0.00917431 
+  99           88.19388     57.03451    0.01010101 
+  115          88.12603     57.0242     0.00869565 
+  135          89.2009      57.01391    0.00740741 
+  114          91.96003     57.00363    0.00877193 
+  154          97.4176      56.99336    0.00649351 
+  130          107.18167    56.9831     0.00769231 
+  150          123.15997    56.97286    0.00666667 
+  162          146.57959    56.96264    0.00617284 
+  186          176.07083    56.95242    0.00537634 
+  219          204.40457    56.94222    0.00456621 
+  235          216.77746    56.93203    0.00425532 
+  203          204.71334    56.92185    0.00492611 
+  191          180.06548    56.91169    0.0052356 
+  175          158.34016    56.90154    0.00571429 
+  177          148.16746    56.8914     0.00564972 
+  169          155.88568    56.88127    0.00591716 
+  202          189.3069     56.87116    0.0049505 
+  205          255.23823    56.86106    0.00487805 
+  197          349.68003    56.85097    0.00507614 
+  240          441.32418    56.8409     0.00416667 
+  259          466.74716    56.83084    0.003861  
+  231          404.63206    56.82079    0.004329  
+  236          308.45643    56.81075    0.00423729 
+  203          224.74426    56.80073    0.00492611 
+  198          169.26816    56.79072    0.00505051 
+  155          140.193      56.78072    0.00645161 
+  161          131.8719     56.77073    0.00621118 
+  161          141.75355    56.76076    0.00621118 
+  154          169.08409    56.7508     0.00649351 
+  162          208.19735    56.74085    0.00617284 
+  132          239.46222    56.73091    0.00757576 
+  156          233.80992    56.72098    0.00641026 
+  122          194.66751    56.71107    0.00819672 
+  117          150.76704    56.70117    0.00854701 
+  138          117.47974    56.69128    0.00724638 
+  125          96.96016     56.68141    0.008     
+  114          85.74104     56.67154    0.00877193 
+  107          79.67144     56.66169    0.00934579 
+  93           76.07204     56.65185    0.01075269 
+  108          73.69158     56.64202    0.00925926 
+  99           72.03677     56.63221    0.01010101 
+  101          70.91656     56.62241    0.00990099 
+  83           70.23205     56.61261    0.01204819 
+  91           69.8555      56.60284    0.01098901 
+  86           69.52677     56.59307    0.01162791 
+  87           68.9233      56.58331    0.01149425 
+  88           68.09576     56.57357    0.01136364 
+  87           67.33026     56.56384    0.01149425 
+  85           66.76641     56.55412    0.01176471 
+  100          66.41283     56.54441    0.01      
+  84           66.22661     56.53471    0.01190476 
+  69           66.1677      56.52503    0.01449275 
+  91           66.23177     56.51535    0.01098901 
+  91           66.43225     56.50569    0.01098901 
+  86           66.74352     56.49604    0.01162791 
+  95           67.05544     56.4864     0.01052632 
+  68           67.24888     56.47678    0.01470588 
+  79           67.41292     56.46716    0.01265823 
+  69           67.71903     56.45756    0.01449275 
+  75           68.26764     56.44796    0.01333333 
+  93           69.11745     56.43838    0.01075269 
+  84           70.33557     56.42881    0.01190476 
+  88           72.05919     56.41926    0.01136364 
+  89           74.63071     56.40971    0.01123596 
+  93           78.9478      56.40017    0.01075269 
+  107          87.21939     56.39065    0.00934579 
+  122          103.83224    56.38114    0.00819672 
+  113          134.74005    56.37163    0.00884956 
+  158          183.29302    56.36214    0.00632911 
+  158          242.03715    56.35266    0.00632911 
+  185          282.18167    56.3432     0.00540541 
+  153          268.24997    56.33374    0.00653595 
+  173          214.68814    56.32429    0.00578035 
+  129          159.92009    56.31486    0.00775194 
+  132          121.46079    56.30543    0.00757576 
+  95           100.68019    56.29602    0.01052632 
+  94           93.32343     56.28662    0.0106383 
+  83           96.21458     56.27723    0.01204819 
+  113          109.07743    56.26785    0.00884956 
+  129          131.86785    56.25848    0.00775194 
+  121          159.57561    56.24912    0.00826446 
+  136          176.55748    56.23977    0.00735294 
+  110          166.08265    56.23044    0.00909091 
+  142          137.62187    56.22111    0.00704225 
+  94           109.79868    56.21179    0.0106383 
+  81           90.2931      56.20249    0.01234568 
+  87           79.07728     56.1932     0.01149425 
+  83           73.3185      56.18391    0.01204819 
+  72           70.34939     56.17464    0.01388889 
+  63           68.6322      56.16538    0.01587302 
+  71           67.49667     56.15613    0.01408451 
+  60           66.6813      56.14689    0.01666667 
+  63           66.07321     56.13766    0.01587302 
+  61           65.61251     56.12844    0.01639344 
+  55           65.26078     56.11923    0.01818182 
+  73           64.99213     56.11003    0.01369863 
+  57           64.78826     56.10084    0.01754386 
+  64           64.63626     56.09166    0.015625  
+  76           64.52549     56.08249    0.01315789 
+  57           64.44873     56.07333    0.01754386 
+  64           64.40003     56.06419    0.015625  
+  61           64.37464     56.05505    0.01639344 
+  61           64.36862     56.04592    0.01639344 
+  75           64.37881     56.0368     0.01333333 
+  62           64.40257     56.0277     0.01612903 
+  58           64.43847     56.0186     0.01724138 
+  55           64.48719     56.00951    0.01818182 
+  79           64.55525     56.00044    0.01265823 
+  74           64.66095     55.99137    0.01351351 
+  82           64.83736     55.98232    0.01219512 
+  65           65.11851     55.97327    0.01538462 
+  73           65.49943     55.96423    0.01369863 
+  68           65.87108     55.95521    0.01470588 
+  86           65.98534     55.94619    0.01162791 
+  74           65.73532     55.93718    0.01351351 
+  59           65.34704     55.92819    0.01694915 
+  87           65.01544     55.9192     0.01149425 
+  66           64.79475     55.91022    0.01515152 
+  80           64.66951     55.90125    0.0125    
+  76           64.61317     55.89229    0.01315789 
+  64           64.61656     55.88335    0.015625  
+  73           64.68943     55.87441    0.01369863 
+  85           64.84021     55.86548    0.01176471 
+  76           65.04787     55.85656    0.01315789 
+  82           65.50696     55.84765    0.01219512 
+  78           65.67259     55.83875    0.01282051 
+  85           65.90336     55.82986    0.01176471 
+  74           66.12729     55.82098    0.01351351 
+  59           66.03416     55.81211    0.01694915 
+  77           65.55324     55.80324    0.01298701 
+  76           64.9925      55.79439    0.01315789 
+  72           64.53327     55.78555    0.01388889 
+  72           64.1763      55.77671    0.01388889 
+  80           63.90869     55.76789    0.0125    
+  70           63.74131     55.75907    0.01428571 
+  73           63.68471     55.75026    0.01369863 
+  105          63.74712     55.74147    0.00952381 
+  88           64.04457     55.73268    0.01136364 
+  83           64.22325     55.7239     0.01204819 
+  107          64.24492     55.71513    0.00934579 
+  120          64.05731     55.70637    0.00833333 
+  107          63.82005     55.69762    0.00934579 
+  121          63.64499     55.68888    0.00826446 
+  110          63.54978     55.68014    0.00909091 
+  105          63.55256     55.67142    0.00952381 
+  109          63.72071     55.6627     0.00917431 
+  93           64.17958     55.654      0.01075269 
+  107          65.08984     55.6453     0.00934579 
+  137          66.51844     55.63661    0.00729927 
+  134          68.19712     55.62793    0.00746269 
+  116          69.23519     55.61926    0.00862069 
+  91           68.72834     55.6106     0.01098901 
+  99           67.26547     55.60194    0.01010101 
+  106          65.89562     55.5933     0.00943396 
+  123          65.05354     55.58466    0.00813008 
+  113          64.7693      55.57603    0.00884956 
+  102          64.97478     55.56742    0.00980392 
+  97           65.73595     55.55881    0.01030928 
+  115          67.39793     55.5502     0.00869565 
+  104          70.57438     55.54161    0.00961538 
+  125          75.81094     55.53303    0.008     
+  119          82.76343     55.52445    0.00840336 
+  103          89.2861      55.51588    0.00970874 
+  109          91.63783     55.50732    0.00917431 
+  100          87.57609     55.49877    0.01      
+  94           80.31144     55.49023    0.0106383 
+  80           73.89237     55.4817     0.0125    
+  77           69.72844     55.47317    0.01298701 
+  73           67.64892     55.46466    0.01369863 
+  81           67.08246     55.45615    0.01234568 
+  78           67.72109     55.44765    0.01282051 
+  88           69.61625     55.43915    0.01136364 
+  93           72.80394     55.43067    0.01075269 
+  92           76.63975     55.4222     0.01086957 
+  78           79.23238     55.41373    0.01282051 
+  80           78.55866     55.40527    0.0125    
+  78           75.36273     55.39682    0.01282051 
+  65           72.02373     55.38837    0.01538462 
+  74           69.73836     55.37994    0.01351351 
+  57           68.37948     55.37151    0.01754386 
+  79           67.38779     55.36309    0.01265823 
+  76           66.61436     55.35468    0.01315789 
+  58           66.12944     55.34628    0.01724138 
+  72           65.95419     55.33788    0.01388889 
+  63           66.05528     55.32949    0.01587302 
+  63           66.34586     55.32111    0.01587302 
+  77           66.66504     55.31274    0.01298701 
+  54           66.83692     55.30438    0.01851852 
+  61           66.91563     55.29602    0.01639344 
+  77           67.05068     55.28767    0.01298701 
+  58           67.2135      55.27933    0.01724138 
+  65           67.27207     55.271      0.01538462 
+  58           67.27415     55.26267    0.01724138 
+  82           67.38623     55.25435    0.01219512 
+  63           67.75689     55.24604    0.01587302 
+  78           68.58056     55.23774    0.01282051 
+  69           70.12785     55.22944    0.01449275 
+  71           72.59905     55.22115    0.01408451 
+  69           75.76057     55.21287    0.01449275 
+  67           78.3926      55.2046     0.01492537 
+  90           78.54014     55.19634    0.01111111 
+  75           76.32344     55.18808    0.01333333 
+  70           73.72477     55.17983    0.01428571 
+  74           71.86635     55.17158    0.01351351 
+  80           70.93227     55.16335    0.0125    
+  77           70.71919     55.15512    0.01298701 
+  74           71.01557     55.1469     0.01351351 
+  55           71.76536     55.13868    0.01818182 
+  69           73.01827     55.13047    0.01449275 
+  51           74.72457     55.12227    0.01960784 
+  74           76.43888     55.11408    0.01351351 
+  62           77.19047     55.1059     0.01612903 
+  74           76.6027      55.09772    0.01351351 
+  81           75.5681      55.08955    0.01234568 
+  67           74.82065     55.08138    0.01492537 
+  66           74.5518      55.07322    0.01515152 
+  56           74.6801      55.06507    0.01785714 
+  53           75.05563     55.05693    0.01886792 
+  57           75.56731     55.04879    0.01754386 
+  69           76.16169     55.04066    0.01449275 
+  77           76.82433     55.03254    0.01298701 
+  83           77.55757     55.02442    0.01204819 
+  78           78.37492     55.01631    0.01282051 
+  74           79.31354     55.00821    0.01351351 
+  66           80.46815     55.00012    0.01515152 
+  83           82.03606     54.99203    0.01204819 
+  69           84.30646     54.98394    0.01449275 
+  75           87.4901      54.97587    0.01333333 
+  69           91.35165     54.9678     0.01449275 
+  60           94.67985     54.95974    0.01666667 
+  68           95.60131     54.95168    0.01470588 
+  71           94.33875     54.94363    0.01408451 
+  59           92.81557     54.93559    0.01694915 
+  66           92.08283     54.92755    0.01515152 
+  71           92.30035     54.91952    0.01408451 
+  80           93.2668      54.9115     0.0125    
+  83           94.78613     54.90348    0.01204819 
+  75           96.81402     54.89547    0.01333333 
+  72           99.4079      54.88747    0.01388889 
+  82           102.53142    54.87947    0.01219512 
+  88           105.78386    54.87148    0.01136364 
+  62           108.24064    54.8635     0.01612903 
+  71           109.46966    54.85552    0.01408451 
+  79           110.30358    54.84755    0.01265823 
+  66           111.48681    54.83958    0.01515152 
+  84           113.22775    54.83162    0.01190476 
+  100          115.45823    54.82367    0.01      
+  94           118.03604    54.81572    0.0106383 
+  92           120.85896    54.80778    0.01086957 
+  111          123.89334    54.79984    0.00900901 
+  102          127.18065    54.79191    0.00980392 
+  105          130.86512    54.78399    0.00952381 
+  114          135.2275     54.77607    0.00877193 
+  113          140.62913    54.76816    0.00884956 
+  123          147.30017    54.76025    0.00813008 
+  149          154.88557    54.75235    0.00671141 
+  136          161.99643    54.74446    0.00735294 
+  162          167.69684    54.73657    0.00617284 
+  145          172.18668    54.72869    0.00689655 
+  154          174.46911    54.72082    0.00649351 
+  184          175.19873    54.71295    0.00543478 
+  197          176.83039    54.70508    0.00507614 
+  199          179.60629    54.69722    0.00502513 
+  197          182.2527     54.68937    0.00507614 
+  235          184.77231    54.68152    0.00425532 
+  243          187.37286    54.67368    0.00411523 
+  182          190.3233     54.66584    0.00549451 
+  199          192.42213    54.65801    0.00502513 
+  192          191.10264    54.65019    0.00520833 
+  199          187.49205    54.64237    0.00502513 
+  186          183.57485    54.63455    0.00537634 
+  194          180.06491    54.62675    0.00515464 
+  181          177.88551    54.61894    0.00552486 
+  219          177.27235    54.61115    0.00456621 
+  177          176.92       54.60335    0.00564972 
+  184          175.53554    54.59557    0.00543478 
+  190          173.14063    54.58779    0.00526316 
+  157          170.38935    54.58001    0.00636943 
+  161          167.68648    54.57224    0.00621118 
+  154          164.21173    54.56447    0.00649351 
+  134          159.54809    54.55671    0.00746269 
+  139          154.82258    54.54896    0.00719424 
+  129          150.73849    54.54121    0.00775194 
+  144          147.43254    54.53347    0.00694444 
+  152          144.73599    54.52573    0.00657895 
+  110          142.33099    54.51799    0.00909091 
+  123          139.78424    54.51026    0.00813008 
+  103          136.82028    54.50254    0.00970874 
+  101          133.65435    54.49482    0.00990099 
+  78           130.56553    54.48711    0.01282051 
+  103          127.65264    54.4794     0.00970874 
+  96           124.90624    54.47169    0.01041667 
+  103          122.2836     54.46399    0.00970874 
+  100          119.75024    54.4563     0.01      
+  81           117.29025    54.44861    0.01234568 
+  87           114.90057    54.44093    0.01149425 
+  93           112.58313    54.43325    0.01075269 
+  75           110.34142    54.42557    0.01333333 
+  83           108.17873    54.4179     0.01204819 
+  72           106.09836    54.41024    0.01388889 
+  66           104.1029     54.40258    0.01515152 
+  76           102.19362    54.39492    0.01315789 
+  95           100.37193    54.38727    0.01052632 
+  93           98.63792     54.37962    0.01075269 
+  62           96.99137     54.37198    0.01612903 
+  72           95.43187     54.36434    0.01388889 
+  79           93.95912     54.35671    0.01265823 
+  71           92.57373     54.34908    0.01408451 
+  64           91.27562     54.34146    0.015625  
+  68           90.06247     54.33384    0.01470588 
+  76           88.92558     54.32623    0.01315789 
+  75           87.84828     54.31862    0.01333333 
+  64           86.82255     54.31101    0.015625  
+  77           85.86002     54.30341    0.01298701 
+  78           84.97142     54.29581    0.01282051 
+  61           84.15974     54.28822    0.01639344 
+  69           83.42562     54.28063    0.01449275 
+  67           82.77279     54.27305    0.01492537 
+  68           82.21534     54.26547    0.01470588 
+  81           81.78733     54.25789    0.01234568 
+  63           81.5463      54.25032    0.01587302 
+  69           81.55596     54.24275    0.01449275 
+  74           81.84139     54.23519    0.01351351 
+  61           82.34091     54.22763    0.01639344 
+  66           82.9609      54.22008    0.01515152 
+  65           84.072       54.21253    0.01538462 
+  65           86.67328     54.20498    0.01538462 
+  68           91.41816     54.19744    0.01470588 
+  68           97.55833     54.1899     0.01470588 
+  75           101.81597    54.18237    0.01333333 
+  71           100.03271    54.17484    0.01408451 
+  69           93.69603     54.16731    0.01449275 
+  87           87.22285     54.15979    0.01149425 
+  67           82.67644     54.15227    0.01492537 
+  83           80.1955      54.14475    0.01204819 
+  78           79.12523     54.13724    0.01282051 
+  78           78.82602     54.12974    0.01282051 
+  60           79.23059     54.12223    0.01666667 
+  73           80.67345     54.11473    0.01369863 
+  65           83.23877     54.10724    0.01538462 
+  67           86.16729     54.09974    0.01492537 
+  76           87.39489     54.09226    0.01315789 
+  68           85.4626      54.08477    0.01470588 
+  86           82.01195     54.07729    0.01162791 
+  86           78.95228     54.06981    0.01162791 
+  88           76.91482     54.06234    0.01136364 
+  79           75.7951      54.05487    0.01265823 
+  69           75.26013     54.0474     0.01449275 
+  85           75.03951     54.03994    0.01176471 
+  72           74.99457     54.03248    0.01388889 
+  73           75.0801      54.02502    0.01369863 
+  94           75.29976     54.01757    0.0106383 
+  80           75.69079     54.01012    0.0125    
+  101          76.34398     54.00267    0.00990099 
+  81           77.49365     53.99523    0.01234568 
+  85           79.7322      53.98779    0.01176471 
+  91           84.31016     53.98035    0.01098901 
+  105          93.11849     53.97292    0.00952381 
+  122          107.66091    53.96549    0.00819672 
+  118          126.73775    53.95806    0.00847458 
+  105          142.99476    53.95064    0.00952381 
+  101          143.97429    53.94322    0.00990099 
+  105          129.99367    53.9358     0.00952381 
+  101          114.61471    53.92839    0.00990099 
+  114          106.70506    53.92098    0.00877193 
+  101          108.46111    53.91357    0.00990099 
+  107          117.21265    53.90616    0.00934579 
+  110          125.55217    53.89876    0.00909091 
+  101          124.81769    53.89136    0.00990099 
+  100          117.47188    53.88397    0.01      
+  83           112.35249    53.87658    0.01204819 
+  103          112.40805    53.86919    0.00970874 
+  130          113.41751    53.8618     0.00769231 
+  99           108.53364    53.85442    0.01010101 
+  102          98.98458     53.84703    0.00980392 
+  116          90.76563     53.83966    0.00862069 
+  77           87.05444     53.83228    0.01298701 
+  92           88.1632      53.82491    0.01086957 
+  104          92.10973     53.81754    0.00961538 
+  76           94.48717     53.81017    0.01315789 
+  79           91.25903     53.80281    0.01265823 
+  75           84.50985     53.79544    0.01333333 
+  70           78.17124     53.78809    0.01428571 
+  72           73.80599     53.78073    0.01388889 
+  65           71.34382     53.77337    0.01538462 
+  79           70.11445     53.76602    0.01265823 
+  71           69.29062     53.75867    0.01408451 
+  73           68.53883     53.75133    0.01369863 
+  86           67.87851     53.74398    0.01162791 
+  86           67.36877     53.73664    0.01162791 
+  74           67.01048     53.7293     0.01351351 
+  72           66.77406     53.72197    0.01388889 
+  58           66.6297      53.71463    0.01724138 
+  84           66.56298     53.7073     0.01190476 
+  82           66.5762      53.69997    0.01219512 
+  64           66.67663     53.69265    0.015625  
+  85           66.85642     53.68532    0.01176471 
+  72           67.06943     53.678      0.01388889 
+  77           67.26077     53.67068    0.01298701 
+  70           67.42231     53.66336    0.01428571 
+  97           67.71729     53.65605    0.01030928 
+  79           68.28342     53.64873    0.01265823 
+  76           69.21209     53.64142    0.01315789 
+  89           70.48929     53.63411    0.01123596 
+  95           71.88485     53.62681    0.01052632 
+  79           72.97197     53.6195     0.01265823 
+  102          73.81915     53.6122     0.00980392 
+  105          75.14913     53.6049     0.00952381 
+  96           77.58681     53.5976     0.01041667 
+  104          81.49171     53.59031    0.00961538 
+  106          86.99291     53.58301    0.00943396 
+  120          94.36596     53.57572    0.00833333 
+  144          104.56826    53.56843    0.00694444 
+  171          118.23826    53.56114    0.00584795 
+  183          134.24719    53.55385    0.00546448 
+  244          148.09257    53.54657    0.00409836 
+  260          152.50747    53.53928    0.00384615 
+  237          144.57414    53.532      0.00421941 
+  214          129.78068    53.52472    0.0046729 
+  189          115.00017    53.51745    0.00529101 
+  134          103.57016    53.51017    0.00746269 
+  117          96.24216     53.5029     0.00854701 
+  138          92.66957     53.49562    0.00724638 
+  108          92.34545     53.48835    0.00925926 
+  117          95.14835     53.48108    0.00854701 
+  127          100.90037    53.47382    0.00787402 
+  113          108.57199    53.46655    0.00884956 
+  164          115.37002    53.45929    0.00609756 
+  172          117.35039    53.45202    0.00581395 
+  130          113.86449    53.44476    0.00769231 
+  148          108.83796    53.4375     0.00675676 
+  116          106.17726    53.43024    0.00862069 
+  105          106.7029     53.42299    0.00952381 
+  103          107.16945    53.41573    0.00970874 
+  84           102.43189    53.40848    0.01190476 
+  91           93.34538     53.40123    0.01098901 
+  87           84.65013     53.39397    0.01149425 
+  96           78.6194      53.38672    0.01041667 
+  96           75.31697     53.37948    0.01041667 
+  76           73.85866     53.37223    0.01315789 
+  77           73.32549     53.36498    0.01298701 
+  64           73.49069     53.35774    0.015625  
+  86           74.66495     53.3505     0.01162791 
+  65           77.13922     53.34325    0.01538462 
+  86           80.58128     53.33601    0.01162791 
+  79           83.21087     53.32877    0.01265823 
+  83           82.58661     53.32153    0.01204819 
+  95           79.376       53.3143     0.01052632 
+  93           76.13195     53.30706    0.01075269 
+  78           74.1533      53.29982    0.01282051 
+  85           73.67905     53.29259    0.01176471 
+  58           74.57861     53.28536    0.01724138 
+  84           76.77799     53.27812    0.01190476 
+  63           80.38637     53.27089    0.01587302 
+  72           85.57329     53.26366    0.01388889 
+  76           92.2738      53.25643    0.01315789 
+  71           99.63081     53.2492     0.01408451 
+  68           105.258      53.24198    0.01470588 
+  79           106.03539    53.23475    0.01265823 
+  78           101.58802    53.22752    0.01282051 
+  73           94.83229     53.2203     0.01369863 
+  85           88.48989     53.21308    0.01176471 
+  79           83.70228     53.20585    0.01265823 
+  76           80.69892     53.19863    0.01315789 
+  79           79.38386     53.19141    0.01265823 
+  90           79.59036     53.18419    0.01111111 
+  89           81.15389     53.17697    0.01123596 
+  66           83.84974     53.16975    0.01515152 
+  79           87.14629     53.16253    0.01265823 
+  69           89.81756     53.15531    0.01449275 
+  80           90.23462     53.14809    0.0125    
+  85           88.07138     53.14087    0.01176471 
+  73           84.72877     53.13366    0.01369863 
+  83           81.63324     53.12644    0.01204819 
+  67           79.49053     53.11922    0.01492537 
+  72           78.58003     53.11201    0.01388889 
+  87           78.96966     53.10479    0.01149425 
+  79           80.41786     53.09758    0.01265823 
+  85           82.05627     53.09036    0.01176471 
+  75           82.34381     53.08315    0.01333333 
+  77           80.86331     53.07594    0.01298701 
+  83           78.94276     53.06872    0.01204819 
+  78           77.55987     53.06151    0.01282051 
+  76           76.95354     53.0543     0.01315789 
+  82           77.00184     53.04709    0.01219512 
+  85           77.48335     53.03988    0.01176471 
+  84           78.19232     53.03266    0.01190476 
+  84           79.00954     53.02545    0.01190476 
+  68           80.04824     53.01824    0.01470588 
+  76           81.43225     53.01103    0.01315789 
+  78           82.91954     53.00382    0.01282051 
+  92           83.81455     52.99661    0.01086957 
+  82           83.79769     52.9894     0.01219512 
+  77           83.48929     52.98219    0.01298701 
+  67           83.43506     52.97498    0.01492537 
+  83           83.79195     52.96777    0.01204819 
+  71           84.51349     52.96056    0.01408451 
+  85           85.48453     52.95335    0.01176471 
+  104          86.57975     52.94614    0.00961538 
+  73           87.68786     52.93893    0.01369863 
+  77           88.80393     52.93172    0.01298701 
+  99           90.0039      52.92451    0.01010101 
+  83           91.33416     52.9173     0.01204819 
+  95           92.80934     52.91009    0.01052632 
+  90           94.43296     52.90287    0.01111111 
+  105          96.2122      52.89566    0.00952381 
+  96           98.16244     52.88845    0.01041667 
+  86           100.32001    52.88124    0.01162791 
+  105          102.77789    52.87403    0.00952381 
+  93           105.69514    52.86682    0.01075269 
+  131          109.20916    52.85961    0.00763359 
+  125          113.26961    52.85239    0.008     
+  117          117.41547    52.84518    0.00854701 
+  138          120.77936    52.83797    0.00724638 
+  139          123.31212    52.83075    0.00719424 
+  171          125.92955    52.82354    0.00584795 
+  153          129.24233    52.81633    0.00653595 
+  169          133.41859    52.80911    0.00591716 
+  192          138.43209    52.8019     0.00520833 
+  192          144.23789    52.79468    0.00520833 
+  187          150.86995    52.78746    0.00534759 
+  190          158.46269    52.78025    0.00526316 
+  193          167.20098    52.77303    0.00518135 
+  200          177.24467    52.76581    0.005     
+  206          188.61073    52.75859    0.00485437 
+  210          201.12895    52.75138    0.0047619 
+  209          214.94208    52.74416    0.00478469 
+  221          230.8422     52.73694    0.00452489 
+  256          249.67448    52.72972    0.00390625 
+  256          272.14341    52.72249    0.00390625 
+  266          299.04155    52.71527    0.0037594 
+  321          331.54889    52.70805    0.00311526 
+  349          371.34064    52.70083    0.00286533 
+  407          420.7452     52.6936     0.002457  
+  457          483.20049    52.68638    0.00218818 
+  603          564.276      52.67915    0.00165837 
+  669          674.06956    52.67192    0.00149477 
+  930          832.36504    52.6647     0.00107527 
+  1304         1077.62895   52.65747    0.00076687 
+  1701         1476.63581   52.65024    0.00058789 
+  2424         2126.42101   52.64301    0.00041254 
+  3324         3131.55083   52.63578    0.00030084 
+  4736         4544.1188    52.62855    0.00021115 
+  6250         6241.7238    52.62131    0.00016   
+  7329         7703.07384   52.61408    0.00013644 
+  7905         8032.08815   52.60685    0.0001265 
+  6984         6976.29011   52.59961    0.00014318 
+  5289         5332.08134   52.59237    0.00018907 
+  3985         3831.07222   52.58513    0.00025094 
+  2869         2736.70974   52.5779     0.00034855 
+  2292         2064.00867   52.57065    0.0004363 
+  2004         1749.39599   52.56341    0.000499  
+  1987         1732.12757   52.55617    0.00050327 
+  2206         1985.13224   52.54893    0.00045331 
+  2710         2498.70373   52.54168    0.000369  
+  3282         3223.7235    52.53444    0.00030469 
+  3935         3964.73097   52.52719    0.00025413 
+  4206         4297.11547   52.51994    0.00023776 
+  3812         3915.16551   52.51269    0.00026233 
+  3051         3088.24535   52.50544    0.00032776 
+  2300         2241.96462   52.49819    0.00043478 
+  1632         1571.74286   52.49093    0.00061275 
+  1150         1106.29      52.48368    0.00086957 
+  847          807.96173    52.47642    0.00118064 
+  625          622.98584    52.46917    0.0016    
+  515          506.06824    52.46191    0.00194175 
+  457          427.4709     52.45465    0.00218818 
+  369          370.77202    52.44738    0.00271003 
+  318          327.5852     52.44012    0.00314465 
+  281          293.56854    52.43286    0.00355872 
+  285          266.31827    52.42559    0.00350877 
+  257          244.48932    52.41832    0.00389105 
+  237          227.44725    52.41105    0.00421941 
+  196          214.92978    52.40378    0.00510204 
+  205          206.43071    52.39651    0.00487805 
+  190          200.23737    52.38923    0.00526316 
+  179          192.59222    52.38196    0.00558659 
+  186          180.81418    52.37468    0.00537634 
+  154          167.47001    52.3674     0.00649351 
+  156          155.6371     52.36012    0.00641026 
+  153          146.26939    52.35284    0.00653595 
+  146          139.10515    52.34556    0.00684932 
+  124          133.53376    52.33827    0.00806452 
+  123          129.10796    52.33098    0.00813008 
+  108          125.70813    52.32369    0.00925926 
+  117          123.45333    52.3164     0.00854701 
+  137          122.43825    52.30911    0.00729927 
+  109          122.32177    52.30181    0.00917431 
+  117          121.80219    52.29452    0.00854701 
+  104          119.03743    52.28722    0.00961538 
+  93           114.35754    52.27992    0.01075269 
+  91           109.62085    52.27262    0.01098901 
+  84           105.78067    52.26531    0.01190476 
+  105          102.93574    52.25801    0.00952381 
+  113          100.83227    52.2507     0.00884956 
+  101          99.18552     52.24339    0.00990099 
+  91           97.81042     52.23608    0.01098901 
+  82           96.6153      52.22876    0.01219512 
+  77           95.55756     52.22145    0.01298701 
+  84           94.61008     52.21413    0.01190476 
+  75           93.75444     52.20681    0.01333333 
+  86           92.9805      52.19949    0.01162791 
+  86           92.28311     52.19216    0.01162791 
+  79           91.65529     52.18483    0.01265823 
+  73           91.08925     52.17751    0.01369863 
+  83           90.57828     52.17018    0.01204819 
+  91           90.10939     52.16284    0.01098901 
+  93           89.68894     52.15551    0.01075269 
+  95           89.30627     52.14817    0.01052632 
+  80           88.95732     52.14083    0.0125    
+  69           88.63868     52.13349    0.01449275 
+  85           88.34728     52.12614    0.01176471 
+  87           88.08095     52.1188     0.01149425 
+  87           87.83669     52.11145    0.01149425 
+  75           87.61456     52.1041     0.01333333 
+  77           87.40885     52.09675    0.01298701 
+  84           87.21926     52.08939    0.01190476 
+  75           87.04134     52.08203    0.01333333 
+  90           86.87895     52.07467    0.01111111 
+  67           86.72766     52.06731    0.01492537 
+  79           86.58617     52.05994    0.01265823 
+  66           86.45387     52.05258    0.01515152 
+  71           86.33061     52.04521    0.01408451 
+  71           86.21712     52.03783    0.01408451 
+  84           86.11539     52.03046    0.01190476 
+  71           86.02908     52.02308    0.01408451 
+  72           85.96482     52.0157     0.01388889 
+  85           85.93394     52.00832    0.01176471 
+  84           85.95691     52.00093    0.01190476 
+  69           86.06406     51.99354    0.01449275 
+  88           86.30447     51.98615    0.01136364 
+  81           86.73836     51.97876    0.01234568 
+  83           87.41835     51.97137    0.01204819 
+  112          88.34373     51.96397    0.00892857 
+  89           89.37093     51.95657    0.01123596 
+  75           90.11249     51.94916    0.01333333 
+  80           90.12685     51.94176    0.0125    
+  82           89.38396     51.93435    0.01219512 
+  82           88.29013     51.92693    0.01219512 
+  80           87.31627     51.91952    0.0125    
+  83           86.49117     51.9121     0.01204819 
+  76           85.91386     51.90468    0.01315789 
+  82           85.56247     51.89726    0.01219512 
+  93           85.40431     51.88983    0.01075269 
+  83           85.4074      51.8824     0.01204819 
+  70           85.54524     51.87497    0.01428571 
+  79           85.78384     51.86754    0.01265823 
+  87           86.00432     51.8601     0.01149425 
+  92           85.97346     51.85266    0.01086957 
+  97           85.52208     51.84522    0.01030928 
+  73           84.7339      51.83777    0.01369863 
+  67           83.83354     51.83032    0.01492537 
+  63           82.97545     51.82287    0.01587302 
+  89           82.24437     51.81542    0.01123596 
+  96           81.56375     51.80796    0.01041667 
+  73           80.94766     51.8005     0.01369863 
+  62           80.36949     51.79303    0.01612903 
+  69           79.80357     51.78557    0.01449275 
+  61           79.2382      51.7781     0.01639344 
+  85           78.67508     51.77062    0.01176471 
+  74           78.11744     51.76315    0.01351351 
+  63           77.56787     51.75567    0.01587302 
+  79           77.02861     51.74818    0.01265823 
+  77           76.50397     51.7407     0.01298701 
+  74           75.99961     51.73321    0.01351351 
+  73           75.52409     51.72572    0.01369863 
+  84           75.08906     51.71822    0.01190476 
+  73           74.71115     51.71072    0.01369863 
+  71           74.41512     51.70322    0.01408451 
+  75           74.24519     51.69572    0.01333333 
+  85           74.30033     51.68821    0.01176471 
+  94           74.82902     51.6807     0.0106383 
+  86           76.39765     51.67318    0.01162791 
+  97           80.00164     51.66566    0.01030928 
+  97           86.74803     51.65814    0.01030928 
+  99           96.80396     51.65062    0.01010101 
+  97           107.59367    51.64309    0.01030928 
+  128          112.18489    51.63556    0.0078125 
+  130          105.78022    51.62802    0.00769231 
+  104          94.07941     51.62048    0.00961538 
+  84           83.62606     51.61294    0.01190476 
+  92           76.60779     51.6054     0.01086957 
+  92           72.72641     51.59785    0.01086957 
+  94           70.95532     51.5903     0.0106383 
+  78           70.57791     51.58274    0.01282051 
+  99           71.50507     51.57518    0.01010101 
+  100          74.08811     51.56762    0.01      
+  114          78.56654     51.56005    0.00877193 
+  123          84.19673     51.55248    0.00813008 
+  129          88.61874     51.54491    0.00775194 
+  111          88.40833     51.53733    0.00900901 
+  116          83.08181     51.52975    0.00862069 
+  105          76.43718     51.52217    0.00952381 
+  95           71.1584      51.51458    0.01052632 
+  78           67.80258     51.50699    0.01282051 
+  83           65.95203     51.4994     0.01204819 
+  79           65.0091      51.4918     0.01265823 
+  72           64.575       51.4842     0.01388889 
+  80           64.4734      51.47659    0.0125    
+  78           64.61596     51.46898    0.01282051 
+  91           64.84654     51.46137    0.01098901 
+  90           64.85013     51.45375    0.01111111 
+  74           64.44904     51.44613    0.01351351 
+  79           63.90294     51.4385     0.01265823 
+  80           63.48168     51.43088    0.0125    
+  84           63.29818     51.42324    0.01190476 
+  73           63.42089     51.41561    0.01369863 
+  65           63.98507     51.40797    0.01538462 
+  77           65.22        51.40032    0.01298701 
+  69           67.29964     51.39268    0.01449275 
+  65           70.00546     51.38503    0.01538462 
+  77           72.22059     51.37737    0.01298701 
+  55           72.16248     51.36971    0.01818182 
+  70           69.95132     51.36205    0.01428571 
+  65           67.41687     51.35438    0.01538462 
+  73           65.64941     51.34671    0.01369863 
+  61           64.94391     51.33904    0.01639344 
+  50           65.29125     51.33136    0.02      
+  63           66.60355     51.32367    0.01587302 
+  69           68.63815     51.31599    0.01449275 
+  61           70.65897     51.3083     0.01639344 
+  62           71.44081     51.3006     0.01612903 
+  64           70.95855     51.2929     0.015625  
+  48           70.34258     51.2852     0.02083333 
+  59           69.76131     51.27749    0.01694915 
+  67           68.54112     51.26978    0.01492537 
+  59           66.82302     51.26207    0.01694915 
+  60           65.32392     51.25435    0.01666667 
+  60           64.37715     51.24663    0.01666667 
+  61           64.036       51.2389     0.01639344 
+  61           64.28688     51.23117    0.01639344 
+  59           65.1276      51.22343    0.01694915 
+  51           66.47957     51.21569    0.01960784 
+  75           67.93661     51.20795    0.01333333 
+  63           68.73633     51.2002     0.01587302 
+  82           68.52379     51.19245    0.01219512 
+  67           67.35125     51.18469    0.01492537 
+  66           65.71326     51.17693    0.01515152 
+  62           64.29495     51.16916    0.01612903 
+  60           63.34013     51.1614     0.01666667 
+  46           62.7917      51.15362    0.02173913 
+  68           62.51002     51.14584    0.01470588 
+  75           62.38239     51.13806    0.01333333 
+  69           62.35772     51.13028    0.01449275 
+  60           62.44071     51.12248    0.01666667 
+  52           62.66626     51.11469    0.01923077 
+  65           63.05693     51.10689    0.01538462 
+  53           63.55386     51.09909    0.01886792 
+  66           63.93087     51.09128    0.01515152 
+  53           63.90747     51.08347    0.01886792 
+  73           63.60645     51.07565    0.01369863 
+  60           63.36503     51.06783    0.01666667 
+  54           63.35345     51.06       0.01851852 
+  68           63.57784     51.05217    0.01470588 
+  55           63.91823     51.04434    0.01818182 
+  60           64.18804     51.0365     0.01666667 
+  67           64.37392     51.02865    0.01492537 
+  62           64.68038     51.02081    0.01612903 
+  63           65.27663     51.01295    0.01587302 
+  79           66.1759      51.0051     0.01265823 
+  63           67.19101     50.99724    0.01587302 
+  55           68.07855     50.98937    0.01818182 
+  72           69.18786     50.9815     0.01388889 
+  73           71.59331     50.97362    0.01369863 
+  85           76.72778     50.96574    0.01176471 
+  71           85.93067     50.95786    0.01408451 
+  89           99.19973     50.94997    0.01123596 
+  59           112.99839    50.94208    0.01694915 
+  80           118.60251    50.93418    0.0125    
+  78           110.99491    50.92628    0.01282051 
+  81           97.70811     50.91837    0.01234568 
+  91           86.37613     50.91046    0.01098901 
+  96           79.36929     50.90254    0.01041667 
+  90           76.1154      50.89462    0.01111111 
+  69           75.2091      50.8867     0.01449275 
+  87           75.82092     50.87876    0.01149425 
+  90           77.94474     50.87083    0.01111111 
+  95           81.90541     50.86289    0.01052632 
+  93           87.75985     50.85495    0.01075269 
+  92           94.86903     50.847      0.01086957 
+  90           101.81018    50.83904    0.01111111 
+  81           105.0225     50.83108    0.01234568 
+  76           102.20104    50.82312    0.01315789 
+  88           97.02854     50.81515    0.01136364 
+  90           93.3303      50.80718    0.01111111 
+  89           92.31608     50.7992     0.01123596 
+  94           93.7762      50.79122    0.0106383 
+  108          97.09297     50.78323    0.00925926 
+  120          101.90426    50.77524    0.00833333 
+  103          108.30621    50.76724    0.00970874 
+  136          116.60317    50.75924    0.00735294 
+  147          127.17138    50.75123    0.00680272 
+  182          140.77542    50.74322    0.00549451 
+  183          159.6651     50.7352     0.00546448 
+  205          188.43889    50.72718    0.00487805 
+  285          235.05274    50.71915    0.00350877 
+  396          311.72074    50.71112    0.00252525 
+  519          433.37238    50.70309    0.00192678 
+  650          611.52392    50.69505    0.00153846 
+  773          841.27688    50.687      0.00129366 
+  1013         1075.02015   50.67895    0.00098717 
+  1119         1198.50218   50.67089    0.00089366 
+  1106         1119.2063    50.66283    0.00090416 
+  848          903.11828    50.65477    0.00117925 
+  637          673.41596    50.6467     0.00156986 
+  495          491.2759     50.63862    0.0020202 
+  412          368.60108    50.63054    0.00242718 
+  329          297.92222    50.62245    0.00303951 
+  313          268.09836    50.61436    0.00319489 
+  338          272.02738    50.60627    0.00295858 
+  354          308.46518    50.59816    0.00282486 
+  404          378.84037    50.59006    0.00247525 
+  522          479.78667    50.58195    0.00191571 
+  530          590.10044    50.57383    0.00188679 
+  598          655.74584    50.56571    0.00167224 
+  617          623.44286    50.55758    0.00162075 
+  512          515.96469    50.54945    0.00195312 
+  382          396.27083    50.54132    0.0026178 
+  304          299.45784    50.53317    0.00328947 
+  230          232.79034    50.52503    0.00434783 
+  178          190.39894    50.51688    0.00561798 
+  141          162.54669    50.50872    0.0070922 
+  119          142.01514    50.50056    0.00840336 
+  138          125.08467    50.49239    0.00724638 
+  116          111.40561    50.48422    0.00862069 
+  101          101.15662    50.47604    0.00990099 
+  103          93.80331     50.46786    0.00970874 
+  78           88.5743      50.45967    0.01282051 
+  76           84.83593     50.45148    0.01315789 
+  87           82.25914     50.44328    0.01149425 
+  80           80.79348     50.43507    0.0125    
+  88           80.48722     50.42686    0.01136364 
+  92           81.16991     50.41865    0.01086957 
+  77           82.00327     50.41043    0.01298701 
+  72           81.68218     50.40221    0.01388889 
+  75           79.74735     50.39398    0.01333333 
+  73           76.49295     50.38574    0.01369863 
+  64           72.98117     50.3775     0.015625  
+  70           70.12631     50.36926    0.01428571 
+  62           68.10622     50.361      0.01612903 
+  68           66.73037     50.35275    0.01470588 
+  73           65.74963     50.34449    0.01369863 
+  70           64.9939      50.33622    0.01428571 
+  63           64.37434     50.32795    0.01587302 
+  56           63.84864     50.31967    0.01785714 
+  70           63.39587     50.31139    0.01428571 
+  63           63.00501     50.3031     0.01587302 
+  63           62.67303     50.29481    0.01587302 
+  58           62.40922     50.28651    0.01724138 
+  61           62.24557     50.2782     0.01639344 
+  60           62.24187     50.26989    0.01666667 
+  68           62.46509     50.26158    0.01470588 
+  67           62.92198     50.25326    0.01492537 
+  44           63.44434     50.24493    0.02272727 
+  63           63.58888     50.2366     0.01587302 
+  50           63.04929     50.22827    0.02      
+  55           62.18669     50.21992    0.01818182 
+  51           61.41952     50.21158    0.01960784 
+  65           60.88849     50.20322    0.01538462 
+  74           60.57427     50.19487    0.01351351 
+  56           60.40818     50.1865     0.01785714 
+  49           60.33607     50.17813    0.02040816 
+  60           60.33963     50.16976    0.01666667 
+  55           60.43333     50.16138    0.01818182 
+  56           60.64942     50.15299    0.01785714 
+  65           61.00684     50.1446     0.01538462 
+  56           61.45982     50.13621    0.01785714 
+  61           61.83186     50.12781    0.01639344 
+  53           61.90828     50.1194     0.01886792 
+  55           61.78253     50.11099    0.01818182 
+  67           61.69841     50.10257    0.01492537 
+  52           61.7723      50.09414    0.01923077 
+  61           62.02242     50.08571    0.01639344 
+  85           62.43021     50.07728    0.01176471 
+  52           62.97939     50.06884    0.01923077 
+  49           63.67155     50.06039    0.02040816 
+  70           64.5263      50.05194    0.01428571 
+  63           65.5781      50.04349    0.01587302 
+  50           66.8789      50.03502    0.02      
+  56           68.50164     50.02655    0.01785714 
+  63           70.55673     50.01808    0.01587302 
+  61           73.22146     50.0096     0.01639344 
+  63           76.79788     50.00112    0.01587302 
+  71           81.79817     49.99263    0.01408451 
+  98           89.06828     49.98413    0.01020408 
+  98           99.86872     49.97563    0.01020408 
+  121          115.83455    49.96712    0.00826446 
+  147          138.68372    49.95861    0.00680272 
+  179          169.52243    49.95009    0.00558659 
+  177          207.39469    49.94157    0.00564972 
+  217          245.65288    49.93304    0.00460829 
+  211          269.67968    49.92451    0.00473934 
+  183          265.16351    49.91597    0.00546448 
+  137          235.73917    49.90742    0.00729927 
+  127          198.0441     49.89887    0.00787402 
+  130          164.28863    49.89031    0.00769231 
+  93           138.84484    49.88175    0.01075269 
+  94           122.08       49.87318    0.0106383 
+  83           112.94718    49.8646     0.01204819 
+  84           110.24788    49.85603    0.01190476 
+  108          113.4026     49.84744    0.00925926 
+  113          122.26278    49.83885    0.00884956 
+  121          136.28358    49.83025    0.00826446 
+  118          153.21303    49.82165    0.00847458 
+  131          167.17441    49.81304    0.00763359 
+  150          169.53396    49.80443    0.00666667 
+  109          157.58061    49.79581    0.00917431 
+  95           137.94875    49.78718    0.01052632 
+  85           118.26706    49.77855    0.01176471 
+  86           102.07139    49.76992    0.01162791 
+  86           90.01492     49.76127    0.01162791 
+  84           81.53244     49.75263    0.01190476 
+  77           75.65573     49.74397    0.01298701 
+  78           71.51645     49.73531    0.01282051 
+  53           68.57702     49.72665    0.01886792 
+  54           66.50261     49.71798    0.01851852 
+  74           65.09293     49.7093     0.01351351 
+  65           64.27311     49.70062    0.01538462 
+  59           64.07097     49.69193    0.01694915 
+  77           64.5615      49.68324    0.01298701 
+  87           65.6251      49.67454    0.01149425 
+  62           66.55953     49.66584    0.01612903 
+  70           66.13975     49.65712    0.01428571 
+  73           64.27609     49.64841    0.01369863 
+  79           62.16084     49.63969    0.01265823 
+  63           60.54612     49.63096    0.01587302 
+  50           59.56893     49.62223    0.02      
+  63           59.06491     49.61349    0.01587302 
+  62           58.79087     49.60474    0.01612903 
+  64           58.63918     49.59599    0.015625  
+  60           58.69379     49.58724    0.01666667 
+  44           59.13396     49.57847    0.02272727 
+  69           60.24818     49.56971    0.01449275 
+  59           62.40237     49.56093    0.01694915 
+  88           65.75029     49.55215    0.01136364 
+  77           69.70023     49.54337    0.01298701 
+  61           72.7098      49.53458    0.01639344 
+  61           72.77168     49.52578    0.01639344 
+  49           69.52309     49.51698    0.02040816 
+  84           65.3721      49.50817    0.01190476 
+  56           62.14108     49.49936    0.01785714 
+  59           60.21913     49.49054    0.01694915 
+  63           59.33314     49.48171    0.01587302 
+  59           59.12415     49.47288    0.01694915 
+  49           59.37895     49.46404    0.02040816 
+  62           60.08153     49.4552     0.01612903 
+  63           61.51676     49.44635    0.01587302 
+  56           64.38888     49.4375     0.01785714 
+  58           69.88051     49.42864    0.01724138 
+  51           79.36955     49.41977    0.01960784 
+  68           93.23138     49.4109     0.01470588 
+  79           109.28161    49.40203    0.01265823 
+  60           121.58834    49.39314    0.01666667 
+  69           120.5452     49.38425    0.01449275 
+  56           106.21138    49.37536    0.01785714 
+  64           89.20289     49.36646    0.015625  
+  67           76.06754     49.35755    0.01492537 
+  63           68.08205     49.34864    0.01587302 
+  66           64.08245     49.33972    0.01515152 
+  61           62.45484     49.3308     0.01639344 
+  59           62.11295     49.32187    0.01694915 
+  75           62.65849     49.31294    0.01333333 
+  63           64.49815     49.304      0.01587302 
+  72           68.53187     49.29505    0.01388889 
+  50           75.16319     49.2861     0.02      
+  54           83.0887      49.27714    0.01851852 
+  53           87.91408     49.26818    0.01886792 
+  60           85.09419     49.25921    0.01666667 
+  53           77.33271     49.25023    0.01886792 
+  74           69.74045     49.24125    0.01351351 
+  57           64.52754     49.23227    0.01754386 
+  68           61.75051     49.22327    0.01470588 
+  51           60.48207     49.21428    0.01960784 
+  67           59.68082     49.20527    0.01492537 
+  68           58.88337     49.19626    0.01470588 
+  55           58.09202     49.18725    0.01818182 
+  53           57.41981     49.17823    0.01886792 
+  79           56.94165     49.1692     0.01265823 
+  70           56.64444     49.16017    0.01428571 
+  52           56.48142     49.15113    0.01923077 
+  55           56.41042     49.14208    0.01818182 
+  63           56.40977     49.13303    0.01587302 
+  65           56.47992     49.12398    0.01538462 
+  65           56.63315     49.11492    0.01538462 
+  58           56.87084     49.10585    0.01724138 
+  49           57.14828     49.09678    0.02040816 
+  52           57.33781     49.0877     0.01923077 
+  63           57.32755     49.07861    0.01587302 
+  60           57.20819     49.06952    0.01666667 
+  51           57.11426     49.06043    0.01960784 
+  63           57.09605     49.05133    0.01587302 
+  63           57.1517      49.04222    0.01587302 
+  58           57.26112     49.03311    0.01724138 
+  52           57.40704     49.02399    0.01923077 
+  66           57.58307     49.01486    0.01515152 
+  60           57.79632     49.00573    0.01666667 
+  67           58.07145     48.9966     0.01492537 
+  61           58.45215     48.98746    0.01639344 
+  70           58.98412     48.97831    0.01428571 
+  67           59.66696     48.96915    0.01492537 
+  70           60.37412     48.96       0.01428571 
+  62           60.79492     48.95083    0.01612903 
+  51           60.75792     48.94166    0.01960784 
+  69           60.5352      48.93249    0.01449275 
+  67           60.39609     48.9233     0.01492537 
+  73           60.42453     48.91412    0.01369863 
+  69           60.60489     48.90492    0.01449275 
+  61           60.89234     48.89572    0.01639344 
+  49           61.25383     48.88652    0.02040816 
+  63           61.67999     48.87731    0.01587302 
+  71           62.18315     48.86809    0.01408451 
+  62           62.79277     48.85887    0.01612903 
+  64           63.54349     48.84965    0.015625  
+  60           64.45756     48.84041    0.01666667 
+  72           65.53027     48.83118    0.01388889 
+  75           66.7748      48.82193    0.01333333 
+  82           68.46958     48.81268    0.01219512 
+  70           71.13329     48.80343    0.01428571 
+  88           74.97454     48.79417    0.01136364 
+  86           79.29564     48.7849     0.01162791 
+  88           81.95544     48.77563    0.01136364 
+  99           81.15937     48.76635    0.01010101 
+  79           78.50064     48.75707    0.01265823 
+  89           76.19881     48.74778    0.01123596 
+  84           75.08037     48.73848    0.01190476 
+  92           75.11043     48.72918    0.01086957 
+  87           75.96482     48.71988    0.01149425 
+  84           77.36849     48.71056    0.01190476 
+  75           79.2139      48.70125    0.01333333 
+  94           81.56167     48.69192    0.0106383 
+  98           84.61283     48.6826     0.01020408 
+  110          88.64388     48.67326    0.00909091 
+  116          93.84444     48.66392    0.00862069 
+  100          100.00052    48.65458    0.01      
+  120          106.14192    48.64523    0.00833333 
+  115          111.48511    48.63587    0.00869565 
+  130          116.30579    48.62651    0.00769231 
+  127          120.76154    48.61714    0.00787402 
+  152          125.86486    48.60777    0.00657895 
+  161          133.08001    48.59839    0.00621118 
+  140          143.28391    48.58901    0.00714286 
+  156          157.13501    48.57962    0.00641026 
+  184          175.60712    48.57022    0.00543478 
+  218          200.61793    48.56082    0.00458716 
+  293          236.09462    48.55142    0.00341297 
+  325          289.82472    48.542      0.00307692 
+  450          375.68415    48.53259    0.00222222 
+  628          514.81793    48.52316    0.00159236 
+  785          732.23934    48.51374    0.00127389 
+  1098         1046.05176   48.5043     0.00091075 
+  1443         1445.03865   48.49486    0.000693  
+  1634         1843.53215   48.48542    0.000612  
+  1734         2044.66399   48.47597    0.0005767 
+  1587         1897.72168   48.46651    0.00063012 
+  1204         1522.09233   48.45705    0.00083056 
+  907          1125.98747   48.44759    0.00110254 
+  674          811.47428    48.43812    0.00148368 
+  565          597.70306    48.42864    0.00176991 
+  436          470.26558    48.41916    0.00229358 
+  419          406.97479    48.40967    0.00238663 
+  419          392.47753    48.40018    0.00238663 
+  488          423.95342    48.39068    0.00204918 
+  578          506.4773     48.38117    0.0017301 
+  659          644.65819    48.37166    0.00151745 
+  769          829.4897     48.36215    0.00130039 
+  949          1014.09941   48.35263    0.00105374 
+  935          1096.69735   48.3431     0.00106952 
+  868          1005.66385   48.33357    0.00115207 
+  638          805.7578     48.32404    0.0015674 
+  496          599.70303    48.3145     0.00201613 
+  379          435.5001     48.30495    0.00263852 
+  276          320.83408    48.2954     0.00362319 
+  199          246.92313    48.28584    0.00502513 
+  197          200.47007    48.27628    0.00507614 
+  141          170.32425    48.26671    0.0070922 
+  161          149.76536    48.25714    0.00621118 
+  113          135.25253    48.24756    0.00884956 
+  132          125.11907    48.23797    0.00757576 
+  120          118.27427    48.22839    0.00833333 
+  128          113.31591    48.21879    0.0078125 
+  90           108.22006    48.20919    0.01111111 
+  92           101.84843    48.19959    0.01086957 
+  97           95.29335     48.18998    0.01030928 
+  96           89.70576     48.18036    0.01041667 
+  72           85.37078     48.17074    0.01388889 
+  85           82.11476     48.16112    0.01176471 
+  93           79.64284     48.15149    0.01075269 
+  88           77.71076     48.14185    0.01136364 
+  81           76.15072     48.13221    0.01234568 
+  70           74.8384      48.12257    0.01428571 
+  55           73.77177     48.11291    0.01818182 
+  92           73.11008     48.10326    0.01086957 
+  71           72.9292      48.0936     0.01408451 
+  80           73.00244     48.08393    0.0125    
+  76           72.68076     48.07426    0.01315789 
+  73           71.53977     48.06458    0.01369863 
+  75           70.08001     48.0549     0.01333333 
+  77           68.75818     48.04521    0.01298701 
+  79           67.60211     48.03552    0.01265823 
+  66           66.49014     48.02583    0.01515152 
+  59           65.78802     48.01612    0.01694915 
+  79           65.23725     48.00642    0.01265823 
+  62           64.64396     47.9967     0.01612903 
+  77           63.9859      47.98699    0.01298701 
+  60           63.37996     47.97727    0.01666667 
+  65           62.88652     47.96754    0.01538462 
+  71           62.50944     47.95781    0.01408451 
+  56           62.23384     47.94807    0.01785714 
+  68           62.0485      47.93833    0.01470588 
+  74           61.94607     47.92858    0.01351351 
+  86           61.90852     47.91883    0.01162791 
+  73           61.87518     47.90908    0.01369863 
+  63           61.68473     47.89931    0.01587302 
+  68           61.51302     47.88955    0.01470588 
+  81           61.37356     47.87978    0.01234568 
+  65           61.28058     47.87       0.01538462 
+  63           61.18247     47.86022    0.01587302 
+  66           61.09257     47.85044    0.01515152 
+  56           61.0896      47.84065    0.01785714 
+  65           61.18159     47.83085    0.01538462 
+  56           61.24882     47.82105    0.01785714 
+  74           61.10201     47.81125    0.01351351 
+  70           60.76065     47.80144    0.01428571 
+  64           60.40021     47.79162    0.015625  
+  60           60.11488     47.7818     0.01666667 
+  67           59.91549     47.77198    0.01492537 
+  84           59.77943     47.76215    0.01190476 
+  61           59.68103     47.75232    0.01639344 
+  54           59.60516     47.74248    0.01851852 
+  54           59.54886     47.73264    0.01851852 
+  63           59.51975     47.72279    0.01587302 
+  45           59.53392     47.71294    0.02222222 
+  67           59.61152     47.70309    0.01492537 
+  62           59.76808     47.69322    0.01612903 
+  61           59.99752     47.68336    0.01639344 
+  52           60.2661      47.67349    0.01923077 
+  47           60.60026     47.66361    0.0212766 
+  66           61.00566     47.65374    0.01515152 
+  60           61.2609      47.64385    0.01666667 
+  56           61.03367     47.63396    0.01785714 
+  58           60.46723     47.62407    0.01724138 
+  57           59.95488     47.61417    0.01754386 
+  54           59.72805     47.60427    0.01851852 
+  63           59.94254     47.59437    0.01587302 
+  51           60.80278     47.58446    0.01960784 
+  58           62.54419     47.57454    0.01724138 
+  43           65.19981     47.56462    0.02325581 
+  51           68.14437     47.5547     0.01960784 
+  67           69.64577     47.54477    0.01492537 
+  55           68.36739     47.53484    0.01818182 
+  64           65.56173     47.5249     0.015625  
+  59           62.93611     47.51496    0.01694915 
+  53           61.10043     47.50501    0.01886792 
+  52           59.85738     47.49506    0.01923077 
+  63           58.94224     47.48511    0.01587302 
+  58           58.2972      47.47515    0.01724138 
+  73           57.90733     47.46519    0.01369863 
+  68           57.78318     47.45522    0.01470588 
+  40           57.99273     47.44525    0.025     
+  52           58.65577     47.43528    0.01923077 
+  46           59.85136     47.4253     0.02173913 
+  56           61.41856     47.41531    0.01785714 
+  57           62.6779      47.40532    0.01754386 
+  64           62.7318      47.39533    0.015625  
+  63           61.78854     47.38534    0.01587302 
+  51           60.60999     47.37534    0.01960784 
+  53           59.57215     47.36533    0.01886792 
+  61           58.5733      47.35532    0.01639344 
+  53           57.53385     47.34531    0.01886792 
+  66           56.6401      47.33529    0.01515152 
+  55           55.98783     47.32527    0.01818182 
+  57           55.55396     47.31525    0.01754386 
+  52           55.27488     47.30522    0.01923077 
+  51           55.09257     47.29519    0.01960784 
+  64           54.97594     47.28515    0.015625  
+  59           54.92136     47.27511    0.01694915 
+  57           54.94153     47.26507    0.01754386 
+  66           55.04793     47.25502    0.01515152 
+  55           55.21835     47.24497    0.01818182 
+  58           55.37807     47.23491    0.01724138 
+  60           55.44975     47.22485    0.01666667 
+  49           55.35958     47.21479    0.02040816 
+  60           55.06156     47.20472    0.01666667 
+  47           54.6964      47.19465    0.0212766 
+  60           54.39361     47.18457    0.01666667 
+  61           54.18689     47.1745     0.01639344 
+  59           54.06183     47.16441    0.01694915 
+  56           53.99357     47.15433    0.01785714 
+  60           53.9703      47.14424    0.01666667 
+  56           54.00065     47.13414    0.01785714 
+  71           54.11552     47.12405    0.01408451 
+  59           54.35087     47.11395    0.01694915 
+  56           54.71475     47.10384    0.01785714 
+  56           55.11397     47.09373    0.01785714 
+  64           55.30121     47.08362    0.015625  
+  54           55.10627     47.07351    0.01851852 
+  49           54.74977     47.06339    0.02040816 
+  49           54.50375     47.05327    0.02040816 
+  48           54.48647     47.04314    0.02083333 
+  64           54.68936     47.03301    0.015625  
+  62           54.98407     47.02288    0.01612903 
+  68           55.1172      47.01274    0.01470588 
+  65           54.91548     47.0026     0.01538462 
+  64           54.57773     46.99246    0.015625  
+  63           54.32131     46.98231    0.01587302 
+  43           54.23238     46.97216    0.02325581 
+  55           54.31327     46.96201    0.01818182 
+  73           54.50971     46.95185    0.01369863 
+  67           54.70312     46.9417     0.01492537 
+  58           54.74879     46.93153    0.01724138 
+  56           54.67475     46.92137    0.01785714 
+  61           54.64438     46.9112     0.01639344 
+  50           54.78395     46.90103    0.02      
+  70           55.18903     46.89085    0.01428571 
+  60           55.94054     46.88067    0.01666667 
+  61           57.04119     46.87049    0.01639344 
+  64           58.33019     46.8603     0.015625  
+  65           59.44822     46.85012    0.01538462 
+  78           59.70713     46.83993    0.01282051 
+  74           58.91362     46.82973    0.01351351 
+  71           57.87244     46.81953    0.01408451 
+  63           57.24533     46.80933    0.01587302 
+  85           57.33239     46.79913    0.01176471 
+  66           58.34032     46.78892    0.01515152 
+  72           60.4947      46.77872    0.01388889 
+  95           63.85926     46.7685     0.01052632 
+  87           67.89745     46.75829    0.01149425 
+  96           71.19366     46.74807    0.01041667 
+  96           71.55821     46.73785    0.01041667 
+  104          68.73198     46.72763    0.00961538 
+  73           65.24479     46.7174     0.01369863 
+  72           62.74226     46.70717    0.01388889 
+  88           61.28444     46.69694    0.01136364 
+  70           60.26239     46.68671    0.01428571 
+  57           59.48622     46.67647    0.01754386 
+  74           59.12181     46.66623    0.01351351 
+  86           59.26942     46.65599    0.01162791 
+  80           59.92864     46.64574    0.0125    
+  67           61.00764     46.6355     0.01492537 
+  71           62.44004     46.62525    0.01408451 
+  62           64.28415     46.61499    0.01612903 
+  81           66.29032     46.60474    0.01234568 
+  79           67.62537     46.59448    0.01265823 
+  80           67.45086     46.58422    0.0125    
+  99           66.62867     46.57396    0.01010101 
+  92           66.86918     46.56369    0.01086957 
+  75           69.41624     46.55343    0.01333333 
+  94           74.87402     46.54316    0.0106383 
+  96           82.66631     46.53288    0.01041667 
+  71           89.88334     46.52261    0.01408451 
+  98           91.27671     46.51233    0.01020408 
+  73           85.88617     46.50206    0.01369863 
+  76           78.70013     46.49177    0.01315789 
+  82           73.2061      46.48149    0.01219512 
+  75           70.37469     46.47121    0.01333333 
+  71           70.09241     46.46092    0.01408451 
+  105          71.8057      46.45063    0.00952381 
+  104          74.63471     46.44034    0.00961538 
+  119          77.02529     46.43004    0.00840336 
+  107          77.44258     46.41975    0.00934579 
+  89           76.8228      46.40945    0.01123596 
+  97           77.24703     46.39915    0.01030928 
+  113          79.66895     46.38885    0.00884956 
+  87           83.60096     46.37854    0.01149425 
+  87           86.87567     46.36824    0.01149425 
+  100          86.97237     46.35793    0.01      
+  108          84.79686     46.34762    0.00925926 
+  95           82.93408     46.33731    0.01052632 
+  117          82.72977     46.32699    0.00854701 
+  116          84.63659     46.31668    0.00862069 
+  114          88.86843     46.30636    0.00877193 
+  119          95.64913     46.29604    0.00840336 
+  139          104.93488    46.28572    0.00719424 
+  117          115.77929    46.2754     0.00854701 
+  161          126.33686    46.26508    0.00621118 
+  142          134.5487     46.25475    0.00704225 
+  158          139.02769    46.24443    0.00632911 
+  142          139.03443    46.2341     0.00704225 
+  152          135.41036    46.22377    0.00657895 
+  132          130.91308    46.21344    0.00757576 
+  131          127.92066    46.20311    0.00763359 
+  130          127.47702    46.19277    0.00769231 
+  130          129.80933    46.18244    0.00769231 
+  131          134.9115     46.1721     0.00763359 
+  144          142.85879    46.16176    0.00694444 
+  178          153.97394    46.15142    0.00561798 
+  213          168.89114    46.14108    0.00469484 
+  206          188.49695    46.13074    0.00485437 
+  243          213.73087    46.1204     0.00411523 
+  270          245.47014    46.11005    0.0037037 
+  318          285.41517    46.09971    0.00314465 
+  411          338.74103    46.08936    0.00243309 
+  540          417.36335    46.07901    0.00185185 
+  661          543.10019    46.06866    0.00151286 
+  922          746.06947    46.05831    0.0010846 
+  1224         1056.31189   46.04796    0.00081699 
+  1674         1486.44227   46.03761    0.00059737 
+  2233         1996.14826   46.02726    0.00044783 
+  2608         2427.40367   46.0169     0.00038344 
+  2512         2519.11407   46.00655    0.00039809 
+  2371         2200.82829   45.99619    0.00042176 
+  1858         1702.8193    45.98584    0.00053821 
+  1424         1240.06114   45.97548    0.00070225 
+  1008         891.4588     45.96512    0.00099206 
+  820          660.57509    45.95477    0.00121951 
+  676          524.07152    45.94441    0.00147929 
+  579          455.66754    45.93405    0.00172712 
+  549          438.48529    45.92369    0.00182149 
+  612          468.61497    45.91332    0.00163399 
+  712          552.30646    45.90296    0.00140449 
+  825          698.79063    45.8926     0.00121212 
+  1060         908.29694    45.88224    0.0009434 
+  1239         1150.1145    45.87188    0.0008071 
+  1341         1329.39384   45.86151    0.00074571 
+  1336         1319.27653   45.85115    0.0007485 
+  1195         1120.44595   45.84078    0.00083682 
+  920          859.32285    45.83042    0.00108696 
+  711          628.61247    45.82005    0.00140647 
+  503          456.93575    45.80969    0.00198807 
+  420          341.13356    45.79932    0.00238095 
+  370          267.38175    45.78896    0.0027027 
+  288          221.0278     45.77859    0.00347222 
+  243          190.93227    45.76823    0.00411523 
+  180          170.17559    45.75786    0.00555556 
+  176          154.96978    45.74749    0.00568182 
+  155          143.32479    45.73713    0.00645161 
+  142          134.12495    45.72676    0.00704225 
+  137          126.67711    45.7164     0.00729927 
+  151          120.56628    45.70603    0.00662252 
+  138          115.53018    45.69567    0.00724638 
+  132          111.35348    45.6853     0.00757576 
+  133          107.85506    45.67493    0.0075188 
+  106          104.93951    45.66457    0.00943396 
+  103          102.57829    45.6542     0.00970874 
+  103          100.77871    45.64384    0.00970874 
+  96           99.55416     45.63348    0.01041667 
+  103          98.83604     45.62311    0.00970874 
+  100          98.33457     45.61275    0.01      
+  81           97.46503     45.60239    0.01234568 
+  103          95.98007     45.59202    0.00970874 
+  97           94.3872      45.58166    0.01030928 
+  95           93.16709     45.5713     0.01052632 
+  96           92.56394     45.56094    0.01041667 
+  110          92.75821     45.55058    0.00909091 
+  67           93.90285     45.54022    0.01492537 
+  90           95.94645     45.52986    0.01111111 
+  87           98.24047     45.5195     0.01149425 
+  104          99.24326     45.50915    0.00961538 
+  106          97.78978     45.49879    0.00943396 
+  105          95.01604     45.48843    0.00952381 
+  108          92.55832     45.47808    0.00925926 
+  100          91.0137      45.46772    0.01      
+  89           90.21601     45.45737    0.01123596 
+  98           89.62898     45.44702    0.01020408 
+  93           88.93092     45.43667    0.01075269 
+  99           88.25494     45.42632    0.01010101 
+  74           87.7724      45.41597    0.01351351 
+  91           87.57766     45.40562    0.01098901 
+  82           87.74876     45.39528    0.01219512 
+  79           88.35661     45.38493    0.01265823 
+  68           89.36606     45.37459    0.01470588 
+  86           90.41167     45.36425    0.01162791 
+  98           90.74828     45.3539     0.01020408 
+  83           89.78989     45.34356    0.01204819 
+  65           88.11849     45.33323    0.01538462 
+  103          86.524       45.32289    0.00970874 
+  93           85.29961     45.31255    0.01075269 
+  81           84.4286      45.30222    0.01234568 
+  80           83.79159     45.29189    0.0125    
+  101          83.28541     45.28156    0.00990099 
+  69           82.86607     45.27123    0.01449275 
+  75           82.5565      45.2609     0.01333333 
+  78           82.4683      45.25058    0.01282051 
+  67           82.84893     45.24025    0.01492537 
+  69           84.06826     45.22993    0.01449275 
+  88           86.48587     45.21961    0.01136364 
+  85           89.95876     45.20929    0.01176471 
+  76           93.21759     45.19898    0.01315789 
+  78           93.72822     45.18866    0.01282051 
+  93           91.01569     45.17835    0.01075269 
+  89           88.03464     45.16804    0.01123596 
+  94           87.3685      45.15773    0.0106383 
+  74           90.11429     45.14743    0.01351351 
+  98           95.8183      45.13713    0.01020408 
+  88           101.6979     45.12682    0.01136364 
+  71           102.53375    45.11653    0.01408451 
+  94           96.8221      45.10623    0.0106383 
+  72           89.4503      45.09594    0.01388889 
+  92           84.31585     45.08564    0.01086957 
+  83           82.40208     45.07535    0.01204819 
+  82           82.69336     45.06507    0.01219512 
+  99           82.99737     45.05478    0.01010101 
+  91           82.0124      45.0445     0.01098901 
+  97           79.56078     45.03422    0.01030928 
+  95           76.03354     45.02395    0.01052632 
+  88           72.9835      45.01367    0.01136364 
+  92           71.58892     45.0034     0.01086957 
+  75           72.23952     44.99313    0.01333333 
+  103          74.63564     44.98287    0.00970874 
+  74           77.45157     44.97261    0.01351351 
+  79           78.10368     44.96235    0.01265823 
+  89           75.51297     44.95209    0.01123596 
+  80           72.07085     44.94184    0.0125    
+  83           70.10038     44.93159    0.01204819 
+  80           70.53664     44.92134    0.0125    
+  84           73.19199     44.9111     0.01190476 
+  74           76.72778     44.90086    0.01351351 
+  68           79.03928     44.89062    0.01470588 
+  90           77.80743     44.88039    0.01111111 
+  68           73.32477     44.87016    0.01470588 
+  81           68.63394     44.85993    0.01234568 
+  102          65.5839      44.8497     0.00980392 
+  103          64.4012      44.83948    0.00970874 
+  75           64.32876     44.82927    0.01333333 
+  95           64.0392      44.81905    0.01052632 
+  90           62.60328     44.80884    0.01111111 
+  79           60.58409     44.79864    0.01265823 
+  69           58.9038      44.78844    0.01449275 
+  78           57.99795     44.77824    0.01282051 
+  67           58.02224     44.76804    0.01492537 
+  81           58.99829     44.75785    0.01234568 
+  75           60.72768     44.74767    0.01333333 
+  67           62.47272     44.73748    0.01492537 
+  72           62.80503     44.7273     0.01388889 
+  72           61.25254     44.71713    0.01388889 
+  56           59.1737      44.70696    0.01785714 
+  83           57.68738     44.69679    0.01204819 
+  82           57.08033     44.68663    0.01219512 
+  74           57.09808     44.67647    0.01351351 
+  62           57.14107     44.66632    0.01612903 
+  71           56.66234     44.65617    0.01408451 
+  68           55.82608     44.64602    0.01470588 
+  66           55.15442     44.63588    0.01515152 
+  70           54.9663      44.62575    0.01428571 
+  73           55.42471     44.61561    0.01369863 
+  64           56.60288     44.60549    0.015625  
+  74           58.3973      44.59536    0.01351351 
+  74           60.30266     44.58525    0.01351351 
+  63           61.59269     44.57513    0.01587302 
+  54           61.97607     44.56503    0.01851852 
+  69           61.66286     44.55492    0.01449275 
+  51           61.50063     44.54482    0.01960784 
+  68           62.0333      44.53473    0.01470588 
+  55           63.0017      44.52464    0.01818182 
+  60           63.59755     44.51456    0.01666667 
+  69           63.24153     44.50448    0.01449275 
+  52           62.15497     44.49441    0.01923077 
+  56           60.73219     44.48434    0.01785714 
+  57           59.19632     44.47427    0.01754386 
+  52           57.99211     44.46422    0.01923077 
+  61           57.49429     44.45416    0.01639344 
+  73           57.77727     44.44412    0.01369863 
+  59           58.61516     44.43408    0.01694915 
+  64           59.56767     44.42404    0.015625  
+  70           60.37506     44.41401    0.01428571 
+  65           61.06662     44.40399    0.01538462 
+  78           62.07576     44.39397    0.01282051 
+  72           63.96466     44.38395    0.01388889 
+  69           67.20549     44.37394    0.01449275 
+  71           72.64858     44.36394    0.01408451 
+  91           82.48216     44.35395    0.01098901 
+  87           100.78019    44.34396    0.01149425 
+  87           131.62419    44.33397    0.01149425 
+  94           174.33865    44.32399    0.0106383 
+  90           216.27735    44.31402    0.01111111 
+  83           228.71727    44.30406    0.01204819 
+  101          198.90374    44.2941     0.00990099 
+  92           152.7922     44.28414    0.01086957 
+  77           113.48525    44.2742     0.01298701 
+  93           87.61915     44.26426    0.01075269 
+  85           73.29863     44.25432    0.01176471 
+  74           66.21613     44.24439    0.01351351 
+  68           62.91471     44.23447    0.01470588 
+  65           61.63786     44.22456    0.01538462 
+  77           61.97619     44.21465    0.01298701 
+  53           64.57612     44.20475    0.01886792 
+  81           71.06816     44.19485    0.01234568 
+  87           83.53039     44.18496    0.01149425 
+  74           102.7618     44.17508    0.01351351 
+  71           125.17061    44.16521    0.01408451 
+  81           138.86233    44.15534    0.01234568 
+  82           131.19831    44.14548    0.01219512 
+  72           109.25737    44.13563    0.01388889 
+  64           87.32853     44.12578    0.015625  
+  69           71.52089     44.11594    0.01449275 
+  71           62.08061     44.10611    0.01408451 
+  77           57.03992     44.09628    0.01298701 
+  56           54.36841     44.08647    0.01785714 
+  60           52.80713     44.07666    0.01666667 
+  59           51.76707     44.06686    0.01694915 
+  60           51.00821     44.05706    0.01666667 
+  54           50.42905     44.04727    0.01851852 
+  59           49.97935     44.03749    0.01694915 
+  45           49.63978     44.02772    0.02222222 
+  64           49.38628     44.01796    0.015625  
+  60           49.21852     44.0082     0.01666667 
+  48           49.12289     43.99845    0.02083333 
+  70           49.05996     43.98871    0.01428571 
+  47           48.96609     43.97898    0.0212766 
+  64           48.84586     43.96926    0.015625  
+  61           48.80907     43.95954    0.01639344 
+  58           48.99407     43.94983    0.01724138 
+  70           49.54891     43.94013    0.01428571 
+  92           50.56984     43.93044    0.01086957 
+  108          51.94651     43.92076    0.00925926 
+  83           53.10791     43.91108    0.01204819 
+  94           53.08441     43.90141    0.0106383 
+  87           51.82732     43.89176    0.01149425 
+  60           50.29467     43.88211    0.01666667 
+  85           49.09179     43.87247    0.01176471 
+  64           48.35069     43.86283    0.015625  
+  51           47.97392     43.85321    0.01960784 
+  58           47.82125     43.84359    0.01724138 
+  68           47.76835     43.83399    0.01470588 
+  43           47.7345      43.82439    0.02325581 
+  72           47.70384     43.8148     0.01388889 
+  59           47.70624     43.80523    0.01694915 
+  71           47.82959     43.79566    0.01408451 
+  74           48.17377     43.7861     0.01351351 
+  55           48.76352     43.77654    0.01818182 
+  56           49.45622     43.767      0.01785714 
+  56           49.83635     43.75747    0.01785714 
+  81           49.54873     43.74795    0.01234568 
+  70           48.92264     43.73843    0.01428571 
+  79           48.44827     43.72893    0.01265823 
+  69           48.32909     43.71944    0.01449275 
+  58           48.52385     43.70995    0.01724138 
+  68           48.77102     43.70048    0.01470588 
+  59           48.68657     43.69101    0.01694915 
+  51           48.23538     43.68156    0.01960784 
+  54           47.71484     43.67211    0.01851852 
+  54           47.29458     43.66267    0.01851852 
+  48           47.00319     43.65325    0.02083333 
+  52           46.82121     43.64383    0.01923077 
+  48           46.71338     43.63443    0.02083333 
+  41           46.64986     43.62503    0.02439024 
+  62           46.61415     43.61565    0.01612903 
+  64           46.60148     43.60628    0.015625  
+  51           46.61829     43.59691    0.01960784 
+  45           46.68273     43.58756    0.02222222 
+  45           46.81564     43.57822    0.02222222 
+  46           47.02411     43.56889    0.02173913 
+  59           47.25884     43.55957    0.01694915 
+  48           47.39302     43.55025    0.02083333 
+  44           47.29447     43.54096    0.02272727 
+  66           47.05647     43.53167    0.01515152 
+  56           46.83346     43.52239    0.01785714 
+  60           46.69156     43.51312    0.01666667 
+  62           46.64032     43.50387    0.01612903 
+  42           46.66828     43.49462    0.02380952 
+  56           46.75643     43.48539    0.01785714 
+  47           46.87        43.47617    0.0212766 
+  53           46.94127     43.46696    0.01886792 
+  49           46.92198     43.45776    0.02040816 
+  56           46.8552      43.44857    0.01785714 
+  44           46.78708     43.4394     0.02272727 
+  52           46.74374     43.43023    0.01923077 
+  43           46.73509     43.42108    0.02325581 
+  51           46.76372     43.41194    0.01960784 
+  55           46.82687     43.40281    0.01818182 
+  62           46.92744     43.39369    0.01612903 
+  52           47.08213     43.38459    0.01923077 
+  52           47.3391      43.3755     0.01923077 
+  48           47.80637     43.36642    0.02083333 
+  63           48.66486     43.35735    0.01587302 
+  61           50.10751     43.34829    0.01639344 
+  49           52.15588     43.33925    0.02040816 
+  56           54.34888     43.33022    0.01785714 
+  75           55.46858     43.3212     0.01333333 
+  63           54.72274     43.31219    0.01587302 
+  62           53.24886     43.3032     0.01612903 
+  56           52.4052      43.29422    0.01785714 
+  60           52.74302     43.28525    0.01666667 
+  46           54.11629     43.27629    0.02173913 
+  46           55.66223     43.26735    0.02173913 
+  49           56.23666     43.25842    0.02040816 
+  50           55.84164     43.2495     0.02      
+  56           54.87108     43.2406     0.01785714 
+  65           53.36556     43.23171    0.01538462 
+  69           51.95673     43.22283    0.01449275 
+  47           51.2672      43.21397    0.0212766 
+  49           51.42635     43.20512    0.02040816 
+  51           52.15828     43.19628    0.01960784 
+  47           52.85804     43.18746    0.0212766 
+  58           52.85939     43.17865    0.01724138 
+  48           52.09801     43.16985    0.02083333 
+  48           51.30833     43.16107    0.02083333 
+  53           51.05053     43.1523     0.01886792 
+  56           51.44853     43.14355    0.01785714 
+  55           52.33999     43.13481    0.01818182 
+  70           53.328       43.12608    0.01428571 
+  54           54.05092     43.11737    0.01851852 
+  69           54.6773      43.10867    0.01449275 
+  49           55.16401     43.09999    0.02040816 
+  60           55.02027     43.09132    0.01666667 
+  53           54.123       43.08266    0.01886792 
+  63           52.88778     43.07402    0.01587302 
+  61           51.73115     43.0654     0.01639344 
+  55           50.86996     43.05678    0.01818182 
+  49           50.29642     43.04819    0.02040816 
+  46           49.98538     43.03961    0.02173913 
+  49           49.92449     43.03104    0.02040816 
+  58           50.10903     43.02249    0.01724138 
+  45           50.57886     43.01395    0.02222222 
+  53           51.42585     43.00543    0.01886792 
+  44           52.76486     42.99692    0.02272727 
+  41           54.59905     42.98843    0.02439024 
+  42           56.5119      42.97995    0.02380952 
+  50           57.5107      42.97149    0.02      
+  65           57.16445     42.96305    0.01538462 
+  61           56.13925     42.95462    0.01639344 
+  55           55.01156     42.9462     0.01818182 
+  56           54.1275      42.93781    0.01785714 
+  52           53.65269     42.92942    0.01923077 
+  55           53.64591     42.92106    0.01818182 
+  55           54.0903      42.91271    0.01818182 
+  60           54.93617     42.90437    0.01666667 
+  66           56.05268     42.89605    0.01515152 
+  71           57.323       42.88775    0.01408451 
+  58           58.52584     42.87946    0.01724138 
+  77           59.87547     42.87119    0.01298701 
+  61           61.80984     42.86294    0.01639344 
+  72           64.58813     42.8547     0.01388889 
+  74           68.2395      42.84648    0.01351351 
+  80           72.68209     42.83828    0.0125    
+  98           78.47594     42.83009    0.01020408 
+  104          87.00092     42.82192    0.00961538 
+  114          99.61207     42.81377    0.00877193 
+  120          117.19325    42.80563    0.00833333 
+  131          139.645      42.79752    0.00763359 
+  162          164.45492    42.78941    0.00617284 
+  153          184.58963    42.78133    0.00653595 
+  133          190.19943    42.77326    0.0075188 
+  116          178.1816     42.76521    0.00862069 
+  114          156.35947    42.75718    0.00877193 
+  117          134.16468    42.74916    0.00854701 
+  106          116.84386    42.74117    0.00943396 
+  93           106.54124    42.73319    0.01075269 
+  113          103.83587    42.72522    0.00884956 
+  93           107.88128    42.71728    0.01075269 
+  81           115.28938    42.70935    0.01234568 
+  114          119.19056    42.70145    0.00877193 
+  104          115.93726    42.69356    0.00961538 
+  86           110.91556    42.68568    0.01162791 
+  111          109.4308     42.67783    0.00900901 
+  124          113.09032    42.67       0.00806452 
+  103          120.63123    42.66218    0.00970874 
+  125          127.81683    42.65438    0.008     
+  117          128.9518     42.6466     0.00854701 
+  108          122.09136    42.63884    0.00925926 
+  111          111.01173    42.6311     0.00900901 
+  82           100.39095    42.62338    0.01219512 
+  76           92.76257     42.61567    0.01315789 
+  86           89.17259     42.60799    0.01162791 
+  93           90.4682      42.60032    0.01075269 
+  78           97.36054     42.59267    0.01282051 
+  88           108.69492    42.58505    0.01136364 
+  90           119.51493    42.57744    0.01111111 
+  101          122.74167    42.56985    0.00990099 
+  84           115.56768    42.56228    0.01190476 
+  84           103.59032    42.55473    0.01190476 
+  88           93.88586     42.5472     0.01136364 
+  89           89.47591     42.53969    0.01123596 
+  98           90.84754     42.5322     0.01020408 
+  103          97.82196     42.52473    0.00970874 
+  110          110.52576    42.51728    0.00909091 
+  124          129.45051    42.50985    0.00806452 
+  140          154.75451    42.50244    0.00714286 
+  184          184.68036    42.49505    0.00543478 
+  180          212.89387    42.48768    0.00555556 
+  181          227.99492    42.48034    0.00552486 
+  153          222.35595    42.47301    0.00653595 
+  163          201.77729    42.4657     0.00613497 
+  151          177.79855    42.45842    0.00662252 
+  106          155.97113    42.45115    0.00943396 
+  99           136.099      42.44391    0.01010101 
+  109          119.40028    42.43668    0.00917431 
+  92           108.37359    42.42948    0.01086957 
+  99           104.03758    42.4223     0.01010101 
+  97           106.44342    42.41514    0.01030928 
+  91           115.16895    42.408      0.01098901 
+  113          129.02782    42.40088    0.00884956 
+  118          145.95419    42.39379    0.00847458 
+  138          166.02618    42.38672    0.00724638 
+  145          191.20099    42.37966    0.00689655 
+  145          218.92382    42.37263    0.00689655 
+  140          239.12189    42.36563    0.00714286 
+  152          239.3418     42.35864    0.00657895 
+  133          217.80682    42.35168    0.0075188 
+  118          185.46547    42.34474    0.00847458 
+  113          153.61213    42.33782    0.00884956 
+  97           127.49352    42.33092    0.01030928 
+  89           108.16329    42.32405    0.01123596 
+  65           94.97108     42.31719    0.01538462 
+  88           86.86078     42.31036    0.01136364 
+  78           82.86219     42.30356    0.01282051 
+  66           82.12831     42.29678    0.01515152 
+  88           83.65183     42.29001    0.01136364 
+  79           85.98942     42.28328    0.01265823 
+  70           88.58314     42.27656    0.01428571 
+  52           92.59535     42.26987    0.01923077 
+  73           98.45957     42.2632     0.01369863 
+  84           104.37395    42.25656    0.01190476 
+  73           106.54473    42.24994    0.01369863 
+  67           102.34217    42.24334    0.01492537 
+  64           93.45669     42.23677    0.015625  
+  68           83.53545     42.23022    0.01470588 
+  60           74.84919     42.22369    0.01666667 
+  55           68.0856      42.21719    0.01818182 
+  54           63.16841     42.21071    0.01851852 
+  48           59.74723     42.20426    0.02083333 
+  46           57.40444     42.19783    0.02173913 
+  68           55.72092     42.19143    0.01470588 
+  54           54.36995     42.18505    0.01851852 
+  75           53.24571     42.17869    0.01333333 
+  72           52.34795     42.17236    0.01388889 
+  61           51.66256     42.16605    0.01639344 
+  63           51.16237     42.15977    0.01587302 
+  52           50.82067     42.15352    0.01923077 
+  67           50.61759     42.14729    0.01492537 
+  56           50.55244     42.14108    0.01785714 
+  60           50.66867     42.1349     0.01666667 
+  67           51.12936     42.12874    0.01492537 
+  58           52.11617     42.12261    0.01724138 
+  53           53.62903     42.11651    0.01886792 
+  65           55.22306     42.11043    0.01538462 
+  48           55.85495     42.10438    0.02083333 
+  52           55.04367     42.09835    0.01923077 
+  57           53.73831     42.09235    0.01754386 
+  66           52.75191     42.08637    0.01515152 
+  62           52.19885     42.08042    0.01612903 
+  47           51.81348     42.0745     0.0212766 
+  68           51.55229     42.0686     0.01470588 
+  54           51.81644     42.06273    0.01851852 
+  58           53.08012     42.05689    0.01724138 
+  64           55.68009     42.05107    0.015625  
+  49           59.50882     42.04528    0.02040816 
+  64           63.40804     42.03952    0.015625  
+  64           64.88079     42.03378    0.015625  
+  63           62.91534     42.02807    0.01587302 
+  38           59.83778     42.02239    0.02631579 
+  66           57.57891     42.01674    0.01515152 
+  72           56.3904      42.01111    0.01388889 
+  52           55.90887     42.00551    0.01923077 
+  78           56.53188     41.99994    0.01282051 
+  54           59.14892     41.99439    0.01851852 
+  59           64.23144     41.98887    0.01694915 
+  72           71.0743      41.98338    0.01388889 
+  63           76.76529     41.97792    0.01587302 
+  58           76.84208     41.97249    0.01724138 
+  62           71.45016     41.96708    0.01612903 
+  63           65.35311     41.96171    0.01587302 
+  67           61.43573     41.95636    0.01492537 
+  48           59.90521     41.95104    0.02083333 
+  45           59.25068     41.94575    0.02222222 
+  71           57.69839     41.94049    0.01408451 
+  61           55.39482     41.93525    0.01639344 
+  61           53.36328     41.93005    0.01639344 
+  62           52.08916     41.92487    0.01612903 
+  67           51.67667     41.91972    0.01492537 
+  50           52.18851     41.91461    0.02      
+  65           53.82787     41.90952    0.01538462 
+  56           56.83826     41.90446    0.01785714 
+  60           61.07562     41.89943    0.01666667 
+  69           65.29314     41.89443    0.01449275 
+  56           66.80857     41.88946    0.01785714 
+  66           64.34295     41.88452    0.01515152 
+  58           60.20229     41.87961    0.01724138 
+  68           56.62707     41.87473    0.01470588 
+  51           54.25619     41.86988    0.01960784 
+  77           52.95226     41.86506    0.01298701 
+  58           52.42813     41.86027    0.01724138 
+  74           52.42868     41.85551    0.01351351 
+  85           52.82184     41.85079    0.01176471 
+  84           53.60754     41.84609    0.01190476 
+  64           54.93112     41.84142    0.015625  
+  90           57.12845     41.83679    0.01111111 
+  83           60.78082     41.83218    0.01204819 
+  120          66.6442      41.82761    0.00833333 
+  121          75.39306     41.82307    0.00826446 
+  154          87.01808     41.81856    0.00649351 
+  228          99.85297     41.81408    0.00438596 
+  304          109.64411    41.80963    0.00328947 
+  318          110.92744    41.80522    0.00314465 
+  328          102.61744    41.80083    0.00304878 
+  246          90.0813      41.79648    0.00406504 
+  203          78.36624     41.79216    0.00492611 
+  149          69.44005     41.78787    0.00671141 
+  138          63.4212      41.78362    0.00724638 
+  117          59.76909     41.7794     0.00854701 
+  105          57.82161     41.77521    0.00952381 
+  89           57.11414     41.77105    0.01123596 
+  95           57.50269     41.76692    0.01052632 
+  110          59.21153     41.76283    0.00909091 
+  101          62.73327     41.75877    0.00990099 
+  114          68.57246     41.75475    0.00877193 
+  111          76.6859      41.75075    0.00900901 
+  146          85.68182     41.74679    0.00684932 
+  176          93.0531      41.74287    0.00568182 
+  191          96.70114     41.73897    0.0052356 
+  190          94.50324     41.73511    0.00526316 
+  191          86.96434     41.73129    0.0052356 
+  172          78.11527     41.7275     0.00581395 
+  116          70.86661     41.72374    0.00862069 
+  98           65.69617     41.72002    0.01020408 
+  107          62.37007     41.71633    0.00934579 
+  95           60.71068     41.71267    0.01052632 
+  107          60.51786     41.70905    0.00934579 
+  76           61.74893     41.70547    0.01315789 
+  87           64.86197     41.70191    0.01149425 
+  97           71.32899     41.6984     0.01030928 
+  105          84.16899     41.69492    0.00952381 
+  115          107.71657    41.69147    0.00869565 
+  162          145.06389    41.68806    0.00617284 
+  174          193.09223    41.68468    0.00574713 
+  201          235.13397    41.68134    0.00497512 
+  202          241.06597    41.67804    0.0049505 
+  206          205.2146     41.67477    0.00485437 
+  172          157.15037    41.67153    0.00581395 
+  147          118.70217    41.66833    0.00680272 
+  127          95.40337     41.66517    0.00787402 
+  119          84.38636     41.66205    0.00840336 
+  99           80.1051      41.65896    0.01010101 
+  95           77.01986     41.6559     0.01052632 
+  87           72.58298     41.65289    0.01149425 
+  84           68.24493     41.6499     0.01190476 
+  93           65.8384      41.64696    0.01075269 
+  76           66.62252     41.64405    0.01315789 
+  87           72.08199     41.64118    0.01149425 
+  101          84.00825     41.63835    0.00990099 
+  116          103.24156    41.63555    0.00862069 
+  122          126.72458    41.6328     0.00819672 
+  129          143.32427    41.63008    0.00775194 
+  119          138.80682    41.62739    0.00840336 
+  123          117.61675    41.62475    0.00813008 
+  115          95.07692     41.62214    0.00869565 
+  95           78.96725     41.61957    0.01052632 
+  94           70.38645     41.61703    0.0106383 
+  96           67.65937     41.61454    0.01041667 
+  92           68.47591     41.61208    0.01086957 
+  61           71.10681     41.60967    0.01639344 
+  71           75.42154     41.60729    0.01408451 
+  77           81.47313     41.60495    0.01298701 
+  50           86.19375     41.60265    0.02      
+  51           84.20324     41.60038    0.01960784 
+  60           76.03218     41.59816    0.01666667 
+  74           67.09973     41.59597    0.01351351 
+  51           60.38705     41.59383    0.01960784 
+  58           56.31264     41.59172    0.01724138 
+  55           54.10981     41.58966    0.01818182 
+  55           52.8099      41.58763    0.01818182 
+  45           51.87111     41.58564    0.02222222 
+  51           51.2008      41.5837     0.01960784 
+  65           50.8176      41.58179    0.01538462 
+  53           50.77033     41.57992    0.01886792 
+  55           51.19744     41.5781     0.01818182 
+  52           52.38835     41.57631    0.01923077 
+  68           54.71001     41.57456    0.01470588 
+  54           58.3137      41.57286    0.01851852 
+  48           62.56115     41.57119    0.02083333 
+  50           65.2698      41.56957    0.02      
+  57           64.00291     41.56799    0.01754386 
+  61           59.93478     41.56645    0.01639344 
+  54           55.79323     41.56495    0.01851852 
+  51           52.81554     41.56349    0.01960784 
+  45           51.06591     41.56207    0.02222222 
+  48           50.12421     41.56069    0.02083333 
+  58           49.53096     41.55936    0.01724138 
+  51           49.07025     41.55807    0.01960784 
+  54           48.71142     41.55682    0.01851852 
+  59           48.40094     41.55561    0.01694915 
+  57           48.21914     41.55445    0.01754386 
+  53           48.09498     41.55332    0.01886792 
+  51           48.00868     41.55224    0.01960784 
+  43           47.94705     41.55121    0.02325581 
+  48           47.90262     41.55021    0.02083333 
+  45           47.87069     41.54926    0.02222222 
+  54           47.84757     41.54835    0.01851852 
+  52           47.83287     41.54749    0.01923077 
+  57           47.82354     41.54666    0.01754386 
+  58           47.82168     41.54589    0.01724138 
+  53           47.82716     41.54515    0.01886792 
+  54           47.83977     41.54446    0.01851852 
+  51           47.85927     41.54381    0.01960784 
+  49           47.86154     41.54321    0.02040816 
+  54           47.89544     41.54265    0.01851852 
+  55           47.93748     41.54214    0.01818182 
+  59           47.98851     41.54167    0.01694915 
+  52           48.05017     41.54124    0.01923077 
+  53           48.12463     41.54086    0.01886792 
+  66           48.21579     41.54053    0.01515152 
+  54           48.3308      41.54023    0.01851852 
+  35           48.48651     41.53999    0.02857143 
+  60           48.72185     41.53979    0.01666667 
+  52           49.11266     41.53963    0.01923077 
+  62           49.76916     41.53952    0.01612903 
+  45           50.77929     41.53946    0.02222222 
+  46           52.08921     41.53944    0.02173913 
+  59           53.30162     41.53947    0.01694915 
+  50           53.67763     41.53954    0.02      
+  61           53.1232      41.53966    0.01639344 
+  48           52.46401     41.53983    0.02083333 
+  44           52.32133     41.54004    0.02272727 
+  52           52.8279      41.5403     0.01923077 
+  50           53.68023     41.54061    0.02      
+  41           54.13859     41.54096    0.02439024 
+  56           53.68658     41.54136    0.01785714 
+  45           52.79208     41.54181    0.02222222 
+  58           52.0515      41.5423     0.01724138 
+  51           51.70215     41.54284    0.01960784 
+  66           51.79773     41.54343    0.01515152 
+  50           52.37416     41.54407    0.02      
+  60           53.49651     41.54475    0.01666667 
+  57           55.16408     41.54549    0.01754386 
+  71           57.08233     41.54627    0.01408451 
+  62           58.38862     41.5471     0.01612903 
+  77           58.23703     41.54798    0.01298701 
+  66           57.09394     41.5489     0.01515152 
+  63           56.02043     41.54988    0.01587302 
+  52           55.58841     41.5509     0.01923077 
+  50           55.90953     41.55198    0.02      
+  64           56.81321     41.5531     0.015625  
+  68           57.8963      41.55427    0.01470588 
+  45           58.75403     41.55549    0.02222222 
+  50           59.24123     41.55676    0.02      
+  46           59.14492     41.55808    0.02173913 
+  43           58.62201     41.55945    0.02325581 
+  58           58.21578     41.56087    0.01724138 
+  49           58.24923     41.56234    0.02040816 
+  48           58.80963     41.56386    0.02083333 
+  52           59.86897     41.56543    0.01923077 
+  61           61.31835     41.56706    0.01639344 
+  63           62.96767     41.56873    0.01587302 
+  56           64.91953     41.57045    0.01785714 
+  74           68.11691     41.57223    0.01351351 
+  70           73.87613     41.57405    0.01428571 
+  89           83.0852      41.57593    0.01123596 
+  69           95.14442     41.57786    0.01449275 
+  77           105.76357    41.57983    0.01298701 
+  83           107.23262    41.58187    0.01204819 
+  79           98.6597      41.58395    0.01265823 
+  69           87.40486     41.58609    0.01449275 
+  64           78.15097     41.58827    0.015625  
+  76           71.85816     41.59051    0.01315789 
+  50           68.11201     41.59281    0.02      
+  58           66.12391     41.59515    0.01724138 
+  53           65.1763      41.59755    0.01886792 
+  71           64.83289     41.6        0.01408451 
+  45           64.88616     41.6025     0.02222222 
+  56           65.29023     41.60506    0.01785714 
+  54           66.15597     41.60767    0.01851852 
+  62           67.78282     41.61033    0.01612903 
+  55           70.63358     41.61305    0.01818182 
+  66           75.12101     41.61582    0.01515152 
+  81           81.11118     41.61865    0.01234568 
+  72           86.85083     41.62153    0.01388889 
+  73           88.55477     41.62446    0.01369863 
+  62           84.83072     41.62745    0.01612903 
+  73           79.16959     41.63049    0.01369863 
+  56           74.43484     41.63359    0.01785714 
+  67           71.3732      41.63674    0.01492537 
+  58           69.72307     41.63995    0.01724138 
+  65           69.00141     41.64321    0.01538462 
+  64           68.79978     41.64653    0.015625  
+  66           68.88209     41.6499     0.01515152 
+  60           69.14522     41.65333    0.01666667 
+  74           69.57548     41.65682    0.01351351 
+  71           70.22802     41.66036    0.01408451 
+  74           71.2121      41.66396    0.01351351 
+  80           72.61799     41.66761    0.0125    
+  77           74.37793     41.67132    0.01298701 
+  65           76.02942     41.67509    0.01538462 
+  69           76.68548     41.67891    0.01449275 
+  84           76.14484     41.68279    0.01190476 
+  72           75.27763     41.68673    0.01388889 
+  72           74.75999     41.69072    0.01388889 
+  82           74.8292      41.69477    0.01219512 
+  90           75.50263     41.69888    0.01111111 
+  75           76.69771     41.70305    0.01333333 
+  83           78.23515     41.70727    0.01204819 
+  81           79.8347      41.71155    0.01234568 
+  78           81.58261     41.71589    0.01282051 
+  87           84.00733     41.72029    0.01149425 
+  83           86.98841     41.72475    0.01204819 
+  82           89.09766     41.72927    0.01219512 
+  69           88.84994     41.73384    0.01449275 
+  75           87.3572      41.73848    0.01333333 
+  89           86.58617     41.74317    0.01123596 
+  84           87.10712     41.74792    0.01190476 
+  78           87.99221     41.75273    0.01282051 
+  78           87.60355     41.7576     0.01282051 
+  66           85.6741      41.76253    0.01515152 
+  81           83.46567     41.76752    0.01234568 
+  66           81.87896     41.77257    0.01515152 
+  77           81.13101     41.77769    0.01298701 
+  76           81.11617     41.78286    0.01315789 
+  68           81.63607     41.78809    0.01470588 
+  75           82.50269     41.79338    0.01333333 
+  67           83.70009     41.79873    0.01492537 
+  73           85.52226     41.80415    0.01369863 
+  66           88.0071      41.80962    0.01515152 
+  74           90.26052     41.81516    0.01351351 
+  63           90.64637     41.82076    0.01587302 
+  77           89.17641     41.82642    0.01298701 
+  68           87.6579      41.83214    0.01470588 
+  64           87.07125     41.83793    0.015625  
+  62           87.0412      41.84377    0.01612903 
+  63           86.49458     41.84968    0.01587302 
+  79           85.08496     41.85565    0.01265823 
+  62           83.51684     41.86168    0.01612903 
+  76           82.47417     41.86778    0.01315789 
+  70           82.19514     41.87394    0.01428571 
+  92           82.71623     41.88016    0.01086957 
+  88           84.10403     41.88645    0.01136364 
+  65           86.65829     41.8928     0.01538462 
+  90           91.05522     41.89921    0.01111111 
+  84           98.42242     41.90569    0.01190476 
+  107          110.24503    41.91223    0.00934579 
+  112          127.86182    41.91883    0.00892857 
+  144          151.59359    41.9255     0.00694444 
+  133          179.11351    41.93224    0.0075188 
+  147          202.64817    41.93903    0.00680272 
+  156          208.68267    41.9459     0.00641026 
+  161          192.14878    41.95283    0.00621118 
+  131          164.07455    41.95982    0.00763359 
+  108          136.46554    41.96688    0.00925926 
+  86           114.56569    41.974      0.01162791 
+  101          99.09351     41.98119    0.00990099 
+  76           88.99772     41.98845    0.01315789 
+  88           82.75612     41.99577    0.01136364 
+  75           79.05947     42.00316    0.01333333 
+  86           77.10362     42.01061    0.01162791 
+  75           76.58718     42.01813    0.01333333 
+  70           77.65427     42.02572    0.01428571 
+  69           80.8014      42.03337    0.01449275 
+  87           86.70894     42.0411     0.01149425 
+  98           95.90507     42.04888    0.01020408 
+  91           108.16597    42.05674    0.01098901 
+  103          121.12877    42.06466    0.00970874 
+  91           128.89635    42.07265    0.01098901 
+  106          125.53023    42.08071    0.00943396 
+  90           113.05368    42.08884    0.01111111 
+  86           98.37428     42.09704    0.01162791 
+  85           85.71955     42.1053     0.01176471 
+  64           76.26342     42.11363    0.015625  
+  71           69.74074     42.12203    0.01408451 
+  59           65.44181     42.1305     0.01694915 
+  58           62.62424     42.13904    0.01724138 
+  60           60.73859     42.14765    0.01666667 
+  63           59.44372     42.15633    0.01587302 
+  62           58.5407      42.16508    0.01612903 
+  44           57.88434     42.1739     0.02272727 
+  44           57.29378     42.18278    0.02272727 
+  48           56.61118     42.19174    0.02083333 
+  56           55.88639     42.20077    0.01785714 
+  48           55.25276     42.20987    0.02083333 
+  54           54.78008     42.21904    0.01851852 
+  59           54.50999     42.22828    0.01694915 
+  59           54.49754     42.23759    0.01694915 
+  46           54.81063     42.24697    0.02173913 
+  54           55.45872     42.25643    0.01851852 
+  46           56.25742     42.26595    0.02173913 
+  57           56.65086     42.27555    0.01754386 
+  65           56.09115     42.28522    0.01538462 
+  69           54.92349     42.29496    0.01449275 
+  66           53.78735     42.30477    0.01515152 
+  49           52.96107     42.31466    0.02040816 
+  65           52.46385     42.32462    0.01538462 
+  53           52.20782     42.33465    0.01886792 
+  51           52.07028     42.34476    0.01960784 
+  40           51.92236     42.35493    0.025     
+  39           51.70614     42.36519    0.02564103 
+  64           51.47738     42.37551    0.015625  
+  55           51.29611     42.38591    0.01818182 
+  52           51.19511     42.39638    0.01923077 
+  58           51.2088      42.40693    0.01724138 
+  49           51.39567     42.41755    0.02040816 
+  60           51.82405     42.42825    0.01666667 
+  46           52.51041     42.43902    0.02173913 
+  62           53.29641     42.44986    0.01612903 
+  55           53.73747     42.46079    0.01818182 
+  54           53.42939     42.47178    0.01851852 
+  61           52.55927     42.48285    0.01639344 
+  53           51.62417     42.494      0.01886792 
+  60           50.90873     42.50522    0.01666667 
+  53           50.45956     42.51652    0.01886792 
+  45           50.22459     42.5279     0.02222222 
+  50           50.13274     42.53935    0.02      
+  61           50.12184     42.55087    0.01639344 
+  58           50.12371     42.56248    0.01724138 
+  54           50.06859     42.57416    0.01851852 
+  50           49.96998     42.58592    0.02      
+  46           49.91348     42.59776    0.02173913 
+  55           49.98276     42.60967    0.01818182 
+  50           50.26023     42.62166    0.02      
+  40           50.81202     42.63373    0.025     
+  53           51.61604     42.64588    0.01886792 
+  47           52.43352     42.6581     0.0212766 
+  47           52.73009     42.6704     0.0212766 
+  44           52.22563     42.68279    0.02272727 
+  53           51.34244     42.69525    0.01886792 
+  48           50.5645      42.70779    0.02083333 
+  55           50.0856      42.72041    0.01818182 
+  52           49.90794     42.73311    0.01923077 
+  45           49.94662     42.74589    0.02222222 
+  37           50.05914     42.75874    0.02702703 
+  37           50.07018     42.77168    0.02702703 
+  49           49.92418     42.7847     0.02040816 
+  50           49.70962     42.7978     0.02      
+  46           49.52325     42.81098    0.02173913 
+  57           49.4239      42.82424    0.01754386 
+  62           49.43673     42.83758    0.01612903 
+  59           49.57603     42.851      0.01694915 
+  45           49.8472      42.8645     0.02222222 
+  49           50.21211     42.87809    0.02040816 
+  63           50.53042     42.89175    0.01587302 
+  51           50.5714      42.9055     0.01960784 
+  52           50.32368     42.91933    0.01923077 
+  54           50.01655     42.93325    0.01851852 
+  44           49.79931     42.94724    0.02272727 
+  61           49.71151     42.96132    0.01639344 
+  47           49.73705     42.97548    0.0212766 
+  64           49.83301     42.98972    0.015625  
+  44           49.93265     43.00405    0.02272727 
+  51           49.96247     43.01846    0.01960784 
+  57           49.92669     43.03296    0.01754386 
+  57           49.88524     43.04753    0.01754386 
+  47           49.87108     43.0622     0.0212766 
+  55           49.88938     43.07694    0.01818182 
+  53           49.93326     43.09177    0.01886792 
+  66           49.99422     43.10669    0.01515152 
+  44           50.06684     43.12169    0.02272727 
+  48           50.15061     43.13678    0.02083333 
+  57           50.25005     43.15195    0.01754386 
+  54           50.37807     43.1672     0.01851852 
+  47           50.55287     43.18255    0.0212766 
+  49           50.79061     43.19797    0.02040816 
+  47           51.08382     43.21349    0.0212766 
+  43           51.36764     43.22909    0.02325581 
+  55           51.5058      43.24477    0.01818182 
+  46           51.44993     43.26055    0.02173913 
+  59           51.32464     43.27641    0.01694915 
+  46           51.23413     43.29236    0.02173913 
+  40           51.20794     43.30839    0.025     
+  54           51.23809     43.32451    0.01851852 
+  54           51.3073      43.34072    0.01851852 
+  38           51.40426     43.35702    0.02631579 
+  48           51.52887     43.37341    0.02083333 
+  56           51.68946     43.38988    0.01785714 
+  51           51.89258     43.40644    0.01960784 
+  47           52.12815     43.42309    0.0212766 
+  51           52.34626     43.43983    0.01960784 
+  62           52.47034     43.45666    0.01612903 
+  39           52.51323     43.47358    0.02564103 
+  59           52.56747     43.49059    0.01694915 
+  64           52.68009     43.50769    0.015625  
+  44           52.82862     43.52488    0.02272727 
+  33           52.93781     43.54215    0.03030303 
+  61           52.97721     43.55952    0.01639344 
+  61           53.00613     43.57698    0.01639344 
+  48           53.07722     43.59453    0.02083333 
+  47           53.20741     43.61217    0.0212766 
+  33           53.3877      43.6299     0.03030303 
+  68           53.58739     43.64773    0.01470588 
+  62           53.7656      43.66564    0.01612903 
+  49           53.90878     43.68365    0.02040816 
+  54           54.05433     43.70175    0.01851852 
+  62           54.24082     43.71994    0.01612903 
+  44           54.4755      43.73822    0.02272727 
+  58           54.73315     43.7566     0.01724138 
+  49           54.96914     43.77507    0.02040816 
+  54           55.18265     43.79363    0.01851852 
+  48           55.41858     43.81229    0.02083333 
+  45           55.71025     43.83104    0.02222222 
+  37           56.07377     43.84988    0.02702703 
+  56           56.52215     43.86882    0.01785714 
+  53           57.07415     43.88785    0.01886792 
+  52           57.76482     43.90697    0.01923077 
+  71           58.65914     43.92619    0.01408451 
+  65           59.86401     43.94551    0.01538462 
+  72           61.54617     43.96492    0.01388889 
+  60           63.92638     43.98442    0.01666667 
+  55           67.26654     44.00402    0.01818182 
+  73           71.80479     44.02372    0.01369863 
+  60           77.73042     44.04351    0.01666667 
+  58           85.26342     44.0634     0.01724138 
+  72           94.39451     44.08338    0.01388889 
+  80           103.87907    44.10346    0.0125    
+  84           110.54832    44.12364    0.01190476 
+  78           110.79821    44.14392    0.01282051 
+  70           104.41089    44.16429    0.01428571 
+  70           94.81982     44.18476    0.01428571 
+  69           85.35991     44.20532    0.01449275 
+  58           77.53174     44.22599    0.01724138 
+  61           71.64815     44.24675    0.01639344 
+  62           67.50344     44.26761    0.01612903 
+  59           64.76725     44.28857    0.01694915 
+  57           63.11722     44.30963    0.01754386 
+  72           62.33406     44.33079    0.01388889 
+  49           62.3143      44.35204    0.02040816 
+  64           63.05665     44.3734     0.015625  
+  59           64.61878     44.39485    0.01694915 
+  63           67.06237     44.41641    0.01587302 
+  66           70.53356     44.43806    0.01515152 
+  72           75.19466     44.45982    0.01388889 
+  71           80.80921     44.48168    0.01408451 
+  57           86.20493     44.50363    0.01754386 
+  85           89.52204     44.52569    0.01176471 
+  81           89.63378     44.54785    0.01234568 
+  93           86.50438     44.57011    0.01075269 
+  76           80.63972     44.59247    0.01315789 
+  79           73.58798     44.61493    0.01265823 
+  67           67.24408     44.6375     0.01492537 
+  70           62.50171     44.66017    0.01428571 
+  64           59.3587      44.68294    0.015625  
+  60           57.48125     44.70581    0.01666667 
+  78           56.52624     44.72879    0.01282051 
+  69           56.25605     44.75187    0.01449275 
+  56           56.46872     44.77505    0.01785714 
+  56           56.81874     44.79833    0.01785714 
+  77           56.7232      44.82172    0.01298701 
+  59           55.97315     44.84522    0.01694915 
+  86           55.11535     44.86882    0.01162791 
+  71           54.69195     44.89252    0.01408451 
+  68           54.97988     44.91633    0.01470588 
+  75           56.04449     44.94024    0.01333333 
+  72           57.63816     44.96426    0.01388889 
+  59           58.99892     44.98838    0.01694915 
+  70           59.14254     45.01261    0.01428571 
+  81           57.85211     45.03695    0.01234568 
+  75           55.94891     45.06139    0.01333333 
+  53           54.29366     45.08593    0.01886792 
+  82           53.19998     45.11059    0.01219512 
+  68           52.64623     45.13535    0.01470588 
+  62           52.5156      45.16022    0.01612903 
+  68           52.7136      45.18519    0.01470588 
+  61           53.17867     45.21028    0.01639344 
+  63           53.82776     45.23547    0.01587302 
+  55           54.49394     45.26077    0.01818182 
+  54           55.13632     45.28617    0.01851852 
+  64           56.17121     45.31169    0.015625  
+  70           58.07242     45.33731    0.01428571 
+  70           60.83701     45.36305    0.01428571 
+  64           63.61705     45.38889    0.015625  
+  64           64.73686     45.41484    0.015625  
+  75           63.46789     45.4409     0.01333333 
+  64           61.17893     45.46707    0.015625  
+  63           59.22825     45.49335    0.01587302 
+  55           58.07195     45.51975    0.01818182 
+  54           57.80513     45.54625    0.01851852 
+  68           58.39019     45.57286    0.01470588 
+  61           59.87856     45.59959    0.01639344 
+  65           62.6288      45.62642    0.01538462 
+  59           67.41727     45.65337    0.01694915 
+  74           75.35952     45.68043    0.01351351 
+  72           87.40125     45.7076     0.01388889 
+  103          103.37803    45.73488    0.00970874 
+  109          120.48256    45.76228    0.00917431 
+  123          134.46637    45.78979    0.00813008 
+  128          143.21901    45.81741    0.0078125 
+  116          143.33805    45.84514    0.00862069 
+  145          132.83151    45.87299    0.00689655 
+  113          116.65586    45.90095    0.00884956 
+  108          100.47422    45.92903    0.00925926 
+  93           87.21426     45.95722    0.01075269 
+  91           77.93451     45.98552    0.01098901 
+  106          72.50961     46.01394    0.00943396 
+  85           70.43211     46.04247    0.01176471 
+  76           71.45675     46.07112    0.01315789 
+  87           75.29266     46.09989    0.01149425 
+  91           80.79012     46.12877    0.01098901 
+  103          85.13538     46.15776    0.00970874 
+  103          86.09237     46.18688    0.00970874 
+  90           85.90569     46.21611    0.01111111 
+  87           87.4304      46.24545    0.01149425 
+  94           91.25338     46.27491    0.0106383 
+  95           95.76318     46.30449    0.01052632 
+  103          99.097       46.33419    0.00970874 
+  105          99.65304     46.364      0.00952381 
+  84           95.25196     46.39393    0.01190476 
+  85           86.83467     46.42398    0.01176471 
+  79           77.87956     46.45415    0.01265823 
+  65           70.53187     46.48444    0.01538462 
+  74           65.31031     46.51485    0.01351351 
+  68           62.01861     46.54537    0.01470588 
+  74           60.32225     46.57602    0.01351351 
+  57           60.02897     46.60678    0.01754386 
+  68           61.08624     46.63766    0.01470588 
+  76           63.19471     46.66867    0.01315789 
+  93           65.2824      46.69979    0.01075269 
+  77           65.51512     46.73104    0.01298701 
+  69           63.54708     46.7624     0.01449275 
+  67           60.83876     46.79389    0.01492537 
+  69           58.39535     46.8255     0.01449275 
+  73           56.66827     46.85723    0.01369863 
+  72           55.69819     46.88908    0.01388889 
+  59           55.3201      46.92105    0.01694915 
+  69           55.33294     46.95315    0.01449275 
+  61           55.49744     46.98537    0.01639344 
+  79           55.73927     47.01771    0.01265823 
+  62           56.18434     47.05017    0.01612903 
+  60           56.68309     47.08276    0.01666667 
+  65           56.70288     47.11547    0.01538462 
+  77           56.07122     47.14831    0.01298701 
+  89           55.28423     47.18127    0.01123596 
+  59           54.74054     47.21435    0.01694915 
+  74           54.55383     47.24756    0.01351351 
+  67           54.70532     47.2809     0.01492537 
+  74           55.13152     47.31435    0.01351351 
+  66           55.84204     47.34794    0.01515152 
+  58           57.0308      47.38165    0.01724138 
+  79           59.16757     47.41548    0.01265823 
+  72           63.10838     47.44945    0.01388889 
+  86           70.00024     47.48354    0.01162791 
+  94           80.74698     47.51775    0.0106383 
+  93           94.74487     47.55209    0.01075269 
+  91           107.9177     47.58656    0.01098901 
+  79           113.25252    47.62116    0.01265823 
+  94           109.97934    47.65588    0.0106383 
+  87           104.46562    47.69074    0.01149425 
+  84           98.4869      47.72572    0.01190476 
+  87           89.61846     47.76083    0.01149425 
+  61           79.35906     47.79607    0.01639344 
+  67           70.83613     47.83143    0.01492537 
+  80           64.90018     47.86693    0.0125    
+  79           61.12378     47.90256    0.01265823 
+  85           58.91507     47.93831    0.01176471 
+  65           57.75414     47.9742     0.01538462 
+  98           57.29634     48.01022    0.01020408 
+  77           57.44383     48.04636    0.01298701 
+  74           58.36231     48.08264    0.01351351 
+  89           60.49552     48.11905    0.01123596 
+  66           64.43217     48.15559    0.01515152 
+  68           70.50204     48.19227    0.01470588 
+  78           77.98872     48.22907    0.01282051 
+  72           84.11067     48.26601    0.01388889 
+  88           85.47022     48.30308    0.01136364 
+  79           83.1018      48.34028    0.01265823 
+  70           80.19301     48.37761    0.01428571 
+  66           76.7148      48.41508    0.01515152 
+  74           71.62888     48.45269    0.01351351 
+  76           66.33484     48.49042    0.01315789 
+  55           62.18738     48.52829    0.01818182 
+#--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--#
+
+
+# start Validation Reply Form
+_vrf_PLAT741_QPAPBMXHandGrindSamplePrep_phase_1 # for all atoms in 1_quartz
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT741_QPAPBMXHandGrindSamplePrep_phase_3 # for all atoms in 3_pyrrhotite
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT741_QPAPBMXHandGrindSamplePrep_phase_4 # for all atoms in 4_rutile
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT741_QPAPBMXHandGrindSamplePrep_phase_2 # for all atoms in 2_albite
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT155_QPAPBMXHandGrindSamplePrep_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT141_QPAPBMXHandGrindSamplePrep_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT142_QPAPBMXHandGrindSamplePrep_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT143_QPAPBMXHandGrindSamplePrep_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT144_QPAPBMXHandGrindSamplePrep_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT145_QPAPBMXHandGrindSamplePrep_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT146_QPAPBMXHandGrindSamplePrep_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT151_QPAPBMXHandGrindSamplePrep_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT148_QPAPBMXHandGrindSamplePrep_phase_3 # for 3_pyrrhotite
+;
+PROBLEM: s.u. on the a-Axis and c-Axis is (Too) Large 
+RESPONSE: untreated sample, s.u. expected to be high
+;
+# end Validation Reply Form

--- a/data/hamish/fixed/vb5042sup3.cif
+++ b/data/hamish/fixed/vb5042sup3.cif
@@ -1,0 +1,6630 @@
+
+data_QPABAT3_publ
+_audit_creation_method  "created in GSAS-II"
+_audit_creation_date  2021-08-04T17:27
+_audit_author_name  "McDougall, Hamish"
+_audit_update_record
+   "2021-08-04T17:27  Initial software-generated CIF"
+_pd_block_id  2021-08-04T17:27|QPABAT3|McDougallHamish|Overall
+# GSAS-II edited template follows Publication_Template
+#=============================================================================
+# this information describes the project, paper etc. for the CIF             #
+# Acta Cryst. Section C papers and editorial correspondence is generated     #
+# from the information in this section                                       #
+#                                                                            #
+#   (from)   CIF submission form for Rietveld refinements (Acta Cryst. C)    #
+#                                                 Version 14 December 1998   #
+#=============================================================================
+# 1. SUBMISSION DETAILS
+
+_publ_contact_author_name            "Suzanne Neville; Vanessa Peterson; Christophe Didier"   # Name of author for correspondence
+_publ_contact_author_address             # Address of author for correspondence
+; ?
+;
+_publ_contact_author_email           "s.neville@unsw.edu.au; vanessa.peterson@ansto.gov.au; drchristophedidier@gmail.com"
+_publ_contact_author_fax             ?
+_publ_contact_author_phone           ?
+
+_publ_contact_letter
+; ?
+;
+   
+_publ_requested_journal              ?
+_publ_requested_coeditor_name        ?
+_publ_requested_category             ?   # Acta C: one of CI/CM/CO/FI/FM/FO
+
+#==============================================================================
+
+# 2. PROCESSING SUMMARY (IUCr Office Use Only)
+
+_journal_data_validation_number      ?
+
+_journal_date_recd_electronic        ?
+_journal_date_to_coeditor            ?
+_journal_date_from_coeditor          ?
+_journal_date_accepted               ?
+_journal_date_printers_first         ?
+_journal_date_printers_final         ?
+_journal_date_proofs_out             ?
+_journal_date_proofs_in              ?
+_journal_coeditor_name               ?
+_journal_coeditor_code               ?
+_journal_coeditor_notes
+; ?
+;
+_journal_techeditor_code             ?
+_journal_techeditor_notes
+; ?
+;
+_journal_coden_ASTM                  ?
+_journal_name_full                   ?
+_journal_year                        ?
+_journal_volume                      ?
+_journal_issue                       ?
+_journal_page_first                  ?
+_journal_page_last                   ?
+_journal_paper_category              ?
+_journal_suppl_publ_number           ?
+_journal_suppl_publ_pages            ?
+
+#==============================================================================
+
+# 3. TITLE AND AUTHOR LIST
+
+_publ_section_title
+; ?
+;
+_publ_section_title_footnote
+; ?
+;         
+ 
+# The loop structure below should contain the names and addresses of all 
+# authors, in the required order of publication. Repeat as necessary.
+
+loop_
+	_publ_author_name
+        _publ_author_footnote
+	_publ_author_address
+ ?                                   #<--'Last name, first name' 
+; ?
+;
+; ?
+;
+
+#==============================================================================
+
+# 4. TEXT
+
+_publ_section_synopsis
+;  ?
+;
+_publ_section_abstract                         
+; ?
+;          
+_publ_section_comment                          
+; ?
+;
+_publ_section_exptl_prep      # Details of the preparation of the sample(s)
+                              # should be given here. 
+; ?
+;
+_publ_section_exptl_refinement                  
+; ?
+;
+_publ_section_references
+; ?
+;
+_publ_section_figure_captions
+; ?
+;
+_publ_section_acknowledgements
+; ?
+;
+
+#=============================================================================
+# 5. OVERALL REFINEMENT & COMPUTING DETAILS
+
+_refine_special_details
+; ?
+;
+_pd_proc_ls_special_details
+; ?
+;
+
+# The following items are used to identify the programs used.
+_computing_molecular_graphics     ?
+_computing_publication_material   ?
+
+_refine_ls_weighting_scheme       ?        
+_refine_ls_weighting_details      ?
+_refine_ls_hydrogen_treatment     ?        
+_refine_ls_extinction_method      ?        
+_refine_ls_extinction_coef        ?         
+_refine_ls_number_constraints     ?        
+
+_refine_ls_restrained_S_all       ?        
+_refine_ls_restrained_S_obs       ?
+
+#==============================================================================
+# 6. SAMPLE PREPARATION DATA
+
+# (In the unusual case where multiple samples are used in a single
+#  Rietveld study, this information should be moved into the phase
+#  blocks)
+
+# The following three fields describe the preparation of the material.
+# The cooling rate is in K/min.  The pressure at which the sample was  
+# prepared is in kPa.  The temperature of preparation is in K.
+               
+_pd_prep_cool_rate                N/A        
+_pd_prep_pressure                 101.3        
+_pd_prep_temperature              298         
+
+_pd_char_colour                   ?       # use ICDD colour descriptions
+
+data_QPABAT3_overall
+_pd_proc_info_datetime  2021-08-04T17:27
+_pd_calc_method  "Rietveld Refinement"
+_computing_structure_refinement
+   "GSAS-II (Toby & Von Dreele, J. Appl. Cryst. 46, 544-549, 2013)"
+_refine_ls_number_parameters  31
+_refine_ls_goodness_of_fit_all  1.948
+_refine_ls_shift/su_max  0.0409
+
+# OVERALL WEIGHTED R-FACTOR
+_refine_ls_wR_factor_obs  0.07869
+_refine_ls_matrix_type  full
+# POINTERS TO PHASE AND HISTOGRAM BLOCKS
+loop_   _pd_phase_block_id
+  2021-08-04T17:27|QPABAT3|phase_2|McDougallHamish
+  2021-08-04T17:27|QPABAT3|phase_0|McDougallHamish
+  2021-08-04T17:27|QPABAT3|phase_3|McDougallHamish
+  2021-08-04T17:27|QPABAT3|phase_4|McDougallHamish
+  2021-08-04T17:27|QPABAT3|phase_1|McDougallHamish
+_pd_block_diffractogram_id
+;
+2021-08-04T17:27|QPABAT3|McDougallHamish|PANalytical,Co-EmpyreanII_hist_0
+;
+
+data_QPABAT3_phase_2
+# Information for phase 2
+_pd_block_id  2021-08-04T17:27|QPABAT3|phase_2|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Albite NaAlSi3O8 follows
+_pd_phase_name  "Albite NaAlSi3O8"
+_cell_length_a  8.137
+_cell_length_b  12.785
+_cell_length_c  7.1583
+_cell_angle_alpha  94.26
+_cell_angle_beta   116.6
+_cell_angle_gamma  87.71
+_cell_volume  664.008
+_exptl_crystal_density_diffrn  2.6230
+_symmetry_cell_setting  triclinic
+_symmetry_space_group_name_H-M  "C -1"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -x,-y,-z
+     3  1/2+x,1/2+y,z
+     4  1/2-x,1/2-y,-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Al1    Al3+ 0.00887     0.16846     0.20805     1.000      Uani 0.007      4   
+Si1    Si4+ 0.00375     0.82051     0.23737     1.000      Uani 0.006      4   
+Si2    Si4+ 0.69162     0.11021     0.31466     1.000      Uani 0.006      4   
+Si3    Si4+ 0.68129     0.88190     0.36076     1.000      Uani 0.006      4   
+Na1    Na1+ 0.26799     0.98865     0.14650     1.000      Uani 0.031      4   
+O1     O2-  0.00490     0.13103     0.96660     1.000      Uani 0.012      4   
+O2     O2-  0.59176     0.99756     0.28040     1.000      Uani 0.008      4   
+O3     O2-  0.81230     0.10966     0.19010     1.000      Uani 0.014      4   
+O4     O2-  0.82000     0.85101     0.25870     1.000      Uani 0.018      4   
+O5     O2-  0.01288     0.30238     0.27060     1.000      Uani 0.011      4   
+O6     O2-  0.02329     0.69368     0.22910     1.000      Uani 0.011      4   
+O7     O2-  0.20780     0.10896     0.38900     1.000      Uani 0.011      4   
+O8     O2-  0.18400     0.86817     0.43620     1.000      Uani 0.012      4   
+
+loop_
+   _atom_site_aniso_label
+   _atom_site_aniso_U_11
+   _atom_site_aniso_U_22
+   _atom_site_aniso_U_33
+   _atom_site_aniso_U_12
+   _atom_site_aniso_U_13
+   _atom_site_aniso_U_23
+Al1    0.0074      0.0068      0.0061      -0.0009     0.0031      0.0004      
+Si1    0.0068      0.0065      0.0055      0.0011      0.0030      0.0008      
+Si2    0.0061      0.0055      0.0073      -0.0002     0.0025      0.0004      
+Si3    0.0060      0.0055      0.0074      0.0006      0.0028      0.0009      
+Na1    0.0136      0.0471      0.0315      -0.0050     0.0084      -0.0219     
+O1     0.0164      0.0122      0.0074      -0.0002     0.0067      0.0014      
+O2     0.0074      0.0056      0.0119      0.0003      0.0033      0.0020      
+O3     0.0117      0.0130      0.0162      -0.0040     0.0093      -0.0017     
+O4     0.0134      0.0179      0.0216      0.0046      0.0129      0.0020      
+O5     0.0103      0.0076      0.0150      -0.0020     0.0052      -0.0009     
+O6     0.0101      0.0071      0.0145      0.0022      0.0034      0.0012      
+O7     0.0120      0.0129      0.0080      0.0024      0.0013      0.0015      
+O8     0.0140      0.0140      0.0084      -0.0026     -0.0002     -0.0006     
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Al   4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Na   4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  O    32     ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si   12     ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Al Na O8 Si3"
+_chemical_formula_weight  262.22
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Al1    O1     1.74519      1_555    1_554 yes
+  Al1    O3     1.7429       1_555    1_455 yes
+  Al1    O5     1.73509      1_555    1_555 yes
+  Al1    O7     1.74556      1_555    1_555 yes
+  Si1    O1     1.59985      1_555    2_566 yes
+  Si1    O4     1.59997      1_555    1_455 yes
+  Si1    O6     1.62225      1_555    1_555 yes
+  Si1    O8     1.61907      1_555    1_555 yes
+  Si2    O2     1.63011      1_555    1_545 yes
+  Si2    O3     1.59435      1_555    1_555 yes
+  Si2    O6     1.61836      1_555    3_545 yes
+  Si2    O8     1.6168       1_555    2_666 yes
+  Si3    O2     1.64718      1_555    1_555 yes
+  Si3    O4     1.61975      1_555    1_555 yes
+  Si3    O5     1.59682      1_555    3_555 yes
+  Si3    O7     1.60203      1_555    2_666 yes
+  Na1    O1     2.66887      1_555    1_564 yes
+  Na1    O1     2.53079      1_555    2_566 yes
+  Na1    O2     2.3704       1_555    1_555 yes
+  Na1    O3     2.45321      1_555    2_665 yes
+  Na1    O7     2.43384      1_555    1_565 yes
+  O1     Al1    1.74519      1_555    1_556 yes
+  O1     Si1    1.59985      1_555    2_566 yes
+  O1     Na1    2.66887      1_555    1_546 yes
+  O1     Na1    2.53079      1_555    2_566 yes
+  O2     Si2    1.63011      1_555    1_565 yes
+  O2     Si3    1.64718      1_555    1_555 yes
+  O2     Na1    2.3704       1_555    1_555 yes
+  O3     Al1    1.7429       1_555    1_655 yes
+  O3     Si2    1.59435      1_555    1_555 yes
+  O3     Na1    2.45321      1_555    2_665 yes
+  O4     Si1    1.59997      1_555    1_655 yes
+  O4     Si3    1.61975      1_555    1_555 yes
+  O5     Al1    1.73509      1_555    1_555 yes
+  O5     Si3    1.59682      1_555    3_445 yes
+  O6     Si1    1.62225      1_555    1_555 yes
+  O6     Si2    1.61836      1_555    3_455 yes
+  O7     Al1    1.74556      1_555    1_555 yes
+  O7     Si3    1.60203      1_555    2_666 yes
+  O7     Na1    2.43384      1_555    1_545 yes
+  O8     Si1    1.61907      1_555    1_555 yes
+  O8     Si2    1.6168       1_555    2_666 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Al1    O3     102.836       1_554  1_555    1_455 yes
+  O1     Al1    O5     116.047       1_554  1_555    1_555 yes
+  O3     Al1    O5     112.215       1_455  1_555    1_555 yes
+  O1     Al1    O7     104.004       1_554  1_555    1_555 yes
+  O3     Al1    O7     111.151       1_455  1_555    1_555 yes
+  O5     Al1    O7     110.14        1_555  1_555    1_555 yes
+  O1     Si1    O4     109.433       2_566  1_555    1_455 yes
+  O1     Si1    O6     112.47        2_566  1_555    1_555 yes
+  O4     Si1    O6     108.187       1_455  1_555    1_555 yes
+  O1     Si1    O8     107.176       2_566  1_555    1_555 yes
+  O4     Si1    O8     111.446       1_455  1_555    1_555 yes
+  O6     Si1    O8     108.16        1_555  1_555    1_555 yes
+  O2     Si2    O3     111.144       1_545  1_555    1_555 yes
+  O2     Si2    O6     104.24        1_545  1_555    3_545 yes
+  O3     Si2    O6     112.114       1_555  1_555    3_545 yes
+  O2     Si2    O8     106.97        1_545  1_555    2_666 yes
+  O3     Si2    O8     111.591       1_555  1_555    2_666 yes
+  O6     Si2    O8     110.422       3_545  1_555    2_666 yes
+  O2     Si3    O4     107.269       1_555  1_555    1_555 yes
+  O2     Si3    O5     105.914       1_555  1_555    3_555 yes
+  O4     Si3    O5     110.224       1_555  1_555    3_555 yes
+  O2     Si3    O7     108.565       1_555  1_555    2_666 yes
+  O4     Si3    O7     110.208       1_555  1_555    2_666 yes
+  O5     Si3    O7     114.328       3_555  1_555    2_666 yes
+  Al1    O1     Si1    141.397       1_556  1_555    2_566 yes
+  Si2    O2     Si3    130.019       1_565  1_555    1_555 yes
+  Si2    O2     Na1    120.351       1_565  1_555    1_555 yes
+  Si3    O2     Na1    108.811       1_555  1_555    1_555 yes
+  Al1    O3     Si2    139.461       1_655  1_555    1_555 yes
+  Si1    O4     Si3    161.151       1_655  1_555    1_555 yes
+  Al1    O5     Si3    129.689       1_555  1_555    3_445 yes
+  Si1    O6     Si2    135.676       1_555  1_555    3_455 yes
+  Al1    O7     Si3    133.943       1_555  1_555    2_666 yes
+  Si1    O8     Si2    151.747       1_555  1_555    2_666 yes
+_pd_proc_ls_pref_orient_corr  none
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.111(8), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_QPABAT3_phase_0
+# Information for phase 0
+_pd_block_id  2021-08-04T17:27|QPABAT3|phase_0|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Pyrite FeS2 follows
+_pd_phase_name  "Pyrite FeS2"
+_cell_length_a  5.419411(25)
+_cell_length_b  5.419411(25)
+_cell_length_c  5.419411(25)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  90
+_cell_volume  159.1682(22)
+_exptl_crystal_density_diffrn  5.0063
+_symmetry_cell_setting  cubic
+_symmetry_space_group_name_H-M  "P a -3"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  z,x,y
+     3  y,z,x
+     4  1/2+x,y,1/2-z
+     5  1/2-z,1/2+x,y
+     6  y,1/2-z,1/2+x
+     7  -z,1/2+x,1/2-y
+     8  1/2-y,-z,1/2+x
+     9  1/2+y,1/2-z,-x
+    10  -x,1/2+y,1/2-z
+    11  1/2-z,-x,1/2+y
+    12  1/2+x,1/2-y,-z
+    13  -x,-y,-z
+    14  -z,-x,-y
+    15  -y,-z,-x
+    16  1/2-x,-y,1/2+z
+    17  1/2+z,1/2-x,-y
+    18  -y,1/2+z,1/2-x
+    19  z,1/2-x,1/2+y
+    20  1/2+y,z,1/2-x
+    21  1/2-y,1/2+z,x
+    22  x,1/2-y,1/2+z
+    23  1/2+z,x,1/2-y
+    24  1/2-x,1/2+y,z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Fe1    Fe   0.00000     0.00000     0.00000     1.000      Uiso 0.00508(25) 4   
+S2     S    0.38468(9)  0.38468     0.38468     1.000      Uiso 0.00584(27) 8   
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Fe   4      11.7695    7.3573     3.5222     2.3045     4.7611     0.3072     15.3535    76.8805    1.0369     0.945
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S    8      6.9053     5.2034     1.4379     1.5863     1.4679     22.2151    0.2536     56.172     0.8669     0.2847
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Fe S2"
+_chemical_formula_weight  119.97
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Fe1    S2     2.26435(13)   1_555    4_455 yes
+  Fe1    S2     2.26435(13)   1_555    5_545 yes
+  Fe1    S2     2.26435(13)   1_555    6_554 yes
+  Fe1    S2     2.26435(13)   1_555    7_545 yes
+  Fe1    S2     2.26435(13)   1_555    8_554 yes
+  Fe1    S2     2.2644(4)    1_555    9_455 yes
+  S2     Fe1    2.26435(13)   1_555    4_555 yes
+  S2     Fe1    2.26435(13)   1_555    5_555 yes
+  S2     Fe1    2.2644(4)    1_555    6_555 yes
+  S2     S2     2.1650(6)    1_555   13_666 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.1809(10), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_QPABAT3_phase_3
+# Information for phase 3
+_pd_block_id  2021-08-04T17:27|QPABAT3|phase_3|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Pyrrhotite 4M Fe7S8 follows
+_pd_phase_name  "Pyrrhotite 4M Fe7S8"
+_cell_length_a  11.946(31)
+_cell_length_b  6.857(4)
+_cell_length_c  12.83(3)
+_cell_angle_alpha  90
+_cell_angle_beta   117.25(6)
+_cell_angle_gamma  90
+_cell_volume  934.4(4)
+_exptl_crystal_density_diffrn  4.6023
+_symmetry_cell_setting  monoclinic
+_symmetry_space_group_name_H-M  "C 2/c"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -x,y,1/2-z
+     3  -x,-y,-z
+     4  x,-y,1/2+z
+     5  1/2+x,1/2+y,z
+     6  1/2-x,1/2+y,1/2-z
+     7  1/2-x,1/2-y,-z
+     8  1/2+x,1/2-y,1/2+z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+S1     S    0.01800     0.38330     0.11960     1.000      Uiso 0.010      8   
+S2     S    0.02910     0.11420     0.63900     1.000      Uiso 0.010      8   
+Fe3    Fe   0.10860     0.10250     0.49980     1.000      Uiso 0.010      8   
+S4     S    0.23410     0.13550     0.38260     1.000      Uiso 0.010      8   
+Fe5    Fe   0.24180     0.36600     0.24680     1.000      Uiso 0.010      8   
+S6     S    0.26790     0.13400     0.12360     1.000      Uiso 0.010      8   
+Fe7    Fe   0.38720     0.15000     0.01260     1.000      Uiso 0.010      8   
+Fe8    Fe   0.00000     0.14720     0.25000     1.000      Uiso 0.010      4   
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Fe   28     11.7695    7.3573     3.5222     2.3045     4.7611     0.3072     15.3535    76.8805    1.0369     0.945
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S    32     6.9053     5.2034     1.4379     1.5863     1.4679     22.2151    0.2536     56.172     0.8669     0.2847
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Fe7 S8"
+_chemical_formula_weight  647.41
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  S1     Fe3    2.49393      1_555    2_555 yes
+  S1     Fe5    2.41436      1_555    1_555 yes
+  S1     Fe7    2.38874      1_555    5_455 yes
+  S1     Fe7    2.44361      1_555    7_555 yes
+  S1     Fe8    2.40753      1_555    1_555 yes
+  S2     Fe3    2.37739      1_555    1_555 yes
+  S2     Fe3    2.32434      1_555    3_556 yes
+  S2     Fe5    2.44598      1_555    7_556 yes
+  S2     Fe7    2.36649      1_555    8_456 yes
+  S2     Fe8    2.41154      1_555    3_556 yes
+  Fe3    S1     2.49393      1_555    2_555 yes
+  Fe3    S2     2.37739      1_555    1_555 yes
+  Fe3    S2     2.32434      1_555    3_556 yes
+  Fe3    S6     2.45071      1_555    4_556 yes
+  S4     Fe5    2.38527      1_555    1_555 yes
+  Fe5    S1     2.41436      1_555    1_555 yes
+  Fe5    S2     2.44598      1_555    7_556 yes
+  Fe5    S4     2.38527      1_555    1_555 yes
+  Fe5    S6     2.36183      1_555    1_555 yes
+  S6     Fe3    2.45071      1_555    4_555 yes
+  S6     Fe5    2.36183      1_555    1_555 yes
+  S6     Fe7    2.43526      1_555    1_555 yes
+  S6     Fe7    2.39065      1_555    7_555 yes
+  Fe7    S1     2.38874      1_555    5_545 yes
+  Fe7    S1     2.44361      1_555    7_555 yes
+  Fe7    S2     2.36649      1_555    8_555 yes
+  Fe7    S6     2.43526      1_555    1_555 yes
+  Fe7    S6     2.39065      1_555    7_555 yes
+  Fe8    S1     2.40753      1_555    1_555 yes
+  Fe8    S1     2.40753      1_555    2_555 yes
+  Fe8    S2     2.41154      1_555    3_556 yes
+  Fe8    S2     2.41154      1_555    4_555 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.0305(25), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_QPABAT3_phase_4
+# Information for phase 4
+_pd_block_id  2021-08-04T17:27|QPABAT3|phase_4|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Rutile TiO2 follows
+_pd_phase_name  "Rutile TiO2"
+_cell_length_a  4.5980(13)
+_cell_length_b  4.5980(13)
+_cell_length_c  2.9619(13)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  90
+_cell_volume  62.618(30)
+_exptl_crystal_density_diffrn  4.2376
+_symmetry_cell_setting  tetragonal
+_symmetry_space_group_name_H-M  "P 42/m n m"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  1/2-y,1/2+x,1/2+z
+     3  -x,-y,z
+     4  1/2+y,1/2-x,1/2+z
+     5  1/2-x,1/2+y,1/2+z
+     6  -y,-x,z
+     7  1/2+x,1/2-y,1/2+z
+     8  y,x,z
+     9  -x,-y,-z
+    10  1/2+y,1/2-x,1/2-z
+    11  x,y,-z
+    12  1/2-y,1/2+x,1/2-z
+    13  1/2+x,1/2-y,1/2-z
+    14  y,x,-z
+    15  1/2-x,1/2+y,1/2-z
+    16  -y,-x,-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Ti1    Ti4+ 0.00000     0.00000     0.00000     1.000      Uiso 0.006      2   
+O1     O2-  0.32861     0.32861     0.00000     1.000      Uiso 0.005      4   
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  O    4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Ti   2      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  2
+_chemical_formula_sum  "O2 Ti"
+_chemical_formula_weight  79.9
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Ti1    O1     2.13681      1_555    1_555 yes
+  Ti1    O1     1.85342      1_555    2_544 yes
+  Ti1    O1     1.85342      1_555    2_545 yes
+  Ti1    O1     2.13681      1_555    3_555 yes
+  Ti1    O1     1.85342      1_555    4_454 yes
+  Ti1    O1     1.85342      1_555    4_455 yes
+  O1     Ti1    2.13681      1_555    1_555 yes
+  O1     Ti1    1.85342      1_555    2_554 yes
+  O1     Ti1    1.85342      1_555    2_555 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Ti1    O1     106.075       2_544  1_555    2_545 yes
+  O1     Ti1    O1     73.925        2_544  1_555    4_454 yes
+  O1     Ti1    O1     180           2_545  1_555    4_454 yes
+  O1     Ti1    O1     180           2_544  1_555    4_455 yes
+  O1     Ti1    O1     73.925        2_545  1_555    4_455 yes
+  O1     Ti1    O1     106.075       4_454  1_555    4_455 yes
+  Ti1    O1     Ti1    106.075       2_554  1_555    2_555 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.073(10), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_QPABAT3_phase_1
+# Information for phase 1
+_pd_block_id  2021-08-04T17:27|QPABAT3|phase_1|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Silica SiO2 follows
+_pd_phase_name  "Silica SiO2"
+_cell_length_a  4.9143(5)
+_cell_length_b  4.9143(5)
+_cell_length_c  5.4067(5)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  120
+_cell_volume  113.078(11)
+_exptl_crystal_density_diffrn  2.6470
+_symmetry_cell_setting  trigonal
+_symmetry_space_group_name_H-M  "P 32 2 1"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -y,x-y,2/3+z
+     3  y-x,-x,1/3+z
+     4  y,x,-z
+     5  -x,y-x,2/3-z
+     6  x-y,-y,1/3-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Si1    Si4+ 0.47000     0.00000     0.66670     1.000      Uiso 0.020      3   
+O1     O2-  0.41460     0.26780     0.78543     1.000      Uiso 0.017      6   
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  O    6      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si   3      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  3
+_chemical_formula_sum  "O2 Si"
+_chemical_formula_weight  60.08
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Si1    O1     1.60513      1_555    1_555 yes
+  Si1    O1     1.61166      1_555    2_654 yes
+  Si1    O1     1.6114       1_555    5_656 yes
+  Si1    O1     1.60528      1_555    6_556 yes
+  O1     Si1    1.60513      1_555    1_555 yes
+  O1     Si1    1.61166      1_555    3_665 yes
+  O1     Si1    1.6114       1_555    5_666 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Si1    O1     110.262       1_555  1_555    2_654 yes
+  O1     Si1    O1     108.73        1_555  1_555    5_656 yes
+  O1     Si1    O1     109.698       2_654  1_555    5_656 yes
+  O1     Si1    O1     109.165       1_555  1_555    6_556 yes
+  O1     Si1    O1     108.71        2_654  1_555    6_556 yes
+  O1     Si1    O1     110.268       5_656  1_555    6_556 yes
+  Si1    O1     Si1    143.833       1_555  1_555    3_665 yes
+  Si1    O1     Si1    143.836       1_555  1_555    5_666 yes
+  Si1    O1     Si1    0.009         3_665  1_555    5_666 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.145(6), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_QPABAT3_pwd_0
+_pd_proc_ls_profile_function
+;
+Finger-Cox-Jephcoat function parameters U, V, W, X, Y, SH/L:
+  peak variance(Gauss) = Utan(Th)^2^+Vtan(Th)+W:
+  peak HW(Lorentz) = X/cos(Th)+Ytan(Th); SH/L = S/L+H/L
+  U, V, W in (centideg)^2^, X & Y in centideg
+    0.000, 0.000, 3.345, 2.239, -0.670, 0.034, 
+;
+# Information for histogram 0: PWDR BAT3_Whole_30mm_MonicaHamish_Ruoming_step size 0_BAT3_Whole.xrdml Scan 1
+_pd_block_id
+;
+2021-08-04T17:27|QPABAT3|McDougallHamish|PANalytical,Co-EmpyreanII_hist_0
+;
+# GSAS-II edited template follows Instrument_Template
+#==============================================================================
+# 9. INSTRUMENT CHARACTERIZATION
+
+_exptl_special_details
+; ?
+;
+
+# if regions of the data are excluded, the reason(s) are supplied here:
+_pd_proc_info_excluded_regions
+; ?
+;
+
+# The following item is used to identify the equipment used to record 
+# the powder pattern when the diffractogram was measured at a laboratory 
+# other than the authors' home institution, e.g. when neutron or synchrotron
+# radiation is used.
+
+_pd_instr_location
+; ?
+;
+_pd_calibration_special_details           # description of the method used
+                                          # to calibrate the instrument
+; ?
+;
+
+_diffrn_source                    Co-Ka       
+_diffrn_source_target             Co
+_diffrn_source_type               Graded_Flat
+_diffrn_measurement_device_type   Panalytical_Reflection_Transmission       
+_diffrn_detector                  PIXcel1D       
+_diffrn_detector_type             Empyrean_II       # make or model of detector
+
+_pd_meas_scan_method              ?       # options are 'step', 'cont',
+                                          # 'tof', 'fixed' or
+                                          # 'disp' (= dispersive)
+_pd_meas_special_details
+;  ?
+;
+
+# The following two items identify the program(s) used (if appropriate).
+_computing_data_collection        ?        
+_computing_data_reduction         ?                   
+
+# Describe any processing performed on the data, prior to refinement.
+# For example: a manual Lp correction or a precomputed absorption correction
+_pd_proc_info_data_reduction      ?
+
+# The following item is used for angular dispersive measurements only.
+
+_diffrn_radiation_monochromator   ?        
+
+# The following items are used to define the size of the instrument.
+# Not all distances are appropriate for all instrument types.
+
+_pd_instr_dist_src/mono           ?
+_pd_instr_dist_mono/spec          ?
+_pd_instr_dist_src/spec           ?
+_pd_instr_dist_spec/anal          ?
+_pd_instr_dist_anal/detc          ?
+_pd_instr_dist_spec/detc          ?
+
+# 10. Specimen size and mounting information
+
+# The next three fields give the specimen dimensions in mm.  The equatorial 
+# plane contains the incident and diffracted beam.
+
+_pd_spec_size_axial               ?       # perpendicular to 
+                                          # equatorial plane
+
+_pd_spec_size_equat               ?       # parallel to 
+                                          # scattering vector 
+                                          # in transmission
+
+_pd_spec_size_thick               ?       # parallel to 
+                                          # scattering vector 
+                                          # in reflection
+
+_pd_spec_mounting                         # This field should be
+                                          # used to give details of the 
+                                          # container.
+; ?
+;
+
+_pd_spec_mount_mode               ?       # options are 'reflection' 
+                                          # or 'transmission'
+    
+_pd_spec_shape                    ?       # options are 'cylinder' 
+                                          # 'flat_sheet' or 'irregular'
+
+
+loop_
+     _atom_type_symbol
+     _atom_type_scat_dispersion_real
+     _atom_type_scat_dispersion_imag
+     _atom_type_scat_dispersion_source
+  Al        0.255   0.328   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Fe       -3.332   0.490   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Na        0.167   0.167   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  O         0.063   0.044   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S         0.371   0.733   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si        0.298   0.438   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Ti       -0.063   2.321   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+_diffrn_radiation_type  K\a~1,2~
+loop_
+   _diffrn_radiation_wavelength
+   _diffrn_radiation_wavelength_wt
+   _diffrn_radiation_wavelength_id
+  1.78892         1.0             1     
+  1.79278         0.5000          2     
+
+# PHASE TABLE
+loop_
+   _pd_phase_id
+   _pd_phase_block_id
+   _pd_phase_mass_%
+  2  2021-08-04T17:27|QPABAT3|phase_2|McDougallHamish  0.0851(21)
+  0  2021-08-04T17:27|QPABAT3|phase_0|McDougallHamish  0.8094(27)
+  3  2021-08-04T17:27|QPABAT3|phase_3|McDougallHamish  0.0350(12)
+  4  2021-08-04T17:27|QPABAT3|phase_4|McDougallHamish  0.0106(7)
+  1  2021-08-04T17:27|QPABAT3|phase_1|McDougallHamish  0.0598(8)
+loop_
+   _gsas_proc_phase_R_F_factor
+   _gsas_proc_phase_R_Fsqd_factor
+   _gsas_proc_phase_id
+   _gsas_proc_phase_block_id
+    0.06873  0.15034  2  2021-08-04T17:27|QPABAT3|phase_2|McDougallHamish
+    0.01682  0.03546  0  2021-08-04T17:27|QPABAT3|phase_0|McDougallHamish
+    0.06246  0.11208  3  2021-08-04T17:27|QPABAT3|phase_3|McDougallHamish
+    0.04014  0.07367  4  2021-08-04T17:27|QPABAT3|phase_4|McDougallHamish
+    0.03350  0.06031  1  2021-08-04T17:27|QPABAT3|phase_1|McDougallHamish
+_pd_proc_ls_prof_R_factor     0.05965
+_pd_proc_ls_prof_wR_factor    0.07869
+_gsas_proc_ls_prof_R_B_factor   0.06432
+_gsas_proc_ls_prof_wR_B_factor  0.08293
+_pd_proc_ls_prof_wR_expected  0.04055
+_diffrn_radiation_probe  x-ray
+_diffrn_radiation_polarisn_ratio  0.7000
+_pd_proc_ls_background_function
+;
+Background function: "chebyschev-1" function with 7 terms:
+    374.6(12), -373.9(18), 291.7(17), -139.4(15), 84.2(14), -23.2(11), 
+    6.1(10), 
+;
+_diffrn_ambient_temperature  300
+_diffrn_ambient_pressure  100
+
+# STRUCTURE FACTOR TABLE
+loop_
+   _pd_refln_phase_id
+   _refln_index_h
+   _refln_index_k
+   _refln_index_l
+   _refln_F_squared_meas
+   _refln_F_squared_calc
+   _refln_phase_calc
+   _refln_d_spacing
+   _gsas_i100_meas
+  0  1    1    1    953.6319   888.7034   0.0     3.12890  23.43  
+  0  2    0    0    6373.5500  6318.1937  -0.0    2.70971  86.79  
+  0  2    1    0    3566.6358  3423.9852  0.0     2.42363  76.70  
+  0  2    1    1    1783.6764  1744.8963  -180.0  2.21247  63.21  
+  0  2    2    0    3315.4690  3397.1649  -0.0    1.91605  43.35  
+  0  2    2    1    39.3742    36.6182    -0.0    1.80647  0.91   
+  0  3    1    1    5292.3725  5439.4706  -0.0    1.63401  100.00 
+  0  2    2    2    2393.7744  2433.4337  0.0     1.56445  13.87  
+  0  3    0    2    3112.5363  3118.1042  -0.0    1.50307  25.12  
+  0  3    1    2    606.2251   622.4613   0.0     1.44840  9.17   
+  0  3    2    1    1632.1432  1675.8561  180.0   1.44840  24.70  
+  0  4    0    0    364.7901   382.5763   -180.0  1.35485  1.24   
+  0  3    2    2    37.1980    39.3408    -0.0    1.31440  0.49   
+  0  4    1    0    96.3551    101.9055   -0.0    1.31440  0.63   
+  0  4    1    1    60.6080    55.2470    180.0   1.27737  0.77   
+  0  3    3    1    584.2468   600.2920   -0.0    1.24330  7.20   
+  0  4    0    2    952.5246   959.8730   0.0     1.21182  5.76   
+  0  4    2    0    952.5246   959.8730   0.0     1.21182  5.76   
+  0  4    1    2    1.2517     1.3214     -0.0    1.18261  0.01   
+  0  4    2    1    1360.1940  1435.9676  -180.0  1.18261  16.24  
+  0  3    3    2    753.7695   735.2189   0.0     1.15542  8.95   
+  0  4    2    2    1114.6756  1102.4674  0.0     1.10623  13.35  
+  0  4    3    0    122.9460   123.8227   -0.0    1.08388  0.75   
+  0  4    1    3    59.8256    67.5814    -180.0  1.06283  0.74   
+  0  4    3    1    22.2210    25.1017    0.0     1.06283  0.28   
+  0  3    3    3    1858.0757  1712.9917  -0.0    1.04297  7.94   
+  0  5    1    1    3720.1705  3429.6886  -0.0    1.04297  47.70  
+  1  1    0    0    275.0958   238.6947   180.0   4.25587  0.52   
+  1  1    0    1    636.9922   612.7021   120.0   3.34414  0.74   
+  1  1    0    -1   1527.2812  1469.0424  -120.0  3.34414  1.76   
+  1  1    1    0    308.5001   325.9565   -154.8  2.45713  0.19   
+  1  1    0    -2   90.0390    91.7616    -60.0   2.28191  0.05   
+  1  1    0    2    266.2259   271.3193   -120.0  2.28191  0.14   
+  1  1    1    1    85.0881    89.1200    84.9    2.23696  0.08   
+  1  2    0    0    275.7651   268.8947   0.0     2.12793  0.12   
+  1  2    0    -1   74.9098    70.9920    60.0    1.98009  0.03   
+  1  2    0    1    192.5013   182.4334   -60.0   1.98009  0.07   
+  1  1    1    2    511.5978   527.1769   9.6     1.81828  0.33   
+  1  0    0    3    68.8060    63.7751    0.0     1.80223  0.01   
+  1  2    0    2    82.3512    74.0105    60.0    1.67207  0.02   
+  1  2    0    -2   367.9443   330.6781   120.0   1.67207  0.10   
+  1  1    0    -3   177.1482   170.2804   180.0   1.65956  0.05   
+  1  1    0    3    4.5379     4.3619     0.0     1.65956  0.00   
+  1  2    1    0    15.3764    14.6768    -31.6   1.60857  0.01   
+  1  2    1    -1   306.5110   304.2732   96.0    1.54178  0.14   
+  1  2    1    1    239.6923   237.9424   -108.8  1.54178  0.11   
+  1  1    1    3    120.9267   117.1794   115.5   1.45323  0.05   
+  1  3    0    0    53.6608    63.4236    180.0   1.41862  0.01   
+  1  2    1    -2   324.1279   312.8922   -123.7  1.38236  0.12   
+  1  2    1    2    112.2637   108.3721   146.6   1.38236  0.04   
+  1  2    0    -3   214.1492   196.0323   -0.0    1.37527  0.04   
+  1  2    0    3    890.1879   814.8785   0.0     1.37527  0.17   
+  1  3    0    -1   657.5973   641.0877   -120.0  1.37218  0.12   
+  1  3    0    1    2.2450     2.1887     -60.0   1.37218  0.00   
+  1  1    0    -4   84.8637    73.1913    -120.0  1.28826  0.01   
+  1  1    0    4    355.3450   306.4700   120.0   1.28826  0.06   
+  1  3    0    -2   173.9706   157.0421   120.0   1.25617  0.03   
+  1  3    0    2    370.2963   334.2640   -120.0  1.25617  0.06   
+  1  2    2    0    263.6336   264.4146   -17.2   1.22856  0.04   
+  1  2    1    -3   50.9106    53.9241    177.4   1.20008  0.02   
+  1  2    1    3    218.8440   231.7979   -133.8  1.20008  0.07   
+  1  2    2    1    72.0811    76.2373    87.4    1.19802  0.02   
+  1  1    1    4    238.9946   236.8237   -16.4   1.18431  0.08   
+  1  3    1    0    258.8220   267.3717   121.0   1.18037  0.08   
+  1  3    1    -1   156.4601   140.4949   -21.5   1.15320  0.05   
+  1  3    1    1    42.3482    38.0270    20.3    1.15320  0.01   
+  1  2    0    -4   2.3144     2.2786     -120.0  1.14095  0.00   
+  1  2    0    4    55.4309    54.5722    120.0   1.14095  0.01   
+  1  2    2    2    3.2199     4.0621     -26.6   1.11848  0.00   
+  1  3    0    -3   10.3118    8.3593     -0.0    1.11471  0.00   
+  1  3    0    3    63.4349    51.4234    -180.0  1.11471  0.01   
+  1  3    1    -2   215.8521   218.2199   -10.1   1.08175  0.07   
+  1  3    1    2    83.1443    84.0564    62.7    1.08175  0.03   
+  1  4    0    0    80.3057    101.3482   0.0     1.06397  0.01   
+  1  1    0    -5   262.6261   242.0269   120.0   1.04804  0.05   
+  1  1    0    5    75.0118    69.1282    -120.0  1.04804  0.01   
+  1  4    0    -1   23.1559    20.4749    60.0    1.04395  0.00   
+  1  4    0    1    230.8402   204.1133   120.0   1.04395  0.04   
+  1  2    1    4    122.1357   152.0260   -130.5  1.03483  0.04   
+  1  2    1    -4   4.7801     5.9499     31.3    1.03483  0.00   
+  2  0    2    -1   20.4335    16.5792    0.0     4.66174  0.00   
+  2  0    2    1    4.3112     1.8371     180.0   4.37623  0.00   
+  2  2    0    -1   23726.5316 21037.4763 -0.0    4.02732  0.12   
+  2  1    -1   1    3276.9945  3767.3897  -0.0    3.85265  0.02   
+  2  1    1    1    9435.9706  10390.3834 0.0     3.77565  0.06   
+  2  1    3    0    6547.1186  5886.9121  180.0   3.68167  0.03   
+  2  1    3    -1   5012.8781  4505.3267  0.0     3.66562  0.02   
+  2  1    -3   0    11374.5196 11675.3013 180.0   3.65766  0.05   
+  2  2    0    0    1.6818     2.5781     0.0     3.63776  0.00   
+  2  1    1    -2   5647.9628  4328.5159  0.0     3.50520  0.03   
+  2  2    2    -1   3076.9341  1650.0035  180.0   3.48122  0.01   
+  2  1    -3   -1   49.4079    12.1276    0.0     3.43616  0.00   
+  2  1    -1   -2   6027.1007  5251.4578  0.0     3.37264  0.03   
+  2  2    -2   -1   343.9506   364.8637   0.0     3.33313  0.00   
+  2  2    0    -2   27092.4669 26655.4799 -180.0  3.21484  0.10   
+  2  0    0    2    38628.3382 37071.8044 -180.0  3.19393  0.17   
+  2  0    4    0    26101.0770 25362.8195 180.0   3.18733  0.08   
+  2  2    2    0    13112.2326 13873.6743 180.0   3.16977  0.04   
+  2  2    -2   0    14725.5156 14946.6082 -180.0  3.14934  0.05   
+  2  1    -3   1    12734.4390 11175.2497 -180.0  2.96418  0.04   
+  2  2    2    -2   7782.9054  7187.5067  0.0     2.95504  0.02   
+  2  0    2    -2   5344.1407  5310.5610  0.0     2.93060  0.02   
+  2  0    4    -1   8131.5223  8585.7945  0.0     2.92677  0.02   
+  2  1    3    1    7360.4421  6897.0276  180.0   2.86133  0.02   
+  2  1    3    -2   2000.6337  1923.0466  -0.0    2.83885  0.01   
+  2  2    -2   -2   143.1037   183.4547   -0.0    2.79276  0.00   
+  2  0    2    2    157.6877   191.6414   0.0     2.78600  0.00   
+  2  0    4    1    332.3521   387.5360   -0.0    2.78271  0.00   
+  2  2    0    1    100.4575   109.5836   -0.0    2.68712  0.00   
+  2  3    1    -1   431.4697   431.0071   -180.0  2.66293  0.00   
+  2  1    -3   -2   6607.0063  6171.6319  -0.0    2.63839  0.02   
+  2  3    -1   -1   37.5914    33.5476    -180.0  2.62530  0.00   
+  2  2    4    -1   14422.6270 12550.4891 -180.0  2.55995  0.03   
+  2  3    1    -2   2660.9934  1812.0722  180.0   2.53704  0.01   
+  2  1    -1   2    972.0915   667.2869   180.0   2.51139  0.00   
+  2  2    -2   1    2054.9148  1686.7859  -180.0  2.49495  0.00   
+  2  3    -1   -2   533.5367   451.5613   180.0   2.48043  0.00   
+  2  1    1    2    111.3007   110.2849   180.0   2.46610  0.00   
+  2  2    2    1    1302.9890  1367.0046  -180.0  2.45771  0.00   
+  2  2    -4   -1   9545.1070  10453.7459 -180.0  2.44277  0.02   
+  2  1    5    -1   4179.2302  4093.1663  -0.0    2.42941  0.01   
+  2  1    5    0    57.7340    64.0884    180.0   2.41202  0.00   
+  2  2    4    0    3528.0535  3944.1458  -0.0    2.40628  0.01   
+  2  1    -5   0    2025.2183  2230.8323  180.0   2.40074  0.00   
+  2  2    -4   0    2017.9225  2079.3222  -0.0    2.38844  0.00   
+  2  3    1    0    1550.2269  1565.2946  -0.0    2.38575  0.00   
+  2  3    -1   0    2107.0828  2090.0863  -0.0    2.37918  0.00   
+  2  2    0    -3   7.2396     7.3701     180.0   2.35133  0.00   
+  2  2    4    -2   2.9509     2.9331     0.0     2.34729  0.00   
+  2  1    1    -3   109.8434   110.8373   -0.0    2.33656  0.00   
+  2  0    4    -2   1187.7021  884.3144   -180.0  2.33087  0.00   
+  2  3    3    -1   16745.1147 9809.7794  180.0   2.31766  0.03   
+  2  1    -5   -1   1758.5917  1044.9800  0.0     2.31526  0.00   
+  2  1    -1   -3   2341.8407  2291.2470  -0.0    2.27750  0.01   
+  2  2    2    -3   189.5033   155.6865   -0.0    2.26146  0.00   
+  2  3    3    -2   18.1198    15.9172    0.0     2.25070  0.00   
+  2  3    -3   -1   2864.8502  2703.2457  -180.0  2.24518  0.00   
+  2  1    -3   2    813.3962   824.7896   -0.0    2.22556  0.00   
+  2  0    4    2    2000.7742  2085.0250  0.0     2.18812  0.00   
+  2  2    -4   -2   1373.1665  1431.8638  0.0     2.18799  0.00   
+  2  1    -5   1    3892.8343  4194.8986  180.0   2.18493  0.01   
+  2  2    -2   -3   1643.5006  1851.4932  0.0     2.15451  0.00   
+  2  1    5    -2   299.6445   312.7232   -180.0  2.15169  0.00   
+  2  3    1    -3   190.7957   204.6119   0.0     2.13824  0.00   
+  2  3    -3   -2   477.8601   512.1941   180.0   2.13724  0.00   
+  2  1    3    2    166.3478   174.4523   -180.0  2.13433  0.00   
+  2  0    0    3    461.7157   454.6548   -0.0    2.12929  0.00   
+  2  0    6    0    11087.5489 11042.6256 -0.0    2.12489  0.02   
+  2  1    3    -3   643.1052   674.2906   -180.0  2.11876  0.00   
+  2  1    5    1    4511.3977  4734.7647  180.0   2.11595  0.01   
+  2  3    3    0    1417.1647  1496.6439  -180.0  2.11318  0.00   
+  2  3    -3   0    174.8168   182.7827   -180.0  2.09956  0.00   
+  2  3    -1   -3   1918.9184  2416.5634  0.0     2.08973  0.00   
+  2  2    -4   1    7689.8989  8370.0925  180.0   2.07604  0.01   
+  2  0    2    -3   272.9768   286.8930   -180.0  2.05903  0.00   
+  2  0    6    -1   77.2644    83.9001    -0.0    2.05549  0.00   
+  2  2    4    1    2706.7994  2723.1302  180.0   2.03350  0.00   
+  2  4    0    -2   1394.1408  1673.8545  -0.0    2.01366  0.00   
+  2  1    -5   -2   905.6539   976.2191   -0.0    2.00557  0.00   
+  2  4    0    -1   2624.4957  3207.5402  -0.0    2.00025  0.00   
+  2  2    0    2    713.4040   914.6787   0.0     1.99827  0.00   
+  2  1    -3   -3   1638.1937  2006.9284  -0.0    1.99351  0.00   
+  2  0    2    3    1348.9533  1320.4879  0.0     1.98235  0.00   
+  2  0    6    1    5021.8002  4760.1395  0.0     1.97919  0.01   
+  2  3    -1   1    2022.4513  1778.1424  0.0     1.97162  0.00   
+  2  3    3    -3   845.7463   747.2487   -180.0  1.97003  0.00   
+  2  3    1    1    1018.7966  1049.8991  0.0     1.96352  0.00   
+  2  2    4    -3   203.6082   210.6125   -180.0  1.96339  0.00   
+  2  4    2    -2   1501.5548  1505.1300  0.0     1.94723  0.00   
+  2  2    -2   2    4187.1277  4434.5615  -0.0    1.92633  0.01   
+  2  4    2    -1   186.1111   195.3738   0.0     1.92397  0.00   
+  2  2    6    -1   25.1538    25.7092    -0.0    1.91781  0.00   
+  2  4    -2   -2   15013.6630 14612.2943 -0.0    1.89414  0.02   
+  2  4    -2   -1   86.2608    83.9894    180.0   1.89341  0.00   
+  2  3    5    -1   3542.4830  3253.1319  -180.0  1.88804  0.00   
+  2  2    2    2    12237.5261 11147.4650 -0.0    1.88782  0.02   
+  2  3    -3   -3   360.9007   242.1347   -0.0    1.86184  0.00   
+  2  3    5    -2   221.0097   151.7748   -180.0  1.86122  0.00   
+  2  4    0    -3   15555.3971 17227.6438 -180.0  1.84958  0.02   
+  2  2    -6   -1   530.7776   630.1904   -180.0  1.84310  0.00   
+  2  1    -5   2    27.8720    32.7906    -180.0  1.84286  0.00   
+  2  2    6    0    5534.6608  5973.8074  -0.0    1.84084  0.01   
+  2  2    6    -2   2877.3334  2234.4122  -180.0  1.83281  0.00   
+  2  1    -1   3    2909.2733  2403.8627  -180.0  1.82957  0.00   
+  2  2    -6   0    13306.5004 11170.3478 0.0     1.82883  0.01   
+  2  2    -4   -3   413.3319   351.5785   -0.0    1.82817  0.00   
+  2  0    4    -3   7434.2691  6600.1943  180.0   1.82454  0.01   
+  2  3    -5   -1   598.6795   547.0575   -180.0  1.82305  0.00   
+  2  0    6    -2   10255.2730 9376.7847  -180.0  1.82300  0.01   
+  2  4    0    0    16481.2842 16544.7345 -0.0    1.81888  0.02   
+  2  3    -3   1    1287.1322  1388.1619  -0.0    1.81269  0.00   
+  2  4    2    -3   1807.8317  1698.2109  -0.0    1.80678  0.00   
+  2  1    1    3    14201.7356 13204.6231 -180.0  1.80269  0.02   
+  2  3    3    1    584.6137   659.8672   -0.0    1.79396  0.00   
+  2  1    5    -3   30.6095    36.9138    180.0   1.79152  0.00   
+  2  1    7    -1   315.7516   370.2527   -180.0  1.78554  0.00   
+  2  2    0    -4   25021.5072 29304.7955 0.0     1.78457  0.03   
+  2  1    7    0    1805.8089  1186.7943  -0.0    1.76994  0.00   
+  2  3    5    0    552.4616   192.4714   -180.0  1.76391  0.00   
+  2  1    -7   0    5474.4712  1861.7091  0.0     1.76369  0.00   
+  2  1    5    2    5372.4966  1478.1411  -180.0  1.75728  0.01   
+  2  3    -5   -2   865.3719   292.8600   -180.0  1.75539  0.00   
+  2  2    2    -4   11044.6510 5374.4235  180.0   1.75260  0.01   
+  2  4    2    0    6620.3539  3240.2714  180.0   1.75255  0.01   
+  2  3    -5   0    1.1376     0.6787     -180.0  1.75073  0.00   
+  2  4    -2   -3   2050.1894  1498.9920  -180.0  1.74735  0.00   
+  2  4    -2   0    1893.2370  1478.3757  -180.0  1.74562  0.00   
+  2  4    4    -2   13783.9990 11156.5991 -180.0  1.74061  0.01   
+  2  3    1    -4   15.0473    11.6942    0.0     1.73791  0.00   
+  2  1    1    -4   1212.3837  931.5858   180.0   1.73044  0.00   
+  2  0    4    3    1746.1070  1649.4123  180.0   1.72108  0.00   
+  2  1    -7   -1   575.8025   544.5769   -0.0    1.72100  0.00   
+  2  2    -4   2    5379.7933  5111.9528  -180.0  1.72066  0.01   
+  2  0    6    2    4224.1980  4043.0244  180.0   1.71979  0.00   
+  2  2    -6   -2   6010.3220  5843.5104  180.0   1.71808  0.01   
+  2  1    -3   3    3987.0349  3889.7621  0.0     1.71755  0.00   
+  2  4    4    -1   3518.0361  3425.3612  -0.0    1.71605  0.00   
+  2  3    -1   -4   30.8027    26.3196    -0.0    1.70384  0.00   
+  2  3    5    -3   2183.8957  1781.5059  180.0   1.70048  0.00   
+  2  1    -1   -4   1362.1175  1087.2281  180.0   1.69839  0.00   
+  2  2    -2   -4   6715.4253  6607.2640  -0.0    1.68632  0.01   
+  2  2    -6   1    115.0334   111.8094   180.0   1.68403  0.00   
+  2  1    -7   1    1256.0119  1037.6002  0.0     1.67991  0.00   
+  2  1    7    -2   3574.8147  3014.1863  0.0     1.67337  0.00   
+  2  4    -4   -1   3675.5651  3113.5342  -0.0    1.67328  0.00   
+  2  1    -5   -3   332.7621   322.6770   -180.0  1.66739  0.00   
+  2  2    4    2    7130.3335  6980.1241  -180.0  1.66673  0.01   
+  2  4    -4   -2   3055.7728  2996.9232  -180.0  1.66656  0.00   
+  2  1    3    3    607.7784   605.4945   0.0     1.65314  0.00   
+  2  3    3    -4   464.1250   474.5918   180.0   1.65084  0.00   
+  2  2    6    1    14.8049    15.0623    180.0   1.64996  0.00   
+  2  4    4    -3   80.9860    81.5092    0.0     1.64497  0.00   
+  2  1    3    -4   1274.4571  1267.0308  -180.0  1.64299  0.00   
+  2  2    6    -3   429.2751   438.3802   0.0     1.63845  0.00   
+  2  1    7    1    950.3428   959.6711   0.0     1.63566  0.00   
+  2  5    1    -2   59.1926    62.3555    -180.0  1.62122  0.00   
+  2  2    4    -4   6.9916     6.6299     0.0     1.60885  0.00   
+  2  3    -1   2    251.7843   237.1891   -180.0  1.60779  0.00   
+  2  4    0    -4   27.3435    25.5451    0.0     1.60742  0.00   
+  2  5    -1   -2   119.4990   104.4782   -0.0    1.60481  0.00   
+  2  3    1    2    5.0772     3.3755     -180.0  1.59704  0.00   
+  2  0    0    4    2591.6518  1719.5025  -0.0    1.59697  0.00   
+  2  0    8    0    6445.1147  4104.7411  -0.0    1.59366  0.00   
+  2  3    -5   -3   7551.4786  7048.0684  -180.0  1.58673  0.01   
+  2  4    2    -4   5386.5992  5767.4424  -180.0  1.58523  0.00   
+  2  4    4    0    73.4284    80.5872    180.0   1.58489  0.00   
+  2  3    -5   1    3115.8482  3541.7994  0.0     1.57987  0.00   
+  2  1    -7   -2   101.2926   106.0592   180.0   1.57566  0.00   
+  2  4    -4   0    947.4899   972.7791   180.0   1.57467  0.00   
+  2  4    0    1    1295.0410  1313.3627  0.0     1.57405  0.00   
+  2  0    2    -4   6869.8910  6835.8768  -180.0  1.57267  0.01   
+  2  5    1    -1   1854.5946  1838.8969  0.0     1.57223  0.00   
+  2  5    1    -3   4.6693     4.5305     0.0     1.57056  0.00   
+  2  0    8    -1   5279.3672  5105.5113  -180.0  1.56971  0.00   
+  2  3    -3   -4   226.3807   222.0271   -180.0  1.56739  0.00   
+  2  1    -3   -4   1155.6177  1168.3240  -180.0  1.56437  0.00   
+  2  5    -1   -1   3476.1490  3532.8589  -0.0    1.56314  0.00   
+  2  3    5    1    6320.1099  6630.5027  -0.0    1.55930  0.01   
+  2  2    0    3    1681.3360  1763.6711  -180.0  1.55911  0.00   
+  2  4    -4   -3   636.3388   668.2938   0.0     1.55805  0.00   
+  2  0    6    -3   49.3813    50.4752    180.0   1.55391  0.00   
+  2  5    -1   -3   3177.4605  3177.9812  180.0   1.54983  0.00   
+  2  5    3    -2   1781.8573  1684.3120  0.0     1.53962  0.00   
+  2  3    7    -1   303.4207   255.3064   -0.0    1.53554  0.00   
+  2  4    -2   -4   5048.7194  4566.3850  180.0   1.53333  0.00   
+  2  4    -2   1    369.1985   360.2122   -0.0    1.53138  0.00   
+  2  2    -2   3    3958.9580  3884.5431  0.0     1.52972  0.00   
+  2  1    -5   3    131.1026   114.2358   180.0   1.52775  0.00   
+  2  0    2    4    2355.2911  1999.2534  180.0   1.52655  0.00   
+  2  3    7    -2   1666.5176  1417.6951  180.0   1.52649  0.00   
+  2  4    2    1    64.6394    55.0425    -0.0    1.52494  0.00   
+  2  0    8    1    64.2081    53.4117    0.0     1.52385  0.00   
+  2  3    -3   2    856.5190   713.5252   0.0     1.52351  0.00   
+  2  2    -6   -3   1287.9993  972.3599   180.0   1.52111  0.00   
+  2  1    -7   2    2643.0487  2092.8268  180.0   1.51406  0.00   
+  2  2    -4   -4   4067.2876  3475.0688  -180.0  1.51008  0.00   
+  2  2    8    -1   9396.6043  8932.7653  0.0     1.50687  0.01   
+  2  5    3    -3   10945.5097 11216.4371 -0.0    1.50125  0.01   
+  2  2    2    3    248.1712   261.4234   0.0     1.49966  0.00   
+  2  5    -3   -2   1197.6906  1283.3165  0.0     1.49852  0.00   
+  2  4    6    -2   1522.9594  1643.4734  -180.0  1.49804  0.00   
+  2  3    3    2    2582.1913  2828.3266  0.0     1.49651  0.00   
+  2  5    3    -1   1294.7838  1375.8687  180.0   1.49230  0.00   
+  2  1    7    -3   924.3756   963.7100   -0.0    1.49138  0.00   
+  2  3    5    -4   966.3690   976.7543   0.0     1.48741  0.00   
+  2  3    -7   -1   4.1124     4.1505     -180.0  1.48641  0.00   
+  2  2    -6   2    2117.0368  2225.9899  -180.0  1.48209  0.00   
+  2  1    5    -4   529.1086   569.2303   -0.0    1.48061  0.00   
+  2  4    4    -4   881.0438   936.8644   -0.0    1.47752  0.00   
+  2  4    6    -1   2293.1724  2425.3077  -0.0    1.47727  0.00   
+  2  2    8    -2   2039.2569  2036.6290  -0.0    1.46947  0.00   
+  2  5    -3   -1   2258.8354  2250.7625  180.0   1.46932  0.00   
+  2  0    4    -4   1647.0945  1799.2981  0.0     1.46530  0.00   
+  2  2    8    0    15209.8348 17372.8918 180.0   1.46378  0.01   
+  2  0    8    -2   2343.0482  2670.5014  0.0     1.46338  0.00   
+  2  3    7    0    1221.2445  1344.4772  -0.0    1.46164  0.00   
+  2  0    6    3    9583.0747  9727.2084  -180.0  1.45874  0.01   
+  2  2    -8   -1   280.2527   277.6153   0.0     1.45806  0.00   
+  2  2    -8   0    15572.0028 14971.6548 -180.0  1.45572  0.01   
+  2  1    5    3    87.4077    84.4701    0.0     1.45352  0.00   
+  2  3    -7   0    1883.2745  1874.7884  -0.0    1.45113  0.00   
+  2  5    -3   -3   3914.2348  3973.0050  -0.0    1.44873  0.00   
+  2  1    7    2    329.2853   339.6716   180.0   1.44736  0.00   
+  2  5    1    0    453.9278   468.7582   0.0     1.44694  0.00   
+  2  5    -1   0    267.6661   282.6566   0.0     1.44450  0.00   
+  2  3    -7   -2   385.4776   407.5222   -180.0  1.44435  0.00   
+  2  5    1    -4   355.7039   376.0669   -0.0    1.44434  0.00   
+  2  4    6    -3   4549.2620  4799.2632  180.0   1.44037  0.00   
+  2  3    7    -3   2022.6721  2066.9126  0.0     1.43858  0.00   
+  2  4    -6   -1   13832.8092 13974.0377 -0.0    1.43651  0.01   
+  2  1    -1   4    1870.0717  1747.7612  -0.0    1.43156  0.00   
+  2  2    6    2    15218.6694 14127.5120 -180.0  1.43067  0.01   
+  2  4    -6   -2   11185.6388 11494.7453 -180.0  1.42772  0.01   
+  2  3    1    -5   47.3409    54.5453    0.0     1.42498  0.00   
+  2  2    -4   3    8045.4257  9304.7725  -0.0    1.42492  0.01   
+  2  5    -1   -4   5237.2907  6191.0063  0.0     1.42367  0.00   
+  2  2    0    -5   452.3974   530.6717   -0.0    1.41970  0.00   
+  2  2    6    -4   3525.1793  4109.1661  -0.0    1.41942  0.00   
+  2  4    -4   1    1736.6725  2328.2327  -180.0  1.41643  0.00   
+  2  1    1    4    7280.8753  9765.5200  -0.0    1.41417  0.01   
+  2  2    2    -5   112.4555   102.1798   180.0   1.40774  0.00   
+  2  4    4    1    4065.2686  4251.1055  -180.0  1.40628  0.00   
+  2  1    9    -1   326.3669   313.3806   180.0   1.40427  0.00   
+  2  3    -1   -5   518.4931   559.2035   180.0   1.40173  0.00   
+  2  5    5    -2   107.6280   121.8591   180.0   1.39689  0.00   
+  2  4    -4   -4   306.8289   333.7965   -180.0  1.39638  0.00   
+  2  5    3    -4   10454.5520 10290.7248 -180.0  1.39407  0.01   
+  2  0    4    4    582.9121   603.2489   180.0   1.39300  0.00   
+  2  1    9    0    5771.3979  6061.3448  -180.0  1.39244  0.00   
+  2  0    8    2    811.5302   841.8614   -0.0    1.39135  0.00   
+  2  1    -7   -3   8.4310     8.6161     0.0     1.39082  0.00   
+  2  2    -8   -2   397.3245   389.1003   0.0     1.38958  0.00   
+  2  1    -9   0    5145.2035  5032.6219  -180.0  1.38852  0.00   
+  2  3    -5   -4   724.3311   712.8918   180.0   1.38828  0.00   
+  2  1    -5   -4   12.0757    12.2841    -0.0    1.38705  0.00   
+  2  4    6    0    6750.9811  6881.9956  0.0     1.38694  0.00   
+  2  2    -8   1    2663.9577  2583.5813  -0.0    1.38353  0.00   
+  2  3    -5   2    115.2140   107.7060   180.0   1.38139  0.00   
+  2  1    -3   4    12478.0081 11498.8556 180.0   1.38001  0.01   
+  2  3    3    -5   654.3535   601.2645   -0.0    1.37984  0.00   
+  2  5    3    0    2247.3467  2064.1961  180.0   1.37983  0.00   
+  2  2    4    3    8731.9459  7682.9819  -0.0    1.37735  0.01   
+  2  4    -6   0    3276.0861  2929.6322  0.0     1.37669  0.00   
+  2  5    -3   0    1960.6102  1846.9850  -180.0  1.37349  0.00   
+  2  4    0    -5   10209.7478 9852.1453  -0.0    1.37263  0.01   
+  2  5    5    -3   1049.9923  1000.1841  -0.0    1.37203  0.00   
+  2  1    1    -5   65.3771    51.8333    180.0   1.36876  0.00   
+  2  2    8    -3   1261.0357  897.0709   0.0     1.36740  0.00   
+  2  2    -2   -5   1057.6844  890.9937   -180.0  1.36475  0.00   
+  2  1    -9   -1   2714.8817  2521.2414  180.0   1.36346  0.00   
+  2  4    2    -5   11174.3226 11335.5971 180.0   1.36264  0.01   
+  2  2    8    1    3283.2599  3611.9875  -180.0  1.35827  0.00   
+  2  5    5    -1   820.3367   870.4892   -180.0  1.35737  0.00   
+  2  4    -6   -3   3793.9878  4126.3352  180.0   1.35385  0.00   
+  2  3    -7   1    517.9960   576.4772   0.0     1.35312  0.00   
+  2  1    9    -2   13299.4479 16147.0686 0.0     1.35152  0.01   
+  2  6    0    -2   13809.8083 16981.3924 180.0   1.35133  0.01   
+  2  1    -9   1    2951.8488  3741.5161  -0.0    1.35032  0.00   
+  2  1    -1   -5   8547.1481  10683.9602 -0.0    1.34891  0.01   
+  2  3    5    2    172.6770   209.3398   0.0     1.34817  0.00   
+  2  5    -5   -2   485.2567   568.7530   180.0   1.34647  0.00   
+  2  4    0    2    17071.2909 20266.7951 180.0   1.34356  0.01   
+  2  6    0    -3   363.4278   424.9852   0.0     1.34244  0.00   
+  2  3    -7   -3   866.0162   987.1236   180.0   1.34218  0.00   
+  2  5    -3   -4   17.6076    19.4544    -0.0    1.34037  0.00   
+  2  3    7    1    525.4114   545.2034   0.0     1.33504  0.00   
+  2  1    3    4    296.4809   303.9072   180.0   1.33473  0.00   
+  2  2    4    -5   2110.7646  2138.1647  -0.0    1.33359  0.00   
+  2  6    2    -2   5222.0638  7470.5514  0.0     1.33146  0.00   
+  2  3    -1   3    405.2430   551.6386   -0.0    1.32984  0.00   
+  2  5    -5   -1   2229.9348  3077.6343  -180.0  1.32879  0.00   
+  2  1    -7   3    626.8304   845.5145   -180.0  1.32789  0.00   
+  2  1    3    -5   9610.3784  12956.3684 180.0   1.32785  0.01   
+  2  4    6    -4   904.2649   1219.1637  0.0     1.32754  0.00   
+  2  6    2    -3   4.3860     6.0091     -0.0    1.32656  0.00   
+  2  4    -2   -5   2612.1161  3146.4347  0.0     1.32203  0.00   
+  2  1    9    1    848.0411   1105.1306  -0.0    1.32057  0.00   
+  2  4    -2   2    1715.3861  2255.4357  0.0     1.32028  0.00   
+  2  3    1    3    2455.4955  3237.6008  0.0     1.32015  0.00   
+  2  2    -6   -4   86.3716    114.0134   0.0     1.31919  0.00   
+  2  3    -3   -5   1651.9305  2179.7868  180.0   1.31918  0.00   
+  2  0    6    -4   2981.8665  3685.3963  0.0     1.31717  0.00   
+  2  0    8    -3   3921.2657  4546.6333  -0.0    1.31636  0.00   
+  2  6    -2   -2   335.4577   330.6363   180.0   1.31265  0.00   
+  2  4    2    2    653.7713   505.4413   0.0     1.30914  0.00   
+  2  5    -5   -3   8537.1509  6208.9517  0.0     1.30653  0.00   
+  2  3    7    -4   16.4367    11.5530    -180.0  1.30602  0.00   
+  2  6    0    -1   944.2162   635.2341   -0.0    1.30261  0.00   
+  2  6    -2   -3   7764.1238  4797.6968  0.0     1.30107  0.00   
+  2  1    7    -4   1348.3128  816.7390   180.0   1.30069  0.00   
+  2  4    4    -5   1489.2135  839.8412   -180.0  1.29576  0.00   
+  2  5    -1   1    727.4867   560.8179   -180.0  1.29287  0.00   
+  2  5    5    -4   122.0888   102.0732   -0.0    1.29210  0.00   
+  2  5    1    1    253.4839   213.0414   180.0   1.29128  0.00   
+  2  5    1    -5   1537.2202  1297.0866  -180.0  1.28850  0.00   
+  2  1    -9   -2   8248.8036  7594.2794  0.0     1.28440  0.00   
+  2  3    -3   3    4133.9267  3821.2749  180.0   1.28422  0.00   
+  2  2    -6   3    104.2039   97.9036    -0.0    1.28363  0.00   
+  2  3    5    -5   3193.6145  3037.5557  -0.0    1.28334  0.00   
+  2  6    2    -1   2543.1445  2446.8719  180.0   1.28151  0.00   
+  2  4    8    -2   16671.7315 16043.2073 -0.0    1.27998  0.01   
+  2  6    0    -4   5019.2584  4642.8182  0.0     1.27913  0.00   
+  2  1    -5   4    0.3018     0.2762     -0.0    1.27885  0.00   
+  2  0    0    5    1666.2840  1504.7953  0.0     1.27757  0.00   
+  2  2    -8   -3   1192.0850  969.8153   0.0     1.27578  0.00   
+  2  1    -3   -5   2027.3553  1649.0848  -180.0  1.27554  0.00   
+  2  0    10   0    6740.7560  5612.4673  -0.0    1.27493  0.00   
+  2  3    9    -1   692.4670   567.6734   180.0   1.27318  0.00   
+  2  3    9    -2   223.0776   209.3409   0.0     1.27118  0.00   
+  2  6    -2   -1   639.1128   604.9530   -180.0  1.27102  0.00   
+  2  5    -1   -5   3411.0528  3287.3648  -0.0    1.27057  0.00   
+  2  4    -6   1    2211.8769  2157.0193  180.0   1.27033  0.00   
+  2  2    0    4    5479.7524  5970.9564  -0.0    1.26862  0.00   
+  2  6    2    -4   2392.7378  2642.8907  -180.0  1.26852  0.00   
+  2  0    2    -5   3591.3445  4140.6925  180.0   1.26818  0.00   
+  2  2    -8   2    13368.6636 15669.9235 0.0     1.26800  0.01   
+  2  5    5    0    1305.5882  1539.1640  -0.0    1.26791  0.00   
+  2  0    10   -1   765.0279   722.1628   -180.0  1.26570  0.00   
+  2  4    8    -1   149.3735   116.1733   180.0   1.26381  0.00   
+  2  2    -4   -5   47.1676    34.2839    180.0   1.26302  0.00   
+  2  1    -9   2    561.8092   407.6104   0.0     1.26267  0.00   
+  2  6    4    -2   5247.6837  4060.9393  -0.0    1.26012  0.00   
+  2  1    7    3    1800.8293  1423.0605  -180.0  1.25993  0.00   
+  2  5    -5   0    1545.2396  1251.7915  -0.0    1.25974  0.00   
+  2  4    6    1    41.6794    35.4122    180.0   1.25938  0.00   
+  2  6    4    -3   6544.6023  5742.7030  -180.0  1.25904  0.00   
+  2  3    3    3    38.5511    34.1056    0.0     1.25855  0.00   
+  2  2    -2   4    2998.9627  2630.4316  180.0   1.25569  0.00   
+  2  5    3    -5   9068.6357  7849.9862  180.0   1.25548  0.01   
+  2  1    9    -3   565.3264   446.4585   -180.0  1.25310  0.00   
+  2  4    -4   2    3313.6249  2913.1494  0.0     1.24747  0.00   
+  2  4    8    -3   1696.4876  1591.0184  -180.0  1.24643  0.00   
+  2  5    -3   1    155.9899   154.1169   -180.0  1.24419  0.00   
+  2  4    -6   -4   4710.1568  4649.8078  0.0     1.24074  0.00   
+  2  1    5    -5   21.1823    20.8490    -0.0    1.24058  0.00   
+  2  6    -2   -4   119.3123   116.0421   -0.0    1.24022  0.00   
+  2  5    3    1    903.2639   865.0651   -180.0  1.23993  0.00   
+  2  0    6    4    4698.1018  4402.8269  -0.0    1.23960  0.00   
+  2  0    8    3    2787.3167  2523.8232  0.0     1.23892  0.00   
+  2  5    7    -2   55.7379    48.4702    -180.0  1.23815  0.00   
+  2  0    2    5    7.3252     6.1649     -0.0    1.23770  0.00   
+  2  3    -9   -1   2399.2078  1878.7146  -180.0  1.23697  0.00   
+  2  0    10   1    93.8140    69.0195    180.0   1.23540  0.00   
+  2  2    8    -4   0.9174     0.6712     -0.0    1.23509  0.00   
+  2  2    2    4    276.8933   202.3679   180.0   1.23305  0.00   
+  2  2    10   -1   898.4176   674.5837   -0.0    1.23266  0.00   
+  2  2    6    3    717.5582   591.5126   -0.0    1.23202  0.00   
+  2  4    -8   -1   1786.9839  1660.8265  180.0   1.22975  0.00   
+  2  4    4    2    7383.3269  7216.8110  -0.0    1.22886  0.00   
+  2  6    -4   -2   7549.9953  7429.0559  0.0     1.22874  0.00   
+  2  4    -4   -5   5903.1771  5935.8119  180.0   1.22833  0.00   
+  2  3    9    0    205.0691   207.1256   180.0   1.22722  0.00   
+  2  2    8    2    15157.8048 16367.8700 -0.0    1.22501  0.01   
+  2  3    -7   2    4.1002     4.4310     -180.0  1.22493  0.00   
+  2  5    7    -3   716.7797   701.3947   180.0   1.22357  0.00   
+  2  5    -5   -4   490.9404   527.2945   -180.0  1.22255  0.00   
+  2  2    6    -5   86.0337    93.3157    -0.0    1.22244  0.00   
+  2  3    9    -3   3585.7199  3989.5508  -0.0    1.22187  0.00   
+  2  4    -8   -2   14062.1437 15576.6760 0.0     1.22139  0.01   
+  2  1    5    4    2945.8456  2923.6151  -180.0  1.22003  0.00   
+  2  3    -9   0    66.8726    63.1939    -0.0    1.21922  0.00   
+  2  6    -4   -3   1.7630     1.6171     -180.0  1.21643  0.00   
+  2  6    4    -1   10.7334    10.2523    180.0   1.21473  0.00   
+  2  2    10   -2   3345.0589  3195.8904  -180.0  1.21471  0.00   
+  2  3    -7   -4   9.8847     9.5153     0.0     1.21279  0.00   
+  2  6    0    0    13522.0172 13100.2263 0.0     1.21259  0.01   
+  2  1    9    2    1805.9473  1749.7864  0.0     1.21259  0.00   
+  2  0    4    -5   53.0493    51.4047    -180.0  1.21258  0.00   
+  2  1    -7   -4   694.3890   673.8718   0.0     1.21254  0.00   
+  2  6    4    -4   201.5775   199.9465   0.0     1.21185  0.00   
+  2  0    10   -2   2470.6217  2393.1814  180.0   1.21068  0.00   
+  2  3    -9   -2   2.4743     2.4088     0.0     1.20966  0.00   
+  2  5    7    -1   987.7116   919.5910   -0.0    1.20764  0.00   
+  2  5    -3   -5   1792.8974  1669.4106  -180.0  1.20756  0.00   
+  2  2    10   0    12.6542    11.8619    180.0   1.20601  0.00   
+  2  3    -5   -5   5525.3532  5223.5291  -0.0    1.20426  0.00   
+  2  4    8    0    2102.7255  2036.1638  -180.0  1.20314  0.00   
+  2  2    -10  0    1179.3977  1234.3417  180.0   1.20037  0.00   
+  2  2    -10  -1   1849.2743  1881.5821  0.0     1.19900  0.00   
+  2  2    -4   4    0.0041     0.0043     180.0   1.19841  0.00   
+  2  3    -5   3    4986.1911  5149.8089  -180.0  1.19827  0.00   
+  2  6    -4   -1   3858.0233  4013.4094  180.0   1.19705  0.00   
+  2  4    -8   0    1891.7268  1701.7086  -180.0  1.19422  0.00   
+  2  4    6    -5   6203.8886  5356.2972  -0.0    1.19366  0.00   
+  2  6    2    0    7449.2883  6359.8747  -180.0  1.19287  0.00   
+  2  3    1    -6   201.6447   172.0799   180.0   1.19278  0.00   
+  2  3    7    2    247.9747   210.6961   180.0   1.19262  0.00   
+  2  6    -2   0    2214.1788  1825.4606  -180.0  1.18959  0.00   
+  2  5    -7   -2   291.5197   235.2689   -180.0  1.18926  0.00   
+  2  5    5    -5   634.2807   652.0282   -0.0    1.18202  0.00   
+  2  6    0    -5   1842.6634  1859.8386  -0.0    1.18139  0.00   
+  2  5    -7   -1   1133.5424  1170.6276  -0.0    1.17956  0.00   
+  2  3    -1   -6   10285.3736 10651.6340 0.0     1.17652  0.01   
+  2  1    -9   -3   3339.5608  3479.3329  -0.0    1.17569  0.00   
+  2  4    0    -6   666.9598   694.8770   -180.0  1.17567  0.00   
+  2  6    2    -5   662.4733   690.4314   180.0   1.17553  0.00   
+  2  4    8    -4   4869.1600  5262.2410  180.0   1.17365  0.00   
+  2  1    -1   5    40.8453    44.3347    0.0     1.17349  0.00   
+  2  2    0    -6   2961.1502  3262.2227  -180.0  1.17258  0.00   
+  2  4    2    -6   716.6555   785.7923   0.0     1.17185  0.00   
+  2  4    -8   -3   467.9272   512.5086   -0.0    1.17167  0.00   
+  2  1    -5   -5   4947.1446  5414.4867  -180.0  1.17131  0.00   
+  2  3    3    -6   3199.6081  3178.6335  180.0   1.16840  0.00   
+  2  5    7    -4   5997.9488  5932.4007  0.0     1.16833  0.00   
+  2  2    2    -6   450.7999   444.4424   0.0     1.16828  0.00   
+  2  0    8    -4   6757.6219  6734.2463  -180.0  1.16544  0.00   
+  2  3    5    3    8783.9808  9033.3981  -180.0  1.16397  0.01   
+  2  6    -4   -4   1298.5140  1331.0105  -180.0  1.16381  0.00   
+  2  3    7    -5   1153.8836  1180.8749  180.0   1.16377  0.00   
+  2  3    -9   1    27.3301    24.5109    -0.0    1.16177  0.00   
+  2  1    1    5    2217.6245  1984.2370  0.0     1.16142  0.00   
+  2  2    -10  1    456.9839   408.7012   -180.0  1.16134  0.00   
+  2  0    4    5    4220.1782  3674.6390  -180.0  1.16082  0.00   
+  2  6    6    -3   679.4929   572.9928   0.0     1.16041  0.00   
+  2  5    -5   1    9.8168     8.2052     180.0   1.16017  0.00   
+  2  7    1    -3   391.3171   326.8856   180.0   1.15995  0.00   
+  2  2    4    4    400.5101   334.7388   180.0   1.15990  0.00   
+  2  0    10   2    2316.3656  1953.1670  -180.0  1.15916  0.00   
+  2  5    -7   -3   16.4520    13.9221    0.0     1.15905  0.00   
+  2  6    6    -2   1243.0456  1062.5954  180.0   1.15883  0.00   
+  2  2    -10  -2   1032.8432  927.1428   -180.0  1.15763  0.00   
+  2  2    10   -3   507.7390   456.9863   180.0   1.15752  0.00   
+  2  1    -7   4    8682.8102  7894.1741  -0.0    1.15699  0.00   
+  2  1    11   -1   184.6374   172.4013   -0.0    1.15488  0.00   
+  2  5    5    1    16.0717    14.5872    180.0   1.15443  0.00   
+  2  4    0    3    430.2888   372.8509   -0.0    1.15214  0.00   
+  2  7    -1   -3   223.5957   190.7937   -0.0    1.15103  0.00   
+  2  1    -9   3    458.2758   390.2848   -180.0  1.15086  0.00   
+  2  7    1    -2   499.7933   417.6649   180.0   1.14957  0.00   
+  2  6    -2   -5   3.6630     3.3422     180.0   1.14818  0.00   
+  2  2    -8   -4   1350.5900  1241.1393  -0.0    1.14713  0.00   
+  2  3    9    1    906.3456   840.9132   -180.0  1.14703  0.00   
+  2  1    -3   5    139.4796   131.0137   -0.0    1.14691  0.00   
+  2  4    -6   2    895.5178   884.2580   -180.0  1.14653  0.00   
+  2  1    11   0    651.7144   673.8595   0.0     1.14593  0.00   
+  2  3    -9   -3   6577.6780  6842.7549  -0.0    1.14539  0.00   
+  2  1    -11  0    49.8798    56.5171    180.0   1.14326  0.00   
+  2  7    -1   -2   228.7923   258.5173   180.0   1.14319  0.00   
+  2  2    10   1    1962.7644  2221.3310  -180.0  1.14260  0.00   
+  2  2    -6   -5   7301.3763  8280.7099  -0.0    1.14253  0.00   
+  2  5    -1   2    0.2221     0.2523     -180.0  1.14237  0.00   
+  2  4    -2   -6   159.5567   159.9954   -0.0    1.14109  0.00   
+  2  5    7    0    1592.3624  1584.2307  0.0     1.14103  0.00   
+  2  3    9    -4   3759.4257  3452.1120  -180.0  1.13977  0.00   
+  2  4    -2   3    742.8000   675.3480   180.0   1.13965  0.00   
+  2  2    -8   3    1081.3938  940.5804   180.0   1.13923  0.00   
+  2  5    1    2    179.2079   151.0052   180.0   1.13897  0.00   
+  2  2    -2   -6   557.1492   457.5743   180.0   1.13875  0.00   
+  2  5    1    -6   112.9885   92.8501    180.0   1.13644  0.00   
+  2  6    4    0    11722.6974 9886.1889  -180.0  1.13618  0.01   
+  2  1    9    -4   7250.8869  6387.1239  180.0   1.13575  0.00   
+  2  7    1    -4   109.0622   104.3489   0.0     1.13318  0.00   
+  2  5    -7   0    569.1070   561.3250   0.0     1.13270  0.00   
+  2  6    4    -5   3667.0037  3560.8356  -0.0    1.13225  0.00   
+  2  7    3    -3   1899.4783  1752.7599  180.0   1.13164  0.00   
+  2  1    7    -5   2087.6189  1876.4532  -0.0    1.13113  0.00   
+  2  4    4    -6   79.0412    74.0198    180.0   1.13073  0.00   
+  2  6    -4   0    9432.9423  8996.3605  -180.0  1.13052  0.00   
+  2  1    1    -6   13.2830    12.7255    180.0   1.13041  0.00   
+  2  4    2    3    28.8503    26.9687    0.0     1.12798  0.00   
+  2  1    11   -2   3810.8048  4054.5939  -180.0  1.12721  0.00   
+  2  2    4    -6   563.2021   617.9103   -180.0  1.12706  0.00   
+  2  1    -11  -1   71.6747    80.5660    180.0   1.12692  0.00   
+  2  0    6    -5   717.7937   825.3110   -0.0    1.12677  0.00   
+  2  0    10   -3   17.9789    25.1309    180.0   1.12560  0.00   
+  2  6    6    -4   755.1372   1116.6065  -0.0    1.12535  0.00   
+  2  4    -8   1    932.8382   1428.0735  -0.0    1.12500  0.00   
+  2  4    6    2    321.4515   491.6513   180.0   1.12497  0.00   
+  2  3    -3   -6   2009.4408  2679.1058  0.0     1.12421  0.00   
+  2  1    -11  1    402.7277   520.4388   180.0   1.12385  0.00   
+  2  3    -1   4    45.8189    62.3074    180.0   1.12290  0.00   
+  2  7    -1   -4   250.1668   340.7362   180.0   1.12266  0.00   
+  2  6    -6   -2   4.3375     5.8815     -0.0    1.12259  0.00   
+  2  5    -1   -6   3142.5200  3679.1020  -180.0  1.12188  0.00   
+  2  6    6    -1   16.2908    18.5196    -180.0  1.12105  0.00   
+  2  7    3    -2   372.3235   466.2613   -180.0  1.11981  0.00   
+  2  5    -5   -5   3020.8735  3254.1700  180.0   1.11710  0.00   
+  2  1    -1   -6   1468.7199  1573.1101  -180.0  1.11699  0.00   
+  2  4    -6   -5   11.9968    12.1624    -180.0  1.11621  0.00   
+  2  5    3    -6   3779.7849  3572.8767  0.0     1.11574  0.00   
+  2  3    1    4    662.4661   557.2568   180.0   1.11489  0.00   
+  2  4    8    1    3619.1460  3030.2470  -0.0    1.11486  0.00   
+  2  1    3    5    262.6216   208.8946   -180.0  1.11404  0.00   
+  2  2    -6   4    2124.4727  1626.0861  -0.0    1.11278  0.00   
+  2  6    -6   -3   11481.6152 9170.8262  180.0   1.11104  0.01   
+  2  5    -3   2    28.8898    23.9804    -180.0  1.11049  0.00   
+  2  3    5    -6   89.1563    75.3696    -0.0    1.11017  0.00   
+  2  1    3    -6   4233.7983  3749.4968  0.0     1.10915  0.00   
+  2  7    3    -4   949.2056   851.8273   -0.0    1.10885  0.00   
+  2  7    -3   -3   8.6953     8.0510     -0.0    1.10731  0.00   
+  2  7    1    -1   585.2187   540.2195   -180.0  1.10485  0.00   
+  2  6    0    1    3045.3685  2851.2916  180.0   1.10441  0.00   
+  2  1    11   1    379.3183   353.4958   0.0     1.10278  0.00   
+  2  7    -3   -2   8.2360     7.6618     -0.0    1.10240  0.00   
+  2  4    10   -2   312.6906   293.9448   -180.0  1.10139  0.00   
+  2  7    -1   -1   597.2087   560.8360   -180.0  1.10125  0.00   
+  2  5    3    2    98.6081    92.4856    -180.0  1.10119  0.00   
+  2  2    8    -5   4059.4603  3728.5603  180.0   1.10077  0.00   
+  2  6    -6   -1   6.9146     6.2337     0.0     1.10033  0.00   
+  2  5    -7   -4   146.2968   136.6182   0.0     1.09716  0.00   
+  2  3    -3   4    154.2543   143.6453   -0.0    1.09706  0.00   
+  2  1    7    4    62.7647    57.0295    -0.0    1.09661  0.00   
+  2  0    8    4    3674.0667  2959.2417  180.0   1.09406  0.00   
+  2  4    -8   -4   4605.3899  3685.4545  -180.0  1.09399  0.00   
+  2  4    -4   3    2776.5977  2186.7268  180.0   1.09385  0.00   
+  2  3    -7   3    2305.4637  1814.2931  0.0     1.09384  0.00   
+  2  1    9    3    392.2940   308.2223   180.0   1.09383  0.00   
+  2  2    -10  2    4.9468     3.3265     -0.0    1.09247  0.00   
+  2  2    8    3    587.7213   379.8198   0.0     1.09126  0.00   
+  2  5    9    -2   2573.4413  1582.6840  -0.0    1.09021  0.00   
+  2  4    10   -1   2.6568     1.7369     -180.0  1.08903  0.00   
+  2  6    -2   1    2.3305     1.5406     -180.0  1.08894  0.00   
+  2  1    -5   5    8449.1403  5646.2565  0.0     1.08884  0.01   
+  2  6    2    1    366.8815   245.3481   -0.0    1.08745  0.00   
+  2  2    -10  -3   908.7302   617.4947   180.0   1.08733  0.00   
+  2  5    7    -5   127.2016   91.0318    -180.0  1.08704  0.00   
+  2  6    -4   -5   454.0248   422.0173   180.0   1.08477  0.00   
+  2  3    -7   -5   3388.8888  3180.2930  0.0     1.08232  0.00   
+  2  5    9    -3   38.8031    37.0056    -180.0  1.08217  0.00   
+  2  4    10   -3   495.1552   496.5346   180.0   1.08176  0.00   
+  2  4    8    -5   382.4621   416.8216   0.0     1.08002  0.00   
+  2  7    -3   -4   436.6102   475.9937   -180.0  1.08002  0.00   
+  2  3    11   -2   1056.4507  1209.7235  180.0   1.07973  0.00   
+  2  3    -9   2    978.3047   1162.0253  -0.0    1.07952  0.00   
+  2  1    -11  -2   406.4566   505.5742   -0.0    1.07909  0.00   
+  2  3    11   -1   2027.2121  2531.9784  -180.0  1.07901  0.00   
+  2  4    -4   -6   52.3491    79.4879    0.0     1.07725  0.00   
+  2  7    3    -1   325.2921   517.9063   0.0     1.07642  0.00   
+  2  7    1    -5   15.9005    25.2106    -0.0    1.07626  0.00   
+  2  5    -3   -6   823.0150   1371.1187  180.0   1.07586  0.00   
+  2  2    10   -4   1701.8956  2842.5457  0.0     1.07584  0.00   
+  2  2    -4   -6   108.5183   186.5753   0.0     1.07568  0.00   
+  2  3    3    4    315.6656   560.4316   180.0   1.07511  0.00   
+  2  1    -11  2    309.6133   558.2780   -180.0  1.07370  0.00   
+  2  7    5    -3   506.3881   928.6481   180.0   1.07351  0.00   
+  2  4    4    3    444.9201   818.8776   180.0   1.07348  0.00   
+  2  1    -3   -6   76.4261    135.6225   180.0   1.07233  0.00   
+  2  6    0    -6   2.3698     4.1780     -180.0  1.07161  0.00   
+  2  1    11   -3   301.5372   540.3856   180.0   1.07008  0.00   
+  2  6    2    -6   53.8093    107.8329   0.0     1.06912  0.00   
+  2  6    -6   -4   247.9032   552.9788   0.0     1.06862  0.00   
+  2  5    9    -1   540.5756   1026.4794  0.0     1.06732  0.00   
+  2  2    6    4    2247.4148  4143.5979  0.0     1.06716  0.00   
+  2  7    -3   -1   100.9311   173.9010   0.0     1.06652  0.00   
+  2  2    0    5    1108.4557  1937.9253  0.0     1.06580  0.00   
+  2  0    6    5    206.7761   358.8678   0.0     1.06561  0.00   
+  2  7    -1   -5   1956.0918  3288.8085  0.0     1.06535  0.00   
+  2  5    5    -6   278.1492   447.2840   -180.0  1.06509  0.00   
+  2  0    0    6    35.8768    53.4823    180.0   1.06464  0.00   
+  2  0    10   3    2205.8772  3276.3246  0.0     1.06463  0.00   
+  2  4    6    -6   27.2103    31.3322    -180.0  1.06282  0.00   
+  2  6    6    -5   379.7096   434.3157   -0.0    1.06260  0.00   
+  2  0    12   0    98.9375    112.6819   180.0   1.06244  0.00   
+  2  4    -10  -1   973.2238   1132.6677  180.0   1.06171  0.00   
+  2  7    5    -2   3783.1903  4496.3914  -180.0  1.06153  0.00   
+  2  0    2    -6   609.0520   748.1993   0.0     1.06104  0.00   
+  2  5    -7   1    801.6337   969.1237   180.0   1.06052  0.00   
+  2  1    -9   -4   1429.9855  1706.8793  -180.0  1.06015  0.00   
+  2  2    -2   5    2793.5777  3313.4198  -180.0  1.05994  0.00   
+  2  3    -9   -4   11.5277    13.6703    -180.0  1.05993  0.00   
+  2  2    6    -6   228.2722   288.6216   -180.0  1.05938  0.00   
+  2  0    12   -1   952.2244   1340.4500  -0.0    1.05892  0.00   
+  2  1    -7   -5   5.2740     7.5059     -180.0  1.05860  0.00   
+  2  1    5    -6   33.3334    47.4061    -180.0  1.05858  0.00   
+  2  2    10   2    919.0598   1237.1699  -0.0    1.05797  0.00   
+  2  3    7    3    9.7727     12.9031    -180.0  1.05758  0.00   
+  2  7    3    -5   1657.7963  2239.1302  -180.0  1.05718  0.00   
+  2  6    6    0    304.7781   461.7745   -0.0    1.05659  0.00   
+  2  7    5    -4   1352.5283  2051.4003  0.0     1.05581  0.00   
+  2  4    -10  -2   2047.8750  3145.7849  0.0     1.05450  0.00   
+  2  5    7    1    24.0462    37.2884    180.0   1.05440  0.00   
+  2  6    8    -3   6368.7008  8866.7538  -0.0    1.05196  0.00   
+  2  3    -11  -1   188.1857   261.5320   -0.0    1.05193  0.00   
+  2  5    -5   2    4079.6880  5387.0808  -180.0  1.05131  0.00   
+  2  3    9    2    673.1254   862.2832   -0.0    1.05108  0.00   
+  2  3    11   -3   547.2633   673.7850   180.0   1.05082  0.00   
+  2  6    -6   0    449.4182   488.9045   -0.0    1.04978  0.00   
+  2  6    8    -2   333.1357   331.3808   0.0     1.04899  0.00   
+  2  3    11   0    414.2802   407.0557   -0.0    1.04881  0.00   
+  2  3    -5   -6   1265.2558  1235.7557  -180.0  1.04872  0.00   
+  2  4    10   0    67.4820    61.4161    -0.0    1.04771  0.00   
+  2  5    -9   -2   2484.6310  2208.3085  -0.0    1.04729  0.00   
+  2  5    9    -4   249.5270   228.7958   -180.0  1.04516  0.00   
+  2  6    -2   -6   1430.5244  1293.5044  -0.0    1.04487  0.00   
+  2  6    -4   1    3497.6169  3160.5795  -0.0    1.04485  0.00   
+  2  3    -5   4    2574.0900  2301.6767  -0.0    1.04377  0.00   
+  2  3    9    -5   1995.9849  1817.7670  180.0   1.04328  0.00   
+  2  1    5    5    1793.1801  1623.2967  -0.0    1.04294  0.00   
+  2  3    -11  0    1562.4200  1387.3612  0.0     1.04270  0.00   
+  2  2    2    5    297.9510   264.3036   0.0     1.04269  0.00   
+  2  5    -9   -1   72.7501    62.5557    0.0     1.04240  0.00   
+  2  6    4    1    1206.9577  1021.8291  -0.0    1.04223  0.00   
+  2  4    -10  0    648.0375   554.7785   -0.0    1.04034  0.00   
+  2  2    12   -1   4559.0261  3828.0670  -180.0  1.03971  0.00   
+  2  0    2    6    1773.6290  1492.8101  0.0     1.03949  0.00   
+  2  7    -5   -3   4171.7955  3517.5593  180.0   1.03943  0.00   
+  2  5    5    2    4826.2104  4324.4718  -180.0  1.03825  0.00   
+  2  4    -8   2    325.0577   298.1823   -0.0    1.03802  0.00   
+  2  6    4    -6   1358.2900  1251.2761  -180.0  1.03798  0.00   
+  2  0    12   1    346.4388   335.8693   -0.0    1.03750  0.00   
+  2  7    -5   -2   1486.1518  1492.9651  -180.0  1.03709  0.00   
+  2  7    1    0    1215.5021  1264.8986  -0.0    1.03656  0.00   
+  2  1    -9   4    2.5467     2.8086     180.0   1.03594  0.00   
+  2  1    11   2    1514.6524  1702.3367  180.0   1.03580  0.00   
+  2  7    -1   0    1515.1319  1823.6465  -0.0    1.03529  0.00   
+  2  4    10   -4   7.4288     9.1218     0.0     1.03486  0.00   
+  2  3    -11  -2   1132.1271  1522.0493  -180.0  1.03326  0.00   
+  3  2    0    -2   21414.3960 11511.4582 0.0     5.27278  0.00   
+  3  1    1    1    11116.1116 5910.6018  -180.0  4.69421  0.00   
+  3  1    1    -2   902.2754   470.8008   -180.0  4.67491  0.00   
+  3  1    1    2    1564.4449  1807.3867  -180.0  3.62744  0.00   
+  3  1    1    -3   5385.6955  6211.3199  180.0   3.61259  0.00   
+  3  0    2    0    4732.3341  1736.6491  180.0   3.42848  0.00   
+  3  3    1    -1   2075.4842  1015.9203  -0.0    3.40848  0.00   
+  3  3    1    -2   5917.9239  3190.0695  180.0   3.40107  0.00   
+  3  0    2    1    4827.9839  5002.8861  -0.0    3.28338  0.00   
+  3  2    0    2    12212.4204 11589.5133 -0.0    3.21994  0.00   
+  3  2    0    -4   5201.5796  4999.3789  180.0   3.19515  0.00   
+  3  3    1    0    2245.2837  2138.5462  0.0     3.14549  0.00   
+  3  3    1    -3   2928.3434  2676.9793  180.0   3.12810  0.00   
+  3  4    0    -2   105431.7486 80997.2126 -180.0  2.98634  0.01   
+  3  2    2    -1   92931.3838 75009.6462 -0.0    2.97342  0.01   
+  3  0    2    2    820.7845   792.3120   0.0     2.93844  0.00   
+  3  2    2    0    1758.8094  1808.4094  0.0     2.88026  0.00   
+  3  2    2    -2   533.5572   529.1465   -0.0    2.87430  0.00   
+  3  1    1    3    2551.1495  2484.3535  -0.0    2.86317  0.00   
+  3  1    1    -4   5877.7627  5798.5977  -0.0    2.85294  0.00   
+  3  0    0    4    10449.9421 10330.1978 -0.0    2.85171  0.00   
+  3  3    1    1    3158.0955  3754.6111  -180.0  2.75830  0.00   
+  3  3    1    -4   2653.5221  3264.4514  -0.0    2.73880  0.00   
+  3  4    0    0    74405.8494 71127.9625 0.0     2.65494  0.00   
+  3  2    2    1    142966.4789 132922.3198 0.0     2.64122  0.01   
+  3  4    0    -4   152282.2474 140723.6400 180.0   2.63639  0.01   
+  3  2    2    -3   72136.0229 66238.5325 -180.0  2.63204  0.01   
+  3  0    2    3    18771.3876 14170.9481 180.0   2.54623  0.00   
+  3  3    1    2    9626.8667  9775.9233  -180.0  2.37575  0.00   
+  3  3    1    -5   5673.1953  5862.9516  -0.0    2.35831  0.00   
+  3  2    2    2    147.7776   143.7322   -180.0  2.34711  0.00   
+  3  2    2    -4   984.8233   881.1199   180.0   2.33745  0.00   
+  3  1    1    4    3432.7522  2963.9032  -0.0    2.33543  0.00   
+  3  1    1    -5   399.8024   299.6580   -0.0    2.32829  0.00   
+  3  4    2    -2   1576.3986  1408.2873  -0.0    2.25186  0.00   
+  3  5    1    -2   2294.7716  2126.0831  180.0   2.24688  0.00   
+  3  5    1    -3   566.6560   539.9081   180.0   2.24334  0.00   
+  3  1    3    0    52.4793    52.4047    0.0     2.23449  0.00   
+  3  1    3    -1   4177.9379  4178.6541  -0.0    2.23379  0.00   
+  3  4    2    -1   898.8724   918.6208   0.0     2.21193  0.00   
+  3  4    2    -3   12508.8351 13301.7968 -0.0    2.20653  0.00   
+  3  0    2    4    887.4687   966.4144   180.0   2.19243  0.00   
+  3  5    1    -1   10063.3153 11534.5287 -0.0    2.16765  0.00   
+  3  5    1    -4   631.3083   710.8237   -180.0  2.15815  0.00   
+  3  1    3    1    940.8918   1030.5591  -0.0    2.15401  0.00   
+  3  1    3    -2   10136.3897 10956.6340 0.0     2.15213  0.00   
+  3  2    0    4    1548.4698  1631.5304  0.0     2.13728  0.00   
+  3  2    0    -6   7042.2070  7207.2063  0.0     2.12516  0.00   
+  3  4    2    0    680.2017   728.5675   -180.0  2.09914  0.00   
+  3  4    2    -4   484.2816   548.8323   -180.0  2.08993  0.00   
+  3  4    0    2    273378.4953 286005.4391 180.0   2.07126  0.01   
+  3  2    2    3    281136.5956 292660.3806 0.0     2.06253  0.02   
+  3  2    2    -5   276479.4024 296975.5561 0.0     2.05380  0.02   
+  3  4    0    -6   281498.7779 302465.0083 -180.0  2.05369  0.01   
+  3  3    1    3    1002.2300  1081.5570  -180.0  2.04859  0.00   
+  3  3    1    -6   149.1826   154.7495   -0.0    2.03421  0.00   
+  3  5    1    0    737.5313   771.8585   180.0   2.02885  0.00   
+  3  5    1    -5   12486.3104 14173.7038 -0.0    2.01590  0.00   
+  3  1    3    2    12327.2426 14004.5535 -0.0    2.01560  0.00   
+  3  1    3    -3   1086.3128  1237.4212  -0.0    2.01304  0.00   
+  3  3    3    -1   7280.2589  7019.6674  -0.0    1.97556  0.00   
+  3  3    3    -2   196.2736   188.0590   0.0     1.97412  0.00   
+  3  6    0    -2   961.7763   972.7095   180.0   1.96408  0.00   
+  3  1    1    5    4414.0047  4613.2866  180.0   1.96089  0.00   
+  3  6    0    -4   16317.2404 17295.8116 -180.0  1.95842  0.00   
+  3  1    1    -6   1473.7332  1561.0393  -0.0    1.95572  0.00   
+  3  4    2    1    19837.5507 20967.6709 -0.0    1.94305  0.00   
+  3  4    2    -5   65.8499    70.9580    180.0   1.93212  0.00   
+  3  3    3    0    9566.5507  9831.0649  180.0   1.92017  0.00   
+  3  3    3    -3   2715.8822  2768.0491  -0.0    1.91620  0.00   
+  3  0    0    6    1796.2202  1706.1315  -0.0    1.90114  0.00   
+  3  0    2    5    96.1068    90.1154    -180.0  1.89931  0.00   
+  3  5    1    1    3527.9753  2503.9377  -180.0  1.86201  0.00   
+  3  1    3    3    3687.6628  3420.0327  0.0     1.85016  0.00   
+  3  5    1    -6   2954.9138  2901.7818  -180.0  1.84802  0.00   
+  3  1    3    -4   511.3939   508.3602   -180.0  1.84739  0.00   
+  3  3    3    1    3529.2065  3294.2444  -0.0    1.82094  0.00   
+  3  3    3    -4   15301.0478 15068.8682 -180.0  1.81530  0.00   
+  3  2    2    4    2028.4991  2004.2303  180.0   1.81372  0.00   
+  3  2    2    -6   117.1101   110.8504   -0.0    1.80630  0.00   
+  3  3    1    4    1204.8589  1171.4647  -0.0    1.78242  0.00   
+  3  4    2    2    817.5488   570.0731   -0.0    1.77285  0.00   
+  3  3    1    -7   1151.9615  721.3829   -180.0  1.77084  0.00   
+  3  6    0    0    55711.1427 33175.6283 180.0   1.76996  0.00   
+  3  4    2    -6   3211.0122  1198.9237  -0.0    1.76179  0.00   
+  3  6    0    -6   5.5520     2.0493     0.0     1.75759  0.00   
+  3  6    2    -3   424184.5169 370441.0875 -180.0  1.72167  0.02   
+  3  0    4    0    384419.1257 348292.1094 -180.0  1.71424  0.01   
+  3  6    2    -2   456.1601   389.9646   -0.0    1.70424  0.00   
+  3  6    2    -4   1867.3112  1561.5622  180.0   1.70053  0.00   
+  3  3    3    2    4318.8444  3598.0817  -0.0    1.69681  0.00   
+  3  0    4    1    3878.8403  3253.6697  -0.0    1.69521  0.00   
+  3  5    1    2    2968.7466  2569.6935  -180.0  1.69204  0.00   
+  3  3    3    -5   11923.6387 10528.9461 0.0     1.69043  0.00   
+  3  1    1    6    814.4200   741.9232   -0.0    1.68509  0.00   
+  3  1    3    4    50.5966    44.8709    -0.0    1.68194  0.00   
+  3  1    1    -7   14149.1562 12427.2990 -180.0  1.68121  0.00   
+  3  1    3    -5   5456.0838  4676.5444  0.0     1.67927  0.00   
+  3  5    1    -7   312.5538   266.1130   -180.0  1.67855  0.00   
+  3  0    2    6    1059.5812  1003.4202  0.0     1.66263  0.00   
+  3  7    1    -3   36.0560    35.5714    180.0   1.65261  0.00   
+  3  6    2    -1   875.3269   866.7608   -180.0  1.65158  0.00   
+  3  7    1    -4   562.8836   558.9000   -0.0    1.65064  0.00   
+  3  5    3    -2   337.8339   336.8105   -180.0  1.64794  0.00   
+  3  2    4    -1   2846.8322  2838.5276  180.0   1.64772  0.00   
+  3  5    3    -3   1236.7780  1233.2068  -180.0  1.64654  0.00   
+  3  6    2    -5   508.0507   506.0292   -180.0  1.64486  0.00   
+  3  0    4    2    613.0233   610.4188   -180.0  1.64169  0.00   
+  3  2    4    0    724.5136   752.2049   -0.0    1.63133  0.00   
+  3  2    4    -2   4263.0263  4454.1899  180.0   1.63025  0.00   
+  3  7    1    -2   3534.4259  3579.8293  180.0   1.62084  0.00   
+  3  5    3    -1   1008.1618  966.8328   0.0     1.61591  0.00   
+  3  7    1    -5   964.0720   919.1461   -0.0    1.61527  0.00   
+  3  5    3    -4   4117.7508  3836.3564  -180.0  1.61196  0.00   
+  3  4    0    4    70013.8111 64411.0665 180.0   1.60997  0.00   
+  3  4    2    3    30.4822    27.4330    180.0   1.60782  0.00   
+  3  2    2    5    43356.7368 37123.7775 -180.0  1.60482  0.00   
+  3  2    2    -7   88242.3118 66522.3216 0.0     1.59865  0.00   
+  3  4    0    -8   49907.3525 36968.9224 0.0     1.59758  0.00   
+  3  4    2    -7   3490.4746  2583.0936  -0.0    1.59751  0.00   
+  3  2    4    1    1954.2254  1921.5460  0.0     1.58398  0.00   
+  3  2    4    -3   1837.2293  1873.5320  0.0     1.58199  0.00   
+  3  2    0    6    28485.2641 28903.5841 -0.0    1.57550  0.00   
+  3  6    2    0    319.0935   317.6202   -0.0    1.57274  0.00   
+  3  2    0    -8   5055.5878  4976.9857  -180.0  1.56869  0.00   
+  3  3    1    5    1765.5374  1738.9888  180.0   1.56823  0.00   
+  3  3    3    3    485.9415   484.2721   0.0     1.56474  0.00   
+  3  6    2    -6   1248.9868  1248.6755  -180.0  1.56405  0.00   
+  3  0    4    3    2894.9749  2911.4288  -0.0    1.56276  0.00   
+  3  7    1    -1   2018.9239  2046.3350  -0.0    1.56077  0.00   
+  3  3    1    -8   1828.2043  1859.5582  0.0     1.55890  0.00   
+  3  3    3    -6   1466.8080  1492.1789  -180.0  1.55830  0.00   
+  3  5    3    0    3714.5163  3763.3472  180.0   1.55589  0.00   
+  3  7    1    -6   3788.1731  3795.1599  -180.0  1.55250  0.00   
+  3  5    3    -5   1427.5998  1407.6720  0.0     1.55003  0.00   
+  3  5    1    3    867.3478   788.0574   0.0     1.53300  0.00   
+  3  1    3    5    8.6855     7.4043     -180.0  1.52460  0.00   
+  3  1    3    -6   1399.1204  1154.4221  0.0     1.52216  0.00   
+  3  5    1    -8   6.5839     5.3533     0.0     1.52075  0.00   
+  3  2    4    2    5064.0420  4247.4670  180.0   1.51316  0.00   
+  3  2    4    -4   2849.5794  2483.9424  -0.0    1.51057  0.00   
+  3  6    0    2    9545.5961  8942.8816  -180.0  1.50640  0.00   
+  3  6    0    -8   4202.7153  4394.2493  -180.0  1.49373  0.00   
+  3  8    0    -4   19344.1354 20182.1370 -0.0    1.49317  0.00   
+  3  4    4    -2   19975.5278 20467.2694 -0.0    1.48671  0.00   
+  3  7    1    0    501.4179   523.5234   0.0     1.48128  0.00   
+  3  6    2    1    485.3539   507.6139   180.0   1.47872  0.00   
+  3  5    3    1    1413.4621  1470.2348  180.0   1.47671  0.00   
+  3  4    4    -1   174.3070   180.4280   180.0   1.47504  0.00   
+  3  1    1    7    8771.6268  9078.3281  -0.0    1.47499  0.00   
+  3  4    4    -3   1619.8728  1668.6989  180.0   1.47344  0.00   
+  3  1    1    -8   7220.6776  7396.8151  0.0     1.47199  0.00   
+  3  0    2    7    2442.3072  2499.6537  180.0   1.47177  0.00   
+  3  7    1    -7   227.6067   232.6283   -180.0  1.47141  0.00   
+  3  5    3    -6   0.1764     0.1794     -180.0  1.46970  0.00   
+  3  0    4    4    569.6465   579.1182   180.0   1.46922  0.00   
+  3  6    2    -7   1068.1953  1085.9553  180.0   1.46910  0.00   
+  3  4    2    4    309.2678   309.1522   -180.0  1.45729  0.00   
+  3  4    2    -8   297.8245   302.7889   -180.0  1.44808  0.00   
+  3  8    0    -2   51383.6797 52401.9841 0.0     1.44751  0.00   
+  3  8    0    -6   38382.9273 39579.0897 -180.0  1.44148  0.00   
+  3  4    4    0    39324.7431 40385.4402 -180.0  1.44013  0.00   
+  3  4    4    -4   53617.8118 54092.8025 0.0     1.43715  0.00   
+  3  3    3    4    4612.0218  4616.8695  -180.0  1.43605  0.00   
+  3  2    2    6    0.8235     0.8056     -180.0  1.43158  0.00   
+  3  3    3    -7   1466.1774  1448.2095  0.0     1.42997  0.00   
+  3  2    4    3    2645.4727  2694.8245  180.0   1.42814  0.00   
+  3  2    2    -8   1720.1754  1820.4529  -0.0    1.42647  0.00   
+  3  0    0    8    248541.2310 266732.7000 -0.0    1.42586  0.00   
+  3  2    4    -5   1534.8714  1669.7327  180.0   1.42524  0.00   
+  3  3    1    6    908.1148   938.8410   180.0   1.39505  0.00   
+  3  7    1    1    49.4546    50.2357    -180.0  1.39164  0.00   
+  3  5    1    4    759.9933   766.8174   0.0     1.39062  0.00   
+  3  5    3    2    445.2257   442.8181   -180.0  1.38751  0.00   
+  3  3    1    -9   712.3840   708.4684   -0.0    1.38746  0.00   
+  3  4    4    1    3650.2476  3621.4810  -0.0    1.38663  0.00   
+  3  1    3    6    3245.9674  3145.7496  0.0     1.38367  0.00   
+  3  4    4    -5   1276.2886  1223.4375  0.0     1.38264  0.00   
+  3  1    3    -7   513.1058   485.6292   -180.0  1.38152  0.00   
+  3  7    1    -8   245.9447   231.7453   0.0     1.38113  0.00   
+  3  5    3    -7   1155.6086  1075.8151  180.0   1.38004  0.00   
+  3  5    1    -9   3411.4183  3167.7891  -0.0    1.37980  0.00   
+  3  6    2    2    277.0658   255.6554   -180.0  1.37915  0.00   
+  3  0    4    5    413.4275   361.1609   -180.0  1.37047  0.00   
+  3  6    2    -8   3.3335     2.8442     0.0     1.36940  0.00   
+  3  8    2    -4   875.5352   740.7113   180.0   1.36897  0.00   
+  3  7    3    -3   3737.2077  3201.7654  -180.0  1.36552  0.00   
+  3  7    3    -4   519.1095   462.9948   -180.0  1.36440  0.00   
+  3  8    2    -3   1907.9255  1927.1532  180.0   1.36048  0.00   
+  3  1    5    0    4289.4752  4360.5263  -180.0  1.36010  0.00   
+  3  1    5    -1   56.1489    57.2215    -0.0    1.35994  0.00   
+  3  8    2    -5   13621.2223 14185.1487 180.0   1.35796  0.00   
+  3  7    3    -2   6086.7146  6979.5720  0.0     1.34743  0.00   
+  3  7    3    -5   2130.0693  2393.9202  180.0   1.34423  0.00   
+  3  1    5    1    6827.5061  7418.3946  0.0     1.34132  0.00   
+  3  1    5    -2   2592.7555  2794.4988  180.0   1.34086  0.00   
+  3  2    4    4    199.4314   204.5780   -180.0  1.33725  0.00   
+  3  2    4    -6   3971.8768  4271.0117  180.0   1.33426  0.00   
+  3  8    2    -2   175.1343   192.6542   0.0     1.33353  0.00   
+  3  8    2    -6   93.8271    116.9879   0.0     1.32881  0.00   
+  3  8    0    0    101797.9870 126956.4224 0.0     1.32747  0.00   
+  3  4    2    5    10613.4848 12813.2310 0.0     1.32420  0.00   
+  3  4    4    2    95928.6146 113768.3425 0.0     1.32061  0.00   
+  3  8    0    -8   121188.9249 139544.0331 -0.0    1.31819  0.00   
+  3  3    3    5    1127.1240  1244.6187  -0.0    1.31675  0.00   
+  3  0    2    8    335.9088   368.2815   180.0   1.31654  0.00   
+  3  4    2    -9   5113.7561  5527.8067  180.0   1.31614  0.00   
+  3  4    4    -6   112012.0708 120592.4792 0.0     1.31602  0.00   
+  3  7    3    -1   1104.3786  1033.4915  180.0   1.31232  0.00   
+  3  3    3    -8   7939.0297  7097.5780  180.0   1.31121  0.00   
+  3  1    1    8    182.7036   157.0067   180.0   1.31026  0.00   
+  3  1    1    -9   907.4581   715.4708   180.0   1.30787  0.00   
+  3  7    3    -6   9707.7829  7551.7571  -0.0    1.30740  0.00   
+  3  1    5    2    2319.2961  1733.2782  180.0   1.30583  0.00   
+  3  1    5    -3   9919.1305  7303.6570  -0.0    1.30514  0.00   
+  3  9    1    -4   1259.5017  843.4711   0.0     1.30157  0.00   
+  3  9    1    -5   397.6969   257.6551   0.0     1.30033  0.00   
+  3  7    1    2    6274.5257  3977.9953  -180.0  1.29932  0.00   
+  3  6    4    -3   3737.4331  2357.3599  -0.0    1.29904  0.00   
+  3  5    3    3    524.3398   335.5156   180.0   1.29569  0.00   
+  3  3    5    -1   936.1025   621.7084   0.0     1.29476  0.00   
+  3  3    5    -2   3231.8197  2187.9867  -0.0    1.29435  0.00   
+  3  6    4    -2   33.1922    25.6015    0.0     1.29151  0.00   
+  3  8    2    -1   11511.2384 8940.5721  180.0   1.29125  0.00   
+  3  4    0    6    23640.0666 18472.0747 180.0   1.29100  0.00   
+  3  6    4    -4   8941.9702  7142.6749  -0.0    1.28989  0.00   
+  3  7    1    -9   163.3159   133.2606   180.0   1.28888  0.00   
+  3  5    3    -8   4214.3345  3486.8639  180.0   1.28826  0.00   
+  3  2    2    7    19291.8709 16125.1270 -0.0    1.28781  0.00   
+  3  9    1    -3   6371.1874  5524.9101  180.0   1.28615  0.00   
+  3  8    2    -7   484.0998   430.5464   -180.0  1.28483  0.00   
+  3  2    2    -9   21809.5918 19765.3570 0.0     1.28355  0.00   
+  3  9    1    -6   204.4634   187.1689   -0.0    1.28257  0.00   
+  3  4    0    -10  22576.2861 20681.0743 -180.0  1.28247  0.00   
+  3  6    2    3    0.4162     0.3823     180.0   1.28086  0.00   
+  3  3    5    0    798.6200   720.5954   -0.0    1.27878  0.00   
+  3  3    5    -3   6795.4325  6036.9196  -0.0    1.27761  0.00   
+  3  0    4    6    135.2271   118.5251   180.0   1.27311  0.00   
+  3  6    2    -9   513.5838   465.8532   180.0   1.27149  0.00   
+  3  6    4    -1   496.0143   481.8202   -180.0  1.26813  0.00   
+  3  6    0    4    7773.0922  7271.9004  180.0   1.26631  0.00   
+  3  5    1    5    5022.1052  4614.0892  180.0   1.26584  0.00   
+  3  6    4    -5   653.5362   581.7999   -180.0  1.26508  0.00   
+  3  7    3    0    945.0706   803.6266   180.0   1.26401  0.00   
+  3  1    3    7    10200.9605 8417.2878  -0.0    1.26009  0.00   
+  3  1    3    -8   3644.9133  3095.0525  180.0   1.25822  0.00   
+  3  7    3    -7   2849.0833  2425.9429  180.0   1.25786  0.00   
+  3  1    5    3    41.2073    35.1503    180.0   1.25746  0.00   
+  3  1    5    -4   3634.1785  3097.6918  180.0   1.25659  0.00   
+  3  5    1    -10  8283.4294  7054.0860  -180.0  1.25642  0.00   
+  3  6    0    -10  139.1037   117.7387   180.0   1.25576  0.00   
+  3  9    1    -2   428.6554   362.7881   0.0     1.25576  0.00   
+  3  3    1    7    1967.0686  1612.5440  -0.0    1.25351  0.00   
+  3  9    1    -7   10808.5076 8760.4984  -180.0  1.25022  0.00   
+  3  3    5    1    9751.7680  8337.3020  0.0     1.24817  0.00   
+  3  4    4    3    19.1671    16.4749    0.0     1.24800  0.00   
+  3  3    1    -10  3401.5186  2988.8915  180.0   1.24727  0.00   
+  3  2    4    5    1284.5115  1150.2934  0.0     1.24659  0.00   
+  3  3    5    -4   1211.2354  1091.6733  -0.0    1.24635  0.00   
+  3  2    4    -7   840.3606   790.3905   0.0     1.24369  0.00   
+  3  4    4    -7   6938.6927  6541.8184  -0.0    1.24316  0.00   
+  3  2    0    8    29.5264    27.7546    -0.0    1.24197  0.00   
+  3  8    2    0    856.7491   733.8837   180.0   1.23792  0.00   
+  3  2    0    -10  2360.2121  2005.6643  180.0   1.23768  0.00   
+  3  6    4    0    16252.9945 14152.7382 -0.0    1.23138  0.00   
+  3  8    2    -8   697.9044   629.1885   180.0   1.23039  0.00   
+  3  6    4    -6   133.7100   129.7138   -180.0  1.22719  0.00   
+  3  9    1    -1   2866.1517  2744.2992  -0.0    1.21345  0.00   
+  3  7    1    3    76.2051    73.2189    180.0   1.20941  0.00   
+  3  3    3    6    884.3587   848.7937   0.0     1.20915  0.00   
+  3  4    2    6    431.2526   411.8660   -0.0    1.20819  0.00   
+  3  7    3    1    2881.3776  2739.7130  180.0   1.20692  0.00   
+  3  9    1    -8   2449.9070  2328.1573  0.0     1.20647  0.00   
+  3  5    3    4    7928.6973  7533.8281  -180.0  1.20626  0.00   
+  3  3    5    2    3937.6745  3741.7581  0.0     1.20594  0.00   
+  3  3    3    -9   986.2601   945.2482   -0.0    1.20420  0.00   
+  3  3    5    -5   50.6910    48.8651    180.0   1.20364  0.00   
+  3  4    2    -10  167.1772   165.7399   -0.0    1.20118  0.00   
+  3  1    5    4    3952.6894  3934.1444  180.0   1.20057  0.00   
+  3  7    3    -8   5.4675     5.4499     0.0     1.20005  0.00   
+  3  1    5    -5   658.0967   655.8926   0.0     1.19960  0.00   
+  3  7    1    -10  8343.4253  8313.3024  -180.0  1.19946  0.00   
+  3  5    3    -9   302.2091   300.8794   180.0   1.19918  0.00   
+  3  10   0    -4   7894.7838  6816.4474  0.0     1.18909  0.00   
+  3  0    2    9    310.8739   269.4917   -0.0    1.18880  0.00   
+  3  5    5    -2   3436.7442  3024.8638  -0.0    1.18802  0.00   
+  3  6    2    4    303.5102   268.0503   180.0   1.18787  0.00   
+  3  5    5    -3   0.1120     0.0999     -0.0    1.18749  0.00   
+  3  10   0    -6   12318.9289 11133.5203 0.0     1.18699  0.00   
+  3  6    4    1    1375.4413  1320.3743  0.0     1.18466  0.00   
+  3  0    4    7    285.5702   286.2759   180.0   1.18107  0.00   
+  3  6    4    -7   1772.6655  1787.3679  0.0     1.17969  0.00   
+  3  8    0    2    30957.0046 31252.4162 180.0   1.17918  0.00   
+  3  6    2    -10  2.1959     2.2169     -0.0    1.17916  0.00   
+  3  1    1    9    120.9508   122.6224   -0.0    1.17794  0.00   
+  3  8    2    1    5759.5931  5839.8036  -180.0  1.17792  0.00   
+  3  1    1    -10  742.9927   763.1313   180.0   1.17600  0.00   
+  3  5    5    -1   7113.8846  7315.0281  -180.0  1.17585  0.00   
+  3  5    5    -4   5343.8311  5558.6385  -0.0    1.17432  0.00   
+  3  4    4    4    32304.3359 33773.1476 0.0     1.17355  0.00   
+  3  8    2    -9   8254.6061  8433.6820  180.0   1.16982  0.00   
+  3  8    0    -10  37722.9316 38320.9165 0.0     1.16945  0.00   
+  3  4    4    -8   28465.5927 28599.6035 -180.0  1.16873  0.00   
+  3  2    2    8    101.1420   100.3642   0.0     1.16772  0.00   
+  3  2    2    -10  575.5699   559.7557   -0.0    1.16414  0.00   
+  3  9    1    0    185.7188   176.0111   180.0   1.16288  0.00   
+  3  2    4    6    15405.0755 13773.8803 180.0   1.16000  0.00   
+  3  5    1    6    55.6677    50.4105    0.0     1.15746  0.00   
+  3  2    4    -8   2662.0533  2415.1534  0.0     1.15727  0.00   
+  3  3    5    3    3415.7078  3130.6548  0.0     1.15568  0.00   
+  3  9    1    -9   619.3920   566.7118   180.0   1.15499  0.00   
+  3  3    5    -6   57.3151    51.5975    -0.0    1.15308  0.00   
+  3  1    3    8    3078.1451  2760.9534  0.0     1.15268  0.00   
+  3  5    5    0    7464.4591  6661.9553  -0.0    1.15210  0.00   
+  3  1    3    -9   1.4977     1.3293     -0.0    1.15105  0.00   
+  3  5    5    -5   9516.5649  8505.8774  -180.0  1.14972  0.00   
+  3  5    1    -11  1683.6378  1515.0613  0.0     1.14930  0.00   
+  3  9    3    -4   444.9553   427.8410   0.0     1.14675  0.00   
+  3  9    3    -5   65.6741    65.0163    -0.0    1.14590  0.00   
+  3  7    3    2    4846.9260  4902.8455  -0.0    1.14521  0.00   
+  3  0    6    0    2524.7656  2603.9725  -0.0    1.14283  0.00   
+  3  10   0    -2   15679.7812 16037.3797 0.0     1.14241  0.00   
+  3  0    0    10   442.2009   424.2167   -0.0    1.14068  0.00   
+  3  1    5    5    5586.0332  5037.9825  -0.0    1.13922  0.00   
+  3  1    5    -6   6065.5115  5303.5881  180.0   1.13821  0.00   
+  3  7    3    -9   5354.7779  4668.6503  180.0   1.13804  0.00   
+  3  0    6    1    1890.3431  1644.7919  180.0   1.13714  0.00   
+  3  10   0    -8   1664.0814  1453.4715  0.0     1.13685  0.00   
+  3  3    1    8    77.6954    68.5405    180.0   1.13637  0.00   
+  3  9    3    -3   1610.5516  1428.7035  -180.0  1.13616  0.00   
+  3  9    3    -6   1979.2860  1859.1319  -0.0    1.13369  0.00   
+  3  6    4    2    2971.2285  2826.8128  0.0     1.13157  0.00   
+  3  3    1    -11  32.5000    30.9644    0.0     1.13117  0.00   
+  3  10   2    -5   6240.2468  6295.3268  0.0     1.12803  0.00   
+  3  6    4    -8   1850.0563  2098.5070  -0.0    1.12617  0.00   
+  3  8    4    -4   3620.2539  4166.4798  -180.0  1.12593  0.00   
+  3  7    1    4    4101.0669  4931.2456  -0.0    1.12480  0.00   
+  3  10   2    -4   7.5285     9.0471     180.0   1.12344  0.00   
+  3  2    6    -1   3000.1617  3545.8942  180.0   1.12246  0.00   
+  3  5    3    5    1682.2340  1969.8973  -180.0  1.12209  0.00   
+  3  10   2    -6   148.8068   172.5193   180.0   1.12167  0.00   
+  3  8    4    -3   2890.8352  3322.6561  -180.0  1.12119  0.00   
+  3  0    6    2    1201.6077  1372.9391  -180.0  1.12055  0.00   
+  3  8    4    -5   907.0053   1032.2056  180.0   1.11978  0.00   
+  3  5    5    1    635.2586   710.5254   0.0     1.11882  0.00   
+  3  2    6    0    5106.0592  5310.1542  180.0   1.11724  0.00   
+  3  2    6    -2   972.7134   991.2840   180.0   1.11689  0.00   
+  3  5    5    -6   2635.4547  2502.1692  0.0     1.11577  0.00   
+  3  7    1    -11  2226.3277  2086.3451  180.0   1.11556  0.00   
+  3  5    3    -10  1709.2901  1596.5822  -0.0    1.11551  0.00   
+  3  8    2    2    132.9741   120.8930   0.0     1.11507  0.00   
+  3  9    3    -2   2227.7323  2022.8077  0.0     1.11505  0.00   
+  3  3    3    7    8426.7329  7160.4504  0.0     1.11347  0.00   
+  3  9    3    -7   2076.6655  1754.2932  -180.0  1.11116  0.00   
+  3  3    3    -10  298.1141   264.2368   -0.0    1.10909  0.00   
+  3  10   2    -3   39057.7856 35198.9394 -180.0  1.10829  0.00   
+  3  9    1    1    4179.0980  3814.8159  -180.0  1.10755  0.00   
+  3  4    2    7    10150.6021 9266.0725  0.0     1.10755  0.00   
+  3  8    2    -10  39.7105    36.6106    0.0     1.10683  0.00   
+  3  8    4    -2   31659.7444 29371.8595 -180.0  1.10597  0.00   
+  3  10   2    -7   37701.5154 35018.3253 0.0     1.10490  0.00   
+  3  8    4    -6   32481.4745 30155.6103 0.0     1.10327  0.00   
+  3  6    2    5    143084.4133 132224.1652 -180.0  1.10215  0.00   
+  3  2    6    1    29926.9844 27586.9951 -180.0  1.10167  0.00   
+  3  4    2    -11  2361.3674  2174.1832  -0.0    1.10148  0.00   
+  3  2    6    -3   32530.1627 29856.1362 0.0     1.10100  0.00   
+  3  3    5    4    76.6017    70.2165    0.0     1.10083  0.00   
+  3  4    4    5    2945.4743  2696.1431  180.0   1.10063  0.00   
+  3  9    1    -10  308.7342   280.7417   0.0     1.09923  0.00   
+  3  3    5    -7   3252.0839  2933.4436  0.0     1.09808  0.00   
+  3  0    4    8    153492.0260 133795.8139 -180.0  1.09621  0.00   
+  3  4    4    -9   154.7213   133.9544   0.0     1.09598  0.00   
+  3  0    6    3    4161.4928  3391.0840  -0.0    1.09446  0.00   
+  3  6    2    -11  186569.8446 149937.5693 -180.0  1.09419  0.00   
+  3  9    3    -1   1268.7356  1115.8244  0.0     1.08511  0.00   
+  3  10   2    -2   940.4470   880.8125   -0.0    1.08382  0.00   
+  3  0    2    10   135.8756   133.8301   0.0     1.08235  0.00   
+  3  7    3    3    6057.5859  5998.1447  180.0   1.08222  0.00   
+  3  8    4    -1   6.3753     6.5222     0.0     1.08149  0.00   
+  3  9    3    -8   15.3424    16.9760    180.0   1.08011  0.00   
+  3  2    4    7    123.7007   143.3393   180.0   1.07946  0.00   
+  3  10   2    -8   253.4574   302.3514   0.0     1.07907  0.00   
+  3  5    5    2    4255.5745  5302.6889  0.0     1.07850  0.00   
+  3  8    4    -7   668.8363   885.8789   -0.0    1.07771  0.00   
+  3  2    6    2    342.7297   478.1936   0.0     1.07700  0.00   
+  3  2    4    -9   929.8904   1302.2259  -180.0  1.07695  0.00   
+  3  1    5    6    5251.1013  7484.8835  180.0   1.07669  0.00   
+  3  2    6    -4   2127.8770  3155.4747  -0.0    1.07607  0.00   
+  3  1    5    -7   7362.8557  11172.4404 0.0     1.07568  0.00   
+  3  6    4    3    983.3377   1518.6342  -180.0  1.07536  0.00   
+  3  7    3    -10  7836.1505  12279.4341 0.0     1.07507  0.00   
+  3  5    5    -7   10.4878    16.5024    0.0     1.07498  0.00   
+  3  6    0    6    533.7628   881.0224   180.0   1.07331  0.00   
+  3  11   1    -5   94.1775    157.4610   180.0   1.07181  0.00   
+  3  11   1    -6   3.3812     5.7108     -180.0  1.07097  0.00   
+  3  6    4    -9   477.1930   817.7360   -180.0  1.06980  0.00   
+  3  1    1    10   1509.8494  2600.5368  -180.0  1.06948  0.00   
+  3  4    0    8    13552.5087 23545.6846 -0.0    1.06864  0.00   
+  3  7    5    -3   771.8114   1330.2343  -180.0  1.06807  0.00   
+  3  1    1    -11  24.5615    42.0897    0.0     1.06788  0.00   
+  3  7    5    -4   99.6129    168.4965   180.0   1.06754  0.00   
+  3  4    6    -2   1481.6256  2484.1220  -180.0  1.06734  0.00   
+  3  2    2    9    15161.6332 24387.2566 -0.0    1.06652  0.00   
+  3  6    0    -12  2005.7953  2937.0147  -180.0  1.06505  0.00   
+  3  5    1    7    2505.8511  3266.5087  0.0     1.06351  0.00   
+  3  2    2    -11  16131.4338 21014.7437 -180.0  1.06350  0.00   
+  3  11   1    -4   3981.0800  5130.8036  0.0     1.06330  0.00   
+  3  4    6    -1   1.5808     2.0095     -0.0    1.06300  0.00   
+  3  4    0    -12  22566.2817 28294.4853 -180.0  1.06258  0.00   
+  3  4    6    -3   2257.8470  2820.0151  180.0   1.06240  0.00   
+  3  10   0    0    662.6688   823.5252   0.0     1.06197  0.00   
+  3  11   1    -7   53.1843    66.4369    -180.0  1.06083  0.00   
+  3  0    6    4    1334.7621  1667.5861  0.0     1.06081  0.00   
+  3  1    3    9    1255.1516  1610.5703  0.0     1.05949  0.00   
+  3  7    5    -2   1.2698     1.6367     -0.0    1.05935  0.00   
+  3  1    3    -10  1769.1447  2357.4609  0.0     1.05808  0.00   
+  3  7    5    -5   2897.0825  3882.9000  -180.0  1.05779  0.00   
+  3  5    1    -12  1513.2851  2096.8219  -180.0  1.05643  0.00   
+  3  10   0    -10  3325.4762  4670.5595  0.0     1.05456  0.00   
+  3  8    2    3    17282.3496 22586.4647 180.0   1.05224  0.00   
+  3  10   2    -1   45516.5536 58072.3330 0.0     1.05185  0.00   
+  3  9    1    2    115.5673   132.8636   -0.0    1.05041  0.00   
+  3  4    6    0    1456.0676  1588.0055  0.0     1.04971  0.00   
+  3  8    4    0    57574.4703 62169.3866 -180.0  1.04957  0.00   
+  3  4    6    -4   1153.1348  1168.0135  0.0     1.04855  0.00   
+  3  9    3    0    2336.8164  2359.8361  0.0     1.04850  0.00   
+  3  7    1    5    1076.8673  1024.8294  0.0     1.04685  0.00   
+  3  11   1    -3   29.2948    27.5849    180.0   1.04608  0.00   
+  3  10   2    -9   71621.2424 67433.1239 0.0     1.04607  0.00   
+  3  2    6    3    59949.6074 55749.7605 -180.0  1.04504  0.00   
+  3  8    4    -8   72761.2238 67597.9465 -180.0  1.04497  0.00   
+  3  5    3    6    1516.2982  1400.3734  -180.0  1.04452  0.00   
+  3  3    5    5    3953.8144  3639.2065  -0.0    1.04425  0.00   
+  3  8    2    -11  5.2939     4.8681     0.0     1.04417  0.00   
+  3  2    6    -5   61153.9020 56063.5788 -180.0  1.04390  0.00   
+  3  9    3    -9   547.2838   493.6028   -180.0  1.04270  0.00   
+  3  11   1    -8   5985.6648  5353.4363  0.0     1.04216  0.00   
+  3  7    5    -1   5209.2788  4651.6452  -180.0  1.04203  0.00   
+  3  9    1    -11  5549.8809  4955.5220  180.0   1.04203  0.00   
+  3  3    5    -8   429.1373   381.5611   -0.0    1.04148  0.00   
+  3  7    5    -6   22.9256    20.5764    180.0   1.03956  0.00   
+  3  5    3    -11  180.4017   166.7784   -0.0    1.03851  0.00   
+  3  7    1    -12  608.6499   564.9155   -180.0  1.03841  0.00   
+  3  3    1    9    1052.5079  984.5971   -180.0  1.03823  0.00   
+  3  8    0    4    2635.4088  2830.6748  -0.0    1.03563  0.00   
+  3  3    1    -12  834.7617   960.8990   0.0     1.03384  0.00   
+  3  5    5    3    1203.2535  1391.0003  -180.0  1.03365  0.00   
+  4  1    1    0    1554.5603  1523.1929  -0.0    3.25125  0.08   
+  4  1    0    1    437.9567   356.4613   -0.0    2.48998  0.03   
+  4  2    0    0    305.6561   291.8090   -0.0    2.29898  0.01   
+  4  1    1    1    272.1481   288.4667   180.0   2.18953  0.01   
+  4  2    1    0    214.1767   230.0704   0.0     2.05627  0.01   
+  4  2    1    1    949.2630   879.7935   -0.0    1.68912  0.05   
+  4  2    2    0    792.3184   872.5279   -0.0    1.62563  0.01   
+  4  0    0    2    1309.2159  1394.0051  -0.0    1.48094  0.01   
+  4  3    1    0    282.3887   273.7934   -0.0    1.45400  0.01   
+  4  2    2    1    78.9627    88.9749    180.0   1.42509  0.00   
+  4  3    0    1    1136.3619  1183.6304  -0.0    1.36121  0.02   
+  4  1    1    2    505.8513   598.3989   -0.0    1.34771  0.01   
+  4  3    1    1    1.2445     0.8897     0.0     1.30521  0.00   
+  4  3    2    0    0.8997     0.7519     180.0   1.27525  0.00   
+  4  2    0    2    211.1670   203.6183   -0.0    1.24499  0.00   
+  4  2    1    2    62.6601    62.9745    0.0     1.20171  0.00   
+  4  3    2    1    175.1624   188.7646   -0.0    1.17129  0.01   
+  4  4    0    0    264.4570   227.1319   -0.0    1.14949  0.00   
+  4  4    1    0    70.6931    62.4730    180.0   1.11517  0.00   
+  4  2    2    2    520.8392   440.1237   -0.0    1.09477  0.01   
+  4  3    3    0    764.6751   737.9443   -0.0    1.08375  0.01   
+  4  4    1    1    400.6362   360.8859   -0.0    1.04365  0.01   
+  4  3    1    2    180.9715   174.6004   -0.0    1.03753  0.01   
+_reflns_number_total  1177
+_reflns_d_resolution_low    5.273
+_reflns_d_resolution_high   1.033
+
+# POWDER DATA TABLE
+_pd_meas_2theta_range_min  10.01313
+_pd_meas_2theta_range_max  119.99238
+_pd_meas_2theta_range_inc  0.02626
+_pd_proc_2theta_range_min  9.99428
+_pd_proc_2theta_range_max  119.97353
+_pd_proc_2theta_range_inc  0.02626
+_pd_proc_number_of_points  4189
+
+loop_
+   _pd_meas_intensity_total
+   _pd_calc_intensity_total
+   _pd_proc_intensity_bkg_calc
+   _pd_proc_ls_weight
+  2914         0            0           0         
+  2902         0            0           0         
+  2836         0            0           0         
+  3001         0            0           0         
+  2863         0            0           0         
+  2859         0            0           0         
+  2962         0            0           0         
+  2923         0            0           0         
+  2909         0            0           0         
+  2898         0            0           0         
+  2857         0            0           0         
+  2910         0            0           0         
+  2903         0            0           0         
+  2861         0            0           0         
+  2844         0            0           0         
+  2859         0            0           0         
+  2897         0            0           0         
+  2828         0            0           0         
+  2824         0            0           0         
+  2786         0            0           0         
+  2844         0            0           0         
+  2757         0            0           0         
+  2754         0            0           0         
+  2803         0            0           0         
+  2680         0            0           0         
+  2799         0            0           0         
+  2714         0            0           0         
+  2825         0            0           0         
+  2779         0            0           0         
+  2838         0            0           0         
+  2771         0            0           0         
+  2745         0            0           0         
+  2766         0            0           0         
+  2652         0            0           0         
+  2725         0            0           0         
+  2723         0            0           0         
+  2738         0            0           0         
+  2668         0            0           0         
+  2726         0            0           0         
+  2605         0            0           0         
+  2688         0            0           0         
+  2680         0            0           0         
+  2555         0            0           0         
+  2583         0            0           0         
+  2683         0            0           0         
+  2651         0            0           0         
+  2635         0            0           0         
+  2653         0            0           0         
+  2674         0            0           0         
+  2615         0            0           0         
+  2590         0            0           0         
+  2723         0            0           0         
+  2565         0            0           0         
+  2609         0            0           0         
+  2597         0            0           0         
+  2631         0            0           0         
+  2588         0            0           0         
+  2662         0            0           0         
+  2627         0            0           0         
+  2646         0            0           0         
+  2596         0            0           0         
+  2541         0            0           0         
+  2535         0            0           0         
+  2592         0            0           0         
+  2517         0            0           0         
+  2541         0            0           0         
+  2613         0            0           0         
+  2497         0            0           0         
+  2700         0            0           0         
+  2510         0            0           0         
+  2448         0            0           0         
+  2361         0            0           0         
+  2535         0            0           0         
+  2395         0            0           0         
+  2493         0            0           0         
+  2511         0            0           0         
+  2506         0            0           0         
+  2499         0            0           0         
+  2405         0            0           0         
+  2478         0            0           0         
+  2485         0            0           0         
+  2409         0            0           0         
+  2442         0            0           0         
+  2487         0            0           0         
+  2410         0            0           0         
+  2419         0            0           0         
+  2410         0            0           0         
+  2371         0            0           0         
+  2441         0            0           0         
+  2532         0            0           0         
+  2406         0            0           0         
+  2349         0            0           0         
+  2437         0            0           0         
+  2343         0            0           0         
+  2393         0            0           0         
+  2380         0            0           0         
+  2356         0            0           0         
+  2330         0            0           0         
+  2349         0            0           0         
+  2409         0            0           0         
+  2230         0            0           0         
+  2314         0            0           0         
+  2354         0            0           0         
+  2316         0            0           0         
+  2306         0            0           0         
+  2270         0            0           0         
+  2271         0            0           0         
+  2259         0            0           0         
+  2244         0            0           0         
+  2251         0            0           0         
+  2273         0            0           0         
+  2373         0            0           0         
+  2307         0            0           0         
+  2292         0            0           0         
+  2267         0            0           0         
+  2273         0            0           0         
+  2215         0            0           0         
+  2274         0            0           0         
+  2164         0            0           0         
+  2275         0            0           0         
+  2332         0            0           0         
+  2216         0            0           0         
+  2255         0            0           0         
+  2266         0            0           0         
+  2204         0            0           0         
+  2295         0            0           0         
+  2220         0            0           0         
+  2204         0            0           0         
+  2233         0            0           0         
+  2241         0            0           0         
+  2241         0            0           0         
+  2221         0            0           0         
+  2246         0            0           0         
+  2232         0            0           0         
+  2249         0            0           0         
+  2197         0            0           0         
+  2278         0            0           0         
+  2147         0            0           0         
+  2170         0            0           0         
+  2156         0            0           0         
+  2195         0            0           0         
+  2152         0            0           0         
+  2075         0            0           0         
+  2167         0            0           0         
+  2170         0            0           0         
+  2183         0            0           0         
+  2122         0            0           0         
+  2079         0            0           0         
+  2099         0            0           0         
+  2129         0            0           0         
+  2136         0            0           0         
+  2118         0            0           0         
+  2107         0            0           0         
+  1988         0            0           0         
+  2024         0            0           0         
+  2025         0            0           0         
+  2070         0            0           0         
+  2076         0            0           0         
+  2078         0            0           0         
+  2036         0            0           0         
+  1987         0            0           0         
+  2053         0            0           0         
+  2071         0            0           0         
+  1997         0            0           0         
+  1948         0            0           0         
+  2056         0            0           0         
+  1986         0            0           0         
+  2043         0            0           0         
+  2025         0            0           0         
+  1978         0            0           0         
+  1947         0            0           0         
+  1996         0            0           0         
+  2004         0            0           0         
+  1944         0            0           0         
+  2025         0            0           0         
+  1953         0            0           0         
+  1840         0            0           0         
+  2023         0            0           0         
+  2042         0            0           0         
+  1917         0            0           0         
+  1982         0            0           0         
+  1898         0            0           0         
+  1860         0            0           0         
+  2023         0            0           0         
+  1993         0            0           0         
+  1918         0            0           0         
+  1930         0            0           0         
+  1934         0            0           0         
+  1951         0            0           0         
+  1867         0            0           0         
+  1820         0            0           0         
+  1934         0            0           0         
+  1852         0            0           0         
+  1910         0            0           0         
+  1906         0            0           0         
+  1872         0            0           0         
+  1832         0            0           0         
+  1878         0            0           0         
+  1803         0            0           0         
+  1875         0            0           0         
+  1860         0            0           0         
+  1849         0            0           0         
+  1835         0            0           0         
+  1890         0            0           0         
+  1868         0            0           0         
+  1820         0            0           0         
+  1885         0            0           0         
+  1839         0            0           0         
+  1785         0            0           0         
+  1819         0            0           0         
+  1872         0            0           0         
+  1852         0            0           0         
+  1811         0            0           0         
+  1809         0            0           0         
+  1726         0            0           0         
+  1772         0            0           0         
+  1764         0            0           0         
+  1788         0            0           0         
+  1784         0            0           0         
+  1772         0            0           0         
+  1823         0            0           0         
+  1763         0            0           0         
+  1793         0            0           0         
+  1709         0            0           0         
+  1765         0            0           0         
+  1813         0            0           0         
+  1794         0            0           0         
+  1781         0            0           0         
+  1796         0            0           0         
+  1851         0            0           0         
+  1802         0            0           0         
+  1808         0            0           0         
+  1799         0            0           0         
+  1769         0            0           0         
+  1773         0            0           0         
+  1720         0            0           0         
+  1717         0            0           0         
+  1622         0            0           0         
+  1696         0            0           0         
+  1754         0            0           0         
+  1727         0            0           0         
+  1606         0            0           0         
+  1702         0            0           0         
+  1697         0            0           0         
+  1635         0            0           0         
+  1619         0            0           0         
+  1567         0            0           0         
+  1713         0            0           0         
+  1666         0            0           0         
+  1668         0            0           0         
+  1586         0            0           0         
+  1718         0            0           0         
+  1618         0            0           0         
+  1586         0            0           0         
+  1657         0            0           0         
+  1561         0            0           0         
+  1626         0            0           0         
+  1650         0            0           0         
+  1694         0            0           0         
+  1654         0            0           0         
+  1627         0            0           0         
+  1584         0            0           0         
+  1617         0            0           0         
+  1661         0            0           0         
+  1620         0            0           0         
+  1600         0            0           0         
+  1609         0            0           0         
+  1645         0            0           0         
+  1656         0            0           0         
+  1623         0            0           0         
+  1540         0            0           0         
+  1552         0            0           0         
+  1556         0            0           0         
+  1569         0            0           0         
+  1584         0            0           0         
+  1579         0            0           0         
+  1568         0            0           0         
+  1526         0            0           0         
+  1578         0            0           0         
+  1576         0            0           0         
+  1548         0            0           0         
+  1547         0            0           0         
+  1531         0            0           0         
+  1540         0            0           0         
+  1492         0            0           0         
+  1531         0            0           0         
+  1532         0            0           0         
+  1532         0            0           0         
+  1447         0            0           0         
+  1498         0            0           0         
+  1506         0            0           0         
+  1401         0            0           0         
+  1517         0            0           0         
+  1476         0            0           0         
+  1476         0            0           0         
+  1485         0            0           0         
+  1486         0            0           0         
+  1460         0            0           0         
+  1414         0            0           0         
+  1506         0            0           0         
+  1531         0            0           0         
+  1507         0            0           0         
+  1413         0            0           0         
+  1519         0            0           0         
+  1568         0            0           0         
+  1445         0            0           0         
+  1456         0            0           0         
+  1547         0            0           0         
+  1515         0            0           0         
+  1401         0            0           0         
+  1440         0            0           0         
+  1442         0            0           0         
+  1464         0            0           0         
+  1374         0            0           0         
+  1400         0            0           0         
+  1423         0            0           0         
+  1447         0            0           0         
+  1427         0            0           0         
+  1436         0            0           0         
+  1497         0            0           0         
+  1467         0            0           0         
+  1423         0            0           0         
+  1452         0            0           0         
+  1371         0            0           0         
+  1436         0            0           0         
+  1380         0            0           0         
+  1370         0            0           0         
+  1379         0            0           0         
+  1430         0            0           0         
+  1444         0            0           0         
+  1440         0            0           0         
+  1349         0            0           0         
+  1406         0            0           0         
+  1445         0            0           0         
+  1433         0            0           0         
+  1494         0            0           0         
+  1443         0            0           0         
+  1376         0            0           0         
+  1423         0            0           0         
+  1363         0            0           0         
+  1383         0            0           0         
+  1361         0            0           0         
+  1375         0            0           0         
+  1340         0            0           0         
+  1341         0            0           0         
+  1431         0            0           0         
+  1346         0            0           0         
+  1303         0            0           0         
+  1335         0            0           0         
+  1306         0            0           0         
+  1368         0            0           0         
+  1259         0            0           0         
+  1341         0            0           0         
+  1357         0            0           0         
+  1268         0            0           0         
+  1301         0            0           0         
+  1184         0            0           0         
+  1330         0            0           0         
+  1305         0            0           0         
+  1338         0            0           0         
+  1298         1339.74811   1293.12403  0.000770416 
+  1311         1336.07289   1290.54505  0.000762777 
+  1331         1330.89718   1287.97109  0.000751315 
+  1273         1324.69679   1285.40215  0.000785546 
+  1330         1318.00854   1282.83822  0.00075188 
+  1262         1311.27978   1280.27928  0.000792393 
+  1215         1304.80589   1277.72535  0.000823045 
+  1305         1298.73794   1275.17639  0.000766284 
+  1259         1293.12477   1272.63242  0.000794281 
+  1258         1287.95464   1270.09341  0.000794913 
+  1319         1283.18602   1267.55936  0.00075815 
+  1317         1278.76746   1265.03027  0.000759301 
+  1248         1274.6472    1262.50613  0.000801282 
+  1271         1270.77779   1259.98692  0.000786782 
+  1214         1267.11818   1257.47265  0.000823723 
+  1281         1263.63358   1254.96329  0.00078064 
+  1187         1260.29494   1252.45886  0.00084246 
+  1289         1257.07846   1249.95932  0.000775795 
+  1252         1253.96461   1247.46469  0.000798722 
+  1295         1250.95      1244.97495  0.000772201 
+  1308         1247.99639   1242.4901   0.000764526 
+  1272         1245.10572   1240.01012  0.000786164 
+  1240         1242.2786    1237.53501  0.000806452 
+  1247         1239.48914   1235.06476  0.000801925 
+  1179         1236.74073   1232.59937  0.000848176 
+  1237         1234.02994   1230.13882  0.000808407 
+  1266         1231.34961   1227.68311  0.000789889 
+  1280         1228.69778   1225.23222  0.00078125 
+  1158         1226.07151   1222.78617  0.000863558 
+  1269         1223.46833   1220.34492  0.000788022 
+  1263         1220.88702   1217.90849  0.000791766 
+  1296         1218.32395   1215.47685  0.000771605 
+  1275         1215.77848   1213.05001  0.000784314 
+  1216         1213.24971   1210.62795  0.000822368 
+  1238         1210.73557   1208.21067  0.000807754 
+  1177         1208.23553   1205.79815  0.000849618 
+  1188         1205.7487    1203.3904   0.000841751 
+  1162         1203.27432   1200.98741  0.000860585 
+  1164         1200.81174   1198.58916  0.000859107 
+  1257         1198.36039   1196.19564  0.000795545 
+  1185         1195.91976   1193.80687  0.000843882 
+  1195         1193.48942   1191.42281  0.00083682 
+  1193         1191.069     1189.04347  0.000838223 
+  1185         1188.65817   1186.66884  0.000843882 
+  1175         1186.25665   1184.29892  0.000851064 
+  1216         1183.86422   1181.93368  0.000822368 
+  1146         1181.48068   1179.57314  0.0008726 
+  1200         1179.10586   1177.21727  0.000833333 
+  1164         1176.73965   1174.86607  0.000859107 
+  1177         1174.38195   1172.51954  0.000849618 
+  1148         1172.03269   1170.17767  0.00087108 
+  1146         1169.69187   1167.84044  0.0008726 
+  1142         1167.35946   1165.50786  0.000875657 
+  1186         1165.03552   1163.17991  0.00084317 
+  1163         1162.72011   1160.85659  0.000859845 
+  1101         1160.41333   1158.53789  0.000908265 
+  1166         1158.11532   1156.2238   0.000857633 
+  1163         1155.82627   1153.91431  0.000859845 
+  1162         1153.54641   1151.60943  0.000860585 
+  1141         1151.27602   1149.30913  0.000876424 
+  1181         1149.01543   1147.01341  0.00084674 
+  1179         1146.76506   1144.72228  0.000848176 
+  1116         1144.52538   1142.4357   0.000896057 
+  1176         1142.29696   1140.15369  0.00085034 
+  1135         1140.08048   1137.87624  0.000881057 
+  1169         1137.87672   1135.60333  0.000855432 
+  1123         1135.68663   1133.33496  0.000890472 
+  1143         1133.51132   1131.07112  0.000874891 
+  1172         1131.35574   1128.8118   0.000853242 
+  1136         1129.21422   1126.557    0.000880282 
+  1094         1127.09226   1124.30671  0.000914077 
+  1118         1124.99393   1122.06093  0.000894454 
+  1102         1122.91834   1119.81963  0.000907441 
+  1105         1120.87061   1117.58283  0.000904977 
+  1100         1118.85474   1115.35051  0.000909091 
+  1103         1116.87566   1113.12266  0.000906618 
+  1094         1114.93942   1110.89927  0.000914077 
+  1070         1113.05331   1108.68035  0.000934579 
+  1134         1111.22639   1106.46588  0.000881834 
+  1087         1109.46968   1104.25585  0.000919963 
+  1163         1107.79641   1102.05026  0.000859845 
+  1086         1106.22293   1099.8491   0.00092081 
+  1064         1104.76759   1097.65236  0.00093985 
+  1089         1103.45173   1095.46004  0.000918274 
+  1111         1102.29889   1093.27213  0.00090009 
+  1093         1101.33218   1091.08862  0.000914913 
+  1068         1100.56802   1088.9095   0.00093633 
+  1099         1100.00919   1086.73477  0.000909918 
+  1139         1099.62888   1084.56442  0.000877963 
+  1086         1099.35125   1082.39845  0.00092081 
+  1085         1099.03619   1080.23684  0.000921659 
+  1111         1098.48095   1078.07959  0.00090009 
+  1032         1097.45746   1075.92669  0.000968992 
+  1108         1095.78476   1073.77814  0.000902527 
+  1089         1093.39907   1071.63392  0.000918274 
+  1085         1090.37777   1069.49403  0.000921659 
+  1090         1086.9044    1067.35847  0.000917431 
+  1103         1083.18965   1065.22723  0.000906618 
+  1043         1079.37369   1063.10029  0.000958773 
+  1086         1075.5081    1060.97766  0.00092081 
+  1031         1071.68413   1058.85932  0.000969932 
+  1054         1067.99187   1056.74527  0.000948767 
+  999          1064.49415   1054.6355   0.001001001 
+  1061         1061.2153    1052.53001  0.000942507 
+  1067         1058.13624   1050.42879  0.000937207 
+  1069         1055.22511   1048.33182  0.000935454 
+  1036         1052.45214   1046.23911  0.000965251 
+  1047         1049.79282   1044.15065  0.00095511 
+  992          1047.22735   1042.06642  0.001008065 
+  1001         1044.73994   1039.98643  0.000999001 
+  1102         1042.31785   1037.91066  0.000907441 
+  1055         1039.95091   1035.83911  0.000947867 
+  1029         1037.63052   1033.77178  0.000971817 
+  1028         1035.35008   1031.70865  0.000972763 
+  1003         1033.10402   1029.64972  0.000997009 
+  1071         1030.88791   1027.59498  0.000933707 
+  966          1028.69801   1025.54442  0.001035197 
+  981          1026.53134   1023.49804  0.001019368 
+  1033         1024.3854    1021.45583  0.000968054 
+  988          1022.25816   1019.41779  0.001012146 
+  993          1020.14792   1017.3839   0.001007049 
+  1019         1018.14403   1015.35417  0.000981354 
+  988          1016.06432   1013.32857  0.001012146 
+  1006         1013.99802   1011.30711  0.000994036 
+  1035         1011.98981   1009.28979  0.000966184 
+  1006         1009.94826   1007.27658  0.000994036 
+  1060         1007.91805   1005.26749  0.000943396 
+  977          1005.91287   1003.26252  0.001023541 
+  1014         1003.90407   1001.26164  0.000986193 
+  1017         1001.90545   999.26486   0.000983284 
+  1006         999.92389    997.27217   0.000994036 
+  1069         997.94504    995.28356   0.000935454 
+  1067         995.97588    993.29902   0.000937207 
+  1100         994.01636    991.31856   0.000909091 
+  1101         992.06646    989.34216   0.000908265 
+  1063         990.12627    987.36981   0.000940734 
+  1019         988.22049    985.40151   0.000981354 
+  1043         986.30021    983.43725   0.000958773 
+  933          984.41428    981.47703   0.001071811 
+  999          982.51485    979.52084   0.001001001 
+  987          980.62626    977.56867   0.001013171 
+  1010         978.7549     975.62051   0.000990099 
+  962          976.88943    973.67636   0.001039501 
+  942          975.03636    971.73622   0.001061571 
+  962          973.19642    969.80007   0.001039501 
+  1001         971.37731    967.8679    0.000999001 
+  987          969.56639    965.93972   0.001013171 
+  946          967.7717     964.01552   0.001057082 
+  970          965.99819    962.09528   0.001030928 
+  926          964.24095    960.17901   0.001079914 
+  957          962.50595    958.26669   0.001044932 
+  964          960.79643    956.35832   0.001037344 
+  953          959.11617    954.4539    0.001049318 
+  970          957.46752    952.5534    0.001030928 
+  945          955.85383    950.65684   0.001058201 
+  902          954.2568     948.7642    0.001108647 
+  946          952.69103    946.87548   0.001057082 
+  974          951.17069    944.99067   0.001026694 
+  1015         949.70162    943.10976   0.000985222 
+  978          948.29978    941.23274   0.001022495 
+  949          946.97649    939.35962   0.001053741 
+  954          945.74523    937.49038   0.001048218 
+  863          944.62357    935.62501   0.001158749 
+  992          943.63488    933.76352   0.001008065 
+  920          942.81016    931.90589   0.001086957 
+  916          942.19049    930.05212   0.001091703 
+  947          941.83165    928.2022    0.001055966 
+  938          941.81018    926.35612   0.001066098 
+  904          942.23301    924.51389   0.001106195 
+  974          943.25408    922.67548   0.001026694 
+  948          945.10012    920.8409    0.001054852 
+  956          948.1152     919.01014   0.001046025 
+  940          952.84536    917.18319   0.00106383 
+  970          960.21481    915.36005   0.001030928 
+  991          971.97228    913.5407    0.001009082 
+  943          991.85012    911.72515   0.001060445 
+  1055         1027.84474   909.91339   0.000947867 
+  1150         1094.51275   908.10541   0.000869565 
+  1158         1210.42254   906.3012    0.000863558 
+  1268         1373.22387   904.50076   0.000788644 
+  1471         1487.35548   902.70408   0.00067981 
+  1517         1459.86291   900.91115   0.000659196 
+  1485         1360.09641   899.12198   0.000673401 
+  1316         1220.98904   897.33654   0.000759878 
+  1136         1100.1977    895.55485   0.000880282 
+  1006         1023.39176   893.77688   0.000994036 
+  963          978.87629    892.00263   0.001038422 
+  834          952.68243    890.23211   0.001199041 
+  873          936.04833    888.46529   0.001145475 
+  961          924.49161    886.70218   0.001040583 
+  913          915.87734    884.94276   0.00109529 
+  918          909.12932    883.18704   0.001089325 
+  884          903.63842    881.43501   0.001131222 
+  904          899.02831    879.68665   0.001106195 
+  907          895.05508    877.94197   0.001102536 
+  945          891.5546     876.20095   0.001058201 
+  926          888.4134     874.4636    0.001079914 
+  872          885.55141    872.7299    0.001146789 
+  886          882.9109     870.99984   0.001128668 
+  877          880.44944    869.27343   0.001140251 
+  879          878.13568    867.55066   0.001137656 
+  858          875.94619    865.83151   0.001165501 
+  887          873.86331    864.11599   0.001127396 
+  878          871.87393    862.40409   0.001138952 
+  847          869.9684     860.6958    0.001180638 
+  854          868.13979    858.99111   0.00117096 
+  906          866.3836     857.29002   0.001103753 
+  834          864.69736    855.59253   0.001199041 
+  783          863.08035    853.89862   0.001277139 
+  832          861.53383    852.20829   0.001201923 
+  854          860.0608     850.52154   0.00117096 
+  828          858.66637    848.83835   0.001207729 
+  897          857.35843    847.15873   0.001114827 
+  873          856.14624    845.48266   0.001145475 
+  876          855.04386    843.81015   0.001141553 
+  822          854.06932    842.14117   0.001216545 
+  849          853.24637    840.47574   0.001177856 
+  829          852.6058     838.81383   0.001206273 
+  908          852.1894     837.15546   0.001101322 
+  871          852.05277    835.5006    0.001148106 
+  844          852.27194    833.84925   0.001184834 
+  913          852.9525     832.20142   0.00109529 
+  882          854.24325    830.55708   0.001133787 
+  841          856.36009    828.91624   0.001189061 
+  884          859.62583    827.27889   0.001131222 
+  829          864.54319    825.64503   0.001206273 
+  905          871.95378    824.01464   0.001104972 
+  916          883.3824     822.38772   0.001091703 
+  898          901.7003     820.76427   0.001113586 
+  1012         932.09819    819.14428   0.000988142 
+  1075         982.79533    817.52774   0.000930233 
+  1125         1063.66523   815.91465   0.000888889 
+  1269         1175.72417   814.305     0.000788022 
+  1327         1278.53585   812.69879   0.00075358 
+  1390         1299.41738   811.09601   0.000719424 
+  1237         1247.3362    809.49665   0.000808407 
+  1105         1156.98596   807.90071   0.000904977 
+  1070         1054.3597    806.30818   0.000934579 
+  875          972.78303    804.71906   0.001142857 
+  866          918.52236    803.13334   0.001154734 
+  829          884.1274     801.55101   0.001206273 
+  826          861.99224    799.97207   0.001210654 
+  831          847.01857    798.39651   0.001203369 
+  853          836.24162    796.82433   0.001172333 
+  883          828.04761    795.25553   0.001132503 
+  838          821.54479    793.69008   0.001193317 
+  842          816.20723    792.128     0.001187648 
+  817          811.70444    790.56927   0.00122399 
+  777          807.81652    789.01388   0.001287001 
+  832          804.3922     787.46184   0.001201923 
+  793          801.3246     785.91314   0.001261034 
+  773          798.53978    784.36776   0.001293661 
+  750          795.9762     782.82571   0.001333333 
+  768          793.59823    781.28698   0.001302083 
+  829          791.36901    779.75156   0.001206273 
+  776          789.26564    778.21945   0.00128866 
+  766          787.27329    776.69064   0.001305483 
+  754          785.37524    775.16512   0.00132626 
+  778          783.56362    773.6429    0.001285347 
+  789          781.83109    772.12396   0.001267427 
+  778          780.17386    770.60829   0.001285347 
+  774          778.59037    769.0959    0.00129199 
+  766          777.08161    767.58678   0.001305483 
+  768          775.65163    766.08092   0.001302083 
+  776          774.30739    764.57831   0.00128866 
+  741          773.0608     763.07895   0.001349528 
+  755          771.92951    761.58284   0.001324503 
+  728          770.93967    760.08996   0.001373626 
+  745          770.13012    758.60032   0.001342282 
+  716          769.55919    757.11391   0.001396648 
+  788          769.3179     755.63071   0.001269036 
+  760          769.55696    754.15073   0.001315789 
+  798          770.5454     752.67396   0.001253133 
+  796          772.78906    751.2004    0.001256281 
+  769          777.21307    749.73003   0.00130039 
+  748          785.32026    748.26286   0.001336898 
+  800          799.04671    746.79888   0.00125   
+  829          819.21771    745.33807   0.001206273 
+  824          839.82402    743.88045   0.001213592 
+  831          846.30369    742.42599   0.001203369 
+  820          837.42313    740.9747    0.001219512 
+  811          821.00695    739.52657   0.001233046 
+  818          800.51613    738.08159   0.001222494 
+  746          782.69647    736.63976   0.001340483 
+  740          770.34733    735.20107   0.001351351 
+  724          762.44544    733.76553   0.001381215 
+  785          757.46603    732.33311   0.001273885 
+  748          754.34134    730.90382   0.001336898 
+  732          752.46929    729.47765   0.00136612 
+  760          751.5746     728.05459   0.001315789 
+  752          751.604      726.63464   0.001329787 
+  767          752.66774    725.2178    0.001303781 
+  729          755.06035    723.80406   0.001371742 
+  758          759.37699    722.39341   0.001319261 
+  713          766.7826     720.98585   0.001402525 
+  746          779.48104    719.58136   0.001340483 
+  796          801.22353    718.17996   0.001256281 
+  811          837.28096    716.78163   0.001233046 
+  906          891.81019    715.38636   0.001103753 
+  916          955.51734    713.99415   0.001091703 
+  942          990.18696    712.605     0.001061571 
+  1007         976.34617    711.2189    0.000993049 
+  925          937.70535    709.83584   0.001081081 
+  867          883.68259    708.45582   0.001153403 
+  852          830.64624    707.07883   0.001173709 
+  829          791.84972    705.70487   0.001206273 
+  720          766.61231    704.33394   0.001388889 
+  751          750.50378    702.96602   0.001331558 
+  744          739.91902    701.60111   0.001344086 
+  688          732.58884    700.2392    0.001453488 
+  743          727.23395    698.8803    0.001345895 
+  710          723.16408    697.5244    0.001408451 
+  671          719.99928    696.17148   0.001490313 
+  726          717.52138    694.82155   0.00137741 
+  663          715.60519    693.47459   0.001508296 
+  686          714.18665    692.13062   0.001457726 
+  681          713.24881    690.78961   0.001468429 
+  679          712.81911    689.45156   0.001472754 
+  688          712.97603    688.11647   0.001453488 
+  693          713.86973    686.78434   0.001443001 
+  708          715.77203    685.45515   0.001412429 
+  698          719.18555    684.1289    0.001432665 
+  729          725.03825    682.80559   0.001371742 
+  713          734.9264     681.48521   0.001402525 
+  799          751.22053    680.16776   0.001251564 
+  804          776.38398    678.85323   0.001243781 
+  801          809.02575    677.54162   0.001248439 
+  841          836.06431    676.23291   0.001189061 
+  905          846.50701    674.92711   0.001104972 
+  919          852.43713    673.62421   0.001088139 
+  921          862.86726    672.32421   0.001085776 
+  920          883.66321    671.0271    0.001086957 
+  1038         914.42258    669.73286   0.000963391 
+  1024         948.93332    668.44151   0.000976562 
+  1059         971.42912    667.15304   0.000944287 
+  982          953.69582    665.86743   0.00101833 
+  848          910.85206    664.58468   0.001179245 
+  771          859.90888    663.3048    0.001297017 
+  760          807.10164    662.02776   0.001315789 
+  730          765.3311     660.75358   0.001369863 
+  681          737.34113    659.48223   0.001468429 
+  668          719.47861    658.21373   0.001497006 
+  679          707.95688    656.94806   0.001472754 
+  658          700.2135     655.68521   0.001519757 
+  687          694.69849    654.42519   0.001455604 
+  722          690.51273    653.16798   0.001385042 
+  704          687.09362    651.91359   0.001420455 
+  670          684.06928    650.662     0.001492537 
+  680          681.17501    649.41322   0.001470588 
+  628          678.25827    648.16723   0.001592357 
+  710          675.22769    646.92403   0.001408451 
+  661          672.10952    645.68362   0.001512859 
+  635          668.969      644.44599   0.001574803 
+  643          665.88827    643.21114   0.00155521 
+  672          662.94492    641.97906   0.001488095 
+  645          660.17302    640.74974   0.001550388 
+  645          657.59861    639.52319   0.001550388 
+  678          655.22173    638.29939   0.001474926 
+  641          653.03025    637.07835   0.001560062 
+  613          651.00686    635.86004   0.001631321 
+  613          649.13334    634.64449   0.001631321 
+  637          647.3927     633.43166   0.001569859 
+  610          645.77056    632.22157   0.001639344 
+  629          644.2556     631.0142    0.001589825 
+  635          642.83948    629.80956   0.001574803 
+  601          641.51706    628.60763   0.001663894 
+  668          640.28659    627.40841   0.001497006 
+  619          639.14977    626.2119    0.001615509 
+  651          638.11252    625.01809   0.001536098 
+  623          637.186      623.82697   0.001605136 
+  616          636.38811    622.63855   0.001623377 
+  658          635.74651    621.45281   0.001519757 
+  664          635.30327    620.26975   0.001506024 
+  644          635.12272    619.08937   0.001552795 
+  633          635.30771    617.91167   0.001579779 
+  647          636.03297    616.73662   0.001545595 
+  573          637.61737    615.56424   0.001745201 
+  628          640.65875    614.39452   0.001592357 
+  622          646.21188    613.22745   0.001607717 
+  590          655.88163    612.06302   0.001694915 
+  668          671.43258    610.90124   0.001497006 
+  702          692.30012    609.74209   0.001424501 
+  744          709.19038    608.58558   0.001344086 
+  747          710.00411    607.43169   0.001338688 
+  779          700.43885    606.28043   0.001283697 
+  720          686.3643     605.13178   0.001388889 
+  665          669.61156    603.98575   0.001503759 
+  656          656.70007    602.84232   0.00152439 
+  664          650.40595    601.7015    0.001506024 
+  696          649.44067    600.56328   0.001436782 
+  667          649.46474    599.42764   0.00149925 
+  641          646.06853    598.2946    0.001560062 
+  671          640.59179    597.16414   0.001490313 
+  677          634.23092    596.03626   0.001477105 
+  681          627.26864    594.91096   0.001468429 
+  672          621.39255    593.78822   0.001488095 
+  679          617.15846    592.66805   0.001472754 
+  680          614.20992    591.55044   0.001470588 
+  655          612.1162     590.43539   0.001526718 
+  694          610.57461    589.32288   0.001440922 
+  679          609.40491    588.21292   0.001472754 
+  667          608.50983    587.1055    0.00149925 
+  783          607.83973    586.00062   0.001277139 
+  681          607.36995    584.89827   0.001468429 
+  673          607.08449    583.79844   0.001485884 
+  758          606.95881    582.70114   0.001319261 
+  710          606.94679    581.60635   0.001408451 
+  742          607.05491    580.51408   0.001347709 
+  696          607.29476    579.42431   0.001436782 
+  645          607.67914    578.33705   0.001550388 
+  600          608.23536    577.25228   0.001666667 
+  662          609.0008     576.17001   0.001510574 
+  594          610.00153    575.09023   0.001683502 
+  654          611.26249    574.01293   0.001529052 
+  658          612.8009     572.93812   0.001519757 
+  659          614.62976    571.86577   0.001517451 
+  667          616.76676    570.7959    0.00149925 
+  716          619.25253    569.7285    0.001396648 
+  674          622.17761    568.66355   0.00148368 
+  666          625.71331    567.60106   0.001501502 
+  655          630.14861    566.54102   0.001526718 
+  682          635.95432    565.48343   0.001466276 
+  652          643.90813    564.42829   0.001533742 
+  677          655.29302    563.37558   0.001477105 
+  641          672.08525    562.3253    0.001560062 
+  725          696.83828    561.27745   0.00137931 
+  752          731.12541    560.23203   0.001329787 
+  746          769.47732    559.18903   0.001340483 
+  818          796.86969    558.14844   0.001222494 
+  810          813.82431    557.11026   0.001234568 
+  815          834.22969    556.07449   0.001226994 
+  893          863.67785    555.04112   0.001119821 
+  1006         916.98048    554.01014   0.000994036 
+  1082         1021.10046   552.98156   0.000924214 
+  1296         1220.73833   551.95537   0.000771605 
+  1570         1590.91118   550.93156   0.000636943 
+  2117         2215.93234   549.91013   0.000472367 
+  2729         3030.63789   548.89107   0.000366435 
+  3520         3470.79488   547.87438   0.000284091 
+  3744         3236.74217   546.86006   0.000267094 
+  3048         2871.75657   545.8481    0.000328084 
+  2378         2363.70242   544.83849   0.000420521 
+  1869         1765.30811   543.83123   0.000535045 
+  1302         1326.26895   542.82633   0.000768049 
+  890          1061.31409   541.82376   0.001123596 
+  758          908.14554    540.82354   0.001319261 
+  695          816.53281    539.82564   0.001438849 
+  681          757.69663    538.83008   0.001468429 
+  662          717.28556    537.83684   0.001510574 
+  615          688.20899    536.84592   0.001626016 
+  650          666.63864    535.85732   0.001538462 
+  684          650.29912    534.87103   0.001461988 
+  634          637.74985    533.88705   0.001577287 
+  605          628.04529    532.90537   0.001652893 
+  602          620.55072    531.92599   0.00166113 
+  583          614.82834    530.9489    0.001715266 
+  616          610.57119    529.9741    0.001623377 
+  599          607.54511    529.00159   0.001669449 
+  622          605.58247    528.03135   0.001607717 
+  624          604.55976    527.0634    0.001602564 
+  574          604.4068     526.09771   0.00174216 
+  589          605.14605    525.1343    0.001697793 
+  580          606.92107    524.17314   0.001724138 
+  609          610.04069    523.21425   0.001642036 
+  607          615.03052    522.25761   0.001647446 
+  597          622.71821    521.30322   0.001675042 
+  591          634.35678    520.35108   0.001692047 
+  600          651.76624    519.40117   0.001666667 
+  652          677.41213    518.45351   0.001533742 
+  681          714.17118    517.50808   0.001468429 
+  703          763.85646    516.56487   0.001422475 
+  781          822.46401    515.62389   0.00128041 
+  852          873.28224    514.68513   0.001173709 
+  914          894.16521    513.74859   0.001094092 
+  972          882.80551    512.81426   0.001028807 
+  885          851.64069    511.88213   0.001129944 
+  853          808.36778    510.95221   0.001172333 
+  808          762.82448    510.02449   0.001237624 
+  767          725.81936    509.09896   0.001303781 
+  714          701.75426    508.17562   0.00140056 
+  715          690.66393    507.25447   0.001398601 
+  732          692.29981    506.3355    0.00136612 
+  713          708.37321    505.4187    0.001402525 
+  760          743.55245    504.50408   0.001315789 
+  811          805.03775    503.59163   0.001233046 
+  909          897.11029    502.68134   0.00110011 
+  1013         999.15995    501.77322   0.000987167 
+  1028         1050.17616   500.86724   0.000972763 
+  1066         1039.55951   499.96343   0.000938086 
+  1017         1017.41258   499.06176   0.000983284 
+  963          991.32447    498.16223   0.001038422 
+  922          980.90592    497.26484   0.001084599 
+  1001         1026.4237    496.36959   0.000999001 
+  1097         1147.48985   495.47647   0.000911577 
+  1388         1326.50988   494.58547   0.000720461 
+  1520         1471.73219   493.6966    0.000657895 
+  1676         1516.95425   492.80985   0.000596659 
+  1632         1515.76944   491.92521   0.000612745 
+  1568         1441.72556   491.04268   0.000637755 
+  1345         1289.63066   490.16226   0.000743494 
+  1134         1144.89018   489.28394   0.000881834 
+  975          1028.43333   488.40772   0.001025641 
+  931          946.32423    487.53359   0.001074114 
+  802          911.21299    486.66156   0.001246883 
+  801          908.99504    485.7916    0.001248439 
+  872          901.09129    484.92373   0.001146789 
+  875          875.3286     484.05794   0.001142857 
+  819          851.38398    483.19422   0.001221001 
+  781          829.17787    482.33257   0.00128041 
+  835          813.86805    481.47299   0.001197605 
+  833          821.54114    480.61546   0.00120048 
+  882          859.1525     479.75999   0.001133787 
+  890          921.89752    478.90658   0.001123596 
+  910          985.2692     478.05522   0.001098901 
+  978          1032.71626   477.2059    0.001022495 
+  1055         1093.51175   476.35862   0.000947867 
+  1181         1196.06219   475.51338   0.00084674 
+  1442         1385.52407   474.67017   0.000693481 
+  1910         1787.99994   473.82899   0.00052356 
+  2691         2621.7082    472.98983   0.000371609 
+  3777         4094.15497   472.1527    0.00026476 
+  5386         5788.2775    471.31758   0.000185667 
+  6796         6004.59737   470.48447   0.000147145 
+  6118         5160.743     469.65338   0.000163452 
+  4857         4547.00614   468.82428   0.000205888 
+  4023         3529.01462   467.99719   0.000248571 
+  2906         2381.24963   467.1721    0.000344116 
+  1676         1627.28524   466.349     0.000596659 
+  1190         1212.96009   465.52789   0.000840336 
+  958          989.95683    464.70876   0.001043841 
+  803          859.61081    463.89161   0.00124533 
+  738          774.79842    463.07644   0.001355014 
+  689          715.394      462.26325   0.001451379 
+  658          671.85717    461.45202   0.001519757 
+  637          638.88808    460.64276   0.001569859 
+  598          613.24848    459.83546   0.001672241 
+  587          592.86244    459.03012   0.001703578 
+  582          576.34124    458.22673   0.001718213 
+  584          562.73064    457.42529   0.001712329 
+  563          551.3552     456.62579   0.001776199 
+  606          541.72719    455.82824   0.001650165 
+  572          533.48637    455.03263   0.001748252 
+  616          526.36289    454.23895   0.001623377 
+  504          520.15065    453.4472    0.001984127 
+  554          514.69209    452.65737   0.001805054 
+  511          509.85816    451.86947   0.001956947 
+  537          505.55241    451.08349   0.001862197 
+  591          501.69574    450.29942   0.001692047 
+  555          498.22606    449.51726   0.001801802 
+  571          495.0896     448.73701   0.001751313 
+  535          492.24548    447.95867   0.001869159 
+  543          489.65957    447.18222   0.001841621 
+  506          487.30383    446.40767   0.001976285 
+  558          485.15522    445.63501   0.001792115 
+  489          483.19525    444.86423   0.00204499 
+  521          481.40883    444.09535   0.001919386 
+  515          479.78412    443.32834   0.001941748 
+  532          478.31196    442.56321   0.001879699 
+  494          476.98579    441.79995   0.002024291 
+  484          475.80138    441.03856   0.002066116 
+  507          474.75794    440.27903   0.001972387 
+  498          473.85356    439.52137   0.002008032 
+  481          473.09197    438.76556   0.002079002 
+  471          472.47839    438.01161   0.002123142 
+  487          472.02196    437.25951   0.002053388 
+  504          471.73144    436.50925   0.001984127 
+  509          471.62275    435.76084   0.001964637 
+  436          471.71488    435.01427   0.002293578 
+  469          472.03985    434.26953   0.002132196 
+  446          472.61175    433.52662   0.002242152 
+  458          473.47583    432.78554   0.002183406 
+  503          474.67765    432.04628   0.001988072 
+  451          476.27679    431.30885   0.002217295 
+  487          478.32178    430.57323   0.002053388 
+  508          480.91663    429.83942   0.001968504 
+  503          484.13662    429.10742   0.001988072 
+  489          488.09207    428.37723   0.00204499 
+  516          492.88009    427.64884   0.001937984 
+  461          498.58857    426.92225   0.002169197 
+  554          505.26747    426.19745   0.001805054 
+  556          512.89098    425.47444   0.001798561 
+  604          521.32029    424.75322   0.001655629 
+  580          530.29452    424.03379   0.001724138 
+  575          539.46905    423.31613   0.00173913 
+  637          548.5183     422.60025   0.001569859 
+  655          557.23537    421.88614   0.001526718 
+  584          565.56081    421.1738    0.001712329 
+  652          573.55523    420.46323   0.001533742 
+  672          581.43283    419.75441   0.001488095 
+  672          589.78812    419.04736   0.001488095 
+  675          600.0097     418.34206   0.001481481 
+  682          614.55582    417.63851   0.001466276 
+  671          636.23004    416.93671   0.001490313 
+  727          663.59403    416.23665   0.001375516 
+  725          681.72545    415.53833   0.00137931 
+  651          678.0335     414.84174   0.001536098 
+  691          669.16841    414.14689   0.001447178 
+  687          663.84793    413.45377   0.001455604 
+  678          650.08917    412.76238   0.001474926 
+  595          622.12274    412.0727    0.001680672 
+  583          591.26613    411.38475   0.001715266 
+  574          566.29292    410.69851   0.00174216 
+  621          542.85324    410.01398   0.001610306 
+  498          521.46317    409.33116   0.002008032 
+  536          506.54346    408.65004   0.001865672 
+  481          499.04907    407.97063   0.002079002 
+  505          498.91228    407.29291   0.001980198 
+  487          506.9795     406.61689   0.002053388 
+  566          524.79949    405.94255   0.001766784 
+  571          551.43155    405.2699    0.001751313 
+  604          577.71282    404.59894   0.001655629 
+  619          593.28823    403.92965   0.001615509 
+  568          592.86895    403.26205   0.001760563 
+  562          575.3337     402.59611   0.001779359 
+  552          550.84988    401.93184   0.001811594 
+  486          524.56341    401.26924   0.002057613 
+  459          497.43035    400.60831   0.002178649 
+  509          474.99341    399.94903   0.001964637 
+  429          459.27664    399.2914    0.002331002 
+  449          448.77553    398.63543   0.002227171 
+  392          441.66363    397.98111   0.00255102 
+  397          437.2376     397.32843   0.002518892 
+  397          433.52357    396.67739   0.002518892 
+  418          430.65905    396.02799   0.002392344 
+  394          428.38898    395.38023   0.002538071 
+  425          426.86031    394.73409   0.002352941 
+  414          425.38869    394.08959   0.002415459 
+  446          424.21071    393.44671   0.002242152 
+  423          423.2921     392.80545   0.002364066 
+  412          422.60629    392.16581   0.002427184 
+  376          422.14343    391.52778   0.002659574 
+  421          421.89924    390.89136   0.002375297 
+  399          421.87682    390.25655   0.002506266 
+  419          422.08465    389.62335   0.002386635 
+  446          422.55142    388.99174   0.002242152 
+  428          423.33691    388.36173   0.002336449 
+  399          424.55935    387.73332   0.002506266 
+  435          426.43316    387.1065    0.002298851 
+  455          429.3704     386.48126   0.002197802 
+  468          434.11273    385.85761   0.002136752 
+  441          441.87622    385.23554   0.002267574 
+  470          454.30703    384.61505   0.00212766 
+  431          472.58225    383.99613   0.002320186 
+  477          493.45157    383.37878   0.002096436 
+  530          504.41918    382.763     0.001886792 
+  520          499.96661    382.14878   0.001923077 
+  529          491.54012    381.53612   0.001890359 
+  524          481.802      380.92502   0.001908397 
+  482          467.54244    380.31547   0.002074689 
+  439          453.41952    379.70748   0.002277904 
+  442          443.21782    379.10103   0.002262443 
+  386          436.96618    378.49612   0.002590674 
+  443          433.93737    377.89276   0.002257336 
+  417          433.65721    377.29093   0.002398082 
+  446          435.41804    376.69064   0.002242152 
+  459          436.68004    376.09188   0.002178649 
+  431          434.43282    375.49465   0.002320186 
+  429          430.38744    374.89894   0.002331002 
+  390          426.57929    374.30475   0.002564103 
+  458          422.09413    373.71208   0.002183406 
+  432          417.2642     373.12093   0.002314815 
+  418          413.36755    372.53128   0.002392344 
+  451          410.6298     371.94315   0.002217295 
+  398          408.77402    371.35652   0.002512563 
+  453          407.51556    370.77139   0.002207506 
+  365          406.65416    370.18776   0.002739726 
+  378          406.06869    369.60563   0.002645503 
+  425          405.68978    369.02499   0.002352941 
+  417          405.47794    368.44583   0.002398082 
+  403          405.41029    367.86817   0.00248139 
+  391          405.47406    367.29198   0.002557545 
+  360          405.6633     366.71727   0.002777778 
+  391          405.97859    366.14405   0.002557545 
+  413          406.42691    365.57229   0.002421308 
+  406          407.0259     365.002     0.002463054 
+  413          407.80739    364.43318   0.002421308 
+  377          408.8207     363.86583   0.00265252 
+  346          410.12564    363.29993   0.002890173 
+  408          411.73848    362.73549   0.00245098 
+  394          413.50048    362.17251   0.002538071 
+  433          415.25369    361.61097   0.002309469 
+  404          417.29654    361.05089   0.002475248 
+  355          419.79387    360.49225   0.002816901 
+  440          422.30216    359.93505   0.002272727 
+  390          424.44867    359.37929   0.002564103 
+  457          426.08264    358.82496   0.002188184 
+  412          427.38952    358.27207   0.002427184 
+  394          428.82862    357.7206    0.002538071 
+  414          430.47197    357.17056   0.002415459 
+  438          432.34927    356.62195   0.002283105 
+  457          434.73476    356.07475   0.002188184 
+  407          437.77314    355.52897   0.002457002 
+  445          441.42589    354.98461   0.002247191 
+  469          445.66831    354.44165   0.002132196 
+  473          450.48307    353.9001    0.002114165 
+  424          455.87693    353.35996   0.002358491 
+  458          461.87271    352.82122   0.002183406 
+  439          468.51101    352.28387   0.002277904 
+  424          475.85673    351.74793   0.002358491 
+  418          484.01215    351.21337   0.002392344 
+  465          493.12293    350.6802    0.002150538 
+  488          503.38793    350.14842   0.00204918 
+  482          515.02635    349.61802   0.002074689 
+  469          528.33145    349.089     0.002132196 
+  467          543.64492    348.56136   0.002141328 
+  515          561.37422    348.0351    0.001941748 
+  516          582.01013    347.5102    0.001937984 
+  495          606.18215    346.98667   0.002020202 
+  528          634.69429    346.46451   0.001893939 
+  536          668.62433    345.94371   0.001865672 
+  595          709.43419    345.42426   0.001680672 
+  606          759.1158     344.90618   0.001650165 
+  623          820.45547    344.38945   0.001605136 
+  766          897.40921    343.87406   0.001305483 
+  820          995.7045     343.36003   0.001219512 
+  969          1123.94841   342.84733   0.001031992 
+  1089         1295.50764   342.33598   0.000918274 
+  1380         1532.01515   341.82597   0.000724638 
+  1748         1871.27945   341.31729   0.000572082 
+  2408         2389.1615    340.80995   0.000415282 
+  3443         3265.28254   340.30393   0.000290444 
+  5128         4926.9824    339.79924   0.000195008 
+  8262         8164.648     339.29587   0.000121036 
+  13150        13761.20791  338.79383   0.000076046 
+  19182        20214.86043  338.2931    0.000052132 
+  23442        20971.3483   337.79368   0.000042658 
+  20351        17225.52722  337.29558   0.000049138 
+  15322        15310.66588  336.79879   0.000065266 
+  13256        13473.80612  336.3033    0.000075438 
+  10616        9421.81586   335.80912   0.000094197 
+  5968         5875.16883   335.31623   0.00016756 
+  3130         3748.45655   334.82464   0.000319489 
+  2108         2604.36157   334.33435   0.000474383 
+  1659         1974.0745    333.84535   0.000602773 
+  1327         1589.45636   333.35764   0.00075358 
+  1150         1331.48374   332.87121   0.000869565 
+  1072         1148.13879   332.38607   0.000932836 
+  929          1012.85615   331.9022    0.001076426 
+  842          910.08706    331.41961   0.001187648 
+  783          830.26648    330.9383    0.001277139 
+  715          767.23937    330.45826   0.001398601 
+  707          716.73312    329.97948   0.001414427 
+  679          675.77902    329.50198   0.001472754 
+  612          642.36581    329.02573   0.001633987 
+  609          615.03225    328.55075   0.001642036 
+  623          592.67929    328.07702   0.001605136 
+  542          574.51005    327.60454   0.001845018 
+  558          559.96231    327.13332   0.001792115 
+  518          548.65744    326.66335   0.001930502 
+  509          540.34763    326.19462   0.001964637 
+  545          534.78558    325.72714   0.001834862 
+  533          531.45918    325.26089   0.001876173 
+  526          529.65743    324.79589   0.001901141 
+  541          529.417      324.33212   0.001848429 
+  523          531.02175    323.86958   0.001912046 
+  512          534.16099    323.40827   0.001953125 
+  535          538.5775     322.94818   0.001869159 
+  581          544.4831     322.48932   0.00172117 
+  601          552.14982    322.03168   0.001663894 
+  598          561.80582    321.57526   0.001672241 
+  569          573.71652    321.12005   0.001757469 
+  654          588.14858    320.66606   0.001529052 
+  621          605.3704     320.21327   0.001610306 
+  621          625.5887     319.7617    0.001610306 
+  708          648.44148    319.31132   0.001412429 
+  683          670.33437    318.86215   0.001464129 
+  717          681.00355    318.41418   0.0013947 
+  679          675.50044    317.9674    0.001472754 
+  693          662.80041    317.52182   0.001443001 
+  689          646.50766    317.07743   0.001451379 
+  589          623.22848    316.63423   0.001697793 
+  593          595.44897    316.19221   0.001686341 
+  615          568.05007    315.75137   0.001626016 
+  578          542.66749    315.31171   0.001730104 
+  551          519.4257     314.87323   0.001814882 
+  549          498.27582    314.43593   0.001821494 
+  518          479.23938    313.9998    0.001930502 
+  481          462.29834    313.56483   0.002079002 
+  449          447.36091    313.13103   0.002227171 
+  478          434.30054    312.6984    0.00209205 
+  405          422.94602    312.26693   0.002469136 
+  387          413.09154    311.83661   0.002583979 
+  410          404.53014    311.40745   0.002439024 
+  393          397.07067    310.97945   0.002544529 
+  366          390.542      310.55259   0.00273224 
+  367          384.80636    310.12689   0.002724796 
+  399          379.74092    309.70232   0.002506266 
+  385          375.24399    309.27891   0.002597403 
+  394          371.23532    308.85663   0.002538071 
+  355          368.15174    308.43548   0.002816901 
+  365          364.92735    308.01548   0.002739726 
+  370          362.01923    307.5966    0.002702703 
+  374          359.38396    307.17885   0.002673797 
+  369          357.25509    306.76223   0.002710027 
+  365          355.09465    306.34674   0.002739726 
+  355          353.14172    305.93237   0.002816901 
+  330          351.37427    305.51911   0.003030303 
+  395          349.78431    305.10697   0.002531646 
+  399          348.36496    304.69595   0.002506266 
+  359          347.11575    304.28603   0.002785515 
+  372          346.03792    303.87723   0.002688172 
+  370          345.14228    303.46953   0.002702703 
+  359          344.44666    303.06294   0.002785515 
+  374          343.98225    302.65744   0.002673797 
+  399          343.79318    302.25305   0.002506266 
+  380          343.9543     301.84975   0.002631579 
+  334          344.58511    301.44754   0.002994012 
+  359          345.88988    301.04643   0.002785515 
+  374          348.24483    300.6464    0.002673797 
+  380          352.33913    300.24746   0.002631579 
+  357          359.35154    299.8496    0.00280112 
+  392          370.99337    299.45282   0.00255102 
+  366          388.96053    299.05712   0.00273224 
+  389          411.93342    298.66249   0.002570694 
+  431          428.75156    298.26894   0.002320186 
+  484          426.9666     297.87646   0.002066116 
+  443          416.45085    297.48505   0.002257336 
+  394          408.31904    297.0947    0.002538071 
+  403          397.95207    296.70541   0.00248139 
+  401          382.63772    296.31719   0.002493766 
+  384          368.58592    295.93002   0.002604167 
+  348          358.80624    295.54391   0.002873563 
+  394          352.63363    295.15885   0.002538071 
+  332          348.82343    294.77485   0.003012048 
+  370          346.48776    294.39189   0.002702703 
+  385          345.20899    294.00997   0.002597403 
+  364          344.93943    293.6291    0.002747253 
+  356          345.74348    293.24927   0.002808989 
+  381          347.09281    292.87048   0.002624672 
+  365          346.9862     292.49273   0.002739726 
+  368          344.3921     292.116     0.002717391 
+  393          341.35838    291.74031   0.002544529 
+  364          338.86715    291.36565   0.002747253 
+  339          335.9173     290.99201   0.002949853 
+  337          332.64198    290.6194    0.002967359 
+  363          329.86303    290.2478    0.002754821 
+  378          327.89655    289.87723   0.002645503 
+  351          326.5795     289.50767   0.002849003 
+  372          325.73289    289.13913   0.002688172 
+  360          325.24841    288.77159   0.002777778 
+  336          325.07656    288.40507   0.00297619 
+  365          325.23627    288.03955   0.002739726 
+  354          325.80122    287.67504   0.002824859 
+  362          326.88128    287.31153   0.002762431 
+  358          328.53934    286.94902   0.002793296 
+  349          330.43817    286.5875    0.00286533 
+  369          331.59254    286.22698   0.002710027 
+  352          331.84063    285.86745   0.002840909 
+  340          332.23856    285.50892   0.002941176 
+  360          333.09937    285.15137   0.002777778 
+  329          334.06806    284.7948    0.003039514 
+  343          335.44356    284.43922   0.002915452 
+  356          337.92157    284.08462   0.002808989 
+  355          342.0356     283.73099   0.002816901 
+  411          348.34059    283.37835   0.00243309 
+  315          357.3891     283.02667   0.003174603 
+  414          368.98787    282.67597   0.002415459 
+  367          381.54577    282.32623   0.002724796 
+  421          394.55691    281.97747   0.002375297 
+  421          407.67008    281.62966   0.002375297 
+  483          416.02288    281.28282   0.002070393 
+  455          415.50102    280.93694   0.002197802 
+  440          409.60106    280.59201   0.002272727 
+  410          402.74372    280.24804   0.002439024 
+  455          394.89118    279.90502   0.002197802 
+  409          385.86747    279.56295   0.002444988 
+  417          377.46101    279.22183   0.002398082 
+  348          370.79902    278.88165   0.002873563 
+  369          366.22508    278.54242   0.002710027 
+  390          363.8792     278.20413   0.002564103 
+  386          363.33382    277.86678   0.002590674 
+  388          364.0327     277.53036   0.00257732 
+  411          365.92417    277.19488   0.00243309 
+  380          369.16986    276.86033   0.002631579 
+  360          373.90007    276.52671   0.002777778 
+  384          380.32961    276.19402   0.002604167 
+  413          388.73939    275.86225   0.002421308 
+  395          400.28149    275.53141   0.002531646 
+  369          417.1835     275.20148   0.002710027 
+  432          444.1184     274.87248   0.002314815 
+  483          487.45404    274.54439   0.002070393 
+  547          551.30319    274.21721   0.001828154 
+  595          618.00085    273.89095   0.001680672 
+  621          635.39183    273.56559   0.001610306 
+  569          612.33464    273.24114   0.001757469 
+  579          602.96175    272.9176    0.001727116 
+  564          606.06255    272.59496   0.00177305 
+  568          593.56042    272.27322   0.001760563 
+  555          577.90533    271.95238   0.001801802 
+  545          578.95363    271.63244   0.001834862 
+  568          599.46738    271.31338   0.001760563 
+  620          636.95279    270.99522   0.001612903 
+  619          684.43077    270.67795   0.001615509 
+  646          730.41631    270.36157   0.001547988 
+  672          777.4442     270.04607   0.001488095 
+  785          840.58828    269.73146   0.001273885 
+  877          926.66516    269.41772   0.001140251 
+  938          1038.74086   269.10487   0.001066098 
+  1103         1192.18644   268.79289   0.000906618 
+  1366         1414.41857   268.48178   0.000732064 
+  1726         1747.67021   268.17155   0.000579374 
+  2353         2278.72292   267.86219   0.000424989 
+  3459         3217.51768   267.55369   0.000289101 
+  5416         5031.50846   267.24606   0.000184638 
+  8479         8448.33676   266.9393    0.000117938 
+  13686        13746.48704  266.63339   0.000073067 
+  18605        17864.59147  266.32834   0.000053749 
+  19049        15981.36983  266.02416   0.000052496 
+  14684        12707.55432  265.72082   0.000068101 
+  11637        11794.70584  265.41834   0.000085933 
+  11042        10975.51973  265.11671   0.000090563 
+  8873         7947.39383   264.81593   0.000112701 
+  5435         5006.94188   264.51599   0.000183993 
+  2827         3186.42441   264.2169    0.000353732 
+  1864         2198.48526   263.91865   0.000536481 
+  1345         1658.65325   263.62124   0.000743494 
+  1136         1335.06392   263.32467   0.000880282 
+  961          1122.56987   263.02893   0.001040583 
+  840          973.89052    262.73403   0.001190476 
+  795          862.0553     262.43996   0.001257862 
+  734          773.89719    262.14672   0.001362398 
+  656          705.9138     261.85431   0.00152439 
+  583          653.01102    261.56272   0.001715266 
+  589          607.10499    261.27195   0.001697793 
+  534          565.46811    260.98201   0.001872659 
+  495          530.57759    260.69289   0.002020202 
+  465          502.42842    260.40458   0.002150538 
+  435          478.81926    260.11709   0.002298851 
+  460          458.91041    259.83041   0.002173913 
+  441          443.25138    259.54454   0.002267574 
+  426          431.87297    259.25948   0.002347418 
+  402          423.72796    258.97523   0.002487562 
+  409          416.35959    258.69178   0.002444988 
+  410          408.43795    258.40914   0.002439024 
+  416          400.31215    258.12729   0.002403846 
+  371          392.40404    257.84625   0.002695418 
+  385          385.5278     257.566     0.002597403 
+  365          380.03377    257.28654   0.002739726 
+  402          374.89031    257.00788   0.002487562 
+  385          367.98085    256.73001   0.002597403 
+  376          359.87282    256.45293   0.002659574 
+  342          352.85553    256.17663   0.002923977 
+  334          347.06395    255.90112   0.002994012 
+  344          341.10787    255.62639   0.002906977 
+  330          334.90323    255.35245   0.003030303 
+  313          329.3056     255.07928   0.003194888 
+  338          324.54959    254.80688   0.00295858 
+  324          320.50017    254.53527   0.00308642 
+  344          317.01745    254.26442   0.002906977 
+  291          313.97247    253.99435   0.003436426 
+  299          311.29253    253.72504   0.003344482 
+  260          308.90714    253.4565    0.003846154 
+  302          306.75544    253.18873   0.003311258 
+  284          304.77588    252.92172   0.003521127 
+  307          302.91134    252.65546   0.003257329 
+  302          301.10296    252.38997   0.003311258 
+  289          299.35719    252.12524   0.003460208 
+  284          297.654      251.86126   0.003521127 
+  298          295.98532    251.59803   0.003355705 
+  324          294.39086    251.33555   0.00308642 
+  274          292.86097    251.07383   0.003649635 
+  265          291.42272    250.81285   0.003773585 
+  297          290.09863    250.55261   0.003367003 
+  286          288.90167    250.29312   0.003496503 
+  308          287.83614    250.03437   0.003246753 
+  283          286.9092     249.77636   0.003533569 
+  290          286.14284    249.51909   0.003448276 
+  299          285.54428    249.26255   0.003344482 
+  287          285.12777    249.00675   0.003484321 
+  263          284.91533    248.75168   0.003802281 
+  254          284.895      248.49734   0.003937008 
+  274          284.9874     248.24372   0.003649635 
+  268          285.20333    247.99084   0.003731343 
+  292          285.78016    247.73867   0.003424658 
+  290          286.80526    247.48723   0.003448276 
+  305          287.68452    247.23651   0.003278689 
+  290          287.52495    246.98651   0.003448276 
+  312          286.82755    246.73723   0.003205128 
+  308          286.6649     246.48866   0.003246753 
+  329          287.21597    246.2408    0.003039514 
+  308          288.31418    245.99366   0.003246753 
+  329          290.65869    245.74722   0.003039514 
+  317          295.54618    245.50149   0.003154574 
+  359          304.2357     245.25647   0.002785515 
+  417          317.267      245.01215   0.002398082 
+  373          331.38823    244.76853   0.002680965 
+  432          337.29476    244.52561   0.002314815 
+  403          332.74555    244.28339   0.00248139 
+  392          326.41387    244.04187   0.00255102 
+  398          321.8569     243.80104   0.002512563 
+  384          315.58548    243.5609    0.002604167 
+  364          306.26286    243.32146   0.002747253 
+  338          297.36376    243.0827    0.00295858 
+  303          290.80262    242.84463   0.00330033 
+  336          286.84825    242.60725   0.00297619 
+  304          285.14032    242.37055   0.003289474 
+  302          285.27367    242.13453   0.003311258 
+  316          287.03453    241.89919   0.003164557 
+  243          290.2726     241.66453   0.004115226 
+  303          294.47292    241.43055   0.00330033 
+  321          298.19791    241.19724   0.003115265 
+  300          299.68508    240.9646    0.003333333 
+  277          298.97325    240.73263   0.003610108 
+  287          297.69258    240.50134   0.003484321 
+  276          296.61024    240.27071   0.003623188 
+  287          295.36024    240.04074   0.003484321 
+  302          294.08683    239.81144   0.003311258 
+  309          293.81778    239.58281   0.003236246 
+  263          295.62368    239.35483   0.003802281 
+  303          300.66634    239.12751   0.00330033 
+  307          311.10199    238.90085   0.003257329 
+  313          331.00239    238.67484   0.003194888 
+  365          366.12911    238.44949   0.002739726 
+  423          419.00395    238.22478   0.002364066 
+  441          468.49569    238.00073   0.002267574 
+  480          467.98654    237.77733   0.002083333 
+  427          437.39656    237.55457   0.00234192 
+  437          422.80297    237.33245   0.00228833 
+  378          419.89139    237.11098   0.002645503 
+  361          397.78125    236.89015   0.002770083 
+  349          361.91527    236.66996   0.00286533 
+  362          333.98327    236.45041   0.002762431 
+  300          316.18381    236.23149   0.003333333 
+  313          304.22938    236.01321   0.003194888 
+  312          296.0534     235.79556   0.003205128 
+  323          290.76866    235.57853   0.003095975 
+  294          287.5089     235.36214   0.003401361 
+  322          285.62541    235.14638   0.00310559 
+  294          284.70652    234.93124   0.003401361 
+  314          284.50194    234.71673   0.003184713 
+  290          284.83597    234.50284   0.003448276 
+  289          285.49623    234.28956   0.003460208 
+  297          286.29232    234.07691   0.003367003 
+  292          287.3006     233.86488   0.003424658 
+  309          288.65933    233.65346   0.003236246 
+  324          290.35508    233.44265   0.00308642 
+  294          292.31729    233.23246   0.003401361 
+  320          294.60215    233.02287   0.003125  
+  316          297.33148    232.8139    0.003164557 
+  284          300.61413    232.60553   0.003521127 
+  341          304.5923     232.39777   0.002932551 
+  311          309.49963    232.19061   0.003215434 
+  326          315.67882    231.98405   0.003067485 
+  362          323.40762    231.7781    0.002762431 
+  334          332.19914    231.57274   0.002994012 
+  337          340.05833    231.36798   0.002967359 
+  373          346.41654    231.16382   0.002680965 
+  350          354.45359    230.96025   0.002857143 
+  365          367.18724    230.75727   0.002739726 
+  387          386.28248    230.55488   0.002583979 
+  396          413.36767    230.35308   0.002525253 
+  418          446.20818    230.15187   0.002392344 
+  424          466.02476    229.95125   0.002358491 
+  483          463.83755    229.75121   0.002070393 
+  455          463.27619    229.55175   0.002197802 
+  449          475.17545    229.35287   0.002227171 
+  473          490.0588     229.15457   0.002114165 
+  454          498.98287    228.95685   0.002202643 
+  497          511.36281    228.75971   0.002012072 
+  555          534.3378     228.56314   0.001801802 
+  539          569.17471    228.36714   0.001855288 
+  606          616.37073    228.17172   0.001650165 
+  632          677.37438    227.97686   0.001582278 
+  777          756.66667    227.78257   0.001287001 
+  864          862.59425    227.58885   0.001157407 
+  982          1007.6789    227.3957    0.00101833 
+  1207         1212.34096   227.2031    0.0008285 
+  1528         1515.84332   227.01107   0.00065445 
+  2119         2006.6729    226.8196    0.000471921 
+  3146         2897.41604   226.62869   0.000317864 
+  5073         4623.2985    226.43834   0.000197122 
+  8118         7772.86421   226.24854   0.000123183 
+  12432        12257.58915  226.05929   0.000080438 
+  15362        14704.47088  225.8706    0.000065096 
+  14148        12242.94837  225.68246   0.000070681 
+  10495        9533.90525   225.49487   0.000095283 
+  8691         9009.5804    225.30782   0.000115062 
+  8594         9038.92869   225.12132   0.00011636 
+  7493         7064.75459   224.93537   0.000133458 
+  4685         4560.03892   224.74996   0.000213447 
+  2597         2884.71697   224.56509   0.00038506 
+  1602         1953.08065   224.38076   0.00062422 
+  1084         1448.08973   224.19697   0.000922509 
+  914          1151.21381   224.01372   0.001094092 
+  737          957.30286    223.831     0.001356852 
+  681          821.76727    223.64882   0.001468429 
+  598          723.12493    223.46717   0.001672241 
+  529          649.65773    223.28605   0.001890359 
+  525          594.39499    223.10546   0.001904762 
+  484          553.11141    222.9254    0.002066116 
+  459          523.21985    222.74586   0.002178649 
+  503          502.88601    222.56685   0.001988072 
+  455          489.80493    222.38836   0.002197802 
+  485          480.09351    222.2104    0.002061856 
+  508          469.26125    222.03295   0.001968504 
+  497          455.61041    221.85603   0.002012072 
+  416          441.12206    221.67962   0.002403846 
+  436          427.49941    221.50373   0.002293578 
+  420          410.96258    221.32835   0.002380952 
+  366          391.34118    221.15348   0.00273224 
+  337          372.65999    220.97913   0.002967359 
+  335          356.80935    220.80529   0.002985075 
+  325          342.72263    220.63196   0.003076923 
+  297          329.8071     220.45913   0.003367003 
+  313          319.02722    220.28681   0.003194888 
+  329          310.51417    220.11499   0.003039514 
+  298          303.79889    219.94368   0.003355705 
+  277          298.40557    219.77287   0.003610108 
+  300          293.97984    219.60255   0.003333333 
+  277          290.27306    219.43274   0.003610108 
+  266          287.10495    219.26342   0.003759398 
+  274          284.336      219.0946    0.003649635 
+  254          281.84731    218.92628   0.003937008 
+  272          279.5489     218.75844   0.003676471 
+  254          277.38109    218.5911    0.003937008 
+  281          275.32375    218.42425   0.003558719 
+  282          273.38483    218.25788   0.003546099 
+  248          271.59363    218.09201   0.004032258 
+  246          269.99843    217.92661   0.004065041 
+  270          268.67704    217.76171   0.003703704 
+  257          267.75063    217.59728   0.003891051 
+  257          267.39599    217.43334   0.003891051 
+  260          267.83661    217.26988   0.003846154 
+  263          269.23601    217.10689   0.003802281 
+  245          271.22776    216.94439   0.004081633 
+  252          272.18396    216.78236   0.003968254 
+  267          270.92274    216.6208    0.003745318 
+  250          268.89393    216.45972   0.004     
+  284          267.23436    216.2991    0.003521127 
+  270          265.55874    216.13896   0.003703704 
+  264          263.11451    215.97929   0.003787879 
+  273          260.25481    215.82009   0.003663004 
+  262          257.67023    215.66135   0.003816794 
+  242          255.50466    215.50307   0.004132231 
+  254          253.80666    215.34526   0.003937008 
+  276          252.58976    215.18791   0.003623188 
+  252          251.84417    215.03102   0.003968254 
+  205          251.58426    214.8746    0.004878049 
+  240          251.8689     214.71862   0.004166667 
+  265          252.74352    214.56311   0.003773585 
+  256          254.07784    214.40805   0.00390625 
+  261          255.50476    214.25345   0.003831418 
+  231          257.01034    214.09929   0.004329004 
+  252          259.2966     213.94559   0.003968254 
+  260          263.09279    213.79234   0.003846154 
+  272          269.28057    213.63954   0.003676471 
+  284          279.92639    213.48718   0.003521127 
+  288          298.68002    213.33527   0.003472222 
+  331          329.2825     213.18381   0.003021148 
+  387          368.75419    213.03278   0.002583979 
+  391          393.32455    212.8822    0.002557545 
+  427          387.67851    212.73206   0.00234192 
+  433          379.22866    212.58236   0.002309469 
+  367          377.66199    212.4331    0.002724796 
+  369          371.52463    212.28427   0.002710027 
+  351          351.84108    212.13588   0.002849003 
+  314          329.29864    211.98793   0.003184713 
+  290          313.26868    211.8404    0.003448276 
+  322          300.82572    211.69331   0.00310559 
+  279          291.69047    211.54665   0.003584229 
+  272          287.35571    211.40041   0.003676471 
+  289          285.71459    211.2546    0.003460208 
+  304          282.23012    211.10922   0.003289474 
+  256          277.11707    210.96427   0.00390625 
+  265          272.75904    210.81974   0.003773585 
+  257          268.91811    210.67563   0.003891051 
+  261          264.38117    210.53194   0.003831418 
+  252          258.94859    210.38867   0.003968254 
+  259          254.03193    210.24582   0.003861004 
+  241          249.91184    210.10339   0.004149378 
+  261          246.52164    209.96137   0.003831418 
+  247          244.0813     209.81977   0.004048583 
+  230          242.52004    209.67858   0.004347826 
+  230          241.62138    209.5378    0.004347826 
+  262          241.21117    209.39744   0.003816794 
+  271          241.17983    209.25748   0.003690037 
+  228          241.44434    209.11793   0.004385965 
+  251          241.87207    208.97879   0.003984064 
+  249          242.32415    208.84006   0.004016064 
+  242          242.87635    208.70173   0.004132231 
+  200          243.69525    208.5638    0.005     
+  238          244.85779    208.42628   0.004201681 
+  253          246.39854    208.28915   0.003952569 
+  234          248.46636    208.15243   0.004273504 
+  262          251.36066    208.0161    0.003816794 
+  241          255.29385    207.88018   0.004149378 
+  218          259.84515    207.74465   0.004587156 
+  259          263.22983    207.60951   0.003861004 
+  256          264.33185    207.47476   0.00390625 
+  239          265.02261    207.34041   0.0041841 
+  257          266.91345    207.20645   0.003891051 
+  242          269.71888    207.07288   0.004132231 
+  259          272.35413    206.9397    0.003861004 
+  256          274.99732    206.80691   0.00390625 
+  270          278.74466    206.6745    0.003703704 
+  301          284.22641    206.54248   0.003322259 
+  325          291.86927    206.41084   0.003076923 
+  323          302.25045    206.27959   0.003095975 
+  311          316.1085     206.14871   0.003215434 
+  303          333.60748    206.01822   0.00330033 
+  327          351.97968    205.88811   0.003058104 
+  330          364.79495    205.75837   0.003030303 
+  351          371.72121    205.62901   0.002849003 
+  346          379.33797    205.50003   0.002890173 
+  391          390.12409    205.37142   0.002557545 
+  381          401.15235    205.24318   0.002624672 
+  407          409.04094    205.11532   0.002457002 
+  426          415.44805    204.98783   0.002347418 
+  429          423.0509     204.8607    0.002331002 
+  429          432.55677    204.73395   0.002331002 
+  445          443.75429    204.60756   0.002247191 
+  497          456.16599    204.48154   0.002012072 
+  450          469.18309    204.35588   0.002222222 
+  524          482.13768    204.23059   0.001908397 
+  491          494.49192    204.10566   0.00203666 
+  523          506.06801    203.9811    0.001912046 
+  510          517.16042    203.85689   0.001960784 
+  519          528.30167    203.73304   0.001926782 
+  485          539.74895    203.60955   0.002061856 
+  575          551.13187    203.48642   0.00173913 
+  528          560.9253     203.36365   0.001893939 
+  529          566.4958     203.24123   0.001890359 
+  530          566.48261    203.11916   0.001886792 
+  584          561.638      202.99745   0.001712329 
+  549          552.7306     202.87608   0.001821494 
+  502          539.45583    202.75507   0.001992032 
+  454          521.47034    202.63441   0.002202643 
+  442          499.76792    202.51409   0.002262443 
+  407          476.04071    202.39412   0.002457002 
+  389          451.6339     202.2745    0.002570694 
+  399          427.48155    202.15522   0.002506266 
+  377          404.34617    202.03629   0.00265252 
+  379          382.84719    201.9177    0.002638522 
+  337          363.38345    201.79945   0.002967359 
+  333          346.11055    201.68154   0.003003003 
+  324          331.01429    201.56397   0.00308642 
+  330          317.96642    201.44674   0.003030303 
+  303          306.79752    201.32984   0.00330033 
+  280          297.32648    201.21328   0.003571429 
+  310          289.44212    201.09706   0.003225806 
+  284          283.10929    200.98117   0.003521127 
+  270          278.38692    200.86561   0.003703704 
+  265          275.35882    200.75039   0.003773585 
+  261          273.77203    200.63549   0.003831418 
+  284          272.09412    200.52093   0.003521127 
+  269          268.21567    200.40669   0.003717472 
+  275          263.02226    200.29278   0.003636364 
+  246          258.71889    200.1792    0.004065041 
+  257          255.71678    200.06594   0.003891051 
+  264          252.85225    199.953     0.003787879 
+  238          249.22044    199.84039   0.004201681 
+  255          245.56188    199.7281    0.003921569 
+  254          242.59281    199.61614   0.003937008 
+  245          240.38024    199.50449   0.004081633 
+  244          238.7851     199.39316   0.004098361 
+  225          237.67265    199.28215   0.004444444 
+  208          236.95323    199.17146   0.004807692 
+  248          236.57084    199.06108   0.004032258 
+  244          236.49074    198.95101   0.004098361 
+  216          236.68446    198.84126   0.00462963 
+  236          237.12531    198.73183   0.004237288 
+  237          237.79689    198.6227    0.004219409 
+  208          238.70479    198.51389   0.004807692 
+  251          239.86785    198.40538   0.003984064 
+  234          241.18587    198.29718   0.004273504 
+  243          241.62203    198.1893    0.004115226 
+  235          240.87538    198.08171   0.004255319 
+  232          238.94797    197.97444   0.004310345 
+  216          237.10288    197.86746   0.00462963 
+  204          235.59649    197.76079   0.004901961 
+  213          234.42846    197.65443   0.004694836 
+  230          233.02152    197.54836   0.004347826 
+  254          231.8215     197.4426    0.003937008 
+  252          231.23544    197.33713   0.003968254 
+  225          230.85552    197.23197   0.004444444 
+  204          230.15849    197.1271    0.004901961 
+  238          229.78333    197.02252   0.004201681 
+  238          230.66094    196.91825   0.004201681 
+  226          233.03997    196.81426   0.004424779 
+  247          236.07513    196.71057   0.004048583 
+  222          237.68098    196.60718   0.004504505 
+  225          236.91123    196.50407   0.004444444 
+  236          235.36945    196.40126   0.004237288 
+  207          234.27805    196.29873   0.004830918 
+  218          234.15429    196.19649   0.004587156 
+  223          234.56395    196.09454   0.004484305 
+  214          235.05154    195.99288   0.004672897 
+  240          234.95421    195.8915    0.004166667 
+  230          232.91235    195.79041   0.004347826 
+  203          229.97116    195.6896    0.004926108 
+  224          228.05501    195.58908   0.004464286 
+  240          227.52643    195.48883   0.004166667 
+  221          227.48771    195.38887   0.004524887 
+  226          227.12014    195.28919   0.004424779 
+  226          227.02166    195.18978   0.004424779 
+  202          228.07663    195.09066   0.004950495 
+  209          230.84195    194.99181   0.004784689 
+  215          236.06202    194.89323   0.004651163 
+  256          245.09579    194.79493   0.00390625 
+  270          259.85462    194.69691   0.003703704 
+  294          282.18365    194.59916   0.003401361 
+  348          312.03288    194.50168   0.002873563 
+  331          336.00188    194.40447   0.003021148 
+  344          331.61153    194.30754   0.002906977 
+  323          311.55944    194.21087   0.003095975 
+  318          298.02568    194.11447   0.003144654 
+  296          295.77438    194.01834   0.003378378 
+  295          293.89379    193.92248   0.003389831 
+  279          280.84053    193.82688   0.003584229 
+  259          264.33887    193.73154   0.003861004 
+  262          252.38279    193.63647   0.003816794 
+  266          245.56115    193.54167   0.003759398 
+  255          241.23533    193.44712   0.003921569 
+  244          237.52136    193.35284   0.004098361 
+  255          234.38798    193.25882   0.003921569 
+  241          232.20806    193.16506   0.004149378 
+  231          231.02826    193.07155   0.004329004 
+  240          230.21663    192.9783    0.004166667 
+  227          229.56485    192.88531   0.004405286 
+  234          229.36275    192.79258   0.004273504 
+  232          229.62913    192.7001    0.004310345 
+  240          229.66988    192.60787   0.004166667 
+  217          228.98264    192.5159    0.004608295 
+  233          228.29397    192.42418   0.004291845 
+  232          228.18727    192.33271   0.004310345 
+  207          228.50671    192.24149   0.004830918 
+  225          228.64621    192.15052   0.004444444 
+  221          228.35897    192.0598    0.004524887 
+  224          228.01698    191.96933   0.004464286 
+  210          227.86799    191.87911   0.004761905 
+  214          227.93393    191.78913   0.004672897 
+  225          228.18964    191.69939   0.004444444 
+  223          228.61945    191.6099    0.004484305 
+  220          229.24123    191.52066   0.004545455 
+  238          230.10204    191.43165   0.004201681 
+  238          231.28188    191.34289   0.004201681 
+  244          232.89099    191.25437   0.004098361 
+  215          235.05108    191.16609   0.004651163 
+  232          237.78167    191.07805   0.004310345 
+  263          240.65931    190.99024   0.003802281 
+  222          242.76399    190.90268   0.004504505 
+  284          244.08415    190.81535   0.003521127 
+  248          245.56795    190.72825   0.004032258 
+  247          247.62229    190.6414    0.004048583 
+  246          249.94655    190.55477   0.004065041 
+  234          251.95775    190.46838   0.004273504 
+  249          253.66423    190.38222   0.004016064 
+  248          255.52372    190.29629   0.004032258 
+  243          257.76226    190.2106    0.004115226 
+  249          260.43079    190.12513   0.004016064 
+  249          263.55668    190.03989   0.004016064 
+  271          267.19318    189.95488   0.003690037 
+  247          271.42626    189.8701    0.004048583 
+  281          276.3729     189.78555   0.003558719 
+  265          282.17075    189.70122   0.003773585 
+  275          288.98628    189.61711   0.003636364 
+  277          297.02019    189.53323   0.003610108 
+  271          306.53042    189.44958   0.003690037 
+  292          317.86578    189.36614   0.003424658 
+  321          331.51879    189.28293   0.003115265 
+  325          348.17183    189.19994   0.003076923 
+  333          368.74488    189.11717   0.003003003 
+  377          394.2966     189.03461   0.00265252 
+  428          425.40066    188.95228   0.002336449 
+  472          460.97527    188.87016   0.002118644 
+  470          500.66939    188.78826   0.00212766 
+  559          549.70933    188.70658   0.001788909 
+  592          615.52793    188.62511   0.001689189 
+  697          705.54323    188.54386   0.00143472 
+  711          829.82891    188.46282   0.00140647 
+  876          1007.60555   188.38199   0.001141553 
+  1237         1282.57998   188.30138   0.000808407 
+  1720         1756.32376   188.22097   0.000581395 
+  2677         2651.22059   188.14078   0.000373552 
+  4458         4335.17499   188.0608    0.000224316 
+  7047         7080.5261    187.98102   0.000141904 
+  9338         9841.56504   187.90146   0.000107089 
+  9587         9474.10254   187.8221    0.000104308 
+  7274         6981.83651   187.74295   0.000137476 
+  5347         5447.50551   187.664     0.000187021 
+  5149         5437.35515   187.58526   0.000194212 
+  5649         6025.11801   187.50672   0.000177022 
+  5003         5291.97287   187.42839   0.00019988 
+  3532         3599.896     187.35026   0.000283126 
+  2138         2290.20968   187.27233   0.000467727 
+  1318         1525.44001   187.19461   0.000758725 
+  930          1109.56043   187.11708   0.001075269 
+  790          872.45488    187.03976   0.001265823 
+  698          722.53189    186.96263   0.001432665 
+  566          619.3274     186.8857    0.001766784 
+  492          544.50105    186.80897   0.00203252 
+  496          488.41565    186.73244   0.002016129 
+  422          445.30276    186.6561    0.002369668 
+  387          411.51793    186.57996   0.002583979 
+  387          384.66879    186.50401   0.002583979 
+  378          363.16139    186.42825   0.002645503 
+  348          345.94998    186.35269   0.002873563 
+  345          332.43526    186.27732   0.002898551 
+  390          322.41601    186.20215   0.002564103 
+  349          316.10835    186.12716   0.00286533 
+  328          314.08333    186.05236   0.00304878 
+  327          316.82578    185.97776   0.003058104 
+  301          322.84449    185.90334   0.003322259 
+  320          325.31668    185.82911   0.003125  
+  313          318.02496    185.75507   0.003194888 
+  313          307.17261    185.68121   0.003194888 
+  328          301.0743     185.60754   0.00304878 
+  294          301.78529    185.53406   0.003401361 
+  284          306.42379    185.46076   0.003521127 
+  287          311.21071    185.38764   0.003484321 
+  311          315.21955    185.31471   0.003215434 
+  277          312.59443    185.24196   0.003610108 
+  315          299.35521    185.16939   0.003174603 
+  316          284.36459    185.097     0.003164557 
+  287          274.93306    185.02479   0.003484321 
+  262          270.65194    184.95276   0.003816794 
+  287          265.7853     184.88091   0.003484321 
+  261          256.15306    184.80924   0.003831418 
+  245          245.02202    184.73775   0.004081633 
+  265          235.87047    184.66643   0.003773585 
+  288          229.18316    184.59529   0.003472222 
+  218          224.37457    184.52432   0.004587156 
+  250          220.82631    184.45353   0.004     
+  234          218.08739    184.38291   0.004273504 
+  225          215.8799     184.31247   0.004444444 
+  226          214.0355     184.2422    0.004424779 
+  233          212.45565    184.1721    0.004291845 
+  241          211.07943    184.10217   0.004149378 
+  244          209.86602    184.03241   0.004098361 
+  236          208.78693    183.96282   0.004237288 
+  225          207.82384    183.8934    0.004444444 
+  208          206.95782    183.82415   0.004807692 
+  220          206.17995    183.75507   0.004545455 
+  213          205.48228    183.68616   0.004694836 
+  234          204.85966    183.61741   0.004273504 
+  240          203.99623    183.54883   0.004166667 
+  222          203.51814    183.48041   0.004504505 
+  221          203.11055    183.41216   0.004524887 
+  202          202.77893    183.34407   0.004950495 
+  198          202.37637    183.27614   0.005050505 
+  216          202.23205    183.20838   0.00462963 
+  235          202.20909    183.14078   0.004255319 
+  229          202.31886    183.07334   0.004366812 
+  205          202.50897    183.00606   0.004878049 
+  222          202.59756    182.93894   0.004504505 
+  229          202.45938    182.87199   0.004366812 
+  184          202.25594    182.80519   0.005434783 
+  200          202.20053    182.73854   0.005     
+  209          202.35719    182.67206   0.004784689 
+  196          202.66419    182.60573   0.005102041 
+  226          203.06219    182.53956   0.004424779 
+  214          203.65755    182.47354   0.004672897 
+  219          204.65753    182.40768   0.00456621 
+  208          206.2973     182.34198   0.004807692 
+  227          208.92964    182.27642   0.004405286 
+  232          213.14582    182.21102   0.004310345 
+  247          219.83719    182.14578   0.004048583 
+  257          230.03976    182.08068   0.003891051 
+  259          243.92736    182.01574   0.003861004 
+  260          257.43257    181.95094   0.003846154 
+  217          260.96575    181.8863    0.004608295 
+  241          253.2851     181.8218    0.004149378 
+  209          244.60737    181.75746   0.004784689 
+  216          240.88302    181.69326   0.00462963 
+  209          241.14858    181.62921   0.004784689 
+  199          239.93667    181.56531   0.005025126 
+  220          234.21898    181.50155   0.004545455 
+  209          227.92658    181.43794   0.004784689 
+  214          224.3033     181.37447   0.004672897 
+  213          223.70366    181.31115   0.004694836 
+  215          225.31364    181.24797   0.004651163 
+  214          226.31397    181.18494   0.004672897 
+  222          223.87329    181.12205   0.004504505 
+  211          219.88618    181.0593    0.004739336 
+  220          217.18788    180.99669   0.004545455 
+  196          216.43681    180.93422   0.005102041 
+  229          216.52775    180.8719    0.004366812 
+  203          215.65147    180.80971   0.004926108 
+  226          214.18125    180.74766   0.004424779 
+  219          213.7901     180.68575   0.00456621 
+  224          215.185      180.62398   0.004464286 
+  254          218.11597    180.56235   0.003937008 
+  249          221.70223    180.50085   0.004016064 
+  236          226.12504    180.43949   0.004237288 
+  265          233.27814    180.37827   0.003773585 
+  253          244.1897     180.31718   0.003952569 
+  287          256.53724    180.25622   0.003484321 
+  260          263.88981    180.1954    0.003846154 
+  309          263.04728    180.13471   0.003236246 
+  249          260.68046    180.07416   0.004016064 
+  278          263.89043    180.01373   0.003597122 
+  302          274.14438    179.95344   0.003311258 
+  304          287.75735    179.89328   0.003289474 
+  326          298.26606    179.83325   0.003067485 
+  297          304.39254    179.77336   0.003367003 
+  308          309.39376    179.71359   0.003246753 
+  349          317.1965     179.65394   0.00286533 
+  396          337.37964    179.59443   0.002525253 
+  419          379.80431    179.53505   0.002386635 
+  462          451.15226    179.47579   0.002164502 
+  535          545.92028    179.41666   0.001869159 
+  582          612.59091    179.35766   0.001718213 
+  547          579.67276    179.29878   0.001828154 
+  523          496.30357    179.24002   0.001912046 
+  405          442.65       179.18139   0.002469136 
+  432          433.90499    179.12289   0.002314815 
+  372          446.38181    179.06451   0.002688172 
+  385          428.2746     179.00625   0.002597403 
+  357          374.18821    178.94811   0.00280112 
+  301          323.07541    178.8901    0.003322259 
+  233          288.82062    178.83221   0.004291845 
+  265          269.31685    178.77443   0.003773585 
+  249          261.28863    178.71678   0.004016064 
+  223          262.07926    178.65925   0.004484305 
+  313          273.91407    178.60184   0.003194888 
+  290          302.17331    178.54454   0.003448276 
+  387          351.55417    178.48737   0.002583979 
+  409          403.51395    178.43031   0.002444988 
+  433          399.81298    178.37337   0.002309469 
+  381          355.61136    178.31654   0.002624672 
+  334          330.50471    178.25983   0.002994012 
+  358          338.09264    178.20324   0.002793296 
+  383          365.11474    178.14676   0.002610966 
+  392          370.14676    178.0904    0.00255102 
+  345          333.46037    178.03415   0.002898551 
+  288          293.10036    177.97801   0.003472222 
+  277          268.39907    177.92199   0.003610108 
+  266          257.03968    177.86608   0.003759398 
+  235          250.1288     177.81028   0.004255319 
+  249          240.23863    177.7546    0.004016064 
+  227          228.70071    177.69902   0.004405286 
+  260          219.36114    177.64356   0.003846154 
+  233          213.05507    177.5882    0.004291845 
+  202          209.18332    177.53296   0.004950495 
+  221          206.91158    177.47782   0.004524887 
+  189          205.36688    177.42279   0.005291005 
+  184          204.11121    177.36787   0.005434783 
+  197          203.36278    177.31306   0.005076142 
+  199          203.34782    177.25835   0.005025126 
+  194          204.10651    177.20376   0.005154639 
+  184          205.61327    177.14926   0.005434783 
+  206          207.973      177.09488   0.004854369 
+  224          211.81297    177.0406    0.004464286 
+  198          218.2655     176.98642   0.005050505 
+  247          228.90429    176.93235   0.004048583 
+  206          245.70112    176.87838   0.004854369 
+  256          269.93857    176.82451   0.00390625 
+  253          297.63094    176.77075   0.003952569 
+  307          312.85376    176.71709   0.003257329 
+  270          303.25595    176.66353   0.003703704 
+  250          283.4321     176.61007   0.004     
+  245          270.29138    176.55671   0.004081633 
+  257          267.18103    176.50346   0.003891051 
+  257          267.49081    176.4503    0.003891051 
+  235          259.94134    176.39725   0.004255319 
+  227          244.02523    176.34429   0.004405286 
+  218          228.33369    176.29143   0.004587156 
+  208          216.7529     176.23867   0.004807692 
+  179          209.02999    176.186     0.005586592 
+  200          204.04733    176.13344   0.005     
+  220          200.8411     176.08097   0.004545455 
+  194          198.76395    176.0286    0.005154639 
+  178          197.43192    175.97632   0.005617978 
+  215          196.63377    175.92414   0.004651163 
+  180          196.2595     175.87205   0.005555556 
+  192          196.25865    175.82006   0.005208333 
+  207          196.61351    175.76816   0.004830918 
+  222          197.29068    175.71635   0.004504505 
+  199          198.0897     175.66464   0.005025126 
+  148          198.45233    175.61302   0.006756757 
+  221          198.02484    175.5615    0.004524887 
+  219          197.30815    175.51006   0.00456621 
+  187          196.83758    175.45872   0.005347594 
+  208          196.76739    175.40747   0.004807692 
+  223          196.98364    175.3563    0.004484305 
+  213          197.25553    175.30523   0.004694836 
+  199          197.65374    175.25425   0.005025126 
+  216          198.24713    175.20336   0.00462963 
+  228          198.34152    175.15255   0.004385965 
+  223          197.35431    175.10184   0.004484305 
+  227          196.04898    175.05121   0.004405286 
+  265          195.27784    175.00067   0.003773585 
+  275          195.23906    174.95022   0.003636364 
+  292          195.67057    174.89985   0.003424658 
+  287          196.08702    174.84957   0.003484321 
+  268          196.52998    174.79938   0.003731343 
+  315          197.44079    174.74927   0.003174603 
+  318          198.61262    174.69924   0.003144654 
+  315          199.35313    174.6493    0.003174603 
+  289          200.00406    174.59945   0.003460208 
+  260          201.65805    174.54968   0.003846154 
+  289          205.0356     174.49999   0.003460208 
+  298          210.54016    174.45039   0.003355705 
+  244          217.46248    174.40086   0.004098361 
+  294          222.43369    174.35142   0.003401361 
+  257          221.39076    174.30206   0.003891051 
+  241          216.32372    174.25279   0.004149378 
+  231          212.20649    174.20359   0.004329004 
+  231          211.02921    174.15448   0.004329004 
+  243          212.13171    174.10544   0.004115226 
+  230          212.92429    174.05648   0.004347826 
+  226          211.59046    174.00761   0.004424779 
+  204          209.28631    173.95881   0.004901961 
+  200          207.18677    173.91009   0.005     
+  210          205.82271    173.86145   0.004761905 
+  185          205.03304    173.81289   0.005405405 
+  223          204.74536    173.7644    0.004484305 
+  212          205.53072    173.71599   0.004716981 
+  243          207.672      173.66766   0.004115226 
+  225          211.47667    173.61941   0.004444444 
+  243          217.33786    173.57123   0.004115226 
+  206          224.34541    173.52312   0.004854369 
+  234          228.78432    173.47509   0.004273504 
+  220          226.85837    173.42714   0.004545455 
+  228          221.58199    173.37926   0.004385965 
+  214          217.84383    173.33145   0.004672897 
+  217          217.10217    173.28372   0.004608295 
+  221          218.22072    173.23606   0.004524887 
+  227          218.24097    173.18848   0.004405286 
+  238          215.69948    173.14096   0.004201681 
+  241          212.61566    173.09352   0.004149378 
+  253          210.64208    173.04615   0.003952569 
+  220          210.01049    172.99885   0.004545455 
+  220          210.5166     172.95162   0.004545455 
+  227          211.971      172.90446   0.004405286 
+  233          214.27249    172.85738   0.004291845 
+  214          217.33847    172.81036   0.004672897 
+  221          220.8796     172.76341   0.004524887 
+  254          224.36569    172.71653   0.003937008 
+  265          227.84811    172.66972   0.003773585 
+  232          232.00521    172.62298   0.004310345 
+  272          237.26027    172.57631   0.003676471 
+  268          243.70779    172.5297    0.003731343 
+  272          251.1999     172.48317   0.003676471 
+  284          259.5346     172.4367    0.003521127 
+  299          269.00095    172.39029   0.003344482 
+  311          279.6076     172.34395   0.003215434 
+  330          291.51752    172.29768   0.003030303 
+  306          304.61258    172.25148   0.003267974 
+  305          318.74904    172.20533   0.003278689 
+  341          333.78075    172.15926   0.002932551 
+  375          349.20102    172.11325   0.002666667 
+  360          362.65961    172.0673    0.002777778 
+  342          371.01722    172.02142   0.002923977 
+  395          374.29689    171.9756    0.002531646 
+  399          375.78032    171.92984   0.002506266 
+  364          377.94492    171.88415   0.002747253 
+  368          378.50759    171.83852   0.002717391 
+  378          374.14779    171.79295   0.002645503 
+  350          365.69148    171.74744   0.002857143 
+  358          355.17016    171.70199   0.002793296 
+  344          344.29053    171.65661   0.002906977 
+  322          334.42737    171.61129   0.00310559 
+  310          324.38403    171.56602   0.003225806 
+  306          313.3703     171.52082   0.003267974 
+  296          302.36303    171.47568   0.003378378 
+  285          291.70307    171.4306    0.003508772 
+  305          281.50183    171.38557   0.003278689 
+  281          272.1858     171.34061   0.003558719 
+  269          263.80965    171.2957    0.003717472 
+  254          256.21542    171.25086   0.003937008 
+  273          249.29413    171.20607   0.003663004 
+  262          243.01891    171.16133   0.003816794 
+  239          237.40212    171.11666   0.0041841 
+  221          232.45524    171.07204   0.004524887 
+  227          228.17278    171.02748   0.004405286 
+  239          224.53119    170.98298   0.0041841 
+  242          221.49929    170.93853   0.004132231 
+  220          219.04629    170.89414   0.004545455 
+  206          217.14971    170.8498    0.004854369 
+  225          215.82782    170.80552   0.004444444 
+  232          215.14787    170.76129   0.004310345 
+  231          215.17847    170.71712   0.004329004 
+  221          215.82509    170.673     0.004524887 
+  232          216.53403    170.62894   0.004310345 
+  224          216.72778    170.58493   0.004464286 
+  221          216.83608    170.54097   0.004524887 
+  256          217.28749    170.49707   0.00390625 
+  220          217.71773    170.45322   0.004545455 
+  219          218.0959     170.40942   0.00456621 
+  202          218.72766    170.36567   0.004950495 
+  252          219.71712    170.32198   0.003968254 
+  256          221.41748    170.27833   0.00390625 
+  261          224.03365    170.23474   0.003831418 
+  224          227.54759    170.1912    0.004464286 
+  258          232.40226    170.14771   0.003875969 
+  280          239.43446    170.10427   0.003571429 
+  246          249.50685    170.06088   0.004065041 
+  291          263.54333    170.01754   0.003436426 
+  298          282.36302    169.97425   0.003355705 
+  331          305.75965    169.93101   0.003021148 
+  336          330.38258    169.88782   0.00297619 
+  350          348.27593    169.84468   0.002857143 
+  359          352.26165    169.80158   0.002785515 
+  380          345.3232     169.75854   0.002631579 
+  339          337.28893    169.71554   0.002949853 
+  315          333.57204    169.67259   0.003174603 
+  318          330.84348    169.62968   0.003144654 
+  323          322.71278    169.58683   0.003095975 
+  306          308.0553     169.54402   0.003267974 
+  272          290.72122    169.50125   0.003676471 
+  267          275.29391    169.45854   0.003745318 
+  247          263.41861    169.41587   0.004048583 
+  264          253.53187    169.37324   0.003787879 
+  253          244.35682    169.33066   0.003952569 
+  192          236.82943    169.28813   0.005208333 
+  239          231.5155     169.24564   0.0041841 
+  234          227.84655    169.20319   0.004273504 
+  255          224.99678    169.16079   0.003921569 
+  223          222.80955    169.11843   0.004484305 
+  248          221.53257    169.07612   0.004032258 
+  208          221.27907    169.03385   0.004807692 
+  252          222.08481    168.99163   0.003968254 
+  277          223.99414    168.94944   0.003610108 
+  252          227.28731    168.9073    0.003968254 
+  280          232.97447    168.8652    0.003571429 
+  284          242.77376    168.82315   0.003521127 
+  284          258.55454    168.78114   0.003521127 
+  302          280.95921    168.73916   0.003311258 
+  308          307.57505    168.69723   0.003246753 
+  346          325.36892    168.65535   0.002890173 
+  305          315.45233    168.6135    0.003278689 
+  303          292.60943    168.57169   0.00330033 
+  291          278.2875     168.52992   0.003436426 
+  308          276.41337    168.4882    0.003246753 
+  310          283.5837     168.44651   0.003225806 
+  283          290.74943    168.40487   0.003533569 
+  287          287.1856     168.36326   0.003484321 
+  295          278.63133    168.32169   0.003389831 
+  259          270.68144    168.28016   0.003861004 
+  246          261.19125    168.23867   0.004065041 
+  240          251.924      168.19722   0.004166667 
+  244          246.10843    168.15581   0.004098361 
+  235          244.34328    168.11444   0.004255319 
+  254          245.46615    168.0731    0.003937008 
+  250          246.92202    168.0318    0.004     
+  228          246.77048    167.99054   0.004385965 
+  274          246.79697    167.94932   0.003649635 
+  265          249.93421    167.90813   0.003773585 
+  291          257.7527     167.86698   0.003436426 
+  268          269.35946    167.82586   0.003731343 
+  282          277.21787    167.78478   0.003546099 
+  248          273.32348    167.74374   0.004032258 
+  302          265.20334    167.70274   0.003311258 
+  257          261.00747    167.66177   0.003891051 
+  250          261.96234    167.62083   0.004     
+  270          267.17334    167.57993   0.003703704 
+  259          271.86914    167.53907   0.003861004 
+  285          271.37259    167.49824   0.003508772 
+  274          268.95573    167.45744   0.003649635 
+  265          268.35128    167.41668   0.003773585 
+  282          270.17787    167.37595   0.003546099 
+  281          273.53728    167.33526   0.003558719 
+  272          277.79292    167.2946    0.003676471 
+  264          282.94356    167.25397   0.003787879 
+  284          289.08199    167.21338   0.003521127 
+  284          296.0608     167.17281   0.003521127 
+  294          303.76533    167.13229   0.003401361 
+  349          312.28314    167.09179   0.00286533 
+  308          321.76743    167.05133   0.003246753 
+  334          332.74385    167.0109    0.002994012 
+  337          345.00274    166.9705    0.002967359 
+  353          358.92464    166.93013   0.002832861 
+  321          374.71474    166.88979   0.003115265 
+  404          392.80641    166.84949   0.002475248 
+  393          413.73904    166.80921   0.002544529 
+  426          438.09698    166.76897   0.002347418 
+  450          466.60592    166.72876   0.002222222 
+  443          500.23207    166.68858   0.002257336 
+  577          539.50468    166.64843   0.001733102 
+  633          585.55125    166.6083    0.001579779 
+  704          640.71188    166.56821   0.001420455 
+  792          708.50154    166.52815   0.001262626 
+  864          793.20353    166.48812   0.001157407 
+  881          900.64953    166.44812   0.001135074 
+  989          1039.24277   166.40814   0.001011122 
+  1109         1221.81061   166.3682    0.000901713 
+  1329         1469.32903   166.32828   0.000752445 
+  1636         1818.02451   166.28839   0.000611247 
+  2262         2337.52202   166.24853   0.000442087 
+  3142         3182.12204   166.2087    0.000318269 
+  4985         4696.83829   166.1689    0.000200602 
+  8015         7519.4636    166.12912   0.000124766 
+  12936        12411.16961  166.08937   0.000077304 
+  18532        18953.91899  166.04965   0.000053961 
+  21445        22000.73393  166.00996   0.000046631 
+  17527        17630.32384  165.97029   0.000057055 
+  11970        12128.29711  165.93065   0.000083542 
+  8892         9262.67735   165.89104   0.000112461 
+  9094         9207.20202   165.85145   0.000109963 
+  10694        11162.37404  165.81189   0.00009351 
+  11296        12432.86107  165.77235   0.000088527 
+  9550         10096.00332  165.73285   0.000104712 
+  6121         6646.61094   165.69336   0.000163372 
+  3675         4215.84611   165.65391   0.000272109 
+  2404         2815.49999   165.61447   0.000415973 
+  1745         2042.41945   165.57507   0.000573066 
+  1317         1590.98042   165.53568   0.000759301 
+  1136         1300.69548   165.49633   0.000880282 
+  898          1098.13743   165.457     0.001113586 
+  812          947.58894    165.41769   0.001231527 
+  749          830.59545    165.3784    0.001335113 
+  684          737.93381    165.33914   0.001461988 
+  623          664.29503    165.29991   0.001605136 
+  549          605.4328     165.2607    0.001821494 
+  468          557.40873    165.22151   0.002136752 
+  504          516.66721    165.18235   0.001984127 
+  442          480.92478    165.1432    0.002262443 
+  443          449.48696    165.10409   0.002257336 
+  394          422.25604    165.06499   0.002538071 
+  371          398.91305    165.02592   0.002695418 
+  349          378.92368    164.98687   0.00286533 
+  380          361.73144    164.94784   0.002631579 
+  325          346.85452    164.90884   0.003076923 
+  354          333.88917    164.86986   0.002824859 
+  294          322.52581    164.8309    0.003401361 
+  321          312.53159    164.79196   0.003115265 
+  318          303.72234    164.75304   0.003144654 
+  307          295.94892    164.71415   0.003257329 
+  288          289.09279    164.67527   0.003472222 
+  278          283.05468    164.63642   0.003597122 
+  295          277.75402    164.59759   0.003389831 
+  299          273.11753    164.55878   0.003344482 
+  291          269.08113    164.51999   0.003436426 
+  263          265.58955    164.48122   0.003802281 
+  285          262.61168    164.44247   0.003508772 
+  261          260.15668    164.40374   0.003831418 
+  271          258.30549    164.36504   0.003690037 
+  245          257.18507    164.32635   0.004081633 
+  266          256.74652    164.28768   0.003759398 
+  261          256.05151    164.24903   0.003831418 
+  235          253.66406    164.2104    0.004255319 
+  258          250.32711    164.17179   0.003875969 
+  235          247.43755    164.1332    0.004255319 
+  235          245.43171    164.09463   0.004255319 
+  254          244.24757    164.05608   0.003937008 
+  275          243.39691    164.01755   0.003636364 
+  225          241.92139    163.97904   0.004444444 
+  245          239.7126     163.94054   0.004081633 
+  230          237.53137    163.90206   0.004347826 
+  284          235.75754    163.86361   0.003521127 
+  258          234.44533    163.82517   0.003875969 
+  261          233.54187    163.78674   0.003831418 
+  245          232.96574    163.74834   0.004081633 
+  218          232.63463    163.70995   0.004587156 
+  225          232.49235    163.67158   0.004444444 
+  267          232.50243    163.63323   0.003745318 
+  264          232.62348    163.5949    0.003787879 
+  269          232.83717    163.55658   0.003717472 
+  264          233.15663    163.51828   0.003787879 
+  241          233.52194    163.48      0.004149378 
+  274          233.49764    163.44174   0.003649635 
+  260          232.36538    163.40349   0.003846154 
+  291          230.38507    163.36526   0.003436426 
+  278          228.63219    163.32704   0.003597122 
+  262          227.75627    163.28884   0.003816794 
+  281          227.79419    163.25066   0.003558719 
+  303          227.84563    163.21249   0.00330033 
+  261          226.05706    163.17434   0.003831418 
+  264          222.15733    163.13621   0.003787879 
+  241          218.03067    163.09809   0.004149378 
+  259          214.94504    163.05999   0.003861004 
+  227          213.11909    163.0219    0.004405286 
+  254          212.24117    162.98383   0.003937008 
+  243          211.55431    162.94577   0.004115226 
+  232          210.60082    162.90773   0.004310345 
+  256          210.04908    162.8697    0.00390625 
+  238          210.76142    162.83169   0.004201681 
+  237          213.21459    162.79369   0.004219409 
+  243          217.4046     162.75571   0.004115226 
+  220          222.03048    162.71774   0.004545455 
+  240          224.56369    162.67979   0.004166667 
+  220          224.81338    162.64185   0.004545455 
+  210          224.15598    162.60393   0.004761905 
+  204          222.15246    162.56602   0.004901961 
+  191          219.55897    162.52812   0.005235602 
+  201          218.03718    162.49024   0.004975124 
+  215          217.21524    162.45237   0.004651163 
+  214          216.16928    162.41451   0.004672897 
+  216          215.29266    162.37667   0.00462963 
+  194          214.51518    162.33884   0.005154639 
+  201          213.61146    162.30103   0.004975124 
+  209          213.30915    162.26323   0.004784689 
+  200          213.53215    162.22544   0.005     
+  207          213.42979    162.18767   0.004830918 
+  190          212.28525    162.14991   0.005263158 
+  203          211.60986    162.11216   0.004926108 
+  208          212.04881    162.07442   0.004807692 
+  202          213.66174    162.0367    0.004950495 
+  215          216.21035    161.99899   0.004651163 
+  224          219.11365    161.96129   0.004464286 
+  204          222.24646    161.9236    0.004901961 
+  222          225.87939    161.88593   0.004504505 
+  230          230.77544    161.84827   0.004347826 
+  231          236.97602    161.81062   0.004329004 
+  247          244.46508    161.77298   0.004048583 
+  234          253.25967    161.73536   0.004273504 
+  283          261.80438    161.69774   0.003533569 
+  255          267.52567    161.66014   0.003921569 
+  267          271.7494     161.62255   0.003745318 
+  285          278.25342    161.58497   0.003508772 
+  289          289.1115     161.54741   0.003460208 
+  328          304.61601    161.50985   0.00304878 
+  356          323.61054    161.47231   0.002808989 
+  326          345.06887    161.43477   0.003067485 
+  383          371.97901    161.39725   0.002610966 
+  428          411.34025    161.35974   0.002336449 
+  473          472.86492    161.32224   0.002114165 
+  600          574.05763    161.28475   0.001666667 
+  807          753.23285    161.24727   0.001239157 
+  1105         1084.86234   161.20981   0.000904977 
+  1711         1670.73729   161.17235   0.000584454 
+  2501         2522.72257   161.1349    0.00039984 
+  2970         3133.44924   161.09747   0.0003367 
+  2600         2741.30896   161.06004   0.000384615 
+  1933         1951.16615   161.02262   0.000517331 
+  1517         1435.49265   160.98522   0.000659196 
+  1361         1283.45634   160.94782   0.000734754 
+  1488         1441.53191   160.91044   0.000672043 
+  1590         1754.17147   160.87306   0.000628931 
+  1686         1774.98359   160.8357    0.00059312 
+  1291         1363.47126   160.79834   0.000774593 
+  907          944.79984    160.761     0.001102536 
+  621          674.46176    160.72366   0.001610306 
+  495          518.11643    160.68633   0.002020202 
+  400          426.5486     160.64902   0.0025    
+  336          369.46332    160.61171   0.00297619 
+  314          331.66353    160.57441   0.003184713 
+  288          305.84281    160.53712   0.003472222 
+  277          287.54691    160.49984   0.003610108 
+  278          272.88008    160.46257   0.003597122 
+  254          259.5257     160.42531   0.003937008 
+  259          247.73664    160.38806   0.003861004 
+  253          238.00075    160.35081   0.003952569 
+  214          230.19627    160.31358   0.004672897 
+  223          224.01503    160.27635   0.004484305 
+  209          219.16422    160.23913   0.004784689 
+  191          215.4221     160.20192   0.005235602 
+  210          212.66667    160.16472   0.004761905 
+  226          210.85326    160.12753   0.004424779 
+  233          209.91439    160.09035   0.004291845 
+  202          209.45016    160.05317   0.004950495 
+  194          208.46085    160.01601   0.005154639 
+  200          206.40887    159.97885   0.005     
+  198          204.1727     159.9417    0.005050505 
+  199          202.63519    159.90456   0.005025126 
+  197          202.06153    159.86742   0.005076142 
+  193          202.41716    159.8303    0.005181347 
+  217          203.42165    159.79318   0.004608295 
+  208          204.63794    159.75607   0.004807692 
+  226          206.26499    159.71897   0.004424779 
+  220          209.25078    159.68187   0.004545455 
+  210          214.76133    159.64479   0.004761905 
+  234          224.59202    159.60771   0.004273504 
+  276          241.97437    159.57064   0.003623188 
+  265          271.87572    159.53357   0.003773585 
+  335          319.25575    159.49652   0.002985075 
+  377          379.09042    159.45947   0.00265252 
+  422          413.07636    159.42243   0.002369668 
+  335          384.39215    159.3854    0.002985075 
+  319          332.21108    159.34837   0.003134796 
+  275          296.53688    159.31135   0.003636364 
+  267          284.58992    159.27434   0.003745318 
+  301          292.78808    159.23733   0.003322259 
+  327          309.95189    159.20034   0.003058104 
+  247          309.59051    159.16334   0.004048583 
+  307          281.86253    159.12636   0.003257329 
+  259          250.41067    159.08938   0.003861004 
+  250          228.01529    159.05241   0.004     
+  209          214.19414    159.01545   0.004784689 
+  213          205.91231    158.9785    0.004694836 
+  227          201.01659    158.94155   0.004405286 
+  226          198.4537     158.9046    0.004424779 
+  231          197.73678    158.86767   0.004329004 
+  205          198.2589     158.83074   0.004878049 
+  212          198.56466    158.79382   0.004716981 
+  204          197.23856    158.7569    0.004901961 
+  202          195.08518    158.71999   0.004950495 
+  181          193.66331    158.68309   0.005524862 
+  195          193.59885    158.64619   0.005128205 
+  178          194.93925    158.6093    0.005617978 
+  208          197.31631    158.57242   0.004807692 
+  173          199.21123    158.53554   0.005780347 
+  195          198.64829    158.49867   0.005128205 
+  180          196.15469    158.4618    0.005555556 
+  177          193.96733    158.42494   0.005649718 
+  186          193.25118    158.38809   0.005376344 
+  237          194.11587    158.35125   0.004219409 
+  226          196.06708    158.31441   0.004424779 
+  220          197.46023    158.27757   0.004545455 
+  207          196.44938    158.24074   0.004830918 
+  167          193.8553     158.20392   0.005988024 
+  188          191.65386    158.1671    0.005319149 
+  197          190.63044    158.13029   0.005076142 
+  215          190.72247    158.09349   0.004651163 
+  182          191.39701    158.05669   0.005494505 
+  189          191.68932    158.0199    0.005291005 
+  181          191.16912    157.98311   0.005524862 
+  189          190.53561    157.94633   0.005291005 
+  217          190.39385    157.90956   0.004608295 
+  217          190.65727    157.87279   0.004608295 
+  205          190.90692    157.83602   0.004878049 
+  216          191.02171    157.79926   0.00462963 
+  181          191.17921    157.76251   0.005524862 
+  220          191.57908    157.72576   0.004545455 
+  225          192.35015    157.68902   0.004444444 
+  186          193.48133    157.65229   0.005376344 
+  205          194.82329    157.61556   0.004878049 
+  212          196.21125    157.57883   0.004716981 
+  190          197.72035    157.54211   0.005263158 
+  207          199.55463    157.5054    0.004830918 
+  248          201.84709    157.46869   0.004032258 
+  231          204.686      157.43199   0.004329004 
+  214          208.13599    157.39529   0.004672897 
+  224          212.12385    157.3586    0.004464286 
+  233          216.21392    157.32191   0.004291845 
+  235          219.91999    157.28523   0.004255319 
+  249          223.65742    157.24855   0.004016064 
+  255          228.21664    157.21188   0.003921569 
+  232          234.07149    157.17522   0.004310345 
+  264          241.50621    157.13856   0.003787879 
+  291          250.71579    157.1019    0.003436426 
+  286          261.62033    157.06525   0.003496503 
+  340          273.67758    157.02861   0.002941176 
+  312          286.236      156.99197   0.003205128 
+  354          300.02509    156.95534   0.002824859 
+  314          317.40285    156.91871   0.003184713 
+  364          340.61978    156.88208   0.002747253 
+  353          371.66323    156.84546   0.002832861 
+  428          412.57487    156.80885   0.002336449 
+  490          465.01437    156.77224   0.002040816 
+  542          531.59057    156.73564   0.001845018 
+  563          622.79133    156.69904   0.001776199 
+  807          762.81342    156.66245   0.001239157 
+  1087         999.95108    156.62586   0.000919963 
+  1524         1431.41692   156.58928   0.000656168 
+  2450         2215.82676   156.5527    0.000408163 
+  3627         3495.43941   156.51613   0.00027571 
+  4915         4966.44388   156.47956   0.000203459 
+  5148         5221.57826   156.443     0.00019425 
+  4000         3974.89696   156.40644   0.00025   
+  2706         2739.89439   156.36988   0.000369549 
+  2097         2090.26313   156.33334   0.000476872 
+  2061         2000.07245   156.29679   0.000485201 
+  2292         2370.98358   156.26026   0.0004363 
+  2714         2929.56295   156.22372   0.00036846 
+  2733         2907.51301   156.1872    0.000365898 
+  2039         2172.1547    156.15067   0.000490436 
+  1404         1455.54612   156.11415   0.000712251 
+  932          996.2045     156.07764   0.001072961 
+  674          733.74525    156.04113   0.00148368 
+  539          582.951      156.00463   0.001855288 
+  468          489.93399    155.96813   0.002136752 
+  408          427.11617    155.93164   0.00245098 
+  358          381.40272    155.89515   0.002793296 
+  318          347.06334    155.85867   0.003144654 
+  311          320.86931    155.82219   0.003215434 
+  273          300.46267    155.78572   0.003663004 
+  265          284.43991    155.74925   0.003773585 
+  258          271.84098    155.71278   0.003875969 
+  235          261.551      155.67633   0.004255319 
+  239          252.67709    155.63987   0.0041841 
+  230          244.87038    155.60342   0.004347826 
+  230          237.87069    155.56698   0.004347826 
+  239          231.5706     155.53054   0.0041841 
+  211          225.93622    155.49411   0.004739336 
+  217          221.11276    155.45768   0.004608295 
+  209          217.22037    155.42126   0.004784689 
+  236          214.17599    155.38484   0.004237288 
+  212          211.71547    155.34842   0.004716981 
+  208          209.57615    155.31202   0.004807692 
+  204          207.6704     155.27561   0.004901961 
+  203          205.87764    155.23921   0.004926108 
+  216          203.99245    155.20282   0.00462963 
+  202          201.99123    155.16643   0.004950495 
+  207          200.14693    155.13005   0.004830918 
+  201          198.66455    155.09367   0.004975124 
+  183          197.60226    155.0573    0.005464481 
+  201          196.97123    155.02093   0.004975124 
+  182          196.75231    154.98456   0.005494505 
+  190          196.88085    154.94821   0.005263158 
+  204          197.41281    154.91185   0.004901961 
+  193          198.63386    154.87551   0.005181347 
+  211          200.75856    154.83916   0.004739336 
+  221          203.56405    154.80283   0.004524887 
+  181          206.28166    154.76649   0.005524862 
+  213          208.2341     154.73017   0.004694836 
+  203          208.89339    154.69384   0.004926108 
+  206          207.76375    154.65753   0.004854369 
+  201          205.41175    154.62121   0.004975124 
+  169          203.22503    154.58491   0.00591716 
+  244          202.07156    154.54861   0.004098361 
+  162          201.91859    154.51231   0.00617284 
+  199          202.38298    154.47602   0.005025126 
+  208          202.86466    154.43973   0.004807692 
+  190          202.20343    154.40345   0.005263158 
+  197          199.68565    154.36718   0.005076142 
+  199          196.25221    154.33091   0.005025126 
+  191          193.25234    154.29465   0.005235602 
+  192          191.21175    154.25839   0.005208333 
+  193          190.10943    154.22213   0.005181347 
+  194          189.70449    154.18589   0.005154639 
+  166          189.52027    154.14964   0.006024096 
+  199          189.02042    154.11341   0.005025126 
+  189          188.21811    154.07717   0.005291005 
+  197          187.52016    154.04095   0.005076142 
+  175          187.13844    154.00473   0.005714286 
+  184          187.10019    153.96851   0.005434783 
+  196          187.40666    153.9323    0.005102041 
+  167          188.10197    153.8961    0.005988024 
+  201          189.27596    153.8599    0.004975124 
+  183          191.00062    153.82371   0.005464481 
+  179          193.0767     153.78752   0.005586592 
+  192          194.65079    153.75134   0.005208333 
+  192          194.80906    153.71516   0.005208333 
+  203          194.08823    153.67899   0.004926108 
+  197          193.66206    153.64283   0.005076142 
+  207          194.10085    153.60667   0.004830918 
+  213          195.55996    153.57052   0.004694836 
+  205          198.04955    153.53437   0.004878049 
+  222          201.36083    153.49823   0.004504505 
+  207          205.16659    153.4621    0.004830918 
+  221          209.63391    153.42597   0.004524887 
+  186          215.27226    153.38985   0.005376344 
+  198          222.67758    153.35373   0.005050505 
+  211          231.4144     153.31762   0.004739336 
+  213          237.57197    153.28151   0.004694836 
+  241          237.15121    153.24541   0.004149378 
+  200          232.7338     153.20932   0.005     
+  200          229.27893    153.17323   0.005     
+  229          228.74021    153.13715   0.004366812 
+  204          230.95743    153.10108   0.004901961 
+  243          235.30134    153.06501   0.004115226 
+  214          240.3209     153.02895   0.004672897 
+  251          243.92784    152.99289   0.003984064 
+  257          246.68377    152.95684   0.003891051 
+  236          251.02109    152.9208    0.004237288 
+  240          256.94452    152.88476   0.004166667 
+  231          261.4199     152.84873   0.004329004 
+  271          263.30469    152.81271   0.003690037 
+  256          265.74225    152.77669   0.00390625 
+  304          271.69632    152.74068   0.003289474 
+  295          282.40443    152.70468   0.003389831 
+  318          297.98059    152.66868   0.003144654 
+  325          316.47107    152.63269   0.003076923 
+  342          333.02158    152.59671   0.002923977 
+  359          345.82869    152.56073   0.002785515 
+  395          360.40416    152.52476   0.002531646 
+  398          382.18885    152.48879   0.002512563 
+  447          412.97264    152.45284   0.002237136 
+  508          450.42799    152.41689   0.001968504 
+  467          487.29004    152.38094   0.002141328 
+  493          524.31845    152.34501   0.002028398 
+  545          573.83415    152.30908   0.001834862 
+  681          648.12404    152.27315   0.001468429 
+  728          760.39871    152.23724   0.001373626 
+  955          932.24063    152.20133   0.00104712 
+  1275         1210.44769   152.16543   0.000784314 
+  1832         1695.21159   152.12954   0.000545852 
+  2810         2568.98222   152.09365   0.000355872 
+  4229         4055.82486   152.05777   0.000236463 
+  5910         6070.77164   152.0219    0.000169205 
+  6693         7209.71754   151.98603   0.00014941 
+  5942         6029.21881   151.95018   0.000168294 
+  3992         4163.24617   151.91432   0.000250501 
+  2840         2932.122     151.87848   0.000352113 
+  2476         2449.28476   151.84265   0.000403877 
+  2655         2604.25833   151.80682   0.000376648 
+  3135         3275.21585   151.771     0.000318979 
+  3660         3976.72248   151.73519   0.000273224 
+  3358         3684.26534   151.69938   0.000297796 
+  2424         2638.13901   151.66359   0.000412541 
+  1629         1744.60169   151.6278    0.000613874 
+  1125         1188.2665    151.59202   0.000888889 
+  816          871.90869    151.55624   0.00122549 
+  667          689.91699    151.52048   0.00149925 
+  566          577.02863    151.48472   0.001766784 
+  506          501.24306    151.44897   0.001976285 
+  443          447.65708    151.41323   0.002257336 
+  386          408.56982    151.3775    0.002590674 
+  347          379.22157    151.34177   0.002881844 
+  331          355.97988    151.30606   0.003021148 
+  300          336.27595    151.27035   0.003333333 
+  292          319.68736    151.23465   0.003424658 
+  317          306.55753    151.19896   0.003154574 
+  326          296.54085    151.16327   0.003067485 
+  279          288.93284    151.1276    0.003584229 
+  277          283.61338    151.09193   0.003610108 
+  287          280.66524    151.05627   0.003484321 
+  265          279.13971    151.02062   0.003773585 
+  289          276.61627    150.98498   0.003460208 
+  267          270.23423    150.94935   0.003745318 
+  226          260.71602    150.91373   0.004424779 
+  215          251.36224    150.87811   0.004651163 
+  268          243.91165    150.84251   0.003731343 
+  248          238.83092    150.80691   0.004032258 
+  254          236.04134    150.77133   0.003937008 
+  240          234.73764    150.73575   0.004166667 
+  242          233.17537    150.70018   0.004132231 
+  225          230.45163    150.66462   0.004444444 
+  228          228.1317     150.62907   0.004385965 
+  222          227.95445    150.59353   0.004504505 
+  222          230.32143    150.55799   0.004504505 
+  274          234.43437    150.52247   0.003649635 
+  229          238.10516    150.48696   0.004366812 
+  247          237.70292    150.45145   0.004048583 
+  260          232.93166    150.41596   0.003846154 
+  265          228.10953    150.38047   0.003773585 
+  245          226.38647    150.345     0.004081633 
+  251          228.56894    150.30953   0.003984064 
+  241          234.17855    150.27408   0.004149378 
+  239          241.12694    150.23863   0.0041841 
+  250          244.91977    150.2032    0.004     
+  216          242.62624    150.16777   0.00462963 
+  234          237.72552    150.13236   0.004273504 
+  253          234.68633    150.09695   0.003952569 
+  259          235.09397    150.06155   0.003861004 
+  230          238.69878    150.02617   0.004347826 
+  229          243.57207    149.99079   0.004366812 
+  231          245.72521    149.95543   0.004329004 
+  201          242.76372    149.92007   0.004975124 
+  231          236.93334    149.88473   0.004329004 
+  200          230.40533    149.8494    0.005     
+  223          223.82858    149.81407   0.004484305 
+  197          218.51083    149.77876   0.005076142 
+  210          215.11075    149.74346   0.004761905 
+  198          212.6359     149.70817   0.005050505 
+  184          209.59829    149.67289   0.005434783 
+  182          206.19519    149.63762   0.005494505 
+  198          203.40164    149.60236   0.005050505 
+  191          201.27323    149.56711   0.005235602 
+  220          199.90423    149.53188   0.004545455 
+  180          199.28614    149.49665   0.005555556 
+  217          198.6366     149.46144   0.004608295 
+  194          197.13939    149.42623   0.005154639 
+  182          193.68025    149.39104   0.005494505 
+  180          189.265      149.35586   0.005555556 
+  172          186.24938    149.32069   0.005813953 
+  154          185.36902    149.28554   0.006493506 
+  167          186.14976    149.25039   0.005988024 
+  196          187.38812    149.21526   0.005102041 
+  170          188.26284    149.18014   0.005882353 
+  208          188.96585    149.14503   0.004807692 
+  193          189.86658    149.10993   0.005181347 
+  172          191.86765    149.07484   0.005813953 
+  176          194.04469    149.03977   0.005681818 
+  160          193.20811    149.0047    0.00625   
+  172          188.69361    148.96965   0.005813953 
+  167          183.25189    148.93462   0.005988024 
+  141          178.93112    148.89959   0.007092199 
+  174          176.42721    148.86458   0.005747126 
+  170          175.72731    148.82957   0.005882353 
+  174          176.25084    148.79459   0.005747126 
+  177          176.50335    148.75961   0.005649718 
+  161          174.83506    148.72465   0.00621118 
+  149          171.70206    148.6897    0.006711409 
+  178          168.63547    148.65476   0.005617978 
+  183          166.30754    148.61983   0.005464481 
+  164          164.72988    148.58492   0.006097561 
+  169          163.75976    148.55002   0.00591716 
+  175          163.2896     148.51513   0.005714286 
+  177          163.27077    148.48026   0.005649718 
+  175          163.70715    148.4454    0.005714286 
+  156          164.6415     148.41055   0.006410256 
+  181          166.02182    148.37572   0.005524862 
+  150          167.27441    148.3409    0.006666667 
+  155          167.28816    148.30609   0.006451613 
+  157          165.90504    148.2713    0.006369427 
+  146          164.22973    148.23652   0.006849315 
+  161          163.03932    148.20175   0.00621118 
+  155          162.47133    148.167     0.006451613 
+  177          162.41013    148.13226   0.005649718 
+  173          162.66986    148.09754   0.005780347 
+  173          162.86559    148.06283   0.005780347 
+  182          162.48501    148.02813   0.005494505 
+  142          161.63169    147.99345   0.007042254 
+  154          160.81974    147.95878   0.006493506 
+  164          160.19376    147.92413   0.006097561 
+  151          159.5941     147.88949   0.006622517 
+  170          158.97473    147.85487   0.005882353 
+  155          158.44458    147.82026   0.006451613 
+  164          158.08271    147.78566   0.006097561 
+  137          157.90002    147.75108   0.00729927 
+  145          157.8772     147.71651   0.006896552 
+  158          157.97518    147.68196   0.006329114 
+  177          158.11519    147.64743   0.005649718 
+  142          158.23797    147.6129    0.007042254 
+  144          158.40397    147.5784    0.006944444 
+  139          158.7159     147.54391   0.007194245 
+  139          159.23247    147.50943   0.007194245 
+  173          159.95551    147.47497   0.005780347 
+  144          160.88945    147.44053   0.006944444 
+  157          162.12213    147.4061    0.006369427 
+  176          163.92653    147.37168   0.005681818 
+  174          166.66653    147.33728   0.005747126 
+  170          170.59067    147.3029    0.005882353 
+  207          175.35982    147.26853   0.004830918 
+  172          179.25882    147.23418   0.005813953 
+  174          180.35071    147.19985   0.005747126 
+  197          179.55676    147.16553   0.005076142 
+  163          179.1607     147.13122   0.006134969 
+  174          179.33281    147.09694   0.005747126 
+  167          179.05924    147.06267   0.005988024 
+  165          178.37534    147.02841   0.006060606 
+  167          178.12189    146.99417   0.005988024 
+  194          177.82594    146.95995   0.005154639 
+  169          176.8112     146.92575   0.00591716 
+  169          175.83953    146.89156   0.00591716 
+  179          175.92362    146.85739   0.005586592 
+  180          176.95032    146.82323   0.005555556 
+  196          178.24309    146.7891    0.005102041 
+  196          179.51042    146.75498   0.005102041 
+  165          180.2965     146.72087   0.006060606 
+  182          180.27886    146.68679   0.005494505 
+  196          180.47189    146.65272   0.005102041 
+  166          181.57505    146.61867   0.006024096 
+  175          182.54261    146.58463   0.005714286 
+  190          182.20887    146.55062   0.005263158 
+  161          181.48792    146.51662   0.00621118 
+  181          181.68187    146.48263   0.005524862 
+  192          182.91311    146.44867   0.005208333 
+  174          185.19514    146.41473   0.005747126 
+  193          189.41125    146.3808    0.005181347 
+  209          196.65245    146.34689   0.004784689 
+  201          207.79812    146.313     0.004975124 
+  235          224.37205    146.27912   0.004255319 
+  247          249.26075    146.24527   0.004048583 
+  296          282.52618    146.21143   0.003378378 
+  310          308.56985    146.17761   0.003225806 
+  278          301.76448    146.14381   0.003597122 
+  255          272.99594    146.11003   0.003921569 
+  274          249.11703    146.07627   0.003649635 
+  244          238.74426    146.04253   0.004098361 
+  228          241.05457    146.0088    0.004385965 
+  274          252.50231    145.9751    0.003649635 
+  253          266.82319    145.94141   0.003952569 
+  270          273.96585    145.90775   0.003703704 
+  280          264.14604    145.8741    0.003571429 
+  265          245.63643    145.84047   0.003773585 
+  268          232.41001    145.80686   0.003731343 
+  257          228.26156    145.77327   0.003891051 
+  252          231.4451     145.7397    0.003968254 
+  248          238.08884    145.70615   0.004032258 
+  246          245.74025    145.67262   0.004065041 
+  269          257.43976    145.63911   0.003717472 
+  314          279.65185    145.60562   0.003184713 
+  354          314.85705    145.57215   0.002824859 
+  370          347.79908    145.5387    0.002702703 
+  363          346.19664    145.50527   0.002754821 
+  341          314.60177    145.47186   0.002932551 
+  333          285.05898    145.43847   0.003003003 
+  287          270.67953    145.40511   0.003484321 
+  285          273.56812    145.37176   0.003508772 
+  281          294.39424    145.33843   0.003558719 
+  328          331.4816     145.30512   0.00304878 
+  381          369.38396    145.27184   0.002624672 
+  311          372.15637    145.23858   0.003215434 
+  319          331.51       145.20533   0.003134796 
+  287          283.48317    145.17211   0.003484321 
+  259          249.51382    145.13891   0.003861004 
+  241          231.13227    145.10573   0.004149378 
+  233          225.10699    145.07257   0.004291845 
+  200          228.0755     145.03944   0.005     
+  220          234.81342    145.00632   0.004545455 
+  213          235.00854    144.97323   0.004694836 
+  233          222.33236    144.94016   0.004291845 
+  213          205.56114    144.90711   0.004694836 
+  207          192.45255    144.87408   0.004830918 
+  198          183.89106    144.84108   0.005050505 
+  196          178.55126    144.8081    0.005102041 
+  207          175.15019    144.77514   0.004830918 
+  240          173.0434     144.7422    0.004166667 
+  194          171.96722    144.70928   0.005154639 
+  182          171.7951     144.67639   0.005494505 
+  177          172.47718    144.64352   0.005649718 
+  180          174.0077     144.61068   0.005555556 
+  200          176.32175    144.57785   0.005     
+  189          179.36438    144.54505   0.005291005 
+  195          183.46475    144.51227   0.005128205 
+  186          189.1624     144.47952   0.005376344 
+  222          196.53086    144.44679   0.004504505 
+  205          205.01178    144.41408   0.004878049 
+  182          213.08199    144.3814    0.005494505 
+  205          219.09175    144.34874   0.004878049 
+  217          223.93185    144.3161    0.004608295 
+  206          228.50927    144.28349   0.004854369 
+  216          231.16799    144.2509    0.00462963 
+  227          230.15161    144.21833   0.004405286 
+  259          226.33525    144.18579   0.003861004 
+  224          222.17737    144.15327   0.004464286 
+  226          219.09024    144.12078   0.004424779 
+  209          216.93751    144.08831   0.004784689 
+  197          215.99276    144.05587   0.005076142 
+  186          216.59093    144.02345   0.005376344 
+  189          217.32128    143.99106   0.005291005 
+  191          216.14312    143.95869   0.005235602 
+  222          213.25189    143.92634   0.004504505 
+  213          210.85462    143.89402   0.004694836 
+  198          211.19497    143.86173   0.005050505 
+  205          216.64828    143.82946   0.004878049 
+  233          230.92281    143.79721   0.004291845 
+  293          260.02919    143.765     0.003412969 
+  298          310.95544    143.7328    0.003355705 
+  363          381.1761     143.70064   0.002754821 
+  407          426.64264    143.66849   0.002457002 
+  393          392.76775    143.63638   0.002544529 
+  352          326.98814    143.60429   0.002840909 
+  293          279.26829    143.57222   0.003412969 
+  240          255.70339    143.54019   0.004166667 
+  267          252.91847    143.50818   0.003745318 
+  258          269.53338    143.47619   0.003875969 
+  320          304.09376    143.44423   0.003125  
+  338          340.17826    143.4123    0.00295858 
+  325          341.29538    143.38039   0.003076923 
+  264          310.89384    143.34851   0.003787879 
+  223          276.89094    143.31666   0.004484305 
+  208          250.77994    143.28484   0.004807692 
+  205          234.67579    143.25304   0.004878049 
+  203          227.14113    143.22127   0.004926108 
+  208          226.83799    143.18953   0.004807692 
+  207          231.98878    143.15781   0.004830918 
+  197          238.19568    143.12612   0.005076142 
+  210          239.99107    143.09446   0.004761905 
+  214          235.9207     143.06283   0.004672897 
+  215          228.66087    143.03122   0.004651163 
+  190          220.64054    142.99964   0.005263158 
+  210          212.97566    142.96809   0.004761905 
+  202          206.91724    142.93657   0.004950495 
+  195          203.22899    142.90508   0.005128205 
+  196          200.98582    142.87361   0.005102041 
+  178          199.00913    142.84218   0.005617978 
+  185          197.317      142.81077   0.005405405 
+  203          196.92831    142.77939   0.004926108 
+  208          198.13909    142.74804   0.004807692 
+  205          201.00639    142.71672   0.004878049 
+  208          205.20677    142.68543   0.004807692 
+  184          207.95185    142.65416   0.005434783 
+  186          205.05126    142.62293   0.005376344 
+  203          197.07062    142.59172   0.004926108 
+  145          188.72188    142.56055   0.006896552 
+  171          182.56513    142.5294    0.005847953 
+  185          178.85265    142.49829   0.005405405 
+  166          177.42827    142.4672    0.006024096 
+  184          178.01443    142.43614   0.005434783 
+  180          179.35768    142.40512   0.005555556 
+  136          178.9511     142.37412   0.007352941 
+  179          175.44999    142.34315   0.005586592 
+  141          170.72627    142.31222   0.007092199 
+  174          166.57233    142.28131   0.005747126 
+  162          163.34677    142.25043   0.00617284 
+  179          160.87378    142.21959   0.005586592 
+  153          159.01968    142.18878   0.006535948 
+  160          157.67245    142.15799   0.00625   
+  172          156.70825    142.12724   0.005813953 
+  149          156.02626    142.09652   0.006711409 
+  144          155.58797    142.06583   0.006944444 
+  166          155.30905    142.03517   0.006024096 
+  166          155.21392    142.00454   0.006024096 
+  150          155.31259    141.97395   0.006666667 
+  151          155.62626    141.94338   0.006622517 
+  148          156.16037    141.91285   0.006756757 
+  146          156.84883    141.88235   0.006849315 
+  175          157.57346    141.85188   0.005714286 
+  171          158.34281    141.82144   0.005847953 
+  162          159.2967     141.79104   0.00617284 
+  154          160.35476    141.76067   0.006493506 
+  183          161.13927    141.73033   0.005464481 
+  182          161.67281    141.70002   0.005494505 
+  159          162.55333    141.66974   0.006289308 
+  161          164.26302    141.6395    0.00621118 
+  150          166.84907    141.60929   0.006666667 
+  141          169.75533    141.57912   0.007092199 
+  160          171.70045    141.54897   0.00625   
+  142          171.90687    141.51886   0.007042254 
+  166          171.29642    141.48879   0.006024096 
+  161          171.05019    141.45874   0.00621118 
+  161          171.83382    141.42873   0.00621118 
+  171          174.00564    141.39876   0.005847953 
+  180          177.76766    141.36882   0.005555556 
+  167          183.1353     141.33891   0.005988024 
+  162          189.40902    141.30903   0.00617284 
+  178          195.3801     141.27919   0.005617978 
+  193          199.75688    141.24939   0.005181347 
+  191          200.23883    141.21961   0.005235602 
+  188          196.19756    141.18988   0.005319149 
+  179          190.6459     141.16017   0.005586592 
+  158          186.2977     141.13051   0.006329114 
+  162          183.98116    141.10087   0.00617284 
+  169          183.53792    141.07127   0.00591716 
+  165          184.4644     141.04171   0.006060606 
+  166          186.15385    141.01218   0.006024096 
+  181          187.36456    140.98269   0.005524862 
+  169          186.54659    140.95323   0.00591716 
+  174          184.05768    140.92381   0.005747126 
+  164          181.56556    140.89442   0.006097561 
+  169          180.01955    140.86507   0.00591716 
+  185          179.60465    140.83576   0.005405405 
+  161          180.26881    140.80648   0.00621118 
+  201          181.92335    140.77724   0.004975124 
+  177          184.34391    140.74803   0.005649718 
+  186          186.95844    140.71886   0.005376344 
+  191          189.17541    140.68973   0.005235602 
+  186          191.29395    140.66063   0.005376344 
+  197          194.06145    140.63157   0.005076142 
+  166          197.67527    140.60255   0.006024096 
+  173          201.45676    140.57356   0.005780347 
+  205          204.18989    140.54461   0.004878049 
+  190          205.51879    140.5157    0.005263158 
+  175          206.31097    140.48682   0.005714286 
+  171          206.90575    140.45798   0.005847953 
+  184          207.22985    140.42918   0.005434783 
+  197          208.02044    140.40042   0.005076142 
+  178          210.09106    140.3717    0.005617978 
+  195          213.57435    140.34301   0.005128205 
+  185          217.8341     140.31436   0.005405405 
+  196          221.72555    140.28575   0.005102041 
+  175          224.84608    140.25718   0.005714286 
+  208          228.0502     140.22864   0.004807692 
+  232          232.32947    140.20015   0.004310345 
+  255          240.02559    140.17169   0.003921569 
+  218          256.28523    140.14327   0.004587156 
+  270          287.93649    140.11489   0.003703704 
+  298          339.71856    140.08655   0.003355705 
+  386          397.40483    140.05825   0.002590674 
+  392          406.01749    140.02999   0.00255102 
+  342          353.08096    140.00176   0.002923977 
+  290          295.49768    139.97358   0.003448276 
+  249          257.54099    139.94543   0.004016064 
+  211          238.17587    139.91733   0.004739336 
+  228          233.79057    139.88927   0.004385965 
+  263          243.05974    139.86124   0.003802281 
+  242          264.66193    139.83326   0.004132231 
+  284          285.26799    139.80531   0.003521127 
+  282          275.97498    139.77741   0.003546099 
+  242          243.13531    139.74954   0.004132231 
+  209          213.69675    139.72172   0.004784689 
+  208          194.38667    139.69394   0.004807692 
+  172          182.79272    139.6662    0.005813953 
+  165          175.79896    139.6385    0.006060606 
+  171          171.29575    139.61084   0.005847953 
+  186          168.11784    139.58322   0.005376344 
+  194          165.71356    139.55564   0.005154639 
+  160          163.93139    139.52811   0.00625   
+  182          162.77485    139.50061   0.005494505 
+  159          162.27       139.47316   0.006289308 
+  159          162.45607    139.44575   0.006289308 
+  169          163.31414    139.41838   0.00591716 
+  188          164.48512    139.39105   0.005319149 
+  172          164.93976    139.36377   0.005813953 
+  180          163.75408    139.33653   0.005555556 
+  179          161.49441    139.30933   0.005586592 
+  176          159.29753    139.28217   0.005681818 
+  170          157.68371    139.25506   0.005882353 
+  179          156.71869    139.22798   0.005586592 
+  143          156.35042    139.20095   0.006993007 
+  135          156.56216    139.17397   0.007407407 
+  158          156.93628    139.14703   0.006329114 
+  164          156.99369    139.12013   0.006097561 
+  169          156.22701    139.09327   0.00591716 
+  169          155.36168    139.06646   0.00591716 
+  143          154.70252    139.03969   0.006993007 
+  152          154.38526    139.01297   0.006578947 
+  187          154.48788    138.98629   0.005347594 
+  174          155.13312    138.95965   0.005747126 
+  167          156.21876    138.93306   0.005988024 
+  159          157.0224     138.90651   0.006289308 
+  168          156.85589    138.88001   0.005952381 
+  161          155.5509     138.85355   0.00621118 
+  177          153.95403    138.82713   0.005649718 
+  157          152.65283    138.80076   0.006369427 
+  163          151.79021    138.77444   0.006134969 
+  149          151.36789    138.74816   0.006711409 
+  151          151.3763     138.72193   0.006622517 
+  160          151.68832    138.69574   0.00625   
+  151          151.91993    138.66959   0.006622517 
+  177          151.61718    138.6435    0.005649718 
+  170          150.81588    138.61744   0.005882353 
+  149          149.92817    138.59144   0.006711409 
+  158          149.24421    138.56548   0.006329114 
+  167          148.84327    138.53957   0.005988024 
+  172          148.70306    138.5137    0.005813953 
+  154          148.74505    138.48788   0.006493506 
+  166          148.81112    138.4621    0.006024096 
+  170          148.73124    138.43637   0.005882353 
+  147          148.53236    138.41069   0.006802721 
+  164          148.37384    138.38506   0.006097561 
+  143          148.34874    138.35947   0.006993007 
+  185          148.48291    138.33393   0.005405405 
+  152          148.78397    138.30844   0.006578947 
+  167          149.2553     138.283     0.005988024 
+  150          149.86912    138.2576    0.006666667 
+  148          150.50615    138.23225   0.006756757 
+  155          150.99314    138.20695   0.006451613 
+  138          151.33252    138.18169   0.007246377 
+  149          151.69447    138.15649   0.006711409 
+  152          152.19385    138.13133   0.006578947 
+  155          152.86275    138.10622   0.006451613 
+  151          153.69933    138.08116   0.006622517 
+  148          154.73749    138.05615   0.006756757 
+  173          156.0918     138.03119   0.005780347 
+  166          157.93862    138.00627   0.006024096 
+  174          160.55771    137.98141   0.005747126 
+  168          164.4988     137.95659   0.005952381 
+  217          170.65846    137.93183   0.004608295 
+  178          180.07647    137.90711   0.005617978 
+  182          192.96392    137.88244   0.005494505 
+  227          205.4593     137.85783   0.004405286 
+  209          207.84424    137.83326   0.004784689 
+  189          198.11365    137.80874   0.005291005 
+  212          186.07115    137.78427   0.004716981 
+  204          177.55443    137.75986   0.004901961 
+  162          173.22441    137.73549   0.00617284 
+  194          172.56775    137.71117   0.005154639 
+  182          175.2484     137.68691   0.005494505 
+  188          180.93811    137.66269   0.005319149 
+  177          187.77982    137.63853   0.005649718 
+  176          191.029      137.61442   0.005681818 
+  189          189.10724    137.59036   0.005291005 
+  213          186.41398    137.56635   0.004694836 
+  195          184.76722    137.54239   0.005128205 
+  177          182.53566    137.51848   0.005649718 
+  180          179.11103    137.49462   0.005555556 
+  186          175.69341    137.47082   0.005376344 
+  184          172.89719    137.44707   0.005434783 
+  169          170.75139    137.42337   0.00591716 
+  155          169.67901    137.39973   0.006451613 
+  159          170.10497    137.37613   0.006289308 
+  173          172.00148    137.35259   0.005780347 
+  201          174.63244    137.3291    0.004975124 
+  166          176.6932     137.30567   0.006024096 
+  181          177.9059     137.28228   0.005524862 
+  168          179.60836    137.25895   0.005952381 
+  197          182.7641     137.23568   0.005076142 
+  181          186.74951    137.21245   0.005524862 
+  179          189.47557    137.18929   0.005586592 
+  185          189.6015     137.16617   0.005405405 
+  186          188.789      137.14311   0.005376344 
+  197          189.18437    137.1201    0.005076142 
+  200          192.39217    137.09715   0.005     
+  194          201.20664    137.07425   0.005154639 
+  212          219.58972    137.0514    0.004716981 
+  261          250.34556    137.02861   0.003831418 
+  274          286.07126    137.00588   0.003649635 
+  314          296.06477    136.9832    0.003184713 
+  259          268.08888    136.96057   0.003861004 
+  247          233.81003    136.938     0.004048583 
+  230          210.44016    136.91549   0.004347826 
+  231          198.27338    136.89303   0.004329004 
+  217          194.81067    136.87062   0.004608295 
+  213          198.58701    136.84827   0.004694836 
+  232          209.14657    136.82598   0.004310345 
+  249          223.53586    136.80375   0.004016064 
+  233          228.7597     136.78157   0.004291845 
+  203          214.38307    136.75944   0.004926108 
+  191          194.21573    136.73737   0.005235602 
+  177          179.40874    136.71536   0.005649718 
+  192          170.65365    136.69341   0.005208333 
+  177          165.94524    136.67151   0.005649718 
+  191          163.39649    136.64967   0.005235602 
+  150          161.87195    136.62789   0.006666667 
+  192          160.78247    136.60616   0.005208333 
+  161          159.83935    136.58449   0.00621118 
+  157          159.29091    136.56288   0.006369427 
+  157          159.55135    136.54133   0.006369427 
+  166          160.64874    136.51983   0.006024096 
+  162          162.14094    136.49839   0.00617284 
+  184          163.31755    136.47701   0.005434783 
+  162          163.82816    136.45569   0.00617284 
+  178          164.57179    136.43443   0.005617978 
+  160          166.76683    136.41323   0.00625   
+  181          171.19925    136.39208   0.005524862 
+  181          177.97836    136.371     0.005524862 
+  177          186.00486    136.34997   0.005649718 
+  180          192.78497    136.329     0.005555556 
+  161          195.52988    136.30809   0.00621118 
+  182          192.42447    136.28724   0.005494505 
+  171          184.98954    136.26645   0.005847953 
+  148          177.1826     136.24572   0.006756757 
+  136          171.53672    136.22505   0.007352941 
+  159          168.72266    136.20444   0.006289308 
+  171          168.50121    136.18389   0.005847953 
+  202          170.09288    136.1634    0.004950495 
+  160          172.03959    136.14297   0.00625   
+  159          172.65226    136.12261   0.006289308 
+  146          170.74326    136.1023    0.006849315 
+  160          166.52472    136.08205   0.00625   
+  144          161.73727    136.06187   0.006944444 
+  161          157.76732    136.04174   0.00621118 
+  155          154.9335     136.02168   0.006451613 
+  158          153.05831    136.00168   0.006329114 
+  182          151.88687    135.98174   0.005494505 
+  145          151.19962    135.96186   0.006896552 
+  158          150.78777    135.94205   0.006329114 
+  154          150.49604    135.92229   0.006493506 
+  174          150.31567    135.9026    0.005747126 
+  162          150.35103    135.88297   0.00617284 
+  146          150.7081     135.86341   0.006849315 
+  144          151.47306    135.8439    0.006944444 
+  158          152.74076    135.82446   0.006329114 
+  185          154.61837    135.80509   0.005405405 
+  166          157.14128    135.78577   0.006024096 
+  177          160.00305    135.76652   0.005649718 
+  196          162.39037    135.74733   0.005102041 
+  161          163.72796    135.72821   0.00621118 
+  178          164.38197    135.70915   0.005617978 
+  160          164.73587    135.69016   0.00625   
+  146          164.54412    135.67122   0.006849315 
+  170          164.02773    135.65236   0.005882353 
+  167          164.14814    135.63355   0.005988024 
+  188          165.67827    135.61482   0.005319149 
+  159          169.04414    135.59614   0.006289308 
+  174          174.57755    135.57753   0.005747126 
+  192          182.85703    135.55899   0.005208333 
+  192          195.0562     135.54051   0.005208333 
+  190          211.66498    135.5221    0.005263158 
+  239          227.85676    135.50375   0.0041841 
+  250          231.88148    135.48547   0.004     
+  207          221.47451    135.46725   0.004830918 
+  218          206.76886    135.4491    0.004587156 
+  192          193.7462     135.43102   0.005208333 
+  213          184.38102    135.413     0.004694836 
+  191          179.41612    135.39505   0.005235602 
+  204          178.86957    135.37717   0.004901961 
+  208          182.4987     135.35935   0.004807692 
+  180          189.03081    135.3416    0.005555556 
+  199          193.77695    135.32392   0.005025126 
+  177          191.39307    135.3063    0.005649718 
+  202          184.12596    135.28875   0.004950495 
+  175          176.3905     135.27127   0.005714286 
+  163          169.84523    135.25386   0.006134969 
+  174          165.00456    135.23651   0.005747126 
+  183          161.79448    135.21923   0.005464481 
+  153          159.83191    135.20202   0.006535948 
+  177          158.74533    135.18488   0.005649718 
+  162          158.27306    135.16781   0.00617284 
+  164          158.2364     135.1508    0.006097561 
+  195          158.50456    135.13387   0.005128205 
+  171          158.99948    135.117     0.005847953 
+  197          159.71877    135.10021   0.005076142 
+  174          160.69719    135.08348   0.005747126 
+  163          161.97175    135.06682   0.006134969 
+  169          163.59108    135.05023   0.00591716 
+  166          165.61998    135.03371   0.006024096 
+  162          168.14665    135.01726   0.00617284 
+  197          171.26548    135.00088   0.005076142 
+  171          175.00414    134.98458   0.005847953 
+  212          179.17988    134.96834   0.004716981 
+  194          183.48684    134.95217   0.005154639 
+  182          188.09196    134.93607   0.005494505 
+  197          193.67708    134.92005   0.005076142 
+  208          200.7903     134.90409   0.004807692 
+  213          209.83986    134.88821   0.004694836 
+  214          221.62252    134.8724    0.004672897 
+  247          237.42304    134.85666   0.004048583 
+  263          258.99987    134.84099   0.003802281 
+  282          289.22601    134.82539   0.003546099 
+  333          333.96322    134.80987   0.003003003 
+  397          405.79745    134.79441   0.002518892 
+  550          528.28014    134.77903   0.001818182 
+  758          735.15998    134.76373   0.001319261 
+  1006         1050.35924   134.74849   0.000994036 
+  1324         1395.59917   134.73333   0.000755287 
+  1366         1473.39379   134.71824   0.000732064 
+  1047         1192.01164   134.70322   0.00095511 
+  836          860.71042    134.68828   0.001196172 
+  634          634.82736    134.67341   0.001577287 
+  517          512.93259    134.65862   0.001934236 
+  485          468.65882    134.6439    0.002061856 
+  477          488.16709    134.62925   0.002096436 
+  556          572.69441    134.61468   0.001798561 
+  685          719.76809    134.60018   0.001459854 
+  781          859.18573    134.58575   0.00128041 
+  722          831.79307    134.57141   0.001385042 
+  635          657.6661     134.55713   0.001574803 
+  448          490.40642    134.54293   0.002232143 
+  366          377.83867    134.52881   0.00273224 
+  319          309.1098     134.51476   0.003134796 
+  271          267.35852    134.50079   0.003690037 
+  237          240.72216    134.48689   0.004219409 
+  222          222.54189    134.47307   0.004504505 
+  209          209.58088    134.45932   0.004784689 
+  205          199.99154    134.44565   0.004878049 
+  200          192.67746    134.43206   0.005     
+  173          187.19267    134.41854   0.005780347 
+  191          183.0297     134.40511   0.005235602 
+  191          179.30571    134.39174   0.005235602 
+  196          175.40802    134.37846   0.005102041 
+  182          171.51501    134.36525   0.005494505 
+  169          167.91437    134.35212   0.00591716 
+  177          164.73896    134.33907   0.005649718 
+  164          162.11378    134.32609   0.006097561 
+  174          160.05873    134.31319   0.005747126 
+  165          158.50584    134.30038   0.006060606 
+  159          157.36705    134.28763   0.006289308 
+  184          156.50413    134.27497   0.005434783 
+  167          155.74031    134.26239   0.005988024 
+  172          155.0106     134.24988   0.005813953 
+  167          154.42035    134.23746   0.005988024 
+  167          154.06606    134.22511   0.005988024 
+  177          153.94477    134.21284   0.005649718 
+  164          153.97122    134.20066   0.006097561 
+  166          154.04039    134.18855   0.006024096 
+  165          154.10867    134.17652   0.006060606 
+  166          154.19122    134.16457   0.006024096 
+  164          154.30256    134.15271   0.006097561 
+  140          154.52944    134.14092   0.007142857 
+  157          155.0388     134.12921   0.006369427 
+  139          155.96764    134.11758   0.007194245 
+  160          157.45645    134.10604   0.00625   
+  160          159.68887    134.09458   0.00625   
+  189          162.91406    134.08319   0.005291005 
+  183          167.44808    134.07189   0.005464481 
+  177          173.74454    134.06067   0.005649718 
+  158          182.44339    134.04953   0.006329114 
+  215          193.84271    134.03848   0.004651163 
+  224          205.98832    134.02751   0.004464286 
+  186          212.94061    134.01661   0.005376344 
+  212          209.02729    134.00581   0.004716981 
+  179          197.73414    133.99508   0.005586592 
+  189          186.50855    133.98444   0.005291005 
+  192          178.74052    133.97388   0.005208333 
+  180          174.76035    133.9634    0.005555556 
+  153          174.06715    133.95301   0.006535948 
+  173          176.33349    133.9427    0.005780347 
+  179          181.33069    133.93247   0.005586592 
+  202          187.92615    133.92233   0.004950495 
+  194          193.16145    133.91227   0.005154639 
+  182          194.25962    133.9023    0.005494505 
+  186          192.64927    133.89241   0.005376344 
+  171          190.52668    133.88261   0.005847953 
+  173          186.88424    133.87289   0.005780347 
+  180          180.9305     133.86325   0.005555556 
+  156          174.535      133.85371   0.006410256 
+  175          169.56523    133.84424   0.005714286 
+  193          166.53616    133.83486   0.005181347 
+  184          165.2845     133.82557   0.005434783 
+  181          165.59037    133.81637   0.005524862 
+  168          167.42231    133.80725   0.005952381 
+  174          170.73202    133.79821   0.005747126 
+  166          174.90641    133.78927   0.006024096 
+  152          178.66541    133.78041   0.006578947 
+  153          181.31876    133.77164   0.006535948 
+  175          183.19036    133.76295   0.005714286 
+  158          183.96057    133.75435   0.006329114 
+  181          182.40044    133.74584   0.005524862 
+  167          178.62944    133.73742   0.005988024 
+  166          174.66031    133.72908   0.006024096 
+  150          172.01081    133.72083   0.006666667 
+  165          170.847      133.71268   0.006060606 
+  186          170.54117    133.7046    0.005376344 
+  155          170.62622    133.69662   0.006451613 
+  194          171.24705    133.68873   0.005154639 
+  172          172.40552    133.68093   0.005813953 
+  184          173.49524    133.67321   0.005434783 
+  178          173.62776    133.66559   0.005617978 
+  157          172.65463    133.65805   0.006369427 
+  168          171.53461    133.6506    0.005952381 
+  173          171.10739    133.64325   0.005780347 
+  170          171.51225    133.63598   0.005882353 
+  196          172.45475    133.62881   0.005102041 
+  180          173.67763    133.62172   0.005555556 
+  188          175.29068    133.61473   0.005319149 
+  180          177.53789    133.60782   0.005555556 
+  179          180.57356    133.60101   0.005586592 
+  204          184.50735    133.59429   0.004901961 
+  194          189.48453    133.58766   0.005154639 
+  184          195.71118    133.58112   0.005434783 
+  219          203.4573     133.57468   0.00456621 
+  207          213.01346    133.56832   0.004830918 
+  232          224.61189    133.56206   0.004310345 
+  246          238.60783    133.55589   0.004065041 
+  270          256.12601    133.54982   0.003703704 
+  277          279.30871    133.54383   0.003610108 
+  334          311.24787    133.53794   0.002994012 
+  404          356.84233    133.53215   0.002475248 
+  448          425.16464    133.52644   0.002232143 
+  536          533.55925    133.52083   0.001865672 
+  757          712.6898     133.51532   0.001321004 
+  1108         1007.15805   133.5099    0.000902527 
+  1460         1456.46909   133.50457   0.000684932 
+  1757         1987.82486   133.49933   0.000569152 
+  1997         2211.76384   133.4942    0.000500751 
+  1775         1863.85513   133.48915   0.00056338 
+  1321         1345.98713   133.4842    0.000757002 
+  961          961.94884    133.47935   0.001040583 
+  792          738.08325    133.47459   0.001262626 
+  666          634.02048    133.46993   0.001501502 
+  632          619.62654    133.46536   0.001582278 
+  782          688.15552    133.46089   0.001278772 
+  823          848.13668    133.45652   0.001215067 
+  1040         1083.40882   133.45224   0.000961538 
+  1162         1245.20511   133.44806   0.000860585 
+  1069         1126.72051   133.44398   0.000935454 
+  785          850.66559    133.43999   0.001273885 
+  637          615.88385    133.4361    0.001569859 
+  496          462.28177    133.43231   0.002016129 
+  384          369.36852    133.42861   0.002604167 
+  320          313.04425    133.42502   0.003125  
+  304          276.77737    133.42152   0.003289474 
+  270          251.53447    133.41812   0.003703704 
+  247          233.07471    133.41482   0.004048583 
+  204          219.20271    133.41161   0.004901961 
+  193          208.63988    133.40851   0.005181347 
+  205          200.51768    133.40551   0.004878049 
+  194          194.26009    133.4026    0.005154639 
+  191          189.49813    133.39979   0.005235602 
+  197          185.99285    133.39709   0.005076142 
+  210          183.54745    133.39448   0.004761905 
+  187          181.92114    133.39198   0.005347594 
+  192          180.86931    133.38957   0.005208333 
+  181          180.07183    133.38727   0.005524862 
+  176          178.86792    133.38506   0.005681818 
+  177          176.85012    133.38296   0.005649718 
+  185          174.57691    133.38096   0.005405405 
+  177          172.7612     133.37905   0.005649718 
+  188          171.53648    133.37726   0.005319149 
+  172          170.69624    133.37556   0.005813953 
+  167          170.24583    133.37396   0.005988024 
+  160          170.45038    133.37247   0.00625   
+  166          171.48127    133.37108   0.006024096 
+  178          173.2567     133.36979   0.005617978 
+  191          175.46148    133.36861   0.005235602 
+  161          177.94362    133.36753   0.00621118 
+  189          181.43577    133.36655   0.005291005 
+  181          187.46141    133.36567   0.005524862 
+  192          197.51764    133.3649    0.005208333 
+  220          212.04005    133.36424   0.004545455 
+  207          227.52408    133.36367   0.004830918 
+  237          233.64229    133.36322   0.004219409 
+  225          224.67642    133.36286   0.004444444 
+  189          210.13102    133.36261   0.005291005 
+  212          198.93845    133.36247   0.004716981 
+  186          193.04836    133.36243   0.005376344 
+  198          191.9345     133.3625    0.005050505 
+  197          195.0343     133.36267   0.005076142 
+  182          201.40567    133.36295   0.005494505 
+  195          208.51618    133.36334   0.005128205 
+  214          213.25079    133.36383   0.004672897 
+  195          213.86155    133.36443   0.005128205 
+  174          207.97924    133.36513   0.005747126 
+  172          197.31137    133.36594   0.005813953 
+  211          186.98545    133.36686   0.004739336 
+  161          179.39156    133.36789   0.00621118 
+  182          174.75666    133.36902   0.005494505 
+  177          172.65255    133.37027   0.005649718 
+  193          172.44911    133.37162   0.005181347 
+  188          172.96431    133.37308   0.005319149 
+  167          172.42815    133.37464   0.005988024 
+  154          170.31714    133.37632   0.006493506 
+  168          168.17067    133.37811   0.005952381 
+  145          167.08291    133.38      0.006896552 
+  173          166.96681    133.38201   0.005780347 
+  169          167.38431    133.38412   0.00591716 
+  155          168.07758    133.38634   0.006451613 
+  171          168.72761    133.38868   0.005847953 
+  196          168.98528    133.39112   0.005102041 
+  171          168.97586    133.39368   0.005847953 
+  189          168.73355    133.39635   0.005291005 
+  165          167.7754     133.39912   0.006060606 
+  153          166.15159    133.40201   0.006535948 
+  169          164.6378     133.40501   0.00591716 
+  179          163.80431    133.40812   0.005586592 
+  180          163.74036    133.41135   0.005555556 
+  201          164.27206    133.41468   0.004975124 
+  166          165.15097    133.41813   0.006024096 
+  181          166.08642    133.42169   0.005524862 
+  182          166.94188    133.42537   0.005494505 
+  170          167.83892    133.42916   0.005882353 
+  169          168.70222    133.43306   0.00591716 
+  167          169.30458    133.43707   0.005988024 
+  174          169.7407     133.4412    0.005747126 
+  163          170.19125    133.44544   0.006134969 
+  193          170.66998    133.4498    0.005181347 
+  192          171.27633    133.45427   0.005208333 
+  194          172.20474    133.45886   0.005154639 
+  205          173.5753     133.46356   0.004878049 
+  194          175.42176    133.46838   0.005154639 
+  181          177.75198    133.47331   0.005524862 
+  200          180.5859     133.47836   0.005     
+  193          183.96114    133.48352   0.005181347 
+  185          187.92857    133.4888    0.005405405 
+  204          192.51695    133.4942    0.004901961 
+  216          197.72965    133.49971   0.00462963 
+  217          203.66459    133.50534   0.004608295 
+  210          210.61454    133.51109   0.004761905 
+  253          218.99772    133.51695   0.003952569 
+  254          229.3105     133.52294   0.003937008 
+  247          242.2092     133.52904   0.004048583 
+  241          258.64945    133.53526   0.004149378 
+  290          280.05026    133.54159   0.003448276 
+  321          308.43264    133.54805   0.003115265 
+  342          346.33486    133.55463   0.002923977 
+  402          395.92061    133.56132   0.002487562 
+  434          456.4504     133.56813   0.002304147 
+  588          527.24599    133.57507   0.00170068 
+  618          624.60634    133.58212   0.001618123 
+  743          786.7328     133.58929   0.001345895 
+  1117         1067.81707   133.59658   0.000895255 
+  1475         1534.61171   133.604     0.000677966 
+  2065         2222.9946    133.61153   0.000484262 
+  2637         2941.41011   133.61919   0.000379219 
+  2695         3081.73098   133.62697   0.000371058 
+  2235         2491.11547   133.63487   0.000447427 
+  1674         1785.89947   133.64289   0.000597372 
+  1297         1286.63854   133.65103   0.00077101 
+  970          993.22665    133.65929   0.001030928 
+  874          849.92711    133.66768   0.001144165 
+  862          821.8821     133.67619   0.001160093 
+  901          903.13751    133.68483   0.001109878 
+  1125         1107.36148   133.69358   0.000888889 
+  1335         1429.96344   133.70246   0.000749064 
+  1474         1736.7919    133.71147   0.000678426 
+  1450         1715.74349   133.7206    0.000689655 
+  1223         1357.47474   133.72985   0.000817661 
+  914          977.47291    133.73923   0.001094092 
+  671          708.35262    133.74873   0.001490313 
+  575          540.61953    133.75836   0.00173913 
+  462          439.95768    133.76811   0.002164502 
+  416          379.28281    133.77799   0.002403846 
+  357          342.25256    133.78799   0.00280112 
+  297          319.28583    133.79812   0.003367003 
+  296          302.13692    133.80838   0.003378378 
+  303          284.06698    133.81876   0.00330033 
+  259          265.80948    133.82927   0.003861004 
+  242          251.15905    133.83991   0.004132231 
+  227          241.005      133.85068   0.004405286 
+  223          233.96592    133.86157   0.004484305 
+  239          227.73481    133.87259   0.0041841 
+  210          220.92813    133.88374   0.004761905 
+  213          214.13598    133.89502   0.004694836 
+  195          208.12538    133.90642   0.005128205 
+  214          202.74592    133.91796   0.004672897 
+  204          197.88818    133.92962   0.004901961 
+  189          193.96969    133.94142   0.005291005 
+  189          191.3832     133.95334   0.005291005 
+  191          190.24791    133.9654    0.005235602 
+  170          190.45321    133.97758   0.005882353 
+  209          191.51374    133.9899    0.004784689 
+  192          192.43323    134.00234   0.005208333 
+  191          192.29308    134.01492   0.005235602 
+  185          191.0581     134.02763   0.005405405 
+  170          189.372      134.04047   0.005882353 
+  194          187.87859    134.05344   0.005154639 
+  182          186.85917    134.06654   0.005494505 
+  174          186.28235    134.07978   0.005747126 
+  181          186.08053    134.09315   0.005524862 
+  174          186.56908    134.10665   0.005747126 
+  196          188.04804    134.12029   0.005102041 
+  181          190.20062    134.13406   0.005524862 
+  173          191.98505    134.14796   0.005780347 
+  196          191.90052    134.162     0.005102041 
+  160          189.56296    134.17617   0.00625   
+  182          185.96497    134.19048   0.005494505 
+  179          182.55362    134.20492   0.005586592 
+  202          180.04999    134.21949   0.004950495 
+  156          178.46235    134.23421   0.006410256 
+  167          177.59157    134.24905   0.005988024 
+  160          177.47645    134.26404   0.00625   
+  166          178.26465    134.27916   0.006024096 
+  213          179.87453    134.29441   0.004694836 
+  171          181.83875    134.30981   0.005847953 
+  157          183.44166    134.32534   0.006369427 
+  183          183.71503    134.34101   0.005464481 
+  182          181.96867    134.35681   0.005494505 
+  188          178.40032    134.37276   0.005319149 
+  178          174.26161    134.38884   0.005617978 
+  187          170.65837    134.40506   0.005347594 
+  164          167.98692    134.42142   0.006097561 
+  169          166.247      134.43792   0.00591716 
+  169          165.35463    134.45456   0.00591716 
+  167          165.26149    134.47133   0.005988024 
+  172          165.96755    134.48825   0.005813953 
+  162          167.44238    134.50531   0.00617284 
+  181          169.43047    134.52251   0.005524862 
+  162          171.28894    134.53985   0.00617284 
+  184          172.25631    134.55733   0.005434783 
+  171          171.94997    134.57495   0.005847953 
+  181          170.70248    134.59271   0.005524862 
+  147          169.54151    134.61062   0.006802721 
+  186          169.37604    134.62867   0.005376344 
+  180          170.51442    134.64686   0.005555556 
+  151          172.59325    134.66519   0.006622517 
+  156          174.4141     134.68367   0.006410256 
+  166          174.52731    134.70229   0.006024096 
+  188          172.87413    134.72105   0.005319149 
+  155          170.75278    134.73996   0.006451613 
+  151          169.13121    134.75901   0.006622517 
+  185          168.04139    134.77821   0.005405405 
+  161          167.23941    134.79755   0.00621118 
+  153          166.89742    134.81703   0.006535948 
+  184          167.40771    134.83667   0.005434783 
+  160          168.98738    134.85644   0.00625   
+  181          171.5381     134.87637   0.005524862 
+  191          174.45083    134.89644   0.005235602 
+  172          176.63986    134.91666   0.005813953 
+  148          177.49684    134.93702   0.006756757 
+  188          177.39516    134.95753   0.005319149 
+  186          176.78407    134.97819   0.005376344 
+  192          176.00478    134.999     0.005208333 
+  190          175.5746     135.01995   0.005263158 
+  205          175.87244    135.04106   0.004878049 
+  188          177.01585    135.06231   0.005319149 
+  169          179.02511    135.08371   0.00591716 
+  212          181.89226    135.10526   0.004716981 
+  205          185.45055    135.12696   0.004878049 
+  208          189.41011    135.14881   0.004807692 
+  224          193.6968     135.17081   0.004464286 
+  193          198.60471    135.19297   0.005181347 
+  215          204.55064    135.21527   0.004651163 
+  217          211.97768    135.23772   0.004608295 
+  255          221.56649    135.26033   0.003921569 
+  264          234.15612    135.28308   0.003787879 
+  256          250.67185    135.30599   0.00390625 
+  285          272.31213    135.32906   0.003508772 
+  317          300.96398    135.35227   0.003154574 
+  356          340.79197    135.37564   0.002808989 
+  431          401.33226    135.39916   0.002320186 
+  539          500.18337    135.42283   0.001855288 
+  694          664.15979    135.44666   0.001440922 
+  1007         924.01371    135.47065   0.000993049 
+  1209         1279.54013   135.49479   0.00082713 
+  1349         1584.06417   135.51908   0.00074129 
+  1462         1547.56307   135.54353   0.000683995 
+  1151         1220.09363   135.56813   0.00086881 
+  907          891.49129    135.59289   0.001102536 
+  727          667.39399    135.61781   0.001375516 
+  586          537.26514    135.64288   0.001706485 
+  535          473.94456    135.66811   0.001869159 
+  487          460.3639     135.6935    0.002053388 
+  571          493.19495    135.71904   0.001751313 
+  653          579.35315    135.74474   0.001531394 
+  760          723.757      135.7706    0.001315789 
+  838          891.92345    135.79662   0.001193317 
+  873          955.78738    135.8228    0.001145475 
+  786          828.16638    135.84914   0.001272265 
+  641          632.6712     135.87563   0.001560062 
+  516          476.93836    135.90229   0.001937984 
+  418          374.88187    135.92911   0.002392344 
+  355          312.17063    135.95608   0.002816901 
+  303          274.13755    135.98322   0.00330033 
+  280          250.92892    136.01052   0.003571429 
+  252          236.93995    136.03798   0.003968254 
+  263          228.57747    136.0656    0.003802281 
+  267          221.93037    136.09339   0.003745318 
+  222          213.37557    136.12134   0.004504505 
+  197          203.42129    136.14944   0.005076142 
+  206          194.59826    136.17772   0.004854369 
+  213          187.78959    136.20615   0.004694836 
+  201          182.63343    136.23475   0.004975124 
+  183          178.50335    136.26352   0.005464481 
+  208          174.9518     136.29245   0.004807692 
+  167          171.83304    136.32154   0.005988024 
+  178          169.15226    136.3508    0.005617978 
+  154          166.92232    136.38022   0.006493506 
+  166          165.11645    136.40981   0.006024096 
+  165          163.70464    136.43957   0.006060606 
+  163          162.69122    136.46949   0.006134969 
+  168          162.09596    136.49958   0.005952381 
+  175          161.90201    136.52984   0.005714286 
+  186          161.99329    136.56026   0.005376344 
+  158          162.08698    136.59085   0.006329114 
+  166          161.88155    136.62161   0.006024096 
+  169          161.37217    136.65254   0.00591716 
+  190          160.81535    136.68364   0.005263158 
+  140          160.46692    136.7149    0.007142857 
+  153          160.51707    136.74634   0.006535948 
+  133          161.03059    136.77795   0.007518797 
+  186          161.83412    136.80972   0.005376344 
+  183          162.40559    136.84167   0.005464481 
+  150          162.09156    136.87379   0.006666667 
+  148          160.89829    136.90608   0.006756757 
+  176          159.47871    136.93854   0.005681818 
+  143          158.29306    136.97117   0.006993007 
+  161          157.44475    137.00398   0.00621118 
+  151          156.98385    137.03695   0.006622517 
+  137          156.98882    137.07011   0.00729927 
+  146          157.54762    137.10343   0.006849315 
+  182          158.76675    137.13693   0.005494505 
+  139          160.6025     137.1706    0.007194245 
+  155          163.20592    137.20445   0.006451613 
+  176          166.07266    137.23847   0.005681818 
+  176          168.38043    137.27267   0.005681818 
+  148          169.06781    137.30704   0.006756757 
+  163          167.63385    137.34159   0.006134969 
+  154          164.96643    137.37631   0.006493506 
+  153          162.48623    137.41122   0.006535948 
+  171          161.01432    137.4463    0.005847953 
+  146          160.77967    137.48155   0.006849315 
+  156          161.66225    137.51699   0.006410256 
+  168          163.00711    137.5526    0.005952381 
+  145          163.84111    137.58839   0.006896552 
+  169          163.7641     137.62436   0.00591716 
+  165          163.67265    137.66051   0.006060606 
+  156          164.0606     137.69684   0.006410256 
+  164          164.40906    137.73334   0.006097561 
+  149          164.00494    137.77003   0.006711409 
+  150          162.75913    137.8069    0.006666667 
+  173          161.15121    137.84395   0.005780347 
+  142          159.74648    137.88118   0.007042254 
+  160          158.83463    137.9186    0.00625   
+  168          158.41236    137.95619   0.005952381 
+  166          158.16414    137.99397   0.006024096 
+  165          157.56615    138.03193   0.006060606 
+  166          156.57301    138.07008   0.006024096 
+  165          155.72883    138.10841   0.006060606 
+  183          155.41455    138.14692   0.005464481 
+  159          155.67105    138.18562   0.006289308 
+  155          156.35484    138.2245    0.006451613 
+  179          157.30445    138.26357   0.005586592 
+  169          158.57233    138.30282   0.00591716 
+  166          160.38851    138.34226   0.006024096 
+  196          162.82363    138.38188   0.005102041 
+  159          165.45391    138.4217    0.006289308 
+  195          167.26287    138.46169   0.005128205 
+  151          167.36712    138.50188   0.006622517 
+  159          165.77507    138.54226   0.006289308 
+  179          163.05199    138.58282   0.005586592 
+  157          160.0356     138.62357   0.006369427 
+  154          157.474      138.66451   0.006493506 
+  170          155.68399    138.70564   0.005882353 
+  151          154.68853    138.74696   0.006622517 
+  154          154.42812    138.78847   0.006493506 
+  139          154.84483    138.83017   0.007194245 
+  161          155.84045    138.87206   0.00621118 
+  151          157.14002    138.91415   0.006622517 
+  179          158.20426    138.95642   0.005586592 
+  146          158.7769     138.99889   0.006849315 
+  173          158.44838    139.04155   0.005780347 
+  172          157.70715    139.0844    0.005813953 
+  145          156.97613    139.12745   0.006896552 
+  153          156.60508    139.17069   0.006535948 
+  155          156.64326    139.21412   0.006451613 
+  159          156.86017    139.25775   0.006289308 
+  169          156.96606    139.30157   0.00591716 
+  150          156.97248    139.34559   0.006666667 
+  132          157.11369    139.38981   0.007575758 
+  171          157.52078    139.43422   0.005847953 
+  177          158.2472     139.47883   0.005649718 
+  168          159.29587    139.52363   0.005952381 
+  158          160.56534    139.56864   0.006329114 
+  146          161.75424    139.61384   0.006849315 
+  145          162.19259    139.65923   0.006896552 
+  160          161.51593    139.70483   0.00625   
+  159          159.96376    139.75063   0.006289308 
+  163          158.36093    139.79662   0.006134969 
+  147          157.0083     139.84282   0.006802721 
+  149          155.9739     139.88921   0.006711409 
+  165          155.32095    139.93581   0.006060606 
+  163          155.04836    139.98261   0.006134969 
+  145          155.12241    140.02961   0.006896552 
+  166          155.50911    140.07681   0.006024096 
+  187          156.14431    140.12421   0.005347594 
+  156          156.9045     140.17182   0.006410256 
+  168          157.49946    140.21963   0.005952381 
+  160          157.67159    140.26764   0.00625   
+  163          157.60463    140.31586   0.006134969 
+  163          157.65722    140.36428   0.006134969 
+  180          157.81476    140.41291   0.005555556 
+  151          157.69271    140.46174   0.006622517 
+  155          157.05792    140.51078   0.006451613 
+  140          156.09947    140.56002   0.007142857 
+  167          155.14029    140.60947   0.005988024 
+  147          154.42298    140.65913   0.006802721 
+  168          154.07436    140.709     0.005952381 
+  128          154.13148    140.75907   0.0078125 
+  144          154.58686    140.80935   0.006944444 
+  158          155.39163    140.85984   0.006329114 
+  154          156.4297     140.91054   0.006493506 
+  140          157.52101    140.96145   0.007142857 
+  129          158.44509    141.01257   0.007751938 
+  148          159.02067    141.0639    0.006756757 
+  159          159.22762    141.11544   0.006289308 
+  148          159.14172    141.16719   0.006756757 
+  144          158.69679    141.21915   0.006944444 
+  162          157.86529    141.27133   0.00617284 
+  146          156.89498    141.32372   0.006849315 
+  154          156.09513    141.37632   0.006493506 
+  152          155.64767    141.42913   0.006578947 
+  157          155.594      141.48216   0.006369427 
+  144          155.88091    141.53541   0.006944444 
+  142          156.39445    141.58887   0.007042254 
+  123          157.0372     141.64254   0.008130081 
+  154          157.77624    141.69643   0.006493506 
+  144          158.62125    141.75054   0.006944444 
+  157          159.39334    141.80486   0.006369427 
+  169          159.61883    141.8594    0.00591716 
+  187          159.00692    141.91416   0.005347594 
+  149          157.86714    141.96913   0.006711409 
+  151          156.69956    142.02432   0.006622517 
+  159          155.78066    142.07974   0.006289308 
+  159          155.1829     142.13537   0.006289308 
+  139          154.88796    142.19122   0.007194245 
+  167          154.85342    142.24729   0.005988024 
+  161          155.03489    142.30359   0.00621118 
+  144          155.39097    142.3601    0.006944444 
+  152          155.86787    142.41684   0.006578947 
+  154          156.35708    142.4738    0.006493506 
+  143          156.68977    142.53098   0.006993007 
+  154          156.7536     142.58838   0.006493506 
+  156          156.6518     142.64601   0.006410256 
+  150          156.60532    142.70386   0.006666667 
+  145          156.73938    142.76193   0.006896552 
+  156          157.02368    142.82024   0.006410256 
+  165          157.35952    142.87876   0.006060606 
+  131          157.77764    142.93751   0.007633588 
+  151          158.42614    142.99649   0.006622517 
+  161          159.409      143.0557    0.00621118 
+  151          160.74443    143.11513   0.006622517 
+  169          162.15999    143.17479   0.00591716 
+  161          163.64279    143.23468   0.00621118 
+  155          164.56503    143.2948    0.006451613 
+  154          164.79699    143.35514   0.006493506 
+  167          164.76615    143.41572   0.005988024 
+  151          165.00443    143.47652   0.006622517 
+  171          165.76979    143.53756   0.005847953 
+  144          167.02883    143.59883   0.006944444 
+  156          168.54394    143.66033   0.006410256 
+  188          170.04258    143.72206   0.005319149 
+  185          171.51892    143.78402   0.005405405 
+  159          173.20911    143.84622   0.006289308 
+  162          175.43712    143.90865   0.00617284 
+  189          177.63624    143.97132   0.005291005 
+  189          178.62232    144.03421   0.005291005 
+  207          177.61661    144.09735   0.004830918 
+  165          175.45822    144.16072   0.006060606 
+  181          173.46904    144.22432   0.005524862 
+  176          172.24844    144.28816   0.005681818 
+  193          171.85845    144.35224   0.005181347 
+  182          172.17159    144.41656   0.005494505 
+  169          172.96647    144.48111   0.00591716 
+  175          174.02369    144.54591   0.005714286 
+  214          175.27628    144.61094   0.004672897 
+  162          176.71156    144.67621   0.00617284 
+  208          178.18694    144.74172   0.004807692 
+  201          179.43415    144.80747   0.004975124 
+  193          180.15294    144.87346   0.005181347 
+  213          180.46222    144.9397    0.004694836 
+  204          181.01217    145.00617   0.004901961 
+  177          182.3043     145.07289   0.005649718 
+  209          184.44611    145.13985   0.004784689 
+  201          187.2111     145.20705   0.004975124 
+  219          189.96277    145.2745    0.00456621 
+  203          191.92447    145.34219   0.004926108 
+  214          192.99426    145.41013   0.004672897 
+  196          193.86194    145.47831   0.005102041 
+  209          195.16295    145.54674   0.004784689 
+  213          197.17629    145.61542   0.004694836 
+  208          200.05553    145.68434   0.004807692 
+  204          203.9557     145.75351   0.004901961 
+  242          208.99902    145.82293   0.004132231 
+  231          215.21369    145.8926    0.004329004 
+  243          222.44163    145.96251   0.004115226 
+  230          230.38452    146.03268   0.004347826 
+  245          238.96394    146.10309   0.004081633 
+  275          248.45647    146.17376   0.003636364 
+  272          259.39752    146.24467   0.003676471 
+  311          272.78737    146.31584   0.003215434 
+  302          290.10301    146.38726   0.003311258 
+  316          313.16724    146.45894   0.003164557 
+  345          344.43088    146.53087   0.002898551 
+  445          387.9349     146.60305   0.002247191 
+  443          450.90511    146.67548   0.002257336 
+  547          546.51284    146.74817   0.001828154 
+  759          697.22642    146.82112   0.001317523 
+  980          936.27509    146.89432   0.001020408 
+  1292         1299.95466   146.96778   0.000773994 
+  1612         1782.31559   147.04149   0.000620347 
+  1966         2197.32302   147.11546   0.000508647 
+  2012         2182.42035   147.18969   0.000497018 
+  1753         1760.76078   147.26418   0.000570451 
+  1277         1297.42166   147.33893   0.000783085 
+  1023         960.08228    147.41394   0.000977517 
+  855          748.86564    147.48921   0.001169591 
+  677          628.85446    147.56474   0.001477105 
+  702          571.21674    147.64053   0.001424501 
+  645          561.06178    147.71658   0.001550388 
+  680          597.28525    147.79289   0.001470588 
+  758          689.77096    147.86947   0.001319261 
+  876          852.3968     147.94631   0.001141553 
+  1073         1076.8446    148.02342   0.000931966 
+  1101         1260.62996   148.10079   0.000908265 
+  1098         1223.71267   148.17842   0.000910747 
+  942          994.83856    148.25632   0.001061571 
+  784          754.98057    148.33449   0.00127551 
+  616          579.5252     148.41293   0.001623377 
+  503          465.14729    148.49163   0.001988072 
+  417          392.93636    148.5706    0.002398082 
+  362          346.70681    148.64983   0.002762431 
+  300          315.78926    148.72934   0.003333333 
+  302          293.98311    148.80912   0.003311258 
+  275          277.81867    148.88916   0.003636364 
+  292          265.30998    148.96948   0.003424658 
+  258          255.35494    149.05007   0.003875969 
+  250          247.35366    149.13093   0.004     
+  256          240.88587    149.21207   0.00390625 
+  222          235.57762    149.29347   0.004504505 
+  235          231.08003    149.37515   0.004255319 
+  232          226.98975    149.45711   0.004310345 
+  240          222.93887    149.53934   0.004166667 
+  236          218.88631    149.62184   0.004237288 
+  214          215.06474    149.70462   0.004672897 
+  219          211.66099    149.78768   0.00456621 
+  242          208.72006    149.87101   0.004132231 
+  194          206.20936    149.95463   0.005154639 
+  223          204.07818    150.03852   0.004484305 
+  209          202.28363    150.12268   0.004784689 
+  203          200.79075    150.20713   0.004926108 
+  186          199.56066    150.29186   0.005376344 
+  187          198.54662    150.37687   0.005347594 
+  198          197.6882     150.46216   0.005050505 
+  197          196.88166    150.54773   0.005076142 
+  209          196.00834    150.63359   0.004784689 
+  200          195.08657    150.71972   0.005     
+  191          194.27825    150.80615   0.005235602 
+  218          193.7212     150.89285   0.004587156 
+  203          193.46255    150.97984   0.004926108 
+  200          193.48946    151.06712   0.005     
+  186          193.75694    151.15468   0.005376344 
+  183          194.20681    151.24252   0.005464481 
+  200          194.7961     151.33066   0.005     
+  213          195.51033    151.41908   0.004694836 
+  207          196.3466     151.50779   0.004830918 
+  197          197.30884    151.59679   0.005076142 
+  194          198.41561    151.68608   0.005154639 
+  221          199.70288    151.77566   0.004524887 
+  199          201.22245    151.86553   0.005025126 
+  205          203.03246    151.95569   0.004878049 
+  219          205.17331    152.04615   0.00456621 
+  198          207.62137    152.13689   0.005050505 
+  202          210.23051    152.22793   0.004950495 
+  179          212.71587    152.31927   0.005586592 
+  201          214.76522    152.4109    0.004975124 
+  229          216.26264    152.50282   0.004366812 
+  218          217.33052    152.59504   0.004587156 
+  228          217.98936    152.68755   0.004385965 
+  220          217.79767    152.78037   0.004545455 
+  230          216.16603    152.87347   0.004347826 
+  196          213.16687    152.96688   0.005102041 
+  204          209.60896    153.06059   0.004901961 
+  222          206.2323     153.1546    0.004504505 
+  242          203.58598    153.2489    0.004132231 
+  225          201.64227    153.34351   0.004444444 
+  222          200.28465    153.43842   0.004504505 
+  219          199.30385    153.53363   0.00456621 
+  204          198.46638    153.62914   0.004901961 
+  262          197.61865    153.72496   0.003816794 
+  203          196.75417    153.82108   0.004926108 
+  220          195.90126    153.9175    0.004545455 
+  201          194.90569    154.01423   0.004975124 
+  194          193.42759    154.11127   0.005154639 
+  242          191.3044     154.20861   0.004132231 
+  211          188.74536    154.30626   0.004739336 
+  202          186.24949    154.40421   0.004950495 
+  200          184.07422    154.50248   0.005     
+  198          182.32878    154.60105   0.005050505 
+  204          180.99266    154.69994   0.004901961 
+  215          179.95895    154.79913   0.004651163 
+  185          179.07613    154.89864   0.005405405 
+  210          178.26878    154.99845   0.004761905 
+  173          177.61967    155.09858   0.005780347 
+  192          177.27434    155.19903   0.005208333 
+  202          177.33258    155.29978   0.004950495 
+  187          177.81243    155.40085   0.005347594 
+  217          178.58498    155.50224   0.004608295 
+  180          179.25753    155.60394   0.005555556 
+  184          179.26705    155.70595   0.005434783 
+  194          178.41366    155.80829   0.005154639 
+  184          177.11303    155.91094   0.005434783 
+  192          175.8909     156.01391   0.005208333 
+  178          174.99531    156.1172    0.005617978 
+  189          174.43096    156.22081   0.005291005 
+  180          174.11237    156.32473   0.005555556 
+  207          173.97872    156.42898   0.004830918 
+  213          174.00189    156.53355   0.004694836 
+  170          174.16324    156.63845   0.005882353 
+  208          174.48451    156.74366   0.004807692 
+  177          175.00532    156.8492    0.005649718 
+  184          175.67384    156.95507   0.005434783 
+  177          176.28083    157.06126   0.005649718 
+  182          176.60908    157.16777   0.005494505 
+  188          176.71313    157.27461   0.005319149 
+  155          176.87874    157.38178   0.006451613 
+  185          177.35545    157.48928   0.005405405 
+  204          178.28047    157.5971    0.004901961 
+  184          179.74692    157.70526   0.005434783 
+  187          181.86736    157.81374   0.005347594 
+  205          184.82148    157.92255   0.004878049 
+  167          188.92914    158.0317    0.005988024 
+  193          194.79606    158.14118   0.005181347 
+  179          203.50589    158.25099   0.005586592 
+  233          216.71775    158.36113   0.004291845 
+  243          236.35572    158.47161   0.004115226 
+  248          262.82838    158.58242   0.004032258 
+  291          289.15077    158.69357   0.003436426 
+  267          296.9144     158.80505   0.003745318 
+  265          279.55245    158.91687   0.003773585 
+  232          254.33888    159.02903   0.004310345 
+  228          234.15247    159.14152   0.004385965 
+  222          221.25151    159.25436   0.004504505 
+  215          214.50868    159.36753   0.004651163 
+  225          212.64625    159.48105   0.004444444 
+  239          214.9806     159.5949    0.0041841 
+  227          221.48591    159.7091    0.004405286 
+  286          232.71257    159.82364   0.003496503 
+  239          249.48449    159.93853   0.0041841 
+  274          271.25993    160.05375   0.003649635 
+  282          292.2905     160.16933   0.003546099 
+  287          300.86217    160.28524   0.003484321 
+  283          289.08578    160.40151   0.003533569 
+  282          264.47528    160.51812   0.003546099 
+  231          240.59124    160.63508   0.004329004 
+  216          222.92581    160.75239   0.00462963 
+  237          211.29584    160.87004   0.004219409 
+  209          204.28017    160.98805   0.004784689 
+  211          200.66002    161.1064    0.004739336 
+  189          199.64646    161.22511   0.005291005 
+  227          200.79324    161.34417   0.004405286 
+  210          203.84948    161.46358   0.004761905 
+  198          208.56662    161.58335   0.005050505 
+  219          213.85486    161.70347   0.00456621 
+  196          216.62425    161.82395   0.005102041 
+  209          213.88339    161.94478   0.004784689 
+  180          207.08597    162.06597   0.005555556 
+  194          199.72839    162.18751   0.005154639 
+  195          193.55114    162.30941   0.005128205 
+  180          188.87957    162.43168   0.005555556 
+  181          185.56021    162.5543    0.005524862 
+  192          183.31172    162.67728   0.005208333 
+  173          181.86295    162.80062   0.005780347 
+  182          180.99766    162.92432   0.005494505 
+  171          180.54644    163.04839   0.005847953 
+  174          180.37036    163.17282   0.005747126 
+  174          180.36069    163.29762   0.005747126 
+  176          180.44642    163.42278   0.005681818 
+  169          180.60398    163.5483    0.00591716 
+  174          180.84901    163.67419   0.005747126 
+  180          181.17482    163.80045   0.005555556 
+  180          181.52917    163.92708   0.005555556 
+  162          181.90072    164.05407   0.00617284 
+  181          182.34919    164.18144   0.005524862 
+  187          182.8865     164.30917   0.005347594 
+  188          183.3443     164.43728   0.005319149 
+  147          183.41758    164.56575   0.006802721 
+  163          182.98711    164.6946    0.006134969 
+  160          182.27561    164.82383   0.00625   
+  185          181.56723    164.95343   0.005405405 
+  185          180.97812    165.0834    0.005405405 
+  181          180.50435    165.21375   0.005524862 
+  163          180.1497     165.34447   0.006134969 
+  170          179.95391    165.47557   0.005882353 
+  162          179.95475    165.60705   0.00617284 
+  160          180.1706     165.73891   0.00625   
+  172          180.59862    165.87115   0.005813953 
+  165          181.21177    166.00377   0.006060606 
+  190          181.92406    166.13677   0.005263158 
+  181          182.52282    166.27016   0.005524862 
+  172          182.70217    166.40392   0.005813953 
+  164          182.32551    166.53807   0.006097561 
+  170          181.59174    166.67261   0.005882353 
+  181          180.8083     166.80752   0.005524862 
+  171          180.14123    166.94283   0.005847953 
+  150          179.617      167.07852   0.006666667 
+  153          179.22025    167.2146    0.006535948 
+  149          178.9372     167.35107   0.006711409 
+  191          178.75638    167.48793   0.005235602 
+  178          178.67537    167.62518   0.005617978 
+  157          178.69961    167.76282   0.006369427 
+  171          178.82802    167.90085   0.005847953 
+  169          179.03844    168.03927   0.00591716 
+  187          179.27571    168.17809   0.005347594 
+  181          179.46232    168.3173    0.005524862 
+  148          179.55117    168.45691   0.006756757 
+  156          179.57652    168.59692   0.006410256 
+  176          179.61899    168.73732   0.005681818 
+  180          179.73608    168.87811   0.005555556 
+  173          179.94116    169.01931   0.005780347 
+  165          180.21071    169.16091   0.006060606 
+  186          180.49627    169.3029    0.005376344 
+  171          180.75892    169.4453    0.005847953 
+  177          181.00876    169.5881    0.005649718 
+  170          181.28756    169.7313    0.005882353 
+  200          181.62679    169.8749    0.005     
+  161          182.03601    170.01891   0.00621118 
+  170          182.5106     170.16333   0.005882353 
+  171          183.04155    170.30815   0.005847953 
+  158          183.61686    170.45338   0.006329114 
+  174          184.21675    170.59901   0.005747126 
+  165          184.83186    170.74506   0.006060606 
+  150          185.49784    170.89151   0.006666667 
+  190          186.28417    171.03837   0.005263158 
+  170          187.25412    171.18565   0.005882353 
+  188          188.44728    171.33334   0.005319149 
+  186          189.87437    171.48144   0.005376344 
+  178          191.4884     171.62995   0.005617978 
+  155          193.0987     171.77888   0.006451613 
+  184          194.33359    171.92823   0.005434783 
+  179          194.88942    172.07799   0.005586592 
+  214          194.87827    172.22817   0.004672897 
+  181          194.72263    172.37876   0.005524862 
+  188          194.76903    172.52978   0.005319149 
+  170          195.16625    172.68122   0.005882353 
+  195          195.94804    172.83307   0.005128205 
+  176          197.10581    172.98535   0.005681818 
+  182          198.57211    173.13805   0.005494505 
+  185          200.19565    173.29118   0.005405405 
+  171          201.83725    173.44473   0.005847953 
+  167          203.45641    173.5987    0.005988024 
+  172          205.04933    173.7531    0.005813953 
+  212          206.6407     173.90793   0.004716981 
+  191          208.30766    174.06318   0.005235602 
+  174          210.07257    174.21887   0.005747126 
+  190          211.93111    174.37498   0.005263158 
+  184          214.04127    174.53153   0.005434783 
+  189          216.80535    174.6885    0.005291005 
+  237          220.60062    174.84591   0.004219409 
+  210          225.27119    175.00376   0.004761905 
+  206          230.27178    175.16203   0.004854369 
+  238          236.19816    175.32075   0.004201681 
+  244          245.39801    175.47989   0.004098361 
+  251          260.75782    175.63948   0.003984064 
+  290          284.99622    175.7995    0.003448276 
+  307          318.98154    175.95996   0.003257329 
+  336          355.02566    176.12087   0.00297619 
+  350          369.84716    176.28221   0.002857143 
+  357          349.24492    176.44399   0.00280112 
+  315          313.04089    176.60622   0.003174603 
+  261          281.75694    176.76889   0.003831418 
+  249          260.4133     176.932     0.004016064 
+  259          247.55363    177.09557   0.003861004 
+  249          240.67173    177.25957   0.004016064 
+  214          237.34665    177.42403   0.004672897 
+  243          235.78371    177.58893   0.004115226 
+  222          235.69713    177.75428   0.004504505 
+  235          238.1692     177.92008   0.004255319 
+  228          244.71053    178.08633   0.004385965 
+  234          256.60003    178.25304   0.004273504 
+  291          273.41123    178.42019   0.003436426 
+  260          288.69292    178.5878    0.003846154 
+  295          289.74401    178.75587   0.003389831 
+  252          275.07889    178.92439   0.003968254 
+  235          256.76469    179.09337   0.004255319 
+  231          242.01733    179.2628    0.004329004 
+  243          231.52062    179.4327    0.004115226 
+  235          224.27311    179.60305   0.004255319 
+  235          219.35315    179.77387   0.004255319 
+  199          216.00298    179.94514   0.005025126 
+  213          213.58237    180.11688   0.004694836 
+  191          211.6761     180.28908   0.005235602 
+  189          210.11271    180.46175   0.005291005 
+  188          208.84735    180.63488   0.005319149 
+  204          207.90325    180.80848   0.004901961 
+  198          207.33647    180.98254   0.005050505 
+  204          207.16527    181.15708   0.004901961 
+  197          207.31574    181.33208   0.005076142 
+  213          207.62653    181.50755   0.004694836 
+  195          207.89676    181.6835    0.005128205 
+  196          207.98427    181.85991   0.005102041 
+  221          207.88251    182.0368    0.004524887 
+  206          207.6926     182.21417   0.004854369 
+  180          207.4858     182.39201   0.005555556 
+  225          207.24126    182.57032   0.004444444 
+  202          206.96899    182.74912   0.004950495 
+  208          206.75615    182.92839   0.004807692 
+  181          206.65683    183.10814   0.005524862 
+  189          206.67681    183.28837   0.005291005 
+  196          206.84726    183.46908   0.005102041 
+  205          207.21299    183.65027   0.004878049 
+  192          207.75511    183.83195   0.005208333 
+  190          208.35061    184.01411   0.005263158 
+  206          208.83901    184.19676   0.004854369 
+  211          209.1826     184.37989   0.004739336 
+  200          209.51423    184.56351   0.005     
+  196          209.99753    184.74762   0.005102041 
+  225          210.70482    184.93221   0.004444444 
+  186          211.60263    185.1173    0.005376344 
+  209          212.59324    185.30288   0.004784689 
+  209          213.55643    185.48895   0.004784689 
+  203          214.34822    185.67552   0.004926108 
+  202          214.86639    185.86258   0.004950495 
+  206          215.18886    186.05013   0.004854369 
+  182          215.52356    186.23818   0.005494505 
+  213          216.03471    186.42673   0.004694836 
+  188          216.76879    186.61578   0.005319149 
+  190          217.68312    186.80533   0.005263158 
+  235          218.71334    186.99537   0.004255319 
+  228          219.85308    187.18592   0.004385965 
+  195          221.16783    187.37698   0.005128205 
+  180          222.73881    187.56853   0.005555556 
+  203          224.63216    187.76059   0.004926108 
+  223          226.9011     187.95316   0.004484305 
+  205          229.57955    188.14623   0.004878049 
+  213          232.63868    188.33982   0.004694836 
+  238          235.90647    188.53391   0.004201681 
+  214          239.00744    188.72851   0.004672897 
+  219          241.45254    188.92362   0.00456621 
+  238          242.99031    189.11924   0.004201681 
+  226          243.8974     189.31538   0.004424779 
+  200          244.62572    189.51203   0.005     
+  225          245.27589    189.7092    0.004444444 
+  213          245.65153    189.90689   0.004694836 
+  236          245.70617    190.10509   0.004237288 
+  230          245.67489    190.30381   0.004347826 
+  213          245.83821    190.50305   0.004694836 
+  222          246.3745     190.70281   0.004504505 
+  270          247.37802    190.90309   0.003703704 
+  213          248.88815    191.1039    0.004694836 
+  233          250.90036    191.30523   0.004291845 
+  250          253.35156    191.50708   0.004     
+  249          255.96324    191.70947   0.004016064 
+  211          258.67504    191.91238   0.004739336 
+  253          261.16005    192.11581   0.003952569 
+  248          263.5125     192.31978   0.004032258 
+  251          266.0339     192.52428   0.003984064 
+  303          268.91324    192.72931   0.00330033 
+  248          272.16058    192.93487   0.004032258 
+  275          275.82304    193.14097   0.003636364 
+  282          280.15922    193.3476    0.003546099 
+  273          285.6122     193.55477   0.003663004 
+  294          292.59477    193.76247   0.003401361 
+  330          300.87642    193.97072   0.003030303 
+  358          308.60233    194.1795    0.002793296 
+  314          312.64392    194.38882   0.003184713 
+  325          312.42714    194.59869   0.003076923 
+  307          310.661      194.8091    0.003257329 
+  348          309.88112    195.02005   0.002873563 
+  339          310.8618     195.23155   0.002949853 
+  341          313.4619     195.4436    0.002932551 
+  381          317.42782    195.65619   0.002624672 
+  353          322.67291    195.86933   0.002832861 
+  357          329.22499    196.08302   0.00280112 
+  356          337.13979    196.29726   0.002808989 
+  370          346.5067     196.51206   0.002702703 
+  372          357.50325    196.7274    0.002688172 
+  379          370.40505    196.9433    0.002638522 
+  422          385.41188    197.15976   0.002369668 
+  384          402.19861    197.37677   0.002604167 
+  408          419.62708    197.59434   0.00245098 
+  456          437.01021    197.81247   0.002192982 
+  495          455.68117    198.03116   0.002020202 
+  500          477.82769    198.25042   0.002     
+  529          505.00487    198.47023   0.001890359 
+  554          538.27218    198.69061   0.001805054 
+  629          578.77438    198.91155   0.001589825 
+  708          628.29275    199.13306   0.001412429 
+  765          689.78125    199.35513   0.00130719 
+  835          767.7132     199.57778   0.001197605 
+  978          868.43234    199.80099   0.001022495 
+  1082         1001.11245   200.02477   0.000924214 
+  1305         1179.52207   200.24913   0.000766284 
+  1615         1426.80304   200.47406   0.000619195 
+  1952         1784.14217   200.69956   0.000512295 
+  2544         2319.16369   200.92564   0.000393082 
+  3227         3124.78684   201.15229   0.000309885 
+  4555         4293.74713   201.37953   0.000219539 
+  5752         5800.83138   201.60734   0.000173853 
+  6933         7181.31089   201.83573   0.000144238 
+  7226         7460.85658   202.0647    0.000138389 
+  6570         6383.5693    202.29426   0.000152207 
+  5370         4856.78334   202.5244    0.00018622 
+  4111         3576.45568   202.75512   0.00024325 
+  3311         2681.67167   202.98643   0.000302024 
+  2616         2102.35019   203.21833   0.000382263 
+  2219         1745.61056   203.45082   0.000450653 
+  1934         1540.91379   203.6839    0.000517063 
+  1841         1445.72207   203.91756   0.000543183 
+  1840         1442.86888   204.15182   0.000543478 
+  1800         1538.54116   204.38668   0.000555556 
+  2062         1759.70667   204.62212   0.000484966 
+  2437         2148.41003   204.85817   0.000410341 
+  2843         2738.86127   205.09481   0.000351741 
+  3425         3470.53012   205.33205   0.000291971 
+  3870         4011.37322   205.56989   0.000258398 
+  3764         3891.74044   205.80833   0.000265675 
+  3290         3197.38283   206.04737   0.000303951 
+  2803         2418.02274   206.28702   0.000356761 
+  2180         1805.01365   206.52727   0.000458716 
+  1762         1378.33187   206.76812   0.000567537 
+  1398         1092.68945   207.00959   0.000715308 
+  1211         901.40646    207.25166   0.000825764 
+  958          769.79794    207.49434   0.001043841 
+  825          675.41903    207.73763   0.001212121 
+  760          604.72107    207.98154   0.001315789 
+  690          549.99017    208.22606   0.001449275 
+  568          506.79394    208.47119   0.001760563 
+  546          472.35742    208.71694   0.001831502 
+  522          444.75258    208.9633    0.001915709 
+  468          422.53995    209.21029   0.002136752 
+  460          404.58117    209.45789   0.002173913 
+  447          389.8706     209.70611   0.002237136 
+  411          377.48706    209.95496   0.00243309 
+  402          366.74509    210.20443   0.002487562 
+  391          357.31349    210.45453   0.002557545 
+  364          349.06344    210.70525   0.002747253 
+  357          341.80444    210.9566    0.00280112 
+  323          335.19524    211.20858   0.003095975 
+  362          328.85103    211.46118   0.002762431 
+  316          322.5381     211.71442   0.003164557 
+  343          316.25925    211.9683    0.002915452 
+  310          310.21867    212.2228    0.003225806 
+  302          304.71745    212.47794   0.003311258 
+  273          299.97893    212.73372   0.003663004 
+  302          296.06349    212.99013   0.003311258 
+  290          292.94366    213.24719   0.003448276 
+  318          290.58931    213.50488   0.003144654 
+  306          288.93449    213.76322   0.003267974 
+  275          287.82791    214.0222    0.003636364 
+  276          287.12784    214.28183   0.003623188 
+  287          286.84744    214.5421    0.003484321 
+  305          287.18919    214.80301   0.003278689 
+  273          288.44129    215.06458   0.003663004 
+  241          290.8268     215.32679   0.004149378 
+  308          294.38069    215.58966   0.003246753 
+  286          298.50871    215.85318   0.003496503 
+  296          301.11517    216.11735   0.003378378 
+  277          299.32339    216.38218   0.003610108 
+  282          292.97569    216.64766   0.003546099 
+  268          285.01178    216.9138    0.003731343 
+  268          277.89491    217.1806    0.003731343 
+  280          272.41791    217.44806   0.003571429 
+  264          268.5417     217.71619   0.003787879 
+  244          266.04249    217.98497   0.004098361 
+  247          264.70536    218.25442   0.004048583 
+  249          264.36416    218.52454   0.004016064 
+  268          264.92253    218.79532   0.003731343 
+  240          266.39036    219.06678   0.004166667 
+  232          268.89414    219.3389    0.004310345 
+  265          272.66754    219.61169   0.003773585 
+  236          277.92739    219.88516   0.004237288 
+  258          284.27143    220.1593    0.003875969 
+#--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--#
+
+
+# start Validation Reply Form
+_vrf_PLAT741_QPABAT3_phase_1 # for all atoms in 1_quartz
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT741_QPABAT3_phase_3 # for all atoms in 3_pyrrhotite
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT741_QPABAT3_phase_4 # for all atoms in 4_rutile
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT741_QPABAT3_phase_2 # for all atoms in 2_albite
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT155_QPABAT3_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT141_QPABAT3_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT142_QPABAT3_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT143_QPABAT3_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT144_QPABAT3_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT145_QPABAT3_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT146_QPABAT3_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT151_QPABAT3_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+# end Validation Reply Form

--- a/data/hamish/fixed/vb5042sup4.cif
+++ b/data/hamish/fixed/vb5042sup4.cif
@@ -1,0 +1,6667 @@
+
+data_QPABAT1ug3_publ
+_audit_creation_method  "created in GSAS-II"
+_audit_creation_date  2021-08-04T17:21
+_audit_author_name  "McDougall, Hamish"
+_audit_update_record
+   "2021-08-04T17:21  Initial software-generated CIF"
+_pd_block_id  2021-08-04T17:21|QPABAT1ug3|McDougallHamish|Overall
+# GSAS-II edited template follows Publication_Template
+#=============================================================================
+# this information describes the project, paper etc. for the CIF             #
+# Acta Cryst. Section C papers and editorial correspondence is generated     #
+# from the information in this section                                       #
+#                                                                            #
+#   (from)   CIF submission form for Rietveld refinements (Acta Cryst. C)    #
+#                                                 Version 14 December 1998   #
+#=============================================================================
+# 1. SUBMISSION DETAILS
+
+_publ_contact_author_name            "Suzanne Neville; Vanessa Peterson; Christophe Didier"   # Name of author for correspondence
+_publ_contact_author_address             # Address of author for correspondence
+; ?
+;
+_publ_contact_author_email           "s.neville@unsw.edu.au; vanessa.peterson@ansto.gov.au; drchristophedidier@gmail.com"
+_publ_contact_author_fax             ?
+_publ_contact_author_phone           ?
+
+_publ_contact_letter
+; ?
+;
+   
+_publ_requested_journal              ?
+_publ_requested_coeditor_name        ?
+_publ_requested_category             ?   # Acta C: one of CI/CM/CO/FI/FM/FO
+
+#==============================================================================
+
+# 2. PROCESSING SUMMARY (IUCr Office Use Only)
+
+_journal_data_validation_number      ?
+
+_journal_date_recd_electronic        ?
+_journal_date_to_coeditor            ?
+_journal_date_from_coeditor          ?
+_journal_date_accepted               ?
+_journal_date_printers_first         ?
+_journal_date_printers_final         ?
+_journal_date_proofs_out             ?
+_journal_date_proofs_in              ?
+_journal_coeditor_name               ?
+_journal_coeditor_code               ?
+_journal_coeditor_notes
+; ?
+;
+_journal_techeditor_code             ?
+_journal_techeditor_notes
+; ?
+;
+_journal_coden_ASTM                  ?
+_journal_name_full                   ?
+_journal_year                        ?
+_journal_volume                      ?
+_journal_issue                       ?
+_journal_page_first                  ?
+_journal_page_last                   ?
+_journal_paper_category              ?
+_journal_suppl_publ_number           ?
+_journal_suppl_publ_pages            ?
+
+#==============================================================================
+
+# 3. TITLE AND AUTHOR LIST
+
+_publ_section_title
+; ?
+;
+_publ_section_title_footnote
+; ?
+;         
+ 
+# The loop structure below should contain the names and addresses of all 
+# authors, in the required order of publication. Repeat as necessary.
+
+loop_
+	_publ_author_name
+        _publ_author_footnote
+	_publ_author_address
+ ?                                   #<--'Last name, first name' 
+; ?
+;
+; ?
+;
+
+#==============================================================================
+
+# 4. TEXT
+
+_publ_section_synopsis
+;  ?
+;
+_publ_section_abstract                         
+; ?
+;          
+_publ_section_comment                          
+; ?
+;
+_publ_section_exptl_prep      # Details of the preparation of the sample(s)
+                              # should be given here. 
+; ?
+;
+_publ_section_exptl_refinement                  
+; ?
+;
+_publ_section_references
+; ?
+;
+_publ_section_figure_captions
+; ?
+;
+_publ_section_acknowledgements
+; ?
+;
+
+#=============================================================================
+# 5. OVERALL REFINEMENT & COMPUTING DETAILS
+
+_refine_special_details
+; ?
+;
+_pd_proc_ls_special_details
+; ?
+;
+
+# The following items are used to identify the programs used.
+_computing_molecular_graphics     ?
+_computing_publication_material   ?
+
+_refine_ls_weighting_scheme       ?        
+_refine_ls_weighting_details      ?
+_refine_ls_hydrogen_treatment     ?        
+_refine_ls_extinction_method      ?        
+_refine_ls_extinction_coef        ?         
+_refine_ls_number_constraints     ?        
+
+_refine_ls_restrained_S_all       ?        
+_refine_ls_restrained_S_obs       ?
+
+#==============================================================================
+# 6. SAMPLE PREPARATION DATA
+
+# (In the unusual case where multiple samples are used in a single
+#  Rietveld study, this information should be moved into the phase
+#  blocks)
+
+# The following three fields describe the preparation of the material.
+# The cooling rate is in K/min.  The pressure at which the sample was  
+# prepared is in kPa.  The temperature of preparation is in K.
+               
+_pd_prep_cool_rate                N/A        
+_pd_prep_pressure                 101.3        
+_pd_prep_temperature              298           
+
+_pd_char_colour                   ?       # use ICDD colour descriptions
+
+data_QPABAT1ug3_overall
+_pd_proc_info_datetime  2021-08-04T17:21
+_pd_calc_method  "Rietveld Refinement"
+_computing_structure_refinement
+   "GSAS-II (Toby & Von Dreele, J. Appl. Cryst. 46, 544-549, 2013)"
+_refine_ls_number_parameters  28
+_refine_ls_goodness_of_fit_all  8.337
+_refine_ls_shift/su_max  0.6046
+
+# OVERALL WEIGHTED R-FACTOR
+_refine_ls_wR_factor_obs  0.32290
+_refine_ls_matrix_type  full
+# POINTERS TO PHASE AND HISTOGRAM BLOCKS
+loop_   _pd_phase_block_id
+  2021-08-04T17:21|QPABAT1ug3|phase_2|McDougallHamish
+  2021-08-04T17:21|QPABAT1ug3|phase_0|McDougallHamish
+  2021-08-04T17:21|QPABAT1ug3|phase_3|McDougallHamish
+  2021-08-04T17:21|QPABAT1ug3|phase_1|McDougallHamish
+  2021-08-04T17:21|QPABAT1ug3|phase_4|McDougallHamish
+_pd_block_diffractogram_id
+;
+2021-08-04T17:21|QPABAT1ug3|McDougallHamish|PANalytical,Co-EmpyreanII_hist_0
+;
+
+data_QPABAT1ug3_phase_2
+# Information for phase 2
+_pd_block_id  2021-08-04T17:21|QPABAT1ug3|phase_2|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Albite NaAlSi3O8 follows
+_pd_phase_name  "Albite NaAlSi3O8"
+_cell_length_a  8.137
+_cell_length_b  12.785
+_cell_length_c  7.1583
+_cell_angle_alpha  94.26
+_cell_angle_beta   116.6
+_cell_angle_gamma  87.71
+_cell_volume  664.008
+_exptl_crystal_density_diffrn  2.6230
+_symmetry_cell_setting  triclinic
+_symmetry_space_group_name_H-M  "C -1"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -x,-y,-z
+     3  1/2+x,1/2+y,z
+     4  1/2-x,1/2-y,-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Al1    Al3+ 0.00887     0.16846     0.20805     1.000      Uani 0.007      4   
+Si1    Si4+ 0.00375     0.82051     0.23737     1.000      Uani 0.006      4   
+Si2    Si4+ 0.69162     0.11021     0.31466     1.000      Uani 0.006      4   
+Si3    Si4+ 0.68129     0.88190     0.36076     1.000      Uani 0.006      4   
+Na1    Na1+ 0.26799     0.98865     0.14650     1.000      Uani 0.031      4   
+O1     O2-  0.00490     0.13103     0.96660     1.000      Uani 0.012      4   
+O2     O2-  0.59176     0.99756     0.28040     1.000      Uani 0.008      4   
+O3     O2-  0.81230     0.10966     0.19010     1.000      Uani 0.014      4   
+O4     O2-  0.82000     0.85101     0.25870     1.000      Uani 0.018      4   
+O5     O2-  0.01288     0.30238     0.27060     1.000      Uani 0.011      4   
+O6     O2-  0.02329     0.69368     0.22910     1.000      Uani 0.011      4   
+O7     O2-  0.20780     0.10896     0.38900     1.000      Uani 0.011      4   
+O8     O2-  0.18400     0.86817     0.43620     1.000      Uani 0.012      4   
+
+loop_
+   _atom_site_aniso_label
+   _atom_site_aniso_U_11
+   _atom_site_aniso_U_22
+   _atom_site_aniso_U_33
+   _atom_site_aniso_U_12
+   _atom_site_aniso_U_13
+   _atom_site_aniso_U_23
+Al1    0.0074      0.0068      0.0061      -0.0009     0.0031      0.0004      
+Si1    0.0068      0.0065      0.0055      0.0011      0.0030      0.0008      
+Si2    0.0061      0.0055      0.0073      -0.0002     0.0025      0.0004      
+Si3    0.0060      0.0055      0.0074      0.0006      0.0028      0.0009      
+Na1    0.0136      0.0471      0.0315      -0.0050     0.0084      -0.0219     
+O1     0.0164      0.0122      0.0074      -0.0002     0.0067      0.0014      
+O2     0.0074      0.0056      0.0119      0.0003      0.0033      0.0020      
+O3     0.0117      0.0130      0.0162      -0.0040     0.0093      -0.0017     
+O4     0.0134      0.0179      0.0216      0.0046      0.0129      0.0020      
+O5     0.0103      0.0076      0.0150      -0.0020     0.0052      -0.0009     
+O6     0.0101      0.0071      0.0145      0.0022      0.0034      0.0012      
+O7     0.0120      0.0129      0.0080      0.0024      0.0013      0.0015      
+O8     0.0140      0.0140      0.0084      -0.0026     -0.0002     -0.0006     
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Al   4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Na   4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  O    32     ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si   12     ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Al Na O8 Si3"
+_chemical_formula_weight  262.22
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Al1    O1     1.74519      1_555    1_554 yes
+  Al1    O3     1.7429       1_555    1_455 yes
+  Al1    O5     1.73509      1_555    1_555 yes
+  Al1    O7     1.74556      1_555    1_555 yes
+  Si1    O1     1.59985      1_555    2_566 yes
+  Si1    O4     1.59997      1_555    1_455 yes
+  Si1    O6     1.62225      1_555    1_555 yes
+  Si1    O8     1.61907      1_555    1_555 yes
+  Si2    O2     1.63011      1_555    1_545 yes
+  Si2    O3     1.59435      1_555    1_555 yes
+  Si2    O6     1.61836      1_555    3_545 yes
+  Si2    O8     1.6168       1_555    2_666 yes
+  Si3    O2     1.64718      1_555    1_555 yes
+  Si3    O4     1.61975      1_555    1_555 yes
+  Si3    O5     1.59682      1_555    3_555 yes
+  Si3    O7     1.60203      1_555    2_666 yes
+  Na1    O1     2.66887      1_555    1_564 yes
+  Na1    O1     2.53079      1_555    2_566 yes
+  Na1    O2     2.3704       1_555    1_555 yes
+  Na1    O3     2.45321      1_555    2_665 yes
+  Na1    O7     2.43384      1_555    1_565 yes
+  O1     Al1    1.74519      1_555    1_556 yes
+  O1     Si1    1.59985      1_555    2_566 yes
+  O1     Na1    2.66887      1_555    1_546 yes
+  O1     Na1    2.53079      1_555    2_566 yes
+  O2     Si2    1.63011      1_555    1_565 yes
+  O2     Si3    1.64718      1_555    1_555 yes
+  O2     Na1    2.3704       1_555    1_555 yes
+  O3     Al1    1.7429       1_555    1_655 yes
+  O3     Si2    1.59435      1_555    1_555 yes
+  O3     Na1    2.45321      1_555    2_665 yes
+  O4     Si1    1.59997      1_555    1_655 yes
+  O4     Si3    1.61975      1_555    1_555 yes
+  O5     Al1    1.73509      1_555    1_555 yes
+  O5     Si3    1.59682      1_555    3_445 yes
+  O6     Si1    1.62225      1_555    1_555 yes
+  O6     Si2    1.61836      1_555    3_455 yes
+  O7     Al1    1.74556      1_555    1_555 yes
+  O7     Si3    1.60203      1_555    2_666 yes
+  O7     Na1    2.43384      1_555    1_545 yes
+  O8     Si1    1.61907      1_555    1_555 yes
+  O8     Si2    1.6168       1_555    2_666 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Al1    O3     102.836       1_554  1_555    1_455 yes
+  O1     Al1    O5     116.047       1_554  1_555    1_555 yes
+  O3     Al1    O5     112.215       1_455  1_555    1_555 yes
+  O1     Al1    O7     104.004       1_554  1_555    1_555 yes
+  O3     Al1    O7     111.151       1_455  1_555    1_555 yes
+  O5     Al1    O7     110.14        1_555  1_555    1_555 yes
+  O1     Si1    O4     109.433       2_566  1_555    1_455 yes
+  O1     Si1    O6     112.47        2_566  1_555    1_555 yes
+  O4     Si1    O6     108.187       1_455  1_555    1_555 yes
+  O1     Si1    O8     107.176       2_566  1_555    1_555 yes
+  O4     Si1    O8     111.446       1_455  1_555    1_555 yes
+  O6     Si1    O8     108.16        1_555  1_555    1_555 yes
+  O2     Si2    O3     111.144       1_545  1_555    1_555 yes
+  O2     Si2    O6     104.24        1_545  1_555    3_545 yes
+  O3     Si2    O6     112.114       1_555  1_555    3_545 yes
+  O2     Si2    O8     106.97        1_545  1_555    2_666 yes
+  O3     Si2    O8     111.591       1_555  1_555    2_666 yes
+  O6     Si2    O8     110.422       3_545  1_555    2_666 yes
+  O2     Si3    O4     107.269       1_555  1_555    1_555 yes
+  O2     Si3    O5     105.914       1_555  1_555    3_555 yes
+  O4     Si3    O5     110.224       1_555  1_555    3_555 yes
+  O2     Si3    O7     108.565       1_555  1_555    2_666 yes
+  O4     Si3    O7     110.208       1_555  1_555    2_666 yes
+  O5     Si3    O7     114.328       3_555  1_555    2_666 yes
+  Al1    O1     Si1    141.397       1_556  1_555    2_566 yes
+  Si2    O2     Si3    130.019       1_565  1_555    1_555 yes
+  Si2    O2     Na1    120.351       1_565  1_555    1_555 yes
+  Si3    O2     Na1    108.811       1_555  1_555    1_555 yes
+  Al1    O3     Si2    139.461       1_655  1_555    1_555 yes
+  Si1    O4     Si3    161.151       1_655  1_555    1_555 yes
+  Al1    O5     Si3    129.689       1_555  1_555    3_445 yes
+  Si1    O6     Si2    135.676       1_555  1_555    3_455 yes
+  Al1    O7     Si3    133.943       1_555  1_555    2_666 yes
+  Si1    O8     Si2    151.747       1_555  1_555    2_666 yes
+_pd_proc_ls_pref_orient_corr  none
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.233(12), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_QPABAT1ug3_phase_0
+# Information for phase 0
+_pd_block_id  2021-08-04T17:21|QPABAT1ug3|phase_0|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Pyrite FeS2 follows
+_pd_phase_name  "Pyrite FeS2"
+_cell_length_a  5.41945(8)
+_cell_length_b  5.41945(8)
+_cell_length_c  5.41945(8)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  90
+_cell_volume  159.171(7)
+_exptl_crystal_density_diffrn  5.0062
+_symmetry_cell_setting  cubic
+_symmetry_space_group_name_H-M  "P a -3"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  z,x,y
+     3  y,z,x
+     4  1/2+x,y,1/2-z
+     5  1/2-z,1/2+x,y
+     6  y,1/2-z,1/2+x
+     7  -z,1/2+x,1/2-y
+     8  1/2-y,-z,1/2+x
+     9  1/2+y,1/2-z,-x
+    10  -x,1/2+y,1/2-z
+    11  1/2-z,-x,1/2+y
+    12  1/2+x,1/2-y,-z
+    13  -x,-y,-z
+    14  -z,-x,-y
+    15  -y,-z,-x
+    16  1/2-x,-y,1/2+z
+    17  1/2+z,1/2-x,-y
+    18  -y,1/2+z,1/2-x
+    19  z,1/2-x,1/2+y
+    20  1/2+y,z,1/2-x
+    21  1/2-y,1/2+z,x
+    22  x,1/2-y,1/2+z
+    23  1/2+z,x,1/2-y
+    24  1/2-x,1/2+y,z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Fe1    Fe   0.00000     0.00000     0.00000     1.000      Uiso 0.010      4   
+S2     S    0.3903(4)   0.3903      0.3903      1.000      Uiso 0.010      8   
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Fe   4      11.7695    7.3573     3.5222     2.3045     4.7611     0.3072     15.3535    76.8805    1.0369     0.945
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S    8      6.9053     5.2034     1.4379     1.5863     1.4679     22.2151    0.2536     56.172     0.8669     0.2847
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Fe S2"
+_chemical_formula_weight  119.97
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Fe1    S2     2.2761(6)    1_555    4_455 yes
+  Fe1    S2     2.2761(6)    1_555    5_545 yes
+  Fe1    S2     2.2761(6)    1_555    6_554 yes
+  Fe1    S2     2.2761(6)    1_555    7_545 yes
+  Fe1    S2     2.2761(6)    1_555    8_554 yes
+  Fe1    S2     2.2761(22)   1_555    9_455 yes
+  S2     Fe1    2.2761(6)    1_555    4_555 yes
+  S2     Fe1    2.2761(6)    1_555    5_555 yes
+  S2     Fe1    2.2761(22)   1_555    6_555 yes
+  S2     S2     2.0604(28)   1_555   13_666 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.373(14), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_QPABAT1ug3_phase_3
+# Information for phase 3
+_pd_block_id  2021-08-04T17:21|QPABAT1ug3|phase_3|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Pyrrhotite 4M Fe7S8 follows
+_pd_phase_name  "Pyrrhotite 4M Fe7S8"
+_cell_length_a  11.922(23)
+_cell_length_b  6.870(4)
+_cell_length_c  12.810(27)
+_cell_angle_alpha  90
+_cell_angle_beta   117.18(5)
+_cell_angle_gamma  90
+_cell_volume  933.3(5)
+_exptl_crystal_density_diffrn  4.6074
+_symmetry_cell_setting  monoclinic
+_symmetry_space_group_name_H-M  "C 2/c"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -x,y,1/2-z
+     3  -x,-y,-z
+     4  x,-y,1/2+z
+     5  1/2+x,1/2+y,z
+     6  1/2-x,1/2+y,1/2-z
+     7  1/2-x,1/2-y,-z
+     8  1/2+x,1/2-y,1/2+z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+S1     S    0.01800     0.38330     0.11960     1.000      Uiso 0.010      8   
+S2     S    0.02910     0.11420     0.63900     1.000      Uiso 0.010      8   
+Fe3    Fe   0.10860     0.10250     0.49980     1.000      Uiso 0.010      8   
+S4     S    0.23410     0.13550     0.38260     1.000      Uiso 0.010      8   
+Fe5    Fe   0.24180     0.36600     0.24680     1.000      Uiso 0.010      8   
+S6     S    0.26790     0.13400     0.12360     1.000      Uiso 0.010      8   
+Fe7    Fe   0.38720     0.15000     0.01260     1.000      Uiso 0.010      8   
+Fe8    Fe   0.00000     0.14720     0.25000     1.000      Uiso 0.010      4   
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Fe   28     11.7695    7.3573     3.5222     2.3045     4.7611     0.3072     15.3535    76.8805    1.0369     0.945
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S    32     6.9053     5.2034     1.4379     1.5863     1.4679     22.2151    0.2536     56.172     0.8669     0.2847
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Fe7 S8"
+_chemical_formula_weight  647.41
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  S1     Fe3    2.49599      1_555    2_555 yes
+  S1     Fe5    2.41181      1_555    1_555 yes
+  S1     Fe7    2.39059      1_555    5_455 yes
+  S1     Fe7    2.4384       1_555    7_555 yes
+  S1     Fe8    2.40718      1_555    1_555 yes
+  S2     Fe3    2.37236      1_555    1_555 yes
+  S2     Fe3    2.32514      1_555    3_556 yes
+  S2     Fe5    2.44312      1_555    7_556 yes
+  S2     Fe7    2.36762      1_555    8_456 yes
+  S2     Fe8    2.41196      1_555    3_556 yes
+  Fe3    S1     2.49599      1_555    2_555 yes
+  Fe3    S2     2.37236      1_555    1_555 yes
+  Fe3    S2     2.32514      1_555    3_556 yes
+  Fe3    S6     2.4516       1_555    4_556 yes
+  S4     Fe5    2.38493      1_555    1_555 yes
+  Fe5    S1     2.41181      1_555    1_555 yes
+  Fe5    S2     2.44312      1_555    7_556 yes
+  Fe5    S4     2.38493      1_555    1_555 yes
+  Fe5    S6     2.36141      1_555    1_555 yes
+  S6     Fe3    2.4516       1_555    4_555 yes
+  S6     Fe5    2.36141      1_555    1_555 yes
+  S6     Fe7    2.42983      1_555    1_555 yes
+  S6     Fe7    2.39126      1_555    7_555 yes
+  Fe7    S1     2.39059      1_555    5_545 yes
+  Fe7    S1     2.4384       1_555    7_555 yes
+  Fe7    S2     2.36762      1_555    8_555 yes
+  Fe7    S6     2.42983      1_555    1_555 yes
+  Fe7    S6     2.39126      1_555    7_555 yes
+  Fe8    S1     2.40718      1_555    1_555 yes
+  Fe8    S1     2.40718      1_555    2_555 yes
+  Fe8    S2     2.41196      1_555    3_556 yes
+  Fe8    S2     2.41196      1_555    4_555 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.15(6), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_QPABAT1ug3_phase_1
+# Information for phase 1
+_pd_block_id  2021-08-04T17:21|QPABAT1ug3|phase_1|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Quartz SiO2 follows
+_pd_phase_name  "Quartz SiO2"
+_cell_length_a  4.9161(6)
+_cell_length_b  4.9161(6)
+_cell_length_c  5.4061(5)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  120
+_cell_volume  113.147(14)
+_exptl_crystal_density_diffrn  2.6454
+_symmetry_cell_setting  trigonal
+_symmetry_space_group_name_H-M  "P 32 2 1"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -y,x-y,2/3+z
+     3  y-x,-x,1/3+z
+     4  y,x,-z
+     5  -x,y-x,2/3-z
+     6  x-y,-y,1/3-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Si1    Si4+ 0.47000     0.00000     0.66670     1.000      Uani 0.006      3   
+O1     O2-  0.41460     0.26780     0.78543     1.000      Uani 0.011      6   
+
+loop_
+   _atom_site_aniso_label
+   _atom_site_aniso_U_11
+   _atom_site_aniso_U_22
+   _atom_site_aniso_U_33
+   _atom_site_aniso_U_12
+   _atom_site_aniso_U_13
+   _atom_site_aniso_U_23
+Si1    0.0073      0.0059      0.0053      0.0029      0.0003      0.0006      
+O1     0.0120      0.0105      0.0118      0.0065      -0.0029     -0.0040     
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  O    6      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si   3      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  3
+_chemical_formula_sum  "O2 Si"
+_chemical_formula_weight  60.08
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Si1    O1     1.60559      1_555    1_555 yes
+  Si1    O1     1.61184      1_555    2_654 yes
+  Si1    O1     1.61158      1_555    5_656 yes
+  Si1    O1     1.60574      1_555    6_556 yes
+  O1     Si1    1.60559      1_555    1_555 yes
+  O1     Si1    1.61184      1_555    3_665 yes
+  O1     Si1    1.61158      1_555    5_666 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Si1    O1     110.252       1_555  1_555    2_654 yes
+  O1     Si1    O1     108.753       1_555  1_555    5_656 yes
+  O1     Si1    O1     109.678       2_654  1_555    5_656 yes
+  O1     Si1    O1     109.158       1_555  1_555    6_556 yes
+  O1     Si1    O1     108.733       2_654  1_555    6_556 yes
+  O1     Si1    O1     110.258       5_656  1_555    6_556 yes
+  Si1    O1     Si1    143.831       1_555  1_555    3_665 yes
+  Si1    O1     Si1    143.835       1_555  1_555    5_666 yes
+  Si1    O1     Si1    0.009         3_665  1_555    5_666 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.37(6), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_QPABAT1ug3_phase_4
+# Information for phase 4
+_pd_block_id  2021-08-04T17:21|QPABAT1ug3|phase_4|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Rutile TiO2 follows
+_pd_phase_name  "Rutile TiO2"
+_cell_length_a  4.746(8)
+_cell_length_b  4.746(8)
+_cell_length_c  2.892(7)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  90
+_cell_volume  65.14(17)
+_exptl_crystal_density_diffrn  4.0737
+_symmetry_cell_setting  tetragonal
+_symmetry_space_group_name_H-M  "P 42/m n m"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  1/2-y,1/2+x,1/2+z
+     3  -x,-y,z
+     4  1/2+y,1/2-x,1/2+z
+     5  1/2-x,1/2+y,1/2+z
+     6  -y,-x,z
+     7  1/2+x,1/2-y,1/2+z
+     8  y,x,z
+     9  -x,-y,-z
+    10  1/2+y,1/2-x,1/2-z
+    11  x,y,-z
+    12  1/2-y,1/2+x,1/2-z
+    13  1/2+x,1/2-y,1/2-z
+    14  y,x,-z
+    15  1/2-x,1/2+y,1/2-z
+    16  -y,-x,-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Ti1    Ti4+ 0.00000     0.00000     0.00000     1.000      Uani 0.006      2   
+O1     O2-  0.30493     0.30493     0.00000     1.000      Uani 0.006      4   
+
+loop_
+   _atom_site_aniso_label
+   _atom_site_aniso_U_11
+   _atom_site_aniso_U_22
+   _atom_site_aniso_U_33
+   _atom_site_aniso_U_12
+   _atom_site_aniso_U_13
+   _atom_site_aniso_U_23
+Ti1    0.0070      0.0070      0.0047      -0.0002     0.0000      0.0000      
+O1     0.0060      0.0060      0.0045      -0.0019     0.0000      0.0000      
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  O    4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Ti   2      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  2
+_chemical_formula_sum  "O2 Ti"
+_chemical_formula_weight  79.9
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Ti1    O1     2.0466       1_555    1_555 yes
+  Ti1    O1     1.95063      1_555    2_544 yes
+  Ti1    O1     1.95063      1_555    2_545 yes
+  Ti1    O1     2.0466       1_555    3_555 yes
+  Ti1    O1     1.95063      1_555    4_454 yes
+  Ti1    O1     1.95063      1_555    4_455 yes
+  O1     Ti1    2.0466       1_555    1_555 yes
+  O1     Ti1    1.95063      1_555    2_554 yes
+  O1     Ti1    1.95063      1_555    2_555 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Ti1    O1     95.681        2_544  1_555    2_545 yes
+  O1     Ti1    O1     84.319        2_544  1_555    4_454 yes
+  O1     Ti1    O1     180           2_545  1_555    4_454 yes
+  O1     Ti1    O1     180           2_544  1_555    4_455 yes
+  O1     Ti1    O1     84.319        2_545  1_555    4_455 yes
+  O1     Ti1    O1     95.681        4_454  1_555    4_455 yes
+  Ti1    O1     Ti1    95.681        2_554  1_555    2_555 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.100, 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_QPABAT1ug3_pwd_0
+_pd_proc_ls_profile_function
+;
+Finger-Cox-Jephcoat function parameters U, V, W, X, Y, SH/L:
+  peak variance(Gauss) = Utan(Th)^2^+Vtan(Th)+W:
+  peak HW(Lorentz) = X/cos(Th)+Ytan(Th); SH/L = S/L+H/L
+  U, V, W in (centideg)^2^, X & Y in centideg
+    0.000, 0.000, 3.345, 2.239, -0.670, 0.034, 
+;
+# Information for histogram 0: PWDR BAT1ug3_30mm_MonicaHamish_Ruoming_step size 0_BAT1ug3.xrdml Scan 1
+_pd_block_id
+;
+2021-08-04T17:21|QPABAT1ug3|McDougallHamish|PANalytical,Co-EmpyreanII_hist_0
+;
+# GSAS-II edited template follows Instrument_Template
+#==============================================================================
+# 9. INSTRUMENT CHARACTERIZATION
+
+_exptl_special_details
+; ?
+;
+
+# if regions of the data are excluded, the reason(s) are supplied here:
+_pd_proc_info_excluded_regions
+; ?
+;
+
+# The following item is used to identify the equipment used to record 
+# the powder pattern when the diffractogram was measured at a laboratory 
+# other than the authors' home institution, e.g. when neutron or synchrotron
+# radiation is used.
+
+_pd_instr_location
+; ?
+;
+_pd_calibration_special_details           # description of the method used
+                                          # to calibrate the instrument
+; ?
+;
+
+_diffrn_source                    Co-Ka       
+_diffrn_source_target             Co
+_diffrn_source_type               Graded_Flat
+_diffrn_measurement_device_type   Panalytical_Reflection_Transmission       
+_diffrn_detector                  PIXcel1D       
+_diffrn_detector_type             Empyrean_II       # make or model of detector
+
+_pd_meas_scan_method              ?       # options are 'step', 'cont',
+                                          # 'tof', 'fixed' or
+                                          # 'disp' (= dispersive)
+_pd_meas_special_details
+;  ?
+;
+
+# The following two items identify the program(s) used (if appropriate).
+_computing_data_collection        ?        
+_computing_data_reduction         ?                   
+
+# Describe any processing performed on the data, prior to refinement.
+# For example: a manual Lp correction or a precomputed absorption correction
+_pd_proc_info_data_reduction      ?
+
+# The following item is used for angular dispersive measurements only.
+
+_diffrn_radiation_monochromator   ?        
+
+# The following items are used to define the size of the instrument.
+# Not all distances are appropriate for all instrument types.
+
+_pd_instr_dist_src/mono           ?
+_pd_instr_dist_mono/spec          ?
+_pd_instr_dist_src/spec           ?
+_pd_instr_dist_spec/anal          ?
+_pd_instr_dist_anal/detc          ?
+_pd_instr_dist_spec/detc          ?
+
+# 10. Specimen size and mounting information
+
+# The next three fields give the specimen dimensions in mm.  The equatorial 
+# plane contains the incident and diffracted beam.
+
+_pd_spec_size_axial               ?       # perpendicular to 
+                                          # equatorial plane
+
+_pd_spec_size_equat               ?       # parallel to 
+                                          # scattering vector 
+                                          # in transmission
+
+_pd_spec_size_thick               ?       # parallel to 
+                                          # scattering vector 
+                                          # in reflection
+
+_pd_spec_mounting                         # This field should be
+                                          # used to give details of the 
+                                          # container.
+; ?
+;
+
+_pd_spec_mount_mode               ?       # options are 'reflection' 
+                                          # or 'transmission'
+    
+_pd_spec_shape                    ?       # options are 'cylinder' 
+                                          # 'flat_sheet' or 'irregular'
+
+
+loop_
+     _atom_type_symbol
+     _atom_type_scat_dispersion_real
+     _atom_type_scat_dispersion_imag
+     _atom_type_scat_dispersion_source
+  Al        0.255   0.328   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Fe       -3.332   0.490   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Na        0.167   0.167   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  O         0.063   0.044   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S         0.371   0.733   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si        0.298   0.438   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Ti       -0.063   2.321   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+_diffrn_radiation_type  K\a~1,2~
+loop_
+   _diffrn_radiation_wavelength
+   _diffrn_radiation_wavelength_wt
+   _diffrn_radiation_wavelength_id
+  1.78892         1.0             1     
+  1.79278         0.5000          2     
+
+# PHASE TABLE
+loop_
+   _pd_phase_id
+   _pd_phase_block_id
+   _pd_phase_mass_%
+  2  2021-08-04T17:21|QPABAT1ug3|phase_2|McDougallHamish  0.281(6)
+  0  2021-08-04T17:21|QPABAT1ug3|phase_0|McDougallHamish  0.579(7)
+  3  2021-08-04T17:21|QPABAT1ug3|phase_3|McDougallHamish  0.0297(28)
+  1  2021-08-04T17:21|QPABAT1ug3|phase_1|McDougallHamish  0.104(3)
+  4  2021-08-04T17:21|QPABAT1ug3|phase_4|McDougallHamish  0.0058(21)
+loop_
+   _gsas_proc_phase_R_F_factor
+   _gsas_proc_phase_R_Fsqd_factor
+   _gsas_proc_phase_id
+   _gsas_proc_phase_block_id
+    0.24965  0.69266  2  2021-08-04T17:21|QPABAT1ug3|phase_2|McDougallHamish
+    0.15002  0.34012  0  2021-08-04T17:21|QPABAT1ug3|phase_0|McDougallHamish
+    0.21889  0.48826  3  2021-08-04T17:21|QPABAT1ug3|phase_3|McDougallHamish
+    0.15685  0.44265  1  2021-08-04T17:21|QPABAT1ug3|phase_1|McDougallHamish
+    0.12670  0.33438  4  2021-08-04T17:21|QPABAT1ug3|phase_4|McDougallHamish
+_pd_proc_ls_prof_R_factor     0.23043
+_pd_proc_ls_prof_wR_factor    0.32290
+_gsas_proc_ls_prof_R_B_factor   0.31042
+_gsas_proc_ls_prof_wR_B_factor  0.38227
+_pd_proc_ls_prof_wR_expected  0.03887
+_diffrn_radiation_probe  x-ray
+_diffrn_radiation_polarisn_ratio  0.7000
+_pd_proc_ls_background_function
+;
+Background function: "chebyschev-1" function with 7 terms:
+    426(5), -521(8), 398(8), -193(7), 96(6), -25(5), 15(4), 
+;
+_diffrn_ambient_temperature  300
+_diffrn_ambient_pressure  100
+
+# STRUCTURE FACTOR TABLE
+loop_
+   _pd_refln_phase_id
+   _refln_index_h
+   _refln_index_k
+   _refln_index_l
+   _refln_F_squared_meas
+   _refln_F_squared_calc
+   _refln_phase_calc
+   _refln_d_spacing
+   _gsas_i100_meas
+  0  1    1    1    744.3560   652.8618   0.0     3.12892  13.80  
+  0  2    0    0    9722.6125  7206.1825  -0.0    2.70972  100.00 
+  0  2    1    0    3593.2893  3000.3630  0.0     2.42365  58.41  
+  0  2    1    1    1937.9535  1614.2461  -180.0  2.21248  51.95  
+  0  2    2    0    2504.2917  3412.9735  -0.0    1.91606  24.79  
+  0  2    2    1    37.4592    77.3355    -0.0    1.80648  0.66   
+  0  3    1    1    3539.6161  4748.1959  -0.0    1.63402  50.70  
+  0  2    2    2    2527.2539  2280.9669  0.0     1.56446  11.10  
+  0  3    0    2    2580.1269  3226.6030  -0.0    1.50308  15.80  
+  0  3    1    2    350.4550   367.8942   0.0     1.44841  4.02   
+  0  3    2    1    1744.0503  1830.8371  180.0   1.44841  20.02  
+  0  4    0    0    521.3699   268.6472   -180.0  1.35486  1.35   
+  0  3    2    2    96.9433    98.1154    -0.0    1.31441  0.96   
+  0  4    1    0    203.3363   205.7947   -0.0    1.31441  1.01   
+  0  4    1    1    148.7905   117.7887   180.0   1.27738  1.43   
+  0  3    3    1    674.8097   709.1302   -0.0    1.24331  6.32   
+  0  4    0    2    1093.2511  654.5316   0.0     1.21183  5.02   
+  0  4    2    0    1093.2511  654.5316   0.0     1.21183  5.02   
+  0  4    1    2    8.4222     6.4316     -0.0    1.18262  0.08   
+  0  4    2    1    1375.7245  1050.5598  -180.0  1.18262  12.49  
+  0  3    3    2    435.0464   513.1452   0.0     1.15543  3.93   
+  0  4    2    2    1193.5988  878.2403   0.0     1.10624  10.87  
+  0  4    3    0    154.9278   295.2910   -0.0    1.08389  0.72   
+  0  4    1    3    126.3332   170.1512   180.0   1.06284  1.20   
+  0  4    3    1    25.3858    34.1907    0.0     1.06284  0.24   
+  0  3    3    3    2402.5110  1174.1618  -0.0    1.04297  7.81   
+  0  5    1    1    6760.4466  3303.9839  -0.0    1.04297  65.93  
+  1  1    0    0    447.0354   242.5246   -180.0  4.25742  3.79   
+  1  1    0    1    633.2067   634.4931   120.0   3.34474  3.26   
+  1  1    0    -1   1506.3712  1509.4317  -120.0  3.34474  7.76   
+  1  1    1    0    292.4562   343.8792   -155.6  2.45803  0.79   
+  1  1    0    -2   114.8880   86.1851    -60.0   2.28195  0.26   
+  1  1    0    2    398.3798   298.8511   -120.0  2.28195  0.92   
+  1  1    1    1    165.1318   96.0634    82.9    2.23759  0.73   
+  1  2    0    0    1625.6738  308.9208   -0.0    2.12871  3.24   
+  1  2    0    -1   50.2840    77.2247    60.0    1.98069  0.09   
+  1  2    0    1    120.5019   185.0632   -60.0   1.98069  0.21   
+  1  1    1    2    747.9007   602.8751   9.8     1.81855  2.14   
+  1  0    0    3    30.3987    94.4562    0.0     1.80202  0.01   
+  1  2    0    2    92.1895    82.0908    60.0    1.67237  0.11   
+  1  2    0    -2   409.0663   364.2560   120.0   1.67237  0.49   
+  1  1    0    -3   305.9057   203.8509   180.0   1.65949  0.36   
+  1  1    0    3    3.8788     2.5848     0.0     1.65949  0.00   
+  1  2    1    0    27.8855    14.6460    -38.9   1.60916  0.06   
+  1  2    1    -1   325.4289   356.3967   95.9    1.54228  0.67   
+  1  2    1    1    280.0915   306.7449   -109.6  1.54228  0.58   
+  1  1    1    3    156.4796   142.5789   117.5   1.45331  0.29   
+  1  3    0    0    73.8849    76.3693    180.0   1.41914  0.07   
+  1  2    1    -2   628.9634   413.8371   -123.3  1.38269  1.08   
+  1  2    1    2    195.2834   128.4900   143.4   1.38269  0.34   
+  1  2    0    -3   296.7266   292.6684   -0.0    1.37538  0.25   
+  1  2    0    3    1044.7441  1030.4556  0.0     1.37538  0.89   
+  1  3    0    -1   863.7871   815.9639   -120.0  1.37263  0.73   
+  1  3    0    1    1.0758     1.0163     -60.0   1.37263  0.00   
+  1  1    0    -4   64.4319    120.2819   -120.0  1.28817  0.05   
+  1  1    0    4    212.3639   396.4426   120.0   1.28817  0.17   
+  1  3    0    -2   324.2459   208.3469   120.0   1.25650  0.25   
+  1  3    0    2    739.2011   474.9800   -120.0  1.25650  0.56   
+  1  2    2    0    236.0444   371.1166   -16.5   1.22901  0.18   
+  1  2    1    -3   71.6271    71.0140    179.1   1.20026  0.11   
+  1  2    1    3    304.0404   301.4378   -134.8  1.20026  0.45   
+  1  2    2    1    87.8663    105.6075   88.6    1.19843  0.13   
+  1  1    1    4    497.8841   334.1775   -14.4   1.18430  0.73   
+  1  3    1    0    392.5955   361.6235   121.4   1.18080  0.57   
+  1  3    1    -1   151.0170   189.9539   -18.5   1.15360  0.22   
+  1  3    1    1    50.4093    63.4064    16.4    1.15360  0.07   
+  1  2    0    -4   1.8597     1.4734     -120.0  1.14098  0.00   
+  1  2    0    4    89.2160    70.6815    120.0   1.14098  0.06   
+  1  2    2    2    3.0100     3.3518     -9.9    1.11880  0.00   
+  1  3    0    3    48.9703    62.7345    -180.0  1.11491  0.04   
+  1  3    0    -3   5.2209     6.6884     -0.0    1.11491  0.00   
+  1  3    1    -2   216.0480   304.4026   -8.9    1.08206  0.32   
+  1  3    1    2    88.2711    124.3703   59.1    1.08206  0.13   
+  1  4    0    0    191.8086   168.2132   0.0     1.06436  0.15   
+  1  1    0    -5   399.7216   346.2728   120.0   1.04795  0.31   
+  1  1    0    5    149.9654   129.9128   -120.0  1.04795  0.12   
+  1  4    0    -1   62.3606    31.4123    60.0    1.04431  0.05   
+  1  4    0    1    575.2382   289.7594   120.0   1.04431  0.45   
+  1  2    1    -4   3.6548     10.8628    51.2    1.03492  0.01   
+  1  2    1    4    81.0534    240.9044   -129.5  1.03492  0.13   
+  2  0    0    1    886.0848   685.7541   180.0   6.38786  3.07   
+  2  0    2    0    475.3796   396.3962   180.0   6.37466  0.01   
+  2  1    1    0    181.3815   238.2363   -0.0    6.33955  0.01   
+  2  1    -1   0    224.0326   287.4879   -0.0    6.29869  0.01   
+  2  1    1    -1   871.2945   406.2352   180.0   5.91009  0.03   
+  2  1    -1   -1   617.9879   415.6378   -180.0  5.58552  0.03   
+  2  0    2    -1   8.1163     16.5792    0.0     4.66174  0.00   
+  2  0    2    1    0.5350     1.8371     180.0   4.37623  0.00   
+  2  2    0    -1   67164.8635 21037.4763 -0.0    4.02732  0.77   
+  2  1    -1   1    10687.1948 3767.3897  -0.0    3.85265  0.38   
+  2  1    1    1    16805.0772 10390.3834 0.0     3.77565  1.35   
+  2  1    3    0    36297.4955 5886.9121  180.0   3.68167  0.44   
+  2  1    3    -1   22102.7079 4505.3267  0.0     3.66562  0.21   
+  2  1    -3   0    28045.2336 11675.3013 180.0   3.65766  0.26   
+  2  2    0    0    1.1064     2.5781     0.0     3.63776  0.00   
+  2  1    1    -2   5676.1315  4328.5159  0.0     3.50520  0.23   
+  2  2    2    -1   1361.8993  1650.0035  180.0   3.48122  0.01   
+  2  1    -3   -1   20.8676    12.1276    0.0     3.43616  0.00   
+  2  1    -1   -2   3319.2354  5251.4578  0.0     3.37264  0.28   
+  2  2    -2   -1   242.2970   364.8637   0.0     3.33313  0.00   
+  2  2    0    -2   20350.0836 26655.4799 -180.0  3.21484  0.28   
+  2  0    0    2    55868.4175 37071.8044 -180.0  3.19393  46.95  
+  2  0    4    0    39176.4480 25362.8195 180.0   3.18733  0.29   
+  2  2    2    0    16030.9736 13873.6743 180.0   3.16977  0.16   
+  2  2    -2   0    21530.3174 14946.6082 -180.0  3.14934  0.16   
+  2  1    -3   1    23465.9717 11175.2497 -180.0  2.96418  0.20   
+  2  2    2    -2   8310.6402  7187.5067  0.0     2.95504  0.07   
+  2  0    2    -2   10688.2088 5310.5610  0.0     2.93060  0.28   
+  2  0    4    -1   12308.8220 8585.7945  0.0     2.92677  0.08   
+  2  1    3    1    9250.7400  6897.0276  180.0   2.86133  0.18   
+  2  1    3    -2   2380.6073  1923.0466  -0.0    2.83885  0.02   
+  2  2    -2   -2   37.2063    183.4547   -0.0    2.79276  0.00   
+  2  0    2    2    63.8709    191.6414   0.0     2.78600  0.01   
+  2  0    4    1    160.1903   387.5360   -0.0    2.78271  0.00   
+  2  2    0    1    101.5379   109.5836   -0.0    2.68712  0.00   
+  2  3    1    -1   310.7446   431.0071   -180.0  2.66293  0.00   
+  2  1    -3   -2   17703.9935 6171.6319  -0.0    2.63839  0.36   
+  2  3    -1   -1   66.3248    33.5476    -180.0  2.62530  0.00   
+  2  2    4    -1   114995.1296 12550.4891 -180.0  2.55995  0.50   
+  2  3    1    -2   1486.3676  1812.0722  180.0   2.53704  0.01   
+  2  1    -1   2    394.7395   667.2869   180.0   2.51139  0.01   
+  2  2    -2   1    1987.9991  1686.7859  -180.0  2.49495  0.02   
+  2  3    -1   -2   411.1991   451.5613   180.0   2.48043  0.00   
+  2  1    1    2    107.4173   110.2849   180.0   2.46610  0.01   
+  2  2    2    1    1188.0084  1367.0046  -180.0  2.45771  0.02   
+  2  2    -4   -1   10903.3408 10453.7459 -180.0  2.44277  0.05   
+  2  1    5    -1   5929.4309  4093.1663  -0.0    2.42941  0.02   
+  2  1    5    0    50.7579    64.0884    180.0   2.41202  0.00   
+  2  2    4    0    3123.4317  3944.1458  -0.0    2.40628  0.02   
+  2  1    -5   0    1663.3282  2230.8323  180.0   2.40074  0.01   
+  2  2    -4   0    1694.1514  2079.3222  -0.0    2.38844  0.01   
+  2  3    1    0    1263.2412  1565.2946  -0.0    2.38575  0.01   
+  2  3    -1   0    1393.7250  2090.0863  -0.0    2.37918  0.01   
+  2  2    0    -3   6.4410     7.3701     180.0   2.35133  0.00   
+  2  2    4    -2   2.7144     2.9331     0.0     2.34729  0.00   
+  2  1    1    -3   111.8978   110.8373   -0.0    2.33656  0.00   
+  2  0    4    -2   1263.1060  884.3144   -180.0  2.33087  0.01   
+  2  3    3    -1   22955.8261 9809.7794  180.0   2.31766  0.08   
+  2  1    -5   -1   2590.3326  1044.9800  0.0     2.31526  0.01   
+  2  1    -1   -3   1984.3033  2291.2470  -0.0    2.27750  0.24   
+  2  2    2    -3   179.2390   155.6865   -0.0    2.26146  0.00   
+  2  3    3    -2   22.4759    15.9172    0.0     2.25070  0.00   
+  2  3    -3   -1   3747.1469  2703.2457  -180.0  2.24518  0.01   
+  2  1    -3   2    941.2983   824.7896   -0.0    2.22556  0.01   
+  2  0    4    2    2496.0559  2085.0250  0.0     2.18812  0.04   
+  2  2    -4   -2   1716.9830  1431.8638  0.0     2.18799  0.01   
+  2  1    -5   1    4910.0766  4194.8986  180.0   2.18493  0.02   
+  2  2    -2   -3   2148.5354  1851.4932  0.0     2.15451  0.03   
+  2  1    5    -2   395.8943   312.7232   -180.0  2.15169  0.00   
+  2  3    1    -3   449.7408   204.6119   0.0     2.13824  0.00   
+  2  3    -3   -2   1162.8548  512.1941   180.0   2.13724  0.00   
+  2  1    3    2    461.4282   174.4523   -180.0  2.13433  0.01   
+  2  0    0    3    2270.9231  454.6548   -0.0    2.12929  0.81   
+  2  0    6    0    83086.3137 11042.6256 -0.0    2.12489  0.26   
+  2  1    3    -3   4402.7858  674.2906   -180.0  2.11876  0.04   
+  2  1    5    1    25479.0221 4734.7647  180.0   2.11595  0.16   
+  2  3    3    0    7057.1730  1496.6439  -180.0  2.11318  0.03   
+  2  3    -3   0    298.5653   182.7827   -180.0  2.09956  0.00   
+  2  3    -1   -3   6385.4416  2416.5634  0.0     2.08973  0.04   
+  2  2    -4   1    7190.8064  8370.0925  180.0   2.07604  0.03   
+  2  0    2    -3   159.2922   286.8930   -180.0  2.05903  0.00   
+  2  0    6    -1   46.0371    83.9001    -0.0    2.05549  0.00   
+  2  2    4    1    2277.1828  2723.1302  180.0   2.03350  0.02   
+  2  4    0    -2   2416.2681  1673.8545  -0.0    2.01366  0.01   
+  2  1    -5   -2   2181.0187  976.2191   -0.0    2.00557  0.01   
+  2  4    0    -1   9328.0084  3207.5402  -0.0    2.00025  0.02   
+  2  2    0    2    2993.3028  914.6787   0.0     1.99827  0.05   
+  2  1    -3   -3   8015.6826  2006.9284  -0.0    1.99351  0.26   
+  2  0    2    3    879.0844   1320.4879  0.0     1.98235  0.31   
+  2  0    6    1    3706.6391  4760.1395  0.0     1.97919  0.01   
+  2  3    -1   1    3318.8844  1778.1424  0.0     1.97162  0.02   
+  2  3    3    -3   2056.2310  747.2487   -180.0  1.97003  0.01   
+  2  3    1    1    6797.0163  1049.8991  0.0     1.96352  0.04   
+  2  2    4    -3   1342.4058  210.6125   -180.0  1.96339  0.01   
+  2  4    2    -2   1902.3926  1505.1300  0.0     1.94723  0.00   
+  2  2    -2   2    4574.2931  4434.5615  -0.0    1.92633  0.04   
+  2  4    2    -1   179.6681   195.3738   0.0     1.92397  0.00   
+  2  2    6    -1   18.7342    25.7092    -0.0    1.91781  0.00   
+  2  4    -2   -2   16864.1615 14612.2943 -0.0    1.89414  0.04   
+  2  4    -2   -1   100.3208   83.9894    180.0   1.89341  0.00   
+  2  3    5    -1   4371.0449  3253.1319  -180.0  1.88804  0.01   
+  2  2    2    2    14605.4443 11147.4650 -0.0    1.88782  0.27   
+  2  3    -3   -3   477.5465   242.1347   -0.0    1.86184  0.00   
+  2  3    5    -2   321.3842   151.7748   -180.0  1.86122  0.00   
+  2  4    0    -3   41536.6581 17227.6438 -180.0  1.84958  0.12   
+  2  2    -6   -1   1327.6295  630.1904   -180.0  1.84310  0.00   
+  2  1    -5   2    69.1991    32.7906    -180.0  1.84286  0.00   
+  2  2    6    0    14661.5797 5973.8074  -0.0    1.84084  0.04   
+  2  2    6    -2   4343.6829  2234.4122  -180.0  1.83281  0.01   
+  2  1    -1   3    3155.0238  2403.8627  -180.0  1.82957  0.11   
+  2  2    -6   0    14376.3519 11170.3478 0.0     1.82883  0.03   
+  2  2    -4   -3   464.1226   351.5785   -0.0    1.82817  0.00   
+  2  0    4    -3   9265.4307  6600.1943  180.0   1.82454  0.06   
+  2  3    -5   -1   740.7064   547.0575   -180.0  1.82305  0.00   
+  2  0    6    -2   12716.4709 9376.7847  -180.0  1.82300  0.03   
+  2  4    0    0    20482.8327 16544.7345 -0.0    1.81888  0.06   
+  2  3    -3   1    1254.1837  1388.1619  -0.0    1.81269  0.00   
+  2  4    2    -3   860.6358   1698.2109  -0.0    1.80678  0.00   
+  2  1    1    3    4606.2705  13204.6231 -180.0  1.80269  0.59   
+  2  3    3    1    333.8546   659.8672   -0.0    1.79396  0.00   
+  2  1    5    -3   19.4227    36.9138    180.0   1.79152  0.00   
+  2  1    7    -1   135.2612   370.2527   -180.0  1.78554  0.00   
+  2  2    0    -4   10048.7549 29304.7955 0.0     1.78457  0.20   
+  2  1    7    0    2704.6523  1186.7943  -0.0    1.76994  0.01   
+  2  3    5    0    1040.4855  192.4714   -180.0  1.76391  0.00   
+  2  1    -7   0    10382.0986 1861.7091  0.0     1.76369  0.02   
+  2  1    5    2    12686.7333 1478.1411  -180.0  1.75728  0.11   
+  2  3    -5   -2   1954.8527  292.8600   -180.0  1.75539  0.00   
+  2  2    2    -4   18608.3762 5374.4235  180.0   1.75260  0.17   
+  2  4    2    0    11131.3069 3240.2714  180.0   1.75255  0.03   
+  2  3    -5   0    2.0111     0.6787     -180.0  1.75073  0.00   
+  2  4    -2   -3   4053.5028  1498.9920  -180.0  1.74735  0.01   
+  2  4    -2   0    4124.0380  1478.3757  -180.0  1.74562  0.01   
+  2  4    4    -2   25601.0344 11156.5991 -180.0  1.74061  0.05   
+  2  3    1    -4   30.0423    11.6942    0.0     1.73791  0.00   
+  2  1    1    -4   1990.4239  931.5858   180.0   1.73044  0.07   
+  2  0    4    3    4037.5417  1649.4123  180.0   1.72108  0.11   
+  2  1    -7   -1   1317.2209  544.5769   -0.0    1.72100  0.00   
+  2  2    -4   2    11831.4531 5111.9528  -180.0  1.72066  0.04   
+  2  0    6    2    8612.6369  4043.0244  180.0   1.71979  0.05   
+  2  2    -6   -2   9849.3979  5843.5104  180.0   1.71808  0.03   
+  2  1    -3   3    6070.6051  3889.7621  0.0     1.71755  0.05   
+  2  4    4    -1   4763.2798  3425.3612  -0.0    1.71605  0.01   
+  2  3    -1   -4   52.8235    26.3196    -0.0    1.70384  0.00   
+  2  3    5    -3   3097.7995  1781.5059  180.0   1.70048  0.01   
+  2  1    -1   -4   1550.0218  1087.2281  180.0   1.69839  0.20   
+  2  2    -2   -4   10397.2407 6607.2640  -0.0    1.68632  0.21   
+  2  2    -6   1    174.6989   111.8094   180.0   1.68403  0.00   
+  2  1    -7   1    1685.8827  1037.6002  0.0     1.67991  0.00   
+  2  1    7    -2   3799.0671  3014.1863  0.0     1.67337  0.01   
+  2  4    -4   -1   3875.9743  3113.5342  -0.0    1.67328  0.01   
+  2  1    -5   -3   360.1353   322.6770   -180.0  1.66739  0.00   
+  2  2    4    2    7840.6784  6980.1241  -180.0  1.66673  0.08   
+  2  4    -4   -2   3395.0296  2996.9232  -180.0  1.66656  0.01   
+  2  1    3    3    623.7452   605.4945   0.0     1.65314  0.03   
+  2  3    3    -4   467.2265   474.5918   180.0   1.65084  0.00   
+  2  2    6    1    14.3397    15.0623    180.0   1.64996  0.00   
+  2  4    4    -3   80.9873    81.5092    0.0     1.64497  0.00   
+  2  1    3    -4   1195.7745  1267.0308  -180.0  1.64299  0.01   
+  2  2    6    -3   345.1546   438.3802   0.0     1.63845  0.00   
+  2  1    7    1    787.0384   959.6711   0.0     1.63566  0.00   
+  2  5    1    -2   55.5010    62.3555    -180.0  1.62122  0.00   
+  2  2    4    -4   12.6508    6.6299     0.0     1.60885  0.00   
+  2  3    -1   2    467.8568   237.1891   -180.0  1.60779  0.00   
+  2  4    0    -4   50.3698    25.5451    0.0     1.60742  0.00   
+  2  5    -1   -2   197.8379   104.4782   -0.0    1.60481  0.00   
+  2  3    1    2    8.8358     3.3755     -180.0  1.59704  0.00   
+  2  0    0    4    4519.0899  1719.5025  -0.0    1.59697  0.90   
+  2  0    8    0    15298.3318 4104.7411  -0.0    1.59366  0.03   
+  2  3    -5   -3   13472.9364 7048.0684  -180.0  1.58673  0.04   
+  2  4    2    -4   10345.9603 5767.4424  -180.0  1.58523  0.03   
+  2  4    4    0    147.3923   80.5872    180.0   1.58489  0.00   
+  2  3    -5   1    8264.9479  3541.7994  0.0     1.57987  0.02   
+  2  1    -7   -2   229.6622   106.0592   180.0   1.57566  0.00   
+  2  4    -4   0    2110.4004  972.7791   180.0   1.57467  0.00   
+  2  4    0    1    2854.6751  1313.3627  0.0     1.57405  0.01   
+  2  0    2    -4   13776.1004 6835.8768  -180.0  1.57267  0.30   
+  2  5    1    -1   3459.9260  1838.8969  0.0     1.57223  0.01   
+  2  5    1    -3   7.5209     4.5305     0.0     1.57056  0.00   
+  2  0    8    -1   8265.3378  5105.5113  -180.0  1.56971  0.01   
+  2  3    -3   -4   280.3546   222.0271   -180.0  1.56739  0.00   
+  2  1    -3   -4   1309.7293  1168.3240  -180.0  1.56437  0.06   
+  2  5    -1   -1   3822.8457  3532.8589  -0.0    1.56314  0.01   
+  2  3    5    1    7482.0723  6630.5027  -0.0    1.55930  0.03   
+  2  2    0    3    2009.7424  1763.6711  -180.0  1.55911  0.04   
+  2  4    -4   -3   800.8634   668.2938   0.0     1.55805  0.00   
+  2  0    6    -3   65.6426    50.4752    180.0   1.55391  0.00   
+  2  5    -1   -3   3880.0220  3177.9812  180.0   1.54983  0.01   
+  2  5    3    -2   1976.9007  1684.3120  0.0     1.53962  0.00   
+  2  3    7    -1   406.1865   255.3064   -0.0    1.53554  0.00   
+  2  4    -2   -4   6483.4497  4566.3850  180.0   1.53333  0.02   
+  2  4    -2   1    462.5236   360.2122   -0.0    1.53138  0.00   
+  2  2    -2   3    3251.8178  3884.5431  0.0     1.52972  0.03   
+  2  1    -5   3    60.5199    114.2358   180.0   1.52775  0.00   
+  2  0    2    4    874.3195   1999.2534  180.0   1.52655  0.45   
+  2  3    7    -2   617.1995   1417.6951  180.0   1.52649  0.00   
+  2  4    2    1    27.9603    55.0425    -0.0    1.52494  0.00   
+  2  0    8    1    32.0526    53.4117    0.0     1.52385  0.00   
+  2  3    -3   2    449.3078   713.5252   0.0     1.52351  0.00   
+  2  2    -6   -3   1015.3160  972.3599   180.0   1.52111  0.00   
+  2  1    -7   2    3052.1756  2092.8268  180.0   1.51406  0.01   
+  2  2    -4   -4   4001.0750  3475.0688  -180.0  1.51008  0.04   
+  2  2    8    -1   9021.1839  8932.7653  0.0     1.50687  0.01   
+  2  5    3    -3   10164.6236 11216.4371 -0.0    1.50125  0.02   
+  2  2    2    3    228.3746   261.4234   0.0     1.49966  0.01   
+  2  5    -3   -2   1205.1655  1283.3165  0.0     1.49852  0.00   
+  2  4    6    -2   1617.2773  1643.4734  -180.0  1.49804  0.00   
+  2  3    3    2    3056.9839  2828.3266  0.0     1.49651  0.02   
+  2  5    3    -1   1834.3728  1375.8687  180.0   1.49230  0.00   
+  2  1    7    -3   1323.4074  963.7100   -0.0    1.49138  0.00   
+  2  3    5    -4   1699.4615  976.7543   0.0     1.48741  0.00   
+  2  3    -7   -1   8.5437     4.1505     -180.0  1.48641  0.00   
+  2  2    -6   2    7182.7503  2225.9899  -180.0  1.48209  0.01   
+  2  1    5    -4   2134.9910  569.2303   -0.0    1.48061  0.01   
+  2  4    4    -4   3617.4358  936.8644   -0.0    1.47752  0.01   
+  2  4    6    -1   9401.6065  2425.3077  -0.0    1.47727  0.01   
+  2  2    8    -2   6293.6091  2036.6290  -0.0    1.46947  0.01   
+  2  5    -3   -1   6857.8805  2250.7625  180.0   1.46932  0.01   
+  2  0    4    -4   4032.6965  1799.2981  0.0     1.46530  0.03   
+  2  2    8    0    32253.0467 17372.8918 180.0   1.46378  0.06   
+  2  0    8    -2   4756.4224  2670.5014  0.0     1.46338  0.01   
+  2  3    7    0    2349.1809  1344.4772  -0.0    1.46164  0.00   
+  2  0    6    3    13285.6565 9727.2084  -180.0  1.45874  0.10   
+  2  2    -8   -1   396.0352   277.6153   0.0     1.45806  0.00   
+  2  2    -8   0    19546.1969 14971.6548 -180.0  1.45572  0.03   
+  2  1    5    3    96.3576    84.4701    0.0     1.45352  0.00   
+  2  3    -7   0    1856.3467  1874.7884  -0.0    1.45113  0.00   
+  2  5    -3   -3   3918.0951  3973.0050  -0.0    1.44873  0.01   
+  2  1    7    2    339.2017   339.6716   180.0   1.44736  0.00   
+  2  5    1    0    481.6783   468.7582   0.0     1.44694  0.00   
+  2  5    -1   0    341.2179   282.6566   0.0     1.44450  0.00   
+  2  3    -7   -2   506.6538   407.5222   -180.0  1.44435  0.00   
+  2  5    1    -4   468.3216   376.0669   -0.0    1.44434  0.00   
+  2  4    6    -3   10073.3621 4799.2632  180.0   1.44037  0.01   
+  2  3    7    -3   4550.6714  2066.9126  0.0     1.43858  0.01   
+  2  4    -6   -1   30029.7933 13974.0377 -0.0    1.43651  0.04   
+  2  1    -1   4    2744.3435  1747.7612  -0.0    1.43156  0.09   
+  2  2    6    2    20735.6703 14127.5120 -180.0  1.43067  0.10   
+  2  4    -6   -2   17852.7356 11494.7453 -180.0  1.42772  0.03   
+  2  3    1    -5   100.6718   54.5453    0.0     1.42498  0.00   
+  2  2    -4   3    17319.0057 9304.7725  -0.0    1.42492  0.07   
+  2  5    -1   -4   10354.9634 6191.0063  0.0     1.42367  0.02   
+  2  2    0    -5   544.0634   530.6717   -0.0    1.41970  0.01   
+  2  2    6    -4   4087.2626  4109.1661  -0.0    1.41942  0.01   
+  2  4    -4   1    1331.3375  2328.2327  -180.0  1.41643  0.00   
+  2  1    1    4    3264.8518  9765.5200  -0.0    1.41417  0.41   
+  2  2    2    -5   107.5772   102.1798   180.0   1.40774  0.00   
+  2  4    4    1    6985.9297  4251.1055  -180.0  1.40628  0.02   
+  2  1    9    -1   558.9296   313.3806   180.0   1.40427  0.00   
+  2  3    -1   -5   1143.7837  559.2035   180.0   1.40173  0.01   
+  2  5    5    -2   202.6472   121.8591   180.0   1.39689  0.00   
+  2  4    -4   -4   478.3723   333.7965   -180.0  1.39638  0.00   
+  2  5    3    -4   14399.4945 10290.7248 -180.0  1.39407  0.02   
+  2  0    4    4    841.7208   603.2489   180.0   1.39300  0.04   
+  2  1    9    0    8563.1453  6061.3448  -180.0  1.39244  0.01   
+  2  0    8    2    1273.6108  841.8614   -0.0    1.39135  0.00   
+  2  1    -7   -3   12.8156    8.6161     0.0     1.39082  0.00   
+  2  2    -8   -2   586.7817   389.1003   0.0     1.38958  0.00   
+  2  1    -9   0    6507.9020  5032.6219  -180.0  1.38852  0.01   
+  2  3    -5   -4   888.1430   712.8918   180.0   1.38828  0.00   
+  2  1    -5   -4   14.7218    12.2841    -0.0    1.38705  0.00   
+  2  4    6    0    8316.6014  6881.9956  0.0     1.38694  0.02   
+  2  2    -8   1    3543.8670  2583.5813  -0.0    1.38353  0.00   
+  2  3    -5   2    179.1465   107.7060   180.0   1.38139  0.00   
+  2  1    -3   4    13209.0008 11498.8556 180.0   1.38001  0.12   
+  2  3    3    -5   691.3612   601.2645   -0.0    1.37984  0.00   
+  2  5    3    0    2375.3894  2064.1961  180.0   1.37983  0.00   
+  2  2    4    3    7344.3976  7682.9819  -0.0    1.37735  0.10   
+  2  4    -6   0    2753.1401  2929.6322  0.0     1.37669  0.00   
+  2  5    -3   0    2138.1532  1846.9850  -180.0  1.37349  0.00   
+  2  4    0    -5   11005.3893 9852.1453  -0.0    1.37263  0.04   
+  2  5    5    -3   1269.2102  1000.1841  -0.0    1.37203  0.00   
+  2  1    1    -5   101.9939   51.8333    180.0   1.36876  0.00   
+  2  2    8    -3   2159.3143  897.0709   0.0     1.36740  0.00   
+  2  2    -2   -5   2409.3275  890.9937   -180.0  1.36475  0.06   
+  2  1    -9   -1   6538.2740  2521.2414  180.0   1.36346  0.01   
+  2  4    2    -5   27023.5890 11335.5971 180.0   1.36264  0.08   
+  2  2    8    1    8937.6626  3611.9875  -180.0  1.35827  0.02   
+  2  5    5    -1   2100.9248  870.4892   -180.0  1.35737  0.00   
+  2  4    -6   -3   7110.1380  4126.3352  180.0   1.35385  0.01   
+  2  3    -7   1    888.9117   576.4772   0.0     1.35312  0.00   
+  2  1    9    -2   19250.4930 16147.0686 0.0     1.35152  0.02   
+  2  6    0    -2   19520.5210 16981.3924 180.0   1.35133  0.02   
+  2  1    -9   1    3813.2791  3741.5161  -0.0    1.35032  0.00   
+  2  1    -1   -5   7859.1665  10683.9602 -0.0    1.34891  1.04   
+  2  3    5    2    134.0565   209.3398   0.0     1.34817  0.00   
+  2  5    -5   -2   342.5248   568.7530   180.0   1.34647  0.00   
+  2  4    0    2    8957.1921  20266.7951 180.0   1.34356  0.03   
+  2  6    0    -3   243.9015   424.9852   0.0     1.34244  0.00   
+  2  3    -7   -3   624.9660   987.1236   180.0   1.34218  0.00   
+  2  5    -3   -4   19.2656    19.4544    -0.0    1.34037  0.00   
+  2  3    7    1    369.8184   545.2034   0.0     1.33504  0.00   
+  2  1    3    4    191.3681   303.9072   180.0   1.33473  0.01   
+  2  2    4    -5   1566.8619  2138.1647  -0.0    1.33359  0.01   
+  2  6    2    -2   4560.1920  7470.5514  0.0     1.33146  0.01   
+  2  3    -1   3    386.1438   551.6386   -0.0    1.32984  0.00   
+  2  5    -5   -1   2338.8802  3077.6343  -180.0  1.32879  0.00   
+  2  1    -7   3    589.3123   845.5145   -180.0  1.32789  0.00   
+  2  1    3    -5   9013.3152  12956.3684 180.0   1.32785  0.09   
+  2  4    6    -4   838.1174   1219.1637  0.0     1.32754  0.00   
+  2  6    2    -3   4.5833     6.0091     -0.0    1.32656  0.00   
+  2  4    -2   -5   3320.2425  3146.4347  0.0     1.32203  0.01   
+  2  1    9    1    1162.7104  1105.1306  -0.0    1.32057  0.00   
+  2  4    -2   2    2264.6988  2255.4357  0.0     1.32028  0.01   
+  2  3    1    3    3202.5527  3237.6008  0.0     1.32015  0.03   
+  2  2    -6   -4   121.7612   114.0134   0.0     1.31919  0.00   
+  2  3    -3   -5   2333.0808  2179.7868  180.0   1.31918  0.02   
+  2  0    6    -4   4068.1040  3685.3963  0.0     1.31717  0.01   
+  2  0    8    -3   5027.6754  4546.6333  -0.0    1.31636  0.01   
+  2  6    -2   -2   468.3156   330.6363   180.0   1.31265  0.00   
+  2  4    2    2    1226.5006  505.4413   0.0     1.30914  0.01   
+  2  5    -5   -3   14827.5725 6208.9517  0.0     1.30653  0.02   
+  2  3    7    -4   28.2252    11.5530    -180.0  1.30602  0.00   
+  2  6    0    -1   1701.4873  635.2341   -0.0    1.30261  0.00   
+  2  6    -2   -3   10587.5661 4797.6968  0.0     1.30107  0.01   
+  2  1    7    -4   1728.7636  816.7390   180.0   1.30069  0.00   
+  2  4    4    -5   1563.8869  839.8412   -180.0  1.29576  0.00   
+  2  5    -1   1    1054.6428  560.8179   -180.0  1.29287  0.00   
+  2  5    5    -4   180.2230   102.0732   -0.0    1.29210  0.00   
+  2  5    1    1    317.9211   213.0414   180.0   1.29128  0.00   
+  2  5    1    -5   867.4727   1297.0866  -180.0  1.28850  0.00   
+  2  1    -9   -2   8461.6171  7594.2794  0.0     1.28440  0.02   
+  2  3    -3   3    4531.4042  3821.2749  180.0   1.28422  0.02   
+  2  2    -6   3    143.6359   97.9036    -0.0    1.28363  0.00   
+  2  3    5    -5   4825.4055  3037.5557  -0.0    1.28334  0.01   
+  2  6    2    -1   4626.2717  2446.8719  180.0   1.28151  0.01   
+  2  4    8    -2   34669.5465 16043.2073 -0.0    1.27998  0.04   
+  2  6    0    -4   8327.4850  4642.8182  0.0     1.27913  0.01   
+  2  1    -5   4    0.4844     0.2762     -0.0    1.27885  0.00   
+  2  0    0    5    2071.0301  1504.7953  0.0     1.27757  0.29   
+  2  2    -8   -3   1645.8558  969.8153   0.0     1.27578  0.00   
+  2  1    -3   -5   2752.9071  1649.0848  -180.0  1.27554  0.21   
+  2  0    10   0    8682.6584  5612.4673  -0.0    1.27493  0.01   
+  2  3    9    -1   875.8684   567.6734   180.0   1.27318  0.00   
+  2  3    9    -2   261.5067   209.3409   0.0     1.27118  0.00   
+  2  6    -2   -1   737.4605   604.9530   -180.0  1.27102  0.00   
+  2  5    -1   -5   3631.5724  3287.3648  -0.0    1.27057  0.01   
+  2  4    -6   1    2259.2676  2157.0193  180.0   1.27033  0.00   
+  2  2    0    4    3795.6216  5970.9564  -0.0    1.26862  0.08   
+  2  6    2    -4   1670.6778  2642.8907  -180.0  1.26852  0.00   
+  2  0    2    -5   2689.2899  4140.6925  180.0   1.26818  0.06   
+  2  2    -8   2    10602.8570 15669.9235 0.0     1.26800  0.01   
+  2  5    5    0    1067.7913  1539.1640  -0.0    1.26791  0.00   
+  2  0    10   -1   834.3054   722.1628   -180.0  1.26570  0.00   
+  2  4    8    -1   296.9396   116.1733   180.0   1.26381  0.00   
+  2  2    -4   -5   103.8324   34.2839    180.0   1.26302  0.00   
+  2  1    -9   2    1309.8252  407.6104   0.0     1.26267  0.00   
+  2  6    4    -2   18228.3467 4060.9393  -0.0    1.26012  0.02   
+  2  1    7    3    6162.4785  1423.0605  -180.0  1.25993  0.03   
+  2  5    -5   0    5290.4076  1251.7915  -0.0    1.25974  0.01   
+  2  4    6    1    147.7796   35.4122    180.0   1.25938  0.00   
+  2  6    4    -3   24339.1283 5742.7030  -180.0  1.25904  0.03   
+  2  3    3    3    149.5740   34.1056    0.0     1.25855  0.00   
+  2  2    -2   4    4477.1610  2630.4316  180.0   1.25569  0.04   
+  2  5    3    -5   13509.2699 7849.9862  180.0   1.25548  0.02   
+  2  1    9    -3   530.7785   446.4585   -180.0  1.25310  0.00   
+  2  4    -4   2    2517.0294  2913.1494  0.0     1.24747  0.01   
+  2  4    8    -3   1310.9806  1591.0184  -180.0  1.24643  0.00   
+  2  5    -3   1    151.8859   154.1169   -180.0  1.24419  0.00   
+  2  4    -6   -4   4383.5885  4649.8078  0.0     1.24074  0.01   
+  2  1    5    -5   19.5272    20.8490    -0.0    1.24058  0.00   
+  2  6    -2   -4   108.8832   116.0421   -0.0    1.24022  0.00   
+  2  5    3    1    811.9006   865.0651   -180.0  1.23993  0.00   
+  2  0    6    4    4125.0202  4402.8269  -0.0    1.23960  0.05   
+  2  0    8    3    2354.4110  2523.8232  0.0     1.23892  0.01   
+  2  5    7    -2   43.7173    48.4702    -180.0  1.23815  0.00   
+  2  0    2    5    5.4730     6.1649     -0.0    1.23770  0.00   
+  2  3    -9   -1   1609.1090  1878.7146  -180.0  1.23697  0.00   
+  2  0    10   1    61.0672    69.0195    180.0   1.23540  0.00   
+  2  2    8    -4   0.5740     0.6712     -0.0    1.23509  0.00   
+  2  2    2    4    186.1737   202.3679   180.0   1.23305  0.01   
+  2  2    10   -1   558.7469   674.5837   -0.0    1.23266  0.00   
+  2  2    6    3    461.1024   591.5126   -0.0    1.23202  0.00   
+  2  4    -8   -1   1430.4666  1660.8265  180.0   1.22975  0.00   
+  2  4    4    2    5082.5936  7216.8110  -0.0    1.22886  0.02   
+  2  6    -4   -2   5346.2695  7429.0559  0.0     1.22874  0.01   
+  2  4    -4   -5   4866.1085  5935.8119  180.0   1.22833  0.02   
+  2  3    9    0    249.2299   207.1256   180.0   1.22722  0.00   
+  2  2    8    2    23487.2488 16367.8700 -0.0    1.22501  0.07   
+  2  3    -7   2    6.4079     4.4310     -180.0  1.22493  0.00   
+  2  5    7    -3   1501.4051  701.3947   180.0   1.22357  0.00   
+  2  5    -5   -4   897.6237   527.2945   -180.0  1.22255  0.00   
+  2  2    6    -5   151.8877   93.3157    -0.0    1.22244  0.00   
+  2  3    9    -3   5583.1130  3989.5508  -0.0    1.22187  0.01   
+  2  4    -8   -2   22107.8465 15576.6760 0.0     1.22139  0.03   
+  2  1    5    4    3453.9990  2923.6151  -180.0  1.22003  0.07   
+  2  3    -9   0    89.0455    63.1939    -0.0    1.21922  0.00   
+  2  6    -4   -3   3.0820     1.6171     -180.0  1.21643  0.00   
+  2  6    4    -1   24.9500    10.2523    180.0   1.21473  0.00   
+  2  2    10   -2   7735.1649  3195.8904  -180.0  1.21471  0.01   
+  2  3    -7   -4   16.6015    9.5153     0.0     1.21279  0.00   
+  2  6    0    0    22544.0134 13100.2263 0.0     1.21259  0.03   
+  2  1    9    2    3010.6094  1749.7864  0.0     1.21259  0.01   
+  2  0    4    -5   88.4277    51.4047    -180.0  1.21258  0.00   
+  2  1    -7   -4   1155.8596  673.8718   0.0     1.21254  0.01   
+  2  6    4    -4   337.2264   199.9465   0.0     1.21185  0.00   
+  2  0    10   -2   4279.2461  2393.1814  180.0   1.21068  0.00   
+  2  3    -9   -2   3.9541     2.4088     0.0     1.20966  0.00   
+  2  5    7    -1   1457.1030  919.5910   -0.0    1.20764  0.00   
+  2  5    -3   -5   2598.2398  1669.4106  -180.0  1.20756  0.01   
+  2  2    10   0    17.3316    11.8619    180.0   1.20601  0.00   
+  2  3    -5   -5   4998.6272  5223.5291  -0.0    1.20426  0.03   
+  2  4    8    0    2436.6367  2036.1638  -180.0  1.20314  0.00   
+  2  2    -10  0    1236.1406  1234.3417  180.0   1.20037  0.00   
+  2  2    -10  -1   1982.2459  1881.5821  0.0     1.19900  0.00   
+  2  2    -4   4    0.0037     0.0043     180.0   1.19841  0.00   
+  2  3    -5   3    4455.1898  5149.8089  -180.0  1.19827  0.01   
+  2  6    -4   -1   4512.7555  4013.4094  180.0   1.19705  0.01   
+  2  4    -8   0    2380.0795  1701.7086  -180.0  1.19422  0.00   
+  2  4    6    -5   7947.1313  5356.2972  -0.0    1.19366  0.01   
+  2  6    2    0    8536.8166  6359.8747  -180.0  1.19287  0.01   
+  2  3    1    -6   228.6804   172.0799   180.0   1.19278  0.00   
+  2  3    7    2    278.4225   210.6961   180.0   1.19262  0.00   
+  2  6    -2   0    3031.8895  1825.4606  -180.0  1.18959  0.00   
+  2  5    -7   -2   392.5494   235.2689   -180.0  1.18926  0.00   
+  2  5    5    -5   876.4281   652.0282   -0.0    1.18202  0.00   
+  2  6    0    -5   2332.6282  1859.8386  -0.0    1.18139  0.00   
+  2  5    -7   -1   1275.9390  1170.6276  -0.0    1.17956  0.00   
+  2  3    -1   -6   5251.9458  10651.6340 0.0     1.17652  0.06   
+  2  1    -9   -3   1478.9050  3479.3329  -0.0    1.17569  0.00   
+  2  4    0    -6   295.4168   694.8770   -180.0  1.17567  0.00   
+  2  6    2    -5   292.7567   690.4314   180.0   1.17553  0.00   
+  2  4    8    -4   1756.7089  5262.2410  180.0   1.17365  0.00   
+  2  1    -1   5    14.3368    44.3347    0.0     1.17349  0.00   
+  2  2    0    -6   905.3062   3262.2227  -180.0  1.17258  0.02   
+  2  4    2    -6   251.9423   785.7923   0.0     1.17185  0.00   
+  2  4    -8   -3   172.4371   512.5086   -0.0    1.17167  0.00   
+  2  1    -5   -5   1885.9626  5414.4867  -180.0  1.17131  0.04   
+  2  3    3    -6   2312.2246  3178.6335  180.0   1.16840  0.01   
+  2  5    7    -4   4366.1065  5932.4007  0.0     1.16833  0.01   
+  2  2    2    -6   330.0710   444.4424   0.0     1.16828  0.00   
+  2  0    8    -4   8056.5086  6734.2463  -180.0  1.16544  0.01   
+  2  3    5    3    10147.1733 9033.3981  -180.0  1.16397  0.07   
+  2  6    -4   -4   1448.2890  1331.0105  -180.0  1.16381  0.00   
+  2  3    7    -5   1274.2710  1180.8749  180.0   1.16377  0.00   
+  2  3    -9   1    14.7567    24.5109    -0.0    1.16177  0.00   
+  2  1    1    5    1065.1210  1984.2370  0.0     1.16142  0.14   
+  2  2    -10  1    214.8891   408.7012   -180.0  1.16134  0.00   
+  2  0    4    5    1822.8511  3674.6390  -180.0  1.16082  0.14   
+  2  6    6    -3   311.4835   572.9928   0.0     1.16041  0.00   
+  2  5    -5   1    4.8557     8.2052     180.0   1.16017  0.00   
+  2  7    1    -3   207.1467   326.8856   180.0   1.15995  0.00   
+  2  2    4    4    214.9633   334.7388   180.0   1.15990  0.00   
+  2  0    10   2    1328.3273  1953.1670  -180.0  1.15916  0.00   
+  2  5    -7   -3   9.4309     13.9221    0.0     1.15905  0.00   
+  2  6    6    -2   715.9810   1062.5954  180.0   1.15883  0.00   
+  2  2    -10  -2   750.9440   927.1428   -180.0  1.15763  0.00   
+  2  2    10   -3   381.5241   456.9863   180.0   1.15752  0.00   
+  2  1    -7   4    7151.8631  7894.1741  -0.0    1.15699  0.02   
+  2  1    11   -1   157.7538   172.4013   -0.0    1.15488  0.00   
+  2  5    5    1    13.7183    14.5872    180.0   1.15443  0.00   
+  2  4    0    3    418.3487   372.8509   -0.0    1.15214  0.00   
+  2  7    -1   -3   173.6771   190.7937   -0.0    1.15103  0.00   
+  2  1    -9   3    362.4378   390.2848   -180.0  1.15086  0.00   
+  2  7    1    -2   560.0602   417.6649   180.0   1.14957  0.00   
+  2  6    -2   -5   3.5149     3.3422     180.0   1.14818  0.00   
+  2  2    -8   -4   1336.6984  1241.1393  -0.0    1.14713  0.00   
+  2  3    9    1    920.0149   840.9132   -180.0  1.14703  0.00   
+  2  1    -3   5    148.6637   131.0137   -0.0    1.14691  0.00   
+  2  4    -6   2    1125.1035  884.2580   -180.0  1.14653  0.00   
+  2  1    11   0    714.1948   673.8595   0.0     1.14593  0.00   
+  2  3    -9   -3   6855.9120  6842.7549  -0.0    1.14539  0.01   
+  2  1    -11  0    49.2809    56.5171    180.0   1.14326  0.00   
+  2  7    -1   -2   222.7871   258.5173   180.0   1.14319  0.00   
+  2  2    10   1    1643.7386  2221.3310  -180.0  1.14260  0.00   
+  2  2    -6   -5   6090.2424  8280.7099  -0.0    1.14253  0.05   
+  2  5    -1   2    0.1870     0.2523     -180.0  1.14237  0.00   
+  2  4    -2   -6   201.0994   159.9954   -0.0    1.14109  0.00   
+  2  5    7    0    2010.8883  1584.2307  0.0     1.14103  0.00   
+  2  3    9    -4   5324.2613  3452.1120  -180.0  1.13977  0.01   
+  2  4    -2   3    1057.0222  675.3480   180.0   1.13965  0.00   
+  2  2    -8   3    1515.7640  940.5804   180.0   1.13923  0.00   
+  2  5    1    2    249.6719   151.0052   180.0   1.13897  0.00   
+  2  2    -2   -6   778.8128   457.5743   180.0   1.13875  0.03   
+  2  5    1    -6   292.3412   92.8501    180.0   1.13644  0.00   
+  2  6    4    0    30502.5289 9886.1889  -180.0  1.13618  0.05   
+  2  1    9    -4   20436.9787 6387.1239  180.0   1.13575  0.03   
+  2  7    1    -4   503.2125   104.3489   0.0     1.13318  0.00   
+  2  5    -7   0    3105.3316  561.3250   0.0     1.13270  0.00   
+  2  6    4    -5   24479.8309 3560.8356  -0.0    1.13225  0.03   
+  2  7    3    -3   14429.5144 1752.7599  180.0   1.13164  0.02   
+  2  1    7    -5   13525.9460 1876.4532  -0.0    1.13113  0.03   
+  2  4    4    -6   469.3792   74.0198    180.0   1.13073  0.00   
+  2  6    -4   0    55007.3659 8996.3605  -180.0  1.13052  0.07   
+  2  1    1    -6   77.4517    12.7255    180.0   1.13041  0.00   
+  2  4    2    3    165.3110   26.9687    0.0     1.12798  0.00   
+  2  1    11   -2   20105.8251 4054.5939  -180.0  1.12721  0.02   
+  2  2    4    -6   2895.9314  617.9103   -180.0  1.12706  0.02   
+  2  1    -11  -1   364.1645   80.5660    180.0   1.12692  0.00   
+  2  0    6    -5   3626.7873  825.3110   -0.0    1.12677  0.01   
+  2  0    10   -3   95.2159    25.1309    180.0   1.12560  0.00   
+  2  6    6    -4   3896.3322  1116.6065  -0.0    1.12535  0.00   
+  2  4    -8   1    4421.1156  1428.0735  -0.0    1.12500  0.01   
+  2  4    6    2    1507.5827  491.6513   180.0   1.12497  0.01   
+  2  3    -3   -6   6151.5388  2679.1058  0.0     1.12421  0.07   
+  2  1    -11  1    1200.1093  520.4388   180.0   1.12385  0.00   
+  2  3    -1   4    157.7605   62.3074    180.0   1.12290  0.00   
+  2  7    -1   -4   849.9935   340.7362   180.0   1.12266  0.00   
+  2  6    -6   -2   14.5432    5.8815     -0.0    1.12259  0.00   
+  2  5    -1   -6   7431.9093  3679.1020  -180.0  1.12188  0.02   
+  2  6    6    -1   30.8580    18.5196    -180.0  1.12105  0.00   
+  2  7    3    -2   633.0419   466.2613   -180.0  1.11981  0.00   
+  2  5    -5   -5   1554.9768  3254.1700  180.0   1.11710  0.00   
+  2  1    -1   -6   745.5450   1573.1101  -180.0  1.11699  0.11   
+  2  4    -6   -5   7.5047     12.1624    -180.0  1.11621  0.00   
+  2  5    3    -6   2762.9514  3572.8767  0.0     1.11574  0.01   
+  2  3    1    4    456.7216   557.2568   180.0   1.11489  0.01   
+  2  4    8    1    2501.0844  3030.2470  -0.0    1.11486  0.01   
+  2  1    3    5    200.7886   208.8946   -180.0  1.11404  0.02   
+  2  2    -6   4    2201.9378  1626.0861  -0.0    1.11278  0.01   
+  2  6    -6   -3   13037.3006 9170.8262  180.0   1.11104  0.02   
+  2  5    -3   2    34.9985    23.9804    -180.0  1.11049  0.00   
+  2  3    5    -6   112.1976   75.3696    -0.0    1.11017  0.00   
+  2  1    3    -6   4734.1599  3749.4968  0.0     1.10915  0.06   
+  2  7    3    -4   1065.1670  851.8273   -0.0    1.10885  0.00   
+  2  7    -3   -3   11.2177    8.0510     -0.0    1.10731  0.00   
+  2  7    1    -1   878.1416   540.2195   -180.0  1.10485  0.00   
+  2  6    0    1    4115.5119  2851.2916  180.0   1.10441  0.01   
+  2  1    11   1    518.9207   353.4958   0.0     1.10278  0.00   
+  2  7    -3   -2   10.5489    7.6618     -0.0    1.10240  0.00   
+  2  4    10   -2   354.0121   293.9448   -180.0  1.10139  0.00   
+  2  7    -1   -1   677.1784   560.8360   -180.0  1.10125  0.00   
+  2  5    3    2    111.9064   92.4856    -180.0  1.10119  0.00   
+  2  2    8    -5   4702.2383  3728.5603  180.0   1.10077  0.01   
+  2  6    -6   -1   7.9333     6.2337     0.0     1.10033  0.00   
+  2  5    -7   -4   133.3612   136.6182   0.0     1.09716  0.00   
+  2  3    -3   4    135.3516   143.6453   -0.0    1.09706  0.00   
+  2  1    7    4    45.4374    57.0295    -0.0    1.09661  0.00   
+  2  0    8    4    3247.0637  2959.2417  180.0   1.09406  0.02   
+  2  4    -8   -4   4034.1798  3685.4545  -180.0  1.09399  0.01   
+  2  4    -4   3    2409.8361  2186.7268  180.0   1.09385  0.01   
+  2  3    -7   3    2000.7352  1814.2931  0.0     1.09384  0.00   
+  2  1    9    3    340.3959   308.2223   180.0   1.09383  0.00   
+  2  2    -10  2    4.0432     3.3265     -0.0    1.09247  0.00   
+  2  2    8    3    538.0740   379.8198   0.0     1.09126  0.00   
+  2  5    9    -2   2353.6251  1582.6840  -0.0    1.09021  0.00   
+  2  4    10   -1   2.0893     1.7369     -180.0  1.08903  0.00   
+  2  6    -2   1    1.8354     1.5406     -180.0  1.08894  0.00   
+  2  1    -5   5    6711.4035  5646.2565  0.0     1.08884  0.03   
+  2  6    2    1    331.0733   245.3481   -0.0    1.08745  0.00   
+  2  2    -10  -3   814.6931   617.4947   180.0   1.08733  0.00   
+  2  5    7    -5   110.0790   91.0318    -180.0  1.08704  0.00   
+  2  6    -4   -5   282.0900   422.0173   180.0   1.08477  0.00   
+  2  3    -7   -5   2407.1157  3180.2930  0.0     1.08232  0.01   
+  2  5    9    -3   27.9534    37.0056    -180.0  1.08217  0.00   
+  2  4    10   -3   460.2472   496.5346   180.0   1.08176  0.00   
+  2  4    8    -5   578.0624   416.8216   0.0     1.08002  0.00   
+  2  7    -3   -4   659.3896   475.9937   -180.0  1.08002  0.00   
+  2  3    11   -2   1506.6411  1209.7235  180.0   1.07973  0.00   
+  2  3    -9   2    1488.8241  1162.0253  -0.0    1.07952  0.00   
+  2  1    -11  -2   830.9953   505.5742   -0.0    1.07909  0.00   
+  2  3    11   -1   4384.6154  2531.9784  -180.0  1.07901  0.01   
+  2  4    -4   -6   110.9356   79.4879    0.0     1.07725  0.00   
+  2  7    3    -1   583.2221   517.9063   0.0     1.07642  0.00   
+  2  7    1    -5   28.3207    25.2106    -0.0    1.07626  0.00   
+  2  5    -3   -6   1465.5158  1371.1187  180.0   1.07586  0.01   
+  2  2    10   -4   3024.6624  2842.5457  0.0     1.07584  0.00   
+  2  2    -4   -6   184.9744   186.5753   0.0     1.07568  0.00   
+  2  3    3    4    518.7193   560.4316   180.0   1.07511  0.01   
+  2  1    -11  2    537.5263   558.2780   -180.0  1.07370  0.00   
+  2  7    5    -3   820.0386   928.6481   180.0   1.07351  0.00   
+  2  4    4    3    715.8969   818.8776   180.0   1.07348  0.00   
+  2  1    -3   -6   120.0733   135.6225   180.0   1.07233  0.02   
+  2  6    0    -6   4.2807     4.1780     -180.0  1.07161  0.00   
+  2  1    11   -3   703.2067   540.3856   180.0   1.07008  0.00   
+  2  6    2    -6   117.2773   107.8329   0.0     1.06912  0.00   
+  2  6    -6   -4   650.3023   552.9788   0.0     1.06862  0.00   
+  2  5    9    -1   1163.7713  1026.4794  0.0     1.06732  0.00   
+  2  2    6    4    4544.0946  4143.5979  0.0     1.06716  0.06   
+  2  7    -3   -1   199.8706   173.9010   0.0     1.06652  0.00   
+  2  2    0    5    2088.1670  1937.9253  0.0     1.06580  0.06   
+  2  0    6    5    390.5001   358.8678   0.0     1.06561  0.01   
+  2  7    -1   -5   3671.9199  3288.8085  0.0     1.06535  0.01   
+  2  5    5    -6   506.1051   447.2840   -180.0  1.06509  0.00   
+  2  0    0    6    60.7252    53.4823    180.0   1.06464  0.01   
+  2  0    10   3    3719.6548  3276.3246  0.0     1.06463  0.01   
+  2  4    6    -6   24.9685    31.3322    -180.0  1.06282  0.00   
+  2  6    6    -5   354.3092   434.3157   -0.0    1.06260  0.00   
+  2  0    12   0    96.6266    112.6819   180.0   1.06244  0.00   
+  2  4    -10  -1   1173.0431  1132.6677  180.0   1.06171  0.00   
+  2  7    5    -2   4639.3641  4496.3914  -180.0  1.06153  0.01   
+  2  0    2    -6   695.7675   748.1993   0.0     1.06104  0.02   
+  2  5    -7   1    853.2768   969.1237   180.0   1.06052  0.00   
+  2  1    -9   -4   1638.6355  1706.8793  -180.0  1.06015  0.01   
+  2  2    -2   5    3448.0435  3313.4198  -180.0  1.05994  0.05   
+  2  3    -9   -4   14.3147    13.6703    -180.0  1.05993  0.00   
+  2  2    6    -6   342.2806   288.6216   -180.0  1.05938  0.00   
+  2  0    12   -1   1594.1060  1340.4500  -0.0    1.05892  0.00   
+  2  1    -7   -5   9.6972     7.5059     -180.0  1.05860  0.00   
+  2  1    5    -6   61.4937    47.4061    -180.0  1.05858  0.00   
+  2  2    10   2    1662.9276  1237.1699  -0.0    1.05797  0.00   
+  2  3    7    3    18.8615    12.9031    -180.0  1.05758  0.00   
+  2  7    3    -5   3340.5433  2239.1302  -180.0  1.05718  0.00   
+  2  6    6    0    702.7182   461.7745   -0.0    1.05659  0.00   
+  2  7    5    -4   3435.5304  2051.4003  0.0     1.05581  0.00   
+  2  4    -10  -2   4945.8815  3145.7849  0.0     1.05450  0.01   
+  2  5    7    1    58.3788    37.2884    180.0   1.05440  0.00   
+  2  6    8    -3   12407.6385 8866.7538  -0.0    1.05196  0.01   
+  2  3    -11  -1   363.6283   261.5320   -0.0    1.05193  0.00   
+  2  5    -5   2    6587.1216  5387.0808  -180.0  1.05131  0.01   
+  2  3    9    2    1040.9189  862.2832   -0.0    1.05108  0.00   
+  2  3    11   -3   832.8892   673.7850   180.0   1.05082  0.00   
+  2  6    -6   0    721.7067   488.9045   -0.0    1.04978  0.00   
+  2  6    8    -2   430.9977   331.3808   0.0     1.04899  0.00   
+  2  3    11   0    522.3071   407.0557   -0.0    1.04881  0.00   
+  2  3    -5   -6   1573.5568  1235.7557  -180.0  1.04872  0.02   
+  2  4    10   0    79.7625    61.4161    -0.0    1.04771  0.00   
+  2  5    -9   -2   3246.9340  2208.3085  -0.0    1.04729  0.00   
+  2  5    9    -4   370.8471   228.7958   -180.0  1.04516  0.00   
+  2  6    -2   -6   2326.1823  1293.5044  -0.0    1.04487  0.01   
+  2  6    -4   1    5706.4933  3160.5795  -0.0    1.04485  0.01   
+  2  3    -5   4    4486.5211  2301.6767  -0.0    1.04377  0.02   
+  2  3    9    -5   3484.2498  1817.7670  180.0   1.04328  0.01   
+  2  1    5    5    3435.5975  1623.2967  -0.0    1.04294  0.14   
+  2  3    -11  0    3346.0268  1387.3612  0.0     1.04270  0.00   
+  2  2    2    5    640.8148   264.3036   0.0     1.04269  0.03   
+  2  5    -9   -1   167.7808   62.5557    0.0     1.04240  0.00   
+  2  6    4    1    2716.9022  1021.8291  -0.0    1.04223  0.01   
+  2  4    -10  0    990.2629   554.7785   -0.0    1.04034  0.00   
+  2  2    12   -1   4645.4212  3828.0670  -180.0  1.03971  0.01   
+  2  0    2    6    1474.3313  1492.8101  0.0     1.03949  0.98   
+  2  7    -5   -3   3298.3667  3517.5593  180.0   1.03943  0.00   
+  2  5    5    2    3353.3069  4324.4718  -180.0  1.03825  0.01   
+  2  4    -8   2    212.4610   298.1823   -0.0    1.03802  0.00   
+  2  6    4    -6   873.4961   1251.2761  -180.0  1.03798  0.00   
+  2  0    12   1    161.7080   335.8693   -0.0    1.03750  0.00   
+  2  7    -5   -2   588.5834   1492.9651  -180.0  1.03709  0.00   
+  2  7    1    0    527.4777   1264.8986  -0.0    1.03656  0.00   
+  2  1    -9   4    1.3349     2.8086     180.0   1.03594  0.00   
+  2  1    11   2    797.0010   1702.3367  180.0   1.03580  0.00   
+  2  7    -1   0    688.0185   1823.6465  -0.0    1.03529  0.00   
+  2  4    10   -4   3.2669     9.1218     0.0     1.03486  0.00   
+  2  3    -11  -2   547.7124   1522.0493  -180.0  1.03326  0.00   
+  3  1    1    0    6463.6742  5231.0099  0.0     5.76594  0.00   
+  3  1    1    -1   1809.8283  1404.6004  0.0     5.75232  0.00   
+  3  0    0    2    14974.1237 6633.1011  0.0     5.69783  0.00   
+  3  2    0    0    1940.6645  777.5446   180.0   5.30293  0.00   
+  3  2    0    -2   19490.8279 11502.0778 0.0     5.26091  0.00   
+  3  1    1    1    6788.0010  5911.8003  -180.0  4.69648  0.00   
+  3  1    1    -2   393.3766   470.7803   -180.0  4.67448  0.00   
+  3  1    1    2    871.9095   1807.3929  -180.0  3.62746  0.00   
+  3  1    1    -3   3324.8214  6209.3234  180.0   3.61056  0.00   
+  3  0    2    0    2704.2782  1738.7564  180.0   3.43494  0.00   
+  3  3    1    -1   578.8303   1015.3222  -0.0    3.40549  0.00   
+  3  3    1    -2   1605.2691  3187.5991  180.0   3.39708  0.00   
+  3  0    2    1    2835.6679  5008.5811  -0.0    3.28878  0.00   
+  3  2    0    2    8523.8654  11583.9155 -0.0    3.21754  0.00   
+  3  2    0    -4   7560.7353  4992.9978  180.0   3.18941  0.00   
+  3  3    1    0    3013.2525  2137.5839  0.0     3.14348  0.00   
+  3  3    1    -3   2526.6591  2674.2929  180.0   3.12373  0.00   
+  3  4    0    -2   95800.3927 80889.4927 180.0   2.98036  0.01   
+  3  2    2    -1   112598.8395 75054.9545 -0.0    2.97614  0.01   
+  3  0    2    2    1376.9135  792.9854   0.0     2.94173  0.00   
+  3  2    2    0    632.8276   1810.0141  0.0     2.88297  0.00   
+  3  2    2    -2   434.7141   529.4444   -0.0    2.87616  0.00   
+  3  1    1    3    3329.0766  2483.8012  -0.0    2.86232  0.00   
+  3  1    1    -4   7241.3084  5795.0115  -0.0    2.85068  0.00   
+  3  0    0    4    13605.9883 10327.4229 -0.0    2.84891  0.00   
+  3  3    1    1    2402.3961  3752.9688  -180.0  2.75686  0.00   
+  3  3    1    -4   2332.7951  3260.3471  -0.0    2.73472  0.00   
+  3  4    0    0    71444.0777 71031.9739 0.0     2.65146  0.00   
+  3  2    2    1    267917.1400 133021.8059 0.0     2.64322  0.03   
+  3  2    2    -3   163687.1823 66256.8795 -180.0  2.63275  0.02   
+  3  4    0    -4   326961.0460 140408.5131 180.0   2.63045  0.02   
+  3  0    2    3    24559.3436 14178.9448 180.0   2.54775  0.00   
+  3  3    1    2    4721.8141  9770.8933  -180.0  2.37457  0.00   
+  3  3    1    -5   5401.8916  5853.7195  -0.0    2.35477  0.00   
+  3  2    2    2    128.7011   143.8080   -180.0  2.34824  0.00   
+  3  2    2    -4   903.2548   881.0292   180.0   2.33724  0.00   
+  3  1    1    4    3580.0291  2962.3958  -0.0    2.33431  0.00   
+  3  1    1    -5   502.7893   299.3623   -0.0    2.32619  0.00   
+  3  4    2    -2   1987.0608  1407.7759  -0.0    2.25112  0.00   
+  3  5    1    -2   3005.5764  2122.6657  180.0   2.24357  0.00   
+  3  5    1    -3   857.6279   538.9133   180.0   2.23956  0.00   
+  3  1    3    0    85.3474    52.5069    0.0     2.23838  0.00   
+  3  1    3    -1   6858.4461  4186.4607  -0.0    2.23758  0.00   
+  3  4    2    -1   1059.6264  918.4263   0.0     2.21152  0.00   
+  3  4    2    -3   11884.9861 13293.9488 -0.0    2.20537  0.00   
+  3  0    2    4    938.2615   966.6191   180.0   2.19284  0.00   
+  3  5    1    -1   14550.4745 11518.0733 -0.0    2.16497  0.00   
+  3  1    3    1    1282.8308  1032.4559  -0.0    2.15743  0.00   
+  3  1    3    -2   13244.5999 10975.2744 0.0     2.15528  0.00   
+  3  5    1    -4   863.1385   709.3160   -180.0  2.15419  0.00   
+  3  2    0    4    4101.5140  1630.1550  0.0     2.13573  0.00   
+  3  2    0    -6   52145.2230 7194.5336  0.0     2.12198  0.00   
+  3  4    2    0    1385.6482  728.4665   -180.0  2.09889  0.00   
+  3  4    2    -4   1299.7262  548.3517   -180.0  2.08843  0.00   
+  3  4    0    2    231472.7801 285697.3593 180.0   2.06942  0.01   
+  3  2    2    3    184672.3170 292739.5635 0.0     2.06298  0.01   
+  3  2    2    -5   170952.8957 296841.9566 0.0     2.05304  0.01   
+  3  4    0    -6   156200.5413 301707.2943 -180.0  2.04950  0.00   
+  3  3    1    3    559.0085   1080.9037  -180.0  2.04754  0.00   
+  3  3    1    -6   147.5344   154.5139   -0.0    2.03121  0.00   
+  3  5    1    0    848.7799   770.8901   180.0   2.02676  0.00   
+  3  1    3    2    18879.0076 14027.7008 -0.0    2.01822  0.00   
+  3  1    3    -3   1767.1511  1239.1409  -0.0    2.01530  0.00   
+  3  5    1    -5   21421.9890 14139.5360 -0.0    2.01208  0.00   
+  3  3    3    -1   6740.7990  7028.4172  -0.0    1.97745  0.00   
+  3  3    3    -2   214.6696   188.2663   0.0     1.97579  0.00   
+  3  6    0    -2   3942.6572  970.2995   180.0   1.96059  0.00   
+  3  1    1    5    17010.3617 4609.7618  180.0   1.95972  0.00   
+  3  6    0    -4   28297.4289 17245.6519 -180.0  1.95417  0.00   
+  3  1    1    -6   2519.7247  1559.2190  -0.0    1.95385  0.00   
+  3  4    2    1    25476.2941 20964.5733 -0.0    1.94283  0.00   
+  3  4    2    -5   77.7845    70.8548    180.0   1.93040  0.00   
+  3  3    3    0    8106.8489  9843.8331  180.0   1.92198  0.00   
+  3  3    3    -3   2069.7248  2770.5320  -0.0    1.91744  0.00   
+  3  0    0    6    1466.6974  1703.7779  -0.0    1.89928  0.00   
+  3  0    2    5    78.2095    90.1067    -180.0  1.89911  0.00   
+  3  5    1    1    5110.8483  2500.7434  -180.0  1.86038  0.00   
+  3  1    3    3    9045.1275  3425.0588  0.0     1.85196  0.00   
+  3  1    3    -4   1182.9744  508.9478   -180.0  1.84880  0.00   
+  3  5    1    -6   6280.4526  2893.5082  -180.0  1.84452  0.00   
+  3  3    3    1    4583.6321  3298.2389  -0.0    1.82246  0.00   
+  3  3    3    -4   17227.3178 15077.7022 -180.0  1.81602  0.00   
+  3  2    2    4    1974.2085  2004.2435  180.0   1.81373  0.00   
+  3  2    2    -6   52.2665    110.7433   -0.0    1.80528  0.00   
+  3  3    1    4    588.7349   1170.5401  -0.0    1.78145  0.00   
+  3  4    2    2    1009.7505  569.9378   -0.0    1.77259  0.00   
+  3  3    1    -7   1991.9256  719.8279   -180.0  1.76829  0.00   
+  3  6    0    0    99317.1895 33110.4566 180.0   1.76764  0.00   
+  3  4    2    -6   10021.5968 1197.0761  -0.0    1.76001  0.00   
+  3  6    0    -6   9.2571     2.0519     0.0     1.75364  0.00   
+  3  6    2    -3   807080.6047 369893.0340 -180.0  1.71990  0.03   
+  3  0    4    0    562903.1903 349239.0777 -180.0  1.71747  0.01   
+  3  6    2    -2   796.2563   389.5662   -0.0    1.70275  0.00   
+  3  6    2    -4   2370.4764  1559.0063  180.0   1.69854  0.00   
+  3  0    4    1    5007.7903  3261.4197  -0.0    1.69829  0.00   
+  3  3    3    2    5681.4088  3601.7539  -0.0    1.69795  0.00   
+  3  5    1    2    7589.9250  2566.7316  -180.0  1.69073  0.00   
+  3  3    3    -5   31131.2554 10531.2518 0.0     1.69066  0.00   
+  3  1    1    6    1169.2638  741.4035   -0.0    1.68395  0.00   
+  3  1    3    4    68.8495    44.9522    -0.0    1.68304  0.00   
+  3  1    3    -5   7628.6979  4679.6611  0.0     1.67999  0.00   
+  3  1    1    -7   19962.6347 12408.6046 -180.0  1.67955  0.00   
+  3  5    1    -7   377.3441   265.5075   -180.0  1.67544  0.00   
+  3  0    2    6    1357.7622  1002.9200  0.0     1.66212  0.00   
+  3  6    2    -1   849.5687   865.7198   -180.0  1.65035  0.00   
+  3  2    4    -1   2791.3636  2846.3024  180.0   1.65033  0.00   
+  3  7    1    -3   34.4495    35.4673    180.0   1.64981  0.00   
+  3  5    3    -2   333.5304   336.8527   -180.0  1.64806  0.00   
+  3  7    1    -4   552.9198   557.1489   -0.0    1.64758  0.00   
+  3  5    3    -3   1216.8456  1233.1133  -180.0  1.64647  0.00   
+  3  0    4    2    602.9911   612.1428   -180.0  1.64439  0.00   
+  3  6    2    -5   475.6523   504.8209   -180.0  1.64272  0.00   
+  3  2    4    0    581.3951   754.2136   -0.0    1.63391  0.00   
+  3  2    4    -2   3372.5323  4465.8946  180.0   1.63267  0.00   
+  3  7    1    -2   3856.2643  3569.9801  180.0   1.61839  0.00   
+  3  5    3    -1   1267.9219  967.0564   0.0     1.61614  0.00   
+  3  7    1    -5   1558.5974  916.1043   -0.0    1.61209  0.00   
+  3  5    3    -4   6625.1112  3834.9981  -180.0  1.61165  0.00   
+  3  4    0    4    122560.7306 64347.8084 180.0   1.60877  0.00   
+  3  4    2    3    53.3473    27.4467    180.0   1.60748  0.00   
+  3  2    2    5    70647.5878 37116.5064 -180.0  1.60456  0.00   
+  3  2    2    -7   170715.5509 66460.5555 0.0     1.59754  0.01   
+  3  4    2    -7   8048.8978  2577.6650  -0.0    1.59577  0.00   
+  3  4    0    -8   133913.4977 36891.4626 0.0     1.59471  0.00   
+  3  2    4    1    3705.3885  1926.6405  0.0     1.58631  0.00   
+  3  2    4    -3   3798.7714  1877.8866  0.0     1.58404  0.00   
+  3  2    0    6    61844.6801 28867.0796 -0.0    1.57431  0.00   
+  3  6    2    0    565.0721   317.3964   -0.0    1.57174  0.00   
+  3  3    1    5    2252.3404  1737.0799  180.0   1.56732  0.00   
+  3  2    0    -8   6357.2275  4964.5142  -180.0  1.56658  0.00   
+  3  3    3    3    610.0741   484.9151   0.0     1.56549  0.00   
+  3  0    4    3    3527.3409  2916.9964  -0.0    1.56494  0.00   
+  3  6    2    -6   1422.3264  1246.0869  -180.0  1.56187  0.00   
+  3  7    1    -1   2396.7990  2041.8362  -0.0    1.55870  0.00   
+  3  3    3    -6   1790.4775  1491.9744  -180.0  1.55816  0.00   
+  3  3    1    -8   2344.0942  1854.6907  0.0     1.55673  0.00   
+  3  5    3    0    4822.7355  3764.6000  180.0   1.55615  0.00   
+  3  5    3    -5   1731.4141  1406.8546  0.0     1.54947  0.00   
+  3  7    1    -6   4648.3599  3779.7017  -180.0  1.54933  0.00   
+  3  5    1    3    1004.0515  786.6440   0.0     1.53192  0.00   
+  3  1    3    5    3.9318     7.3949     -180.0  1.52518  0.00   
+  3  1    3    -6   943.5424   1154.8547  0.0     1.52240  0.00   
+  3  5    1    -8   8.3436     5.3938     0.0     1.51801  0.00   
+  3  2    4    2    6899.6954  4259.4685  180.0   1.51513  0.00   
+  3  2    4    -4   3472.5591  2488.9469  -0.0    1.51216  0.00   
+  3  6    0    2    8713.2316  8927.4646  180.0   1.50492  0.00   
+  3  6    0    -8   6176.4697  4374.4012  -180.0  1.49055  0.00   
+  3  8    0    -4   28572.3014 20075.3665 0.0     1.49018  0.00   
+  3  4    4    -2   34040.0671 20515.8401 -0.0    1.48807  0.00   
+  3  7    1    0    1950.0207  521.9936   0.0     1.47957  0.00   
+  3  6    2    1    1906.5675  505.0908   180.0   1.47788  0.00   
+  3  5    3    1    5569.8780  1470.6883  180.0   1.47692  0.00   
+  3  4    4    -1   674.3711   180.6211   180.0   1.47646  0.00   
+  3  4    4    -3   5333.1907  1669.9832  180.0   1.47463  0.00   
+  3  1    1    7    27762.8724 9066.3000  -0.0    1.47392  0.00   
+  3  0    2    7    7296.0117  2496.6943  180.0   1.47110  0.00   
+  3  0    4    4    1725.4507  584.6755   180.0   1.47086  0.00   
+  3  1    1    -8   22217.7080 7382.4328  0.0     1.47051  0.00   
+  3  5    3    -6   0.5264     0.1801     -180.0  1.46895  0.00   
+  3  7    1    -7   655.2331   231.4520   -180.0  1.46838  0.00   
+  3  6    2    -7   2895.3708  1074.5558  180.0   1.46696  0.00   
+  3  4    2    4    461.6036   308.9633   -180.0  1.45690  0.00   
+  3  4    2    -8   324.1415   302.0532   -180.0  1.44643  0.00   
+  3  8    0    -2   59767.4292 52285.4717 0.0     1.44512  0.00   
+  3  4    4    0    70723.0441 40432.7863 -180.0  1.44149  0.00   
+  3  8    0    -6   83937.0077 39471.3565 -180.0  1.43828  0.00   
+  3  4    4    -4   113946.3158 54140.5267 0.0     1.43808  0.00   
+  3  3    3    4    9736.1898  4619.7202  -180.0  1.43649  0.00   
+  3  2    2    6    1.2319     0.8037     -180.0  1.43116  0.00   
+  3  2    4    3    4229.4958  2700.6054  180.0   1.42969  0.00   
+  3  3    3    -7   2279.4806  1447.2851  0.0     1.42957  0.00   
+  3  2    4    -5   2619.7848  1672.6772  180.0   1.42637  0.00   
+  3  2    2    -8   3121.0898  1818.1746  -0.0    1.42534  0.00   
+  3  0    0    8    483452.4970 266275.2162 -0.0    1.42446  0.01   
+  3  3    1    6    1317.4013  937.0051   180.0   1.39419  0.00   
+  3  7    1    1    75.6856    50.2076    -180.0  1.39022  0.00   
+  3  5    1    4    1142.6759  766.2784   0.0     1.38968  0.00   
+  3  4    4    1    4437.6679  3625.7812  -0.0    1.38783  0.00   
+  3  5    3    2    537.6728   442.9270   -180.0  1.38764  0.00   
+  3  3    1    -9   987.4124   705.3414   -0.0    1.38558  0.00   
+  3  1    3    6    4412.3642  3147.0402  0.0     1.38389  0.00   
+  3  4    4    -5   1734.2874  1224.4467  0.0     1.38328  0.00   
+  3  1    3    -7   779.5916   485.6081   -180.0  1.38144  0.00   
+  3  5    3    -7   1304.8002  1074.4975  180.0   1.37915  0.00   
+  3  6    2    2    295.7596   255.5080   -180.0  1.37843  0.00   
+  3  7    1    -8   262.6616   231.0290   0.0     1.37830  0.00   
+  3  5    1    -9   3177.8271  3153.2469  -0.0    1.37741  0.00   
+  3  0    4    5    512.5683   361.2535   -180.0  1.37163  0.00   
+  3  6    2    -8   6.8137     2.8764     0.0     1.36736  0.00   
+  3  8    2    -4   1787.3445  738.3691   180.0   1.36707  0.00   
+  3  7    3    -3   8488.0413  3197.7857  -180.0  1.36475  0.00   
+  3  7    3    -4   1189.0635  462.3547   -180.0  1.36348  0.00   
+  3  1    5    0    10714.1147 4378.3377  -180.0  1.36259  0.00   
+  3  1    5    -1   142.2132   57.4971    -0.0    1.36241  0.00   
+  3  8    2    -3   4689.8054  1921.4590  180.0   1.35877  0.00   
+  3  8    2    -5   28681.2197 14138.1993 180.0   1.35592  0.00   
+  3  7    3    -2   4509.7794  6972.0574  0.0     1.34680  0.00   
+  3  1    5    1    3631.8053  7448.7932  0.0     1.34369  0.00   
+  3  7    3    -5   1226.9794  2389.4463  180.0   1.34316  0.00   
+  3  1    5    -2   1438.7931  2806.0453  180.0   1.34317  0.00   
+  3  2    4    4    252.7519   204.8237   -180.0  1.33840  0.00   
+  3  2    4    -6   3157.8468  4275.4207  180.0   1.33499  0.00   
+  3  8    2    -2   129.7463   192.1770   0.0     1.33203  0.00   
+  3  8    2    -6   88.9939    116.5596   0.0     1.32667  0.00   
+  3  8    0    0    105732.1280 126627.2507 0.0     1.32573  0.00   
+  3  4    2    5    12531.3269 12803.0480 0.0     1.32376  0.00   
+  3  4    4    2    125379.4868 113941.2603 0.0     1.32161  0.00   
+  3  3    3    5    1381.4776  1245.0587  -0.0    1.31694  0.00   
+  3  4    4    -6   134375.3847 120657.4919 0.0     1.31637  0.00   
+  3  0    2    8    406.5007   367.8173   180.0   1.31580  0.00   
+  3  8    0    -8   149090.7294 138911.0933 -0.0    1.31523  0.00   
+  3  4    2    -9   5895.3809  5515.4935  180.0   1.31459  0.00   
+  3  7    3    -1   1667.7788  1032.3073  180.0   1.31181  0.00   
+  3  3    3    -8   13751.5289 7089.9054  180.0   1.31063  0.00   
+  3  1    1    8    368.4748   156.9928   180.0   1.30926  0.00   
+  3  1    5    2    4663.6740  1741.3190  180.0   1.30797  0.00   
+  3  1    5    -3   18951.5048 7332.4016  -0.0    1.30718  0.00   
+  3  1    1    -9   1737.4849  714.2405   180.0   1.30655  0.00   
+  3  7    3    -6   18376.6396 7534.6306  -0.0    1.30621  0.00   
+  3  6    4    -3   4178.5145  2358.6087  -0.0    1.29933  0.00   
+  3  9    1    -4   1438.5559  840.1413   0.0     1.29924  0.00   
+  3  7    1    2    5369.6547  3970.4242  -180.0  1.29813  0.00   
+  3  9    1    -5   362.6330   256.4854   0.0     1.29783  0.00   
+  3  3    5    -1   1241.2766  624.0157   0.0     1.29668  0.00   
+  3  3    5    -2   4218.0766  2195.2865  -0.0    1.29621  0.00   
+  3  5    3    3    639.5484   335.5224   180.0   1.29573  0.00   
+  3  6    4    -2   42.3547    25.6370    0.0     1.29189  0.00   
+  3  6    4    -4   7728.2693  7144.7715  -0.0    1.29005  0.00   
+  3  4    0    6    20052.2610 18430.0994 180.0   1.29008  0.00   
+  3  8    2    -1   9480.1066  8916.0617  180.0   1.28996  0.00   
+  3  5    3    -8   2511.8903  3481.2865  180.0   1.28728  0.00   
+  3  2    2    7    11587.5757 16103.7102 -0.0    1.28730  0.00   
+  3  7    1    -9   115.3345   133.1321   180.0   1.28629  0.00   
+  3  9    1    -3   7127.9148  5502.1713  180.0   1.28403  0.00   
+  3  8    2    -7   738.7385   428.7763   -180.0  1.28268  0.00   
+  3  2    2    -9   34299.1655 19711.1402 0.0     1.28246  0.00   
+  3  3    5    0    1574.4121  723.1256   -0.0    1.28066  0.00   
+  3  4    0    -10  44837.2322 20573.2507 -180.0  1.28039  0.00   
+  3  6    2    3    0.8174     0.3798     180.0   1.28021  0.00   
+  3  9    1    -6   388.0478   186.1560   -0.0    1.27997  0.00   
+  3  3    5    -3   11192.3982 6056.7903  -0.0    1.27931  0.00   
+  3  0    4    6    180.4869   118.7129   180.0   1.27387  0.00   
+  3  6    2    -9   401.2190   464.2431   180.0   1.26958  0.00   
+  3  6    4    -1   346.7061   482.2612   -180.0  1.26855  0.00   
+  3  6    0    4    10236.4934 7253.9356  180.0   1.26527  0.00   
+  3  6    4    -5   880.3684   581.7941   -180.0  1.26508  0.00   
+  3  5    1    5    7151.6707  4606.9251  180.0   1.26501  0.00   
+  3  7    3    0    2151.1570  802.8327   180.0   1.26358  0.00   
+  3  1    3    7    36616.7543 8416.8791  -0.0    1.26006  0.00   
+  3  1    5    3    145.6294   35.3569    180.0   1.25930  0.00   
+  3  1    5    -4   12675.1053 3108.7211  180.0   1.25830  0.00   
+  3  1    3    -8   11592.3325 3093.4250  180.0   1.25793  0.00   
+  3  7    3    -7   4701.3472  2419.4252  180.0   1.25659  0.00   
+  3  5    1    -10  10392.9902 7028.2195  -180.0  1.25432  0.00   
+  3  9    1    -2   483.1919   361.5721   0.0     1.25388  0.00   
+  3  6    0    -10  146.4529   117.8452   -180.0  1.25331  0.00   
+  3  3    1    7    2010.6620  1611.2755  -0.0    1.25270  0.00   
+  3  3    5    1    9774.4179  8365.6876  0.0     1.24990  0.00   
+  3  4    4    3    18.0187    16.4616    0.0     1.24877  0.00   
+  3  3    5    -4   1032.8028  1094.7115  -0.0    1.24782  0.00   
+  3  9    1    -7   7956.0153  8715.4401  -180.0  1.24760  0.00   
+  3  2    4    5    1026.2744  1152.2483  0.0     1.24740  0.00   
+  3  3    1    -10  2673.6264  2982.8745  180.0   1.24561  0.00   
+  3  2    4    -7   780.2464   791.0948   0.0     1.24409  0.00   
+  3  4    4    -7   6440.3862  6542.7513  -0.0    1.24325  0.00   
+  3  2    0    8    26.9640    27.5719    -0.0    1.24099  0.00   
+  3  8    2    0    659.6597   732.3491   180.0   1.23681  0.00   
+  3  2    0    -10  1921.9021  2002.5013  180.0   1.23612  0.00   
+  3  6    4    0    11850.4527 14163.9232 -0.0    1.23179  0.00   
+  3  8    2    -8   555.4441   626.3480   180.0   1.22827  0.00   
+  3  6    4    -6   158.3338   129.6800   -180.0  1.22702  0.00   
+  3  9    1    -1   4666.0080  2736.0544  -0.0    1.21182  0.00   
+  3  3    3    6    1408.6059  848.8094   0.0     1.20915  0.00   
+  3  7    1    3    123.5619   73.3088    180.0   1.20840  0.00   
+  3  4    2    6    654.1537   411.4914   -0.0    1.20771  0.00   
+  3  3    5    2    5732.8478  3752.4577  0.0     1.20747  0.00   
+  3  7    3    1    3898.5609  2737.7149  180.0   1.20655  0.00   
+  3  5    3    4    10826.2851 7533.1217  -180.0  1.20620  0.00   
+  3  3    5    -5   58.3952    48.9010    180.0   1.20485  0.00   
+  3  9    1    -8   2396.1236  2317.0795  0.0     1.20390  0.00   
+  3  3    3    -9   1048.3222  943.1430   -0.0    1.20352  0.00   
+  3  1    5    4    4078.0104  3946.3181  180.0   1.20208  0.00   
+  3  1    5    -5   630.0092   657.9301   0.0     1.20097  0.00   
+  3  4    2    -10  189.7085   165.1119   -0.0    1.19975  0.00   
+  3  7    3    -8   5.3573     5.4244     0.0     1.19874  0.00   
+  3  5    3    -9   276.9309   300.8008   180.0   1.19815  0.00   
+  3  7    1    -10  9064.2556  8276.9170  -180.0  1.19711  0.00   
+  3  5    5    -2   5048.1602  3032.9471  -0.0    1.18914  0.00   
+  3  5    5    -3   0.1701     0.1012     -0.0    1.18854  0.00   
+  3  0    2    9    467.6257   269.3572   -0.0    1.18804  0.00   
+  3  6    2    4    413.5128   267.8685   180.0   1.18728  0.00   
+  3  10   0    -4   9718.9792  6786.3001  0.0     1.18686  0.00   
+  3  6    4    1    1846.4090  1321.4870  0.0     1.18502  0.00   
+  3  10   0    -6   15954.2468 11069.8912 0.0     1.18449  0.00   
+  3  0    4    7    362.1930   286.2966   180.0   1.18151  0.00   
+  3  6    4    -7   1853.0363  1786.0275  0.0     1.17937  0.00   
+  3  8    0    2    24018.5024 31203.7473 180.0   1.17794  0.00   
+  3  6    2    -10  1.6412     2.2500     -0.0    1.17739  0.00   
+  3  5    5    -1   4687.7807  7333.3701  -180.0  1.17698  0.00   
+  3  1    1    9    79.2651    122.6202   -0.0    1.17700  0.00   
+  3  8    2    1    3715.1821  5828.2210  -180.0  1.17697  0.00   
+  3  5    5    -4   2418.6272  5569.9415  -0.0    1.17524  0.00   
+  3  1    1    -10  318.1432   762.3801   180.0   1.17480  0.00   
+  3  4    4    4    13127.7546 33797.9536 0.0     1.17412  0.00   
+  3  4    4    -8   20296.9176 28595.8783 -180.0  1.16862  0.00   
+  3  8    2    -9   7136.8924  8397.1111  180.0   1.16778  0.00   
+  3  2    2    8    98.8753    100.3672   0.0     1.16716  0.00   
+  3  8    0    -10  39822.8500 38189.7985 0.0     1.16691  0.00   
+  3  2    2    -10  519.5371   558.5305   -0.0    1.16310  0.00   
+  3  9    1    0    102.4800   175.9707   180.0   1.16146  0.00   
+  3  2    4    6    7753.3486  13788.4423 180.0   1.16052  0.00   
+  3  2    4    -8   2056.7544  2415.9757  0.0     1.15742  0.00   
+  3  3    5    3    2817.4035  3138.9340  0.0     1.15698  0.00   
+  3  5    1    6    45.8664    50.4532    0.0     1.15671  0.00   
+  3  3    5    -6   46.2596    51.9103    -0.0    1.15401  0.00   
+  3  5    5    0    5986.6090  6678.1581  -0.0    1.15319  0.00   
+  3  9    1    -9   581.4914   564.6421   180.0   1.15252  0.00   
+  3  1    3    8    2864.4817  2759.9706  0.0     1.15249  0.00   
+  3  1    3    -9   1.3632     1.3234     -0.0    1.15063  0.00   
+  3  5    5    -5   9188.8826  8520.9404  -180.0  1.15046  0.00   
+  3  5    1    -11  1644.3172  1510.3893  0.0     1.14744  0.00   
+  3  9    3    -4   442.5488   426.5956   0.0     1.14563  0.00   
+  3  0    6    0    2781.7836  2617.6245  -0.0    1.14498  0.00   
+  3  7    3    2    5202.8059  4899.1825  -0.0    1.14488  0.00   
+  3  9    3    -5   68.0895    64.8278    -0.0    1.14467  0.00   
+  3  10   0    -2   22185.4605 15968.0855 0.0     1.14060  0.00   
+  3  1    5    5    7204.0992  5051.5907  -0.0    1.14041  0.00   
+  3  0    0    10   681.1207   423.2012   -0.0    1.13957  0.00   
+  3  1    5    -6   8837.4255  5314.9524  180.0   1.13925  0.00   
+  3  0    6    1    2751.5321  1653.0194  180.0   1.13924  0.00   
+  3  7    3    -9   14596.0482 4655.8618  180.0   1.13673  0.00   
+  3  3    1    8    237.6740   68.5169    180.0   1.13561  0.00   
+  3  9    3    -3   5898.0527  1425.0085  -180.0  1.13516  0.00   
+  3  10   0    -8   7736.2282  1444.5643  0.0     1.13431  0.00   
+  3  9    3    -6   11868.6586 1853.0409  -0.0    1.13236  0.00   
+  3  6    4    2    21241.6061 2828.5025  0.0     1.13187  0.00   
+  3  3    1    -11  215.1134   30.9235    0.0     1.12971  0.00   
+  3  10   2    -5   25906.7896 6250.7551  0.0     1.12624  0.00   
+  3  6    4    -8   8045.8555  2095.8324  -0.0    1.12572  0.00   
+  3  8    4    -4   15363.5446 4159.5086  -180.0  1.12556  0.00   
+  3  2    6    -1   9057.2389  3577.3431  180.0   1.12442  0.00   
+  3  7    1    4    11770.1015 4922.1591  -0.0    1.12392  0.00   
+  3  0    6    2    3322.2317  1380.3426  -180.0  1.12254  0.00   
+  3  5    3    5    4113.3249  1969.2775  -180.0  1.12196  0.00   
+  3  10   2    -4   17.9845    9.0514     180.0   1.12179  0.00   
+  3  8    4    -3   5649.5270  3321.2004  -180.0  1.12091  0.00   
+  3  5    5    1    987.1608   712.3818   0.0     1.11981  0.00   
+  3  10   2    -6   236.8093   172.3994   180.0   1.11978  0.00   
+  3  8    4    -5   1241.9722  1031.1584  180.0   1.11931  0.00   
+  3  2    6    0    6139.3598  5324.5816  180.0   1.11919  0.00   
+  3  2    6    -2   991.8490   994.7961   180.0   1.11879  0.00   
+  3  5    5    -6   1589.9520  2506.0954  0.0     1.11633  0.00   
+  3  5    3    -10  1483.6392  1592.9982  -0.0    1.11448  0.00   
+  3  8    2    2    116.6558   120.6121   0.0     1.11424  0.00   
+  3  9    3    -2   1972.5147  2018.2403  0.0     1.11417  0.00   
+  3  7    1    -11  2415.2407  2076.1894  180.0   1.11344  0.00   
+  3  3    3    7    8551.7751  7158.7424  0.0     1.11335  0.00   
+  3  9    3    -7   2516.0777  1747.8303  -180.0  1.10976  0.00   
+  3  3    3    -10  348.3663   264.2542   -0.0    1.10836  0.00   
+  3  4    2    7    12737.8916 9257.1392  0.0     1.10705  0.00   
+  3  10   2    -3   47895.1369 35122.0418 -180.0  1.10679  0.00   
+  3  9    1    1    5326.0427  3803.3771  -180.0  1.10633  0.00   
+  3  8    4    -2   47168.1546 29363.1790 -180.0  1.10576  0.00   
+  3  8    2    -10  58.5858    36.3896    0.0     1.10489  0.00   
+  3  2    6    1    39264.9496 27660.2202 -180.0  1.10353  0.00   
+  3  10   2    -7   51106.2482 34918.8172 0.0     1.10295  0.00   
+  3  2    6    -3   43149.2585 29933.5896 0.0     1.10277  0.00   
+  3  8    4    -6   43036.8719 30130.4862 0.0     1.10269  0.00   
+  3  3    5    4    89.7405    70.5207    0.0     1.10188  0.00   
+  3  6    2    5    163368.3648 132075.9030 -180.0  1.10160  0.00   
+  3  4    4    5    3331.7610  2697.8124  180.0   1.10101  0.00   
+  3  4    2    -11  2668.0692  2168.2631  -0.0    1.10016  0.00   
+  3  3    5    -7   3086.9569  2938.6164  0.0     1.09874  0.00   
+  3  9    1    -10  254.2978   278.9248   0.0     1.09690  0.00   
+  3  0    4    8    111427.1720 133852.3770 -180.0  1.09642  0.00   
+  3  0    6    3    2845.4128  3406.0054  -0.0    1.09626  0.00   
+  3  4    4    -9   121.5670   133.8105   0.0     1.09572  0.00   
+  3  6    2    -11  181062.8071 149427.3819 -180.0  1.09256  0.00   
+  3  9    3    -1   687.5529   1114.0707  0.0     1.08435  0.00   
+  3  10   2    -2   725.3740   878.7302   -0.0    1.08248  0.00   
+  3  7    3    3    5466.8278  5993.9369  180.0   1.08190  0.00   
+  3  0    2    10   145.5261   133.4720   0.0     1.08160  0.00   
+  3  8    4    -1   8.4316     6.5251     0.0     1.08134  0.00   
+  3  2    4    7    191.2630   143.5155   180.0   1.07976  0.00   
+  3  5    5    2    7629.0201  5313.8332  0.0     1.07936  0.00   
+  3  2    6    2    923.3011   479.5892   0.0     1.07871  0.00   
+  3  9    3    -8   33.2506    16.9995    180.0   1.07867  0.00   
+  3  2    6    -4   5302.6358  3161.4599  -0.0    1.07764  0.00   
+  3  1    5    6    12293.8891 7500.0737  180.0   1.07759  0.00   
+  3  10   2    -8   409.9839   301.0108   0.0     1.07710  0.00   
+  3  8    4    -7   1186.5162  885.4324   -0.0    1.07703  0.00   
+  3  2    4    -9   1686.5851  1302.0632  -180.0  1.07690  0.00   
+  3  1    5    -7   13001.5960 11193.5196 0.0     1.07644  0.00   
+  3  6    4    3    1498.6082  1519.4304  -180.0  1.07557  0.00   
+  3  5    5    -7   15.6329    16.4899    0.0     1.07535  0.00   
+  3  7    3    -10  12242.6780 12239.7749 0.0     1.07377  0.00   
+  3  6    0    6    785.0599   878.1551   180.0   1.07251  0.00   
+  3  11   1    -5   187.5234   156.7234   180.0   1.06983  0.00   
+  3  6    4    -9   895.3551   816.5987   -180.0  1.06924  0.00   
+  3  11   1    -6   6.4336     5.6606     -180.0  1.06887  0.00   
+  3  4    6    -2   2851.3269  2494.4283  -180.0  1.06882  0.00   
+  3  1    1    10   3030.9673  2596.6805  -180.0  1.06861  0.00   
+  3  7    5    -3   1564.2687  1331.7364  -180.0  1.06848  0.00   
+  3  7    5    -4   206.0271   168.6670   180.0   1.06788  0.00   
+  3  4    0    8    28733.1763 23517.9783 -0.0    1.06787  0.00   
+  3  1    1    -11  47.2896    42.3756    0.0     1.06679  0.00   
+  3  2    2    9    26888.4422 24364.2928 -0.0    1.06594  0.00   
+  3  4    6    -1   2.3271     2.0449     -0.0    1.06449  0.00   
+  3  4    6    -3   3256.6672  2831.4348  180.0   1.06381  0.00   
+  3  6    0    -12  2682.5846  2923.4798  -180.0  1.06314  0.00   
+  3  5    1    7    2788.3445  3261.6628  0.0     1.06281  0.00   
+  3  2    2    -11  18441.5597 20983.9567 -180.0  1.06250  0.00   
+  3  0    6    4    1510.0901  1675.3120  0.0     1.06239  0.00   
+  3  11   1    -4   5167.0767  5105.4905  0.0     1.06146  0.00   
+  3  4    0    -12  26683.1011 28218.7960 -180.0  1.06099  0.00   
+  3  10   0    0    754.1449   818.1245   0.0     1.06059  0.00   
+  3  7    5    -2   1.7944     1.6435     -0.0    1.05981  0.00   
+  3  1    3    9    1907.5654  1609.5467  0.0     1.05919  0.00   
+  3  11   1    -7   83.4918    65.8892    -180.0  1.05866  0.00   
+  3  7    5    -5   5234.9597  3885.4940  -180.0  1.05803  0.00   
+  3  1    3    -10  3394.8634  2354.8872  0.0     1.05759  0.00   
+  3  5    1    -12  3440.2175  2089.2343  -180.0  1.05477  0.00   
+  3  10   0    -10  6964.1588  4636.8736  0.0     1.05218  0.00   
+  3  8    2    3    29088.3918 22544.6331 180.0   1.05151  0.00   
+  3  4    6    0    1995.5551  1594.4768  0.0     1.05116  0.00   
+  3  10   2    -1   76510.6000 57904.1973 0.0     1.05066  0.00   
+  3  4    6    -4   1714.5691  1172.4235  0.0     1.04984  0.00   
+  3  8    4    0    86312.1223 62151.2478 -180.0  1.04945  0.00   
+  3  9    1    2    181.6740   132.4263   -0.0    1.04936  0.00   
+  3  9    3    0    3010.1873  2356.0217  0.0     1.04783  0.00   
+  3  2    6    3    78757.7609 55957.0122 -180.0  1.04656  0.00   
+  3  7    1    5    1447.4255  1023.2699  0.0     1.04608  0.00   
+  3  2    6    -5   89266.8226 56250.7200 -180.0  1.04525  0.00   
+  3  3    5    5    6110.3104  3648.7025  -0.0    1.04507  0.00   
+  3  11   1    -3   52.2561    27.3279    180.0   1.04440  0.00   
+  3  5    3    6    2687.4524  1399.6862  -180.0  1.04433  0.00   
+  3  8    4    -8   130148.3082 67472.6956 -180.0  1.04421  0.00   
+  3  10   2    -9   129772.9934 67104.2744 0.0     1.04411  0.00   
+  3  7    5    -1   11499.6058 4657.8874  -180.0  1.04250  0.00   
+  3  8    2    -11  12.1538    4.8409     0.0     1.04235  0.00   
+  3  3    5    -8   873.4685   382.1113   -0.0    1.04191  0.00   
+  3  9    3    -9   884.7453   492.4025   -180.0  1.04124  0.00   
+  3  11   1    -8   7931.2411  5319.7562  0.0     1.03996  0.00   
+  3  9    1    -11  6827.4401  4922.1695  180.0   1.03985  0.00   
+  3  7    5    -6   25.0514    20.5769    180.0   1.03968  0.00   
+  3  3    1    9    517.6176   982.6857   -180.0  1.03750  0.00   
+  3  5    3    -11  87.1969    166.6629   -0.0    1.03749  0.00   
+  3  7    1    -12  251.6838   562.7466   -180.0  1.03650  0.00   
+  3  8    0    4    1092.1747  2816.3580  -0.0    1.03471  0.00   
+  3  5    5    3    549.7797   1394.6166  -180.0  1.03437  0.00   
+  4  1    1    0    1350.3621  1291.4299  -0.0    3.35586  0.03   
+  4  1    0    1    438.7463   491.2958   -0.0    2.46956  0.01   
+  4  2    0    0    67.5773    146.2787   -0.0    2.37295  0.00   
+  4  1    1    1    409.1202   375.6372   180.0   2.19071  0.01   
+  4  2    1    0    1104.1884  162.4468   0.0     2.12243  0.02   
+  4  2    1    1    1056.6429  896.5147   -0.0    1.71106  0.02   
+  4  2    2    0    1869.4315  1202.3175  -0.0    1.67793  0.01   
+  4  3    1    0    349.4557   370.6401   -0.0    1.50078  0.00   
+  4  2    2    1    31.7328    29.7263    180.0   1.45133  0.00   
+  4  0    0    2    1542.2002  1358.6905  -0.0    1.44596  0.00   
+  4  3    0    1    1400.4855  1096.5893  -0.0    1.38788  0.01   
+  4  3    1    1    24.5078    34.6309    0.0     1.33209  0.00   
+  4  1    1    2    397.3015   529.7813   -0.0    1.32794  0.00   
+  4  3    2    0    18.4506    16.3092    180.0   1.31628  0.00   
+  4  2    0    2    126.8966   144.5590   -0.0    1.23478  0.00   
+  4  3    2    1    156.9231   159.1322   -0.0    1.19802  0.00   
+  4  2    1    2    47.0243    41.5883    0.0     1.19499  0.00   
+  4  4    0    0    629.0228   448.4383   -0.0    1.18647  0.00   
+  4  4    1    0    87.5925    85.8115    180.0   1.15105  0.00   
+  4  3    3    0    647.0837   633.8388   -0.0    1.11862  0.00   
+  4  2    2    2    569.0101   564.8012   -0.0    1.09536  0.00   
+  4  4    1    1    323.9428   285.0225   -0.0    1.06945  0.00   
+  4  4    2    0    260.8393   262.4087   -0.0    1.06122  0.00   
+  4  3    3    1    8.3627     4.2490     180.0   1.04329  0.00   
+  4  3    1    2    407.7514   222.7816   -0.0    1.04129  0.01   
+_reflns_number_total  1188
+_reflns_d_resolution_low    6.388
+_reflns_d_resolution_high   1.033
+
+# POWDER DATA TABLE
+_pd_meas_2theta_range_min  10.01313
+_pd_meas_2theta_range_max  119.99238
+_pd_meas_2theta_range_inc  0.02626
+_pd_proc_2theta_range_min  9.99428
+_pd_proc_2theta_range_max  119.97353
+_pd_proc_2theta_range_inc  0.02626
+_pd_proc_number_of_points  4189
+
+loop_
+   _pd_meas_intensity_total
+   _pd_calc_intensity_total
+   _pd_proc_intensity_bkg_calc
+   _pd_proc_ls_weight
+  2898         0            0           0         
+  2829         0            0           0         
+  2767         0            0           0         
+  2788         0            0           0         
+  2720         0            0           0         
+  2904         0            0           0         
+  2958         0            0           0         
+  3043         0            0           0         
+  3060         0            0           0         
+  3096         0            0           0         
+  3035         0            0           0         
+  3056         0            0           0         
+  2904         0            0           0         
+  2865         0            0           0         
+  2822         0            0           0         
+  2770         0            0           0         
+  2755         0            0           0         
+  2695         0            0           0         
+  2639         0            0           0         
+  2706         0            0           0         
+  2690         0            0           0         
+  2651         0            0           0         
+  2684         0            0           0         
+  2673         0            0           0         
+  2504         0            0           0         
+  2619         0            0           0         
+  2607         0            0           0         
+  2670         0            0           0         
+  2650         0            0           0         
+  2609         0            0           0         
+  2591         0            0           0         
+  2637         0            0           0         
+  2558         0            0           0         
+  2638         0            0           0         
+  2497         0            0           0         
+  2513         0            0           0         
+  2606         0            0           0         
+  2553         0            0           0         
+  2553         0            0           0         
+  2642         0            0           0         
+  2530         0            0           0         
+  2562         0            0           0         
+  2590         0            0           0         
+  2586         0            0           0         
+  2484         0            0           0         
+  2526         0            0           0         
+  2518         0            0           0         
+  2417         0            0           0         
+  2547         0            0           0         
+  2400         0            0           0         
+  2429         0            0           0         
+  2388         0            0           0         
+  2473         0            0           0         
+  2407         0            0           0         
+  2461         0            0           0         
+  2457         0            0           0         
+  2372         0            0           0         
+  2404         0            0           0         
+  2386         0            0           0         
+  2351         0            0           0         
+  2339         0            0           0         
+  2400         0            0           0         
+  2330         0            0           0         
+  2414         0            0           0         
+  2457         0            0           0         
+  2377         0            0           0         
+  2396         0            0           0         
+  2377         0            0           0         
+  2272         0            0           0         
+  2401         0            0           0         
+  2393         0            0           0         
+  2361         0            0           0         
+  2351         0            0           0         
+  2303         0            0           0         
+  2310         0            0           0         
+  2290         0            0           0         
+  2376         0            0           0         
+  2266         0            0           0         
+  2367         0            0           0         
+  2265         0            0           0         
+  2272         0            0           0         
+  2245         0            0           0         
+  2256         0            0           0         
+  2242         0            0           0         
+  2295         0            0           0         
+  2279         0            0           0         
+  2215         0            0           0         
+  2252         0            0           0         
+  2301         0            0           0         
+  2274         0            0           0         
+  2244         0            0           0         
+  2272         0            0           0         
+  2145         0            0           0         
+  2244         0            0           0         
+  2205         0            0           0         
+  2205         0            0           0         
+  2269         0            0           0         
+  2213         0            0           0         
+  2124         0            0           0         
+  2222         0            0           0         
+  2292         0            0           0         
+  2171         0            0           0         
+  2249         0            0           0         
+  2216         0            0           0         
+  2217         0            0           0         
+  2195         0            0           0         
+  2110         0            0           0         
+  2119         0            0           0         
+  2128         0            0           0         
+  2223         0            0           0         
+  2086         0            0           0         
+  2165         0            0           0         
+  2184         0            0           0         
+  1992         0            0           0         
+  2076         0            0           0         
+  2146         0            0           0         
+  2146         0            0           0         
+  2123         0            0           0         
+  2132         0            0           0         
+  2131         0            0           0         
+  2106         0            0           0         
+  2101         0            0           0         
+  2104         0            0           0         
+  2052         0            0           0         
+  2061         0            0           0         
+  1990         0            0           0         
+  2021         0            0           0         
+  2023         0            0           0         
+  2075         0            0           0         
+  2124         0            0           0         
+  2039         0            0           0         
+  1972         0            0           0         
+  1967         0            0           0         
+  2056         0            0           0         
+  1985         0            0           0         
+  1984         0            0           0         
+  1986         0            0           0         
+  1971         0            0           0         
+  1968         0            0           0         
+  2022         0            0           0         
+  1971         0            0           0         
+  2017         0            0           0         
+  2005         0            0           0         
+  1925         0            0           0         
+  1960         0            0           0         
+  1937         0            0           0         
+  2062         0            0           0         
+  1995         0            0           0         
+  1917         0            0           0         
+  1902         0            0           0         
+  1955         0            0           0         
+  1921         0            0           0         
+  1939         0            0           0         
+  1902         0            0           0         
+  1837         0            0           0         
+  1861         0            0           0         
+  1882         0            0           0         
+  1882         0            0           0         
+  1936         0            0           0         
+  1891         0            0           0         
+  1874         0            0           0         
+  1882         0            0           0         
+  1891         0            0           0         
+  1853         0            0           0         
+  1854         0            0           0         
+  1895         0            0           0         
+  1810         0            0           0         
+  1909         0            0           0         
+  1848         0            0           0         
+  1923         0            0           0         
+  1888         0            0           0         
+  1897         0            0           0         
+  1987         0            0           0         
+  1844         0            0           0         
+  1929         0            0           0         
+  1907         0            0           0         
+  1831         0            0           0         
+  1839         0            0           0         
+  1810         0            0           0         
+  1824         0            0           0         
+  1785         0            0           0         
+  1772         0            0           0         
+  1722         0            0           0         
+  1748         0            0           0         
+  1797         0            0           0         
+  1714         0            0           0         
+  1738         0            0           0         
+  1715         1677.6184    1674.10714  0.00058309 
+  1834         1674.4979    1670.83553  0.00054526 
+  1771         1671.39371   1667.57018  0.00056465 
+  1718         1668.30674   1664.3111   0.00058207 
+  1728         1665.23798   1661.05826  0.0005787 
+  1729         1662.18855   1657.81167  0.00057837 
+  1779         1659.15975   1654.5713   0.00056211 
+  1715         1656.15298   1651.33715  0.00058309 
+  1748         1653.16985   1648.10921  0.00057208 
+  1704         1650.21221   1644.88747  0.00058685 
+  1732         1647.28212   1641.67191  0.00057737 
+  1720         1644.38192   1638.46253  0.0005814 
+  1633         1641.51433   1635.25932  0.00061237 
+  1674         1638.68244   1632.06227  0.00059737 
+  1677         1635.88983   1628.87136  0.0005963 
+  1654         1633.14064   1625.68659  0.00060459 
+  1634         1630.43965   1622.50794  0.000612  
+  1699         1627.79247   1619.33541  0.00058858 
+  1728         1625.20569   1616.16898  0.0005787 
+  1707         1622.68703   1613.00865  0.00058582 
+  1683         1620.24568   1609.8544   0.00059418 
+  1686         1617.89264   1606.70623  0.00059312 
+  1632         1615.64104   1603.56412  0.00061275 
+  1683         1613.50677   1600.42806  0.00059418 
+  1609         1611.50927   1597.29805  0.0006215 
+  1655         1609.6723    1594.17407  0.00060423 
+  1602         1608.02533   1591.05612  0.00062422 
+  1586         1606.60535   1587.94418  0.00063052 
+  1639         1605.45888   1584.83824  0.00061013 
+  1590         1604.64579   1581.7383   0.00062893 
+  1630         1604.24335   1578.64434  0.0006135 
+  1601         1604.35312   1575.55635  0.00062461 
+  1641         1605.11127   1572.47433  0.00060938 
+  1569         1606.70258   1569.39826  0.00063735 
+  1614         1609.38355   1566.32813  0.00061958 
+  1605         1613.51997   1563.26394  0.00062305 
+  1609         1619.64553   1560.20567  0.0006215 
+  1584         1628.56562   1557.15331  0.00063131 
+  1533         1641.54646   1554.10686  0.00065232 
+  1697         1660.68297   1551.06629  0.00058928 
+  1719         1689.80486   1548.03162  0.00058173 
+  1702         1737.14666   1545.00281  0.00058754 
+  1765         1822.14502   1541.97987  0.00056657 
+  2144         1986.86506   1538.96278  0.00046642 
+  2248         2300.34818   1535.95154  0.00044484 
+  2782         2814.09411   1532.94613  0.00035945 
+  3753         3575.67231   1529.94654  0.00026645 
+  5611         4320.62986   1526.95277  0.00017822 
+  6413         4440.37867   1523.9648   0.00015593 
+  4696         3751.47746   1520.98262  0.00021295 
+  2679         2864.99898   1518.00623  0.00037327 
+  1790         2246.97555   1515.03562  0.00055866 
+  1686         1935.29028   1512.07077  0.00059312 
+  1675         1785.77199   1509.11167  0.00059701 
+  1545         1704.78171   1506.15832  0.00064725 
+  1567         1654.98304   1503.21071  0.00063816 
+  1559         1621.54632   1500.26882  0.00064144 
+  1585         1595.57398   1497.33265  0.00063091 
+  1514         1573.53406   1494.40218  0.0006605 
+  1591         1555.43829   1491.47742  0.00062854 
+  1527         1541.34446   1488.55833  0.00065488 
+  1559         1530.2597    1485.64493  0.00064144 
+  1504         1521.13451   1482.73719  0.00066489 
+  1533         1513.31284   1479.83512  0.00065232 
+  1451         1506.42119   1476.93869  0.00068918 
+  1483         1500.23068   1474.0479   0.00067431 
+  1455         1494.58526   1471.16274  0.00068729 
+  1487         1489.37186   1468.28319  0.00067249 
+  1442         1484.50662   1465.40926  0.00069348 
+  1508         1479.92573   1462.54093  0.00066313 
+  1509         1475.57969   1459.67819  0.00066269 
+  1462         1471.42988   1456.82103  0.00068399 
+  1447         1467.44565   1453.96945  0.00069109 
+  1467         1463.60227   1451.12342  0.00068166 
+  1504         1459.8799    1448.28295  0.00066489 
+  1470         1456.26231   1445.44802  0.00068027 
+  1490         1452.73616   1442.61863  0.00067114 
+  1484         1449.29053   1439.79476  0.00067385 
+  1467         1445.91636   1436.97641  0.00068166 
+  1451         1442.60617   1434.16356  0.00068918 
+  1466         1439.35386   1431.35621  0.00068213 
+  1426         1436.15446   1428.55434  0.00070126 
+  1435         1433.00406   1425.75795  0.00069686 
+  1458         1429.8998    1422.96703  0.00068587 
+  1351         1426.83981   1420.18157  0.00074019 
+  1448         1423.82341   1417.40156  0.00069061 
+  1453         1420.85143   1414.62699  0.00068823 
+  1414         1417.92671   1411.85785  0.00070721 
+  1442         1415.05521   1409.09412  0.00069348 
+  1386         1412.24816   1406.33582  0.0007215 
+  1466         1409.52695   1403.58291  0.00068213 
+  1442         1406.93806   1400.8354   0.00069348 
+  1451         1404.59857   1398.09327  0.00068918 
+  1411         1402.78659   1395.35652  0.00070872 
+  1392         1402.00177   1392.62513  0.00071839 
+  1424         1402.58211   1389.8991   0.00070225 
+  1404         1404.02737   1387.17841  0.00071225 
+  1422         1405.66672   1384.46306  0.00070323 
+  1401         1402.85188   1381.75305  0.00071378 
+  1446         1396.09958   1379.04835  0.00069156 
+  1383         1388.43926   1376.34896  0.00072307 
+  1364         1382.54927   1373.65487  0.00073314 
+  1422         1378.44425   1370.96608  0.00070323 
+  1415         1375.31569   1368.28257  0.00070671 
+  1389         1372.68957   1365.60433  0.00071994 
+  1412         1370.41217   1362.93135  0.00070822 
+  1292         1368.49604   1360.26364  0.00077399 
+  1345         1367.07154   1357.60117  0.00074349 
+  1374         1366.45236   1354.94393  0.0007278 
+  1358         1367.30579   1352.29193  0.00073638 
+  1392         1370.87468   1349.64514  0.00071839 
+  1383         1378.83935   1347.00356  0.00072307 
+  1394         1391.51384   1344.36719  0.00071736 
+  1378         1406.99574   1341.73601  0.00072569 
+  1348         1418.87697   1339.11001  0.00074184 
+  1410         1416.17733   1336.48918  0.00070922 
+  1464         1401.37533   1333.87352  0.00068306 
+  1394         1381.9189    1331.26302  0.00071736 
+  1351         1366.8383    1328.65766  0.00074019 
+  1311         1359.23621   1326.05745  0.00076278 
+  1309         1358.54061   1323.46236  0.00076394 
+  1384         1361.75052   1320.87239  0.00072254 
+  1432         1364.7503    1318.28754  0.00069832 
+  1421         1359.95061   1315.70778  0.00070373 
+  1447         1348.34547   1313.13312  0.00069109 
+  1420         1335.02642   1310.56355  0.00070423 
+  1348         1324.39248   1307.99905  0.00074184 
+  1314         1317.07779   1305.43962  0.00076104 
+  1363         1311.92302   1302.88525  0.00073368 
+  1313         1307.97633   1300.33593  0.00076161 
+  1274         1304.75835   1297.79165  0.00078493 
+  1325         1302.17261   1295.2524   0.00075472 
+  1309         1300.48414   1292.71818  0.00076394 
+  1367         1300.34215   1290.18897  0.00073153 
+  1375         1302.22872   1287.66476  0.00072727 
+  1289         1305.39479   1285.14555  0.0007758 
+  1265         1308.27195   1282.63133  0.00079051 
+  1266         1304.45275   1280.1221   0.00078989 
+  1267         1296.11787   1277.61783  0.00078927 
+  1181         1286.83197   1275.11852  0.00084674 
+  1237         1279.87436   1272.62417  0.00080841 
+  1217         1275.14183   1270.13476  0.00082169 
+  1213         1271.55142   1267.65029  0.0008244 
+  1201         1268.45087   1265.17075  0.00083264 
+  1216         1265.57355   1262.69612  0.00082237 
+  1237         1262.81957   1260.22641  0.00080841 
+  1219         1260.15151   1257.7616   0.00082034 
+  1288         1257.5304    1255.30168  0.0007764 
+  1232         1254.95272   1252.84664  0.00081169 
+  1310         1252.40206   1250.39648  0.00076336 
+  1286         1249.87615   1247.95119  0.0007776 
+  1231         1247.37103   1245.51076  0.00081235 
+  1295         1244.88401   1243.07518  0.0007722 
+  1271         1242.41329   1240.64444  0.00078678 
+  1231         1239.95767   1238.21853  0.00081235 
+  1256         1237.51646   1235.79745  0.00079618 
+  1209         1235.08934   1233.38119  0.00082713 
+  1227         1232.67635   1230.96973  0.000815  
+  1197         1230.27789   1228.56307  0.00083542 
+  1226         1227.89474   1226.16121  0.00081566 
+  1244         1225.52811   1223.76412  0.00080386 
+  1235         1223.17975   1221.37181  0.00080972 
+  1147         1220.85217   1218.98427  0.00087184 
+  1164         1218.54887   1216.60148  0.00085911 
+  1207         1216.27478   1214.22344  0.0008285 
+  1219         1214.03706   1211.85014  0.00082034 
+  1188         1211.8464    1209.48158  0.00084175 
+  1236         1209.72002   1207.11774  0.00080906 
+  1169         1207.68801   1204.75861  0.00085543 
+  1242         1205.80584   1202.40419  0.00080515 
+  1179         1204.17157   1200.05447  0.00084818 
+  1187         1202.92567   1197.70944  0.00084246 
+  1252         1202.15563   1195.36909  0.00079872 
+  1230         1201.82746   1193.03342  0.00081301 
+  1201         1201.76553   1190.70241  0.00083264 
+  1165         1201.92975   1188.37606  0.00085837 
+  1224         1203.7589    1186.05436  0.00081699 
+  1176         1209.15476   1183.7373   0.00085034 
+  1168         1218.71516   1181.42487  0.00085616 
+  1220         1229.97956   1179.11706  0.00081967 
+  1235         1236.10894   1176.81388  0.00080972 
+  1333         1228.59727   1174.5153   0.00075019 
+  1219         1213.29275   1172.22132  0.00082034 
+  1183         1196.70163   1169.93193  0.00084531 
+  1198         1184.27099   1167.64712  0.00083472 
+  1176         1176.14357   1165.36689  0.00085034 
+  1145         1170.63907   1163.09123  0.00087336 
+  1223         1166.49792   1160.82013  0.00081766 
+  1151         1163.0489    1158.55357  0.00086881 
+  1123         1159.97933   1156.29156  0.00089047 
+  1142         1157.14119   1154.03409  0.00087566 
+  1129         1154.45983   1151.78114  0.00088574 
+  1084         1151.88036   1149.53271  0.00092251 
+  1062         1149.37927   1147.28879  0.00094162 
+  1099         1146.93291   1145.04938  0.00090992 
+  1109         1144.53002   1142.81445  0.00090171 
+  1104         1142.16125   1140.58402  0.0009058 
+  1154         1139.81992   1138.35806  0.00086655 
+  1105         1137.50113   1136.13657  0.00090498 
+  1108         1135.20124   1133.91955  0.00090253 
+  1080         1132.91748   1131.70698  0.00092593 
+  1079         1130.64772   1129.49886  0.00092678 
+  1116         1128.3903    1127.29517  0.00089606 
+  1173         1126.14392   1125.09592  0.00085251 
+  1127         1123.90753   1122.90109  0.00088731 
+  1084         1121.68028   1120.71067  0.00092251 
+  1143         1119.46149   1118.52466  0.00087489 
+  1094         1117.25061   1116.34305  0.00091408 
+  1070         1115.04717   1114.16583  0.00093458 
+  1095         1112.85078   1111.99299  0.00091324 
+  1100         1110.66112   1109.82453  0.00090909 
+  1091         1108.47792   1107.66044  0.00091659 
+  1084         1106.30119   1105.5007   0.00092251 
+  1103         1104.15599   1103.34532  0.00090662 
+  1118         1101.99123   1101.19428  0.00089445 
+  1060         1099.84491   1099.04758  0.0009434 
+  1033         1097.69144   1096.90521  0.00096805 
+  1063         1095.54429   1094.76715  0.00094073 
+  1098         1093.40173   1092.63341  0.00091075 
+  1159         1091.26448   1090.50398  0.00086281 
+  1046         1089.13291   1088.37884  0.00095602 
+  1137         1087.00612   1086.25799  0.00087951 
+  1110         1084.88449   1084.14143  0.0009009 
+  1110         1082.76796   1082.02913  0.0009009 
+  1146         1080.65652   1079.92111  0.0008726 
+  1104         1078.55013   1077.81734  0.0009058 
+  1111         1076.44878   1075.71782  0.00090009 
+  1057         1074.35245   1073.62255  0.00094607 
+  1155         1072.26114   1071.53151  0.0008658 
+  1001         1070.17484   1069.4447   0.000999  
+  1017         1068.09358   1067.36212  0.00098328 
+  1067         1066.01735   1065.28374  0.00093721 
+  1060         1063.95248   1063.20957  0.0009434 
+  1034         1061.88645   1061.1396   0.00096712 
+  1037         1059.82869   1059.07381  0.00096432 
+  1084         1057.77299   1057.01221  0.00092251 
+  1044         1055.72254   1054.95479  0.00095785 
+  1027         1053.67741   1052.90153  0.00097371 
+  1064         1051.6377    1050.85243  0.00093985 
+  952          1049.60351   1048.80748  0.00105042 
+  1040         1047.5772    1046.76668  0.00096154 
+  999          1045.5545    1044.73002  0.001001  
+  929          1043.53891   1042.69748  0.00107643 
+  1044         1041.52844   1040.66907  0.00095785 
+  987          1039.52449   1038.64477  0.00101317 
+  946          1037.52868   1036.62458  0.00105708 
+  1033         1035.5388    1034.60849  0.00096805 
+  947          1033.56059   1032.59649  0.00105597 
+  1003         1031.58679   1030.58857  0.00099701 
+  1052         1029.62207   1028.58473  0.00095057 
+  1013         1027.66902   1026.58497  0.00098717 
+  969          1025.72553   1024.58926  0.00103199 
+  1026         1023.79474   1022.59761  0.00097466 
+  982          1021.87863   1020.61001  0.00101833 
+  991          1019.97972   1018.62645  0.00100908 
+  969          1018.10141   1016.64692  0.00103199 
+  980          1016.24828   1014.67142  0.00102041 
+  1037         1014.42662   1012.69993  0.00096432 
+  991          1012.64529   1010.73246  0.00100908 
+  1008         1010.91702   1008.76899  0.00099206 
+  1022         1009.26062   1006.80951  0.00097847 
+  989          1007.70489   1004.85403  0.00101112 
+  984          1006.29566   1002.90253  0.00101626 
+  942          1005.11068   1000.955    0.00106157 
+  1041         1004.29868   999.01144   0.00096061 
+  971          1004.18491   997.07183   0.00102987 
+  1033         1005.49225   995.13619   0.00096805 
+  1001         1009.57557   993.20448   0.000999  
+  997          1018.15143   991.27672   0.00100301 
+  1004         1030.70445   989.35288   0.00099602 
+  1089         1037.82527   987.43297   0.00091827 
+  1041         1032.7533    985.51698   0.00096061 
+  966          1021.62961   983.60489   0.0010352 
+  966          1008.66534   981.69671   0.0010352 
+  940          998.50621    979.79243   0.00106383 
+  1014         991.19756    977.89203   0.00098619 
+  969          985.78494    975.99551   0.00103199 
+  946          981.39958    974.10286   0.00105708 
+  902          977.72954    972.21408   0.00110865 
+  847          974.63338    970.32917   0.00118064 
+  919          971.90616    968.4481    0.00108814 
+  910          969.45245    966.57088   0.0010989 
+  963          967.18633    964.69749   0.00103842 
+  902          965.03738    962.82794   0.00110865 
+  922          962.96374    960.96221   0.0010846 
+  944          960.94237    959.1003    0.00105932 
+  897          958.95948    957.2422    0.00111483 
+  922          957.00646    955.3879    0.0010846 
+  881          955.07771    953.5374    0.00113507 
+  887          953.16806    951.69069   0.0011274 
+  950          951.27482    949.84776   0.00105263 
+  892          949.39584    948.0086    0.00112108 
+  917          947.52897    946.17321   0.00109051 
+  859          945.67304    944.34158   0.00116414 
+  893          943.82699    942.51371   0.00111982 
+  936          941.99001    940.68958   0.00106838 
+  912          940.16685    938.8692    0.00109649 
+  849          938.34622    937.05254   0.00117786 
+  918          936.53578    935.23962   0.00108932 
+  896          934.72984    933.43041   0.00111607 
+  930          932.93085    931.62491   0.00107527 
+  951          931.13859    929.82313   0.00105152 
+  854          929.35294    928.02503   0.00117096 
+  855          927.5738     926.23064   0.00116959 
+  873          925.80153    924.43992   0.00114548 
+  895          924.03525    922.65289   0.00111732 
+  895          922.27561    920.86952   0.00111732 
+  920          920.52222    919.08982   0.00108696 
+  883          918.77533    917.31378   0.0011325 
+  962          917.03504    915.54139   0.0010395 
+  914          915.30146    913.77264   0.00109409 
+  934          913.57473    912.00753   0.00107066 
+  884          911.85502    910.24606   0.00113122 
+  846          910.14253    908.4882    0.00118203 
+  862          908.43749    906.73396   0.00116009 
+  890          906.74019    904.98334   0.0011236 
+  881          905.05093    903.23631   0.00113507 
+  890          903.37007    901.49289   0.0011236 
+  865          901.69805    899.75305   0.00115607 
+  895          900.03532    898.0168    0.00111732 
+  893          898.38245    896.28412   0.00111982 
+  868          896.74007    894.55501   0.00115207 
+  874          895.10891    892.82947   0.00114416 
+  858          893.48984    891.10748   0.0011655 
+  827          891.88387    889.38905   0.00120919 
+  835          890.2922     887.67416   0.0011976 
+  813          888.71633    885.9628    0.00123001 
+  868          887.15825    884.25498   0.00115207 
+  823          885.62154    882.55068   0.00121507 
+  837          884.11042    880.84989   0.00119474 
+  851          882.6345     879.15262   0.00117509 
+  802          881.20042    877.45885   0.00124688 
+  837          879.8013     875.76858   0.00119474 
+  841          878.40929    874.0818    0.00118906 
+  874          877.00886    872.3985    0.00114416 
+  846          875.64077    870.71868   0.00118203 
+  863          874.31888    869.04233   0.00115875 
+  849          873.07064    867.36945   0.00117786 
+  804          871.90664    865.70002   0.00124378 
+  918          870.83472    864.03405   0.00108932 
+  782          869.86899    862.37152   0.00127877 
+  800          869.04514    860.71243   0.00125   
+  817          868.3659     859.05677   0.00122399 
+  877          867.88585    857.40454   0.00114025 
+  840          867.66779    855.75573   0.00119048 
+  872          867.77567    854.11033   0.00114679 
+  854          868.32648    852.46834   0.00117096 
+  843          869.48113    850.82974   0.00118624 
+  878          871.48221    849.19454   0.00113895 
+  902          874.70775    847.56273   0.00110865 
+  960          879.77585    845.9343    0.00104167 
+  907          887.75455    844.30924   0.00110254 
+  1014         900.65488    842.68755   0.00098619 
+  1084         923.16628    841.06923   0.00092251 
+  1121         969.84799    839.45426   0.00089206 
+  1530         1083.53133   837.84263   0.00065359 
+  2262         1343.61901   836.23435   0.00044209 
+  3073         1752.23812   834.62941   0.00032541 
+  3715         2126.74278   833.0278    0.00026918 
+  2750         2020.1866    831.42951   0.00036364 
+  2258         1737.61315   829.83454   0.00044287 
+  1394         1395.01558   828.24288   0.00071736 
+  977          1107.27817   826.65452   0.00102354 
+  873          967.99121    825.06946   0.00114548 
+  817          910.35348    823.4877    0.00122399 
+  893          882.41241    821.90922   0.00111982 
+  873          865.40637    820.33402   0.00114548 
+  831          853.75652    818.7621    0.00120337 
+  865          845.22298    817.19344   0.00115607 
+  838          838.64361    815.62804   0.00119332 
+  805          833.35344    814.0659    0.00124224 
+  854          828.94999    812.50701   0.00117096 
+  854          825.17654    810.95136   0.00117096 
+  881          821.86376    809.39895   0.00113507 
+  820          818.89661    807.84977   0.00121951 
+  822          816.19409    806.30381   0.00121655 
+  867          813.69812    804.76107   0.0011534 
+  825          811.36644    803.22155   0.00121212 
+  796          809.16738    801.68522   0.00125628 
+  756          807.07701    800.1521    0.00132275 
+  784          805.07719    798.62217   0.00127551 
+  802          803.1538     797.09543   0.00124688 
+  799          801.29589    795.57188   0.00125156 
+  749          799.65344    794.05149   0.00133511 
+  785          797.90429    792.53428   0.00127389 
+  765          796.20067    791.02023   0.00130719 
+  772          794.6179     789.50933   0.00129534 
+  769          792.99514    788.00159   0.00130039 
+  779          791.40959    786.497     0.0012837 
+  775          789.86023    784.99554   0.00129032 
+  764          788.34729    783.49721   0.0013089 
+  714          786.87183    782.00202   0.00140056 
+  801          785.43601    780.50994   0.00124844 
+  723          784.04356    779.02098   0.00138313 
+  764          782.699      777.53513   0.0013089 
+  748          781.40973    776.05238   0.0013369 
+  761          780.1857     774.57273   0.00131406 
+  749          779.04035    773.09617   0.00133511 
+  788          777.99287    771.6227    0.00126904 
+  750          777.07009    770.1523    0.00133333 
+  756          776.31073    768.68498   0.00132275 
+  757          775.78337    767.22073   0.001321  
+  771          775.55138    765.75954   0.00129702 
+  803          775.76233    764.30141   0.00124533 
+  795          776.64599    762.84632   0.00125786 
+  899          778.58523    761.39428   0.00111235 
+  1054         782.38623    759.94528   0.00094877 
+  1221         790.03021    758.49931   0.000819  
+  1624         806.69285    757.05637   0.00061576 
+  2027         844.2779     755.61645   0.00049334 
+  1841         912.29615    754.17954   0.00054318 
+  1546         996.6973     752.74564   0.00064683 
+  1281         1042.1314    751.31475   0.00078064 
+  1011         1003.25231   749.88686   0.00098912 
+  810          946.04069    748.46195   0.00123457 
+  707          874.30121    747.04003   0.00141443 
+  690          817.93708    745.6211    0.00144928 
+  669          787.23039    744.20513   0.00149477 
+  662          771.70827    742.79214   0.00151057 
+  704          763.00554    741.38211   0.00142045 
+  659          757.2386     739.97504   0.00151745 
+  751          752.95568    738.57091   0.00133156 
+  752          749.55131    737.16974   0.00132979 
+  675          746.70695    735.7715    0.00148148 
+  733          744.24173    734.3762    0.00136426 
+  716          742.04274    732.98383   0.00139665 
+  704          740.03723    731.59438   0.00142045 
+  687          738.17664    730.20785   0.0014556 
+  709          736.43127    728.82423   0.00141044 
+  677          734.77089    727.44352   0.0014771 
+  681          733.18415    726.0657    0.00146843 
+  676          731.65567    724.69079   0.00147929 
+  642          730.17864    723.31876   0.00155763 
+  704          728.74696    721.94961   0.00142045 
+  698          727.35643    720.58335   0.00143266 
+  706          726.00443    719.21995   0.00141643 
+  753          724.68962    717.85943   0.00132802 
+  715          723.4119     716.50176   0.0013986 
+  646          722.17236    715.14695   0.00154799 
+  721          720.97343    713.79499   0.00138696 
+  676          719.81903    712.44588   0.00147929 
+  651          718.71502    711.0996    0.0015361 
+  671          717.66976    709.75616   0.00149031 
+  716          716.69502    708.41555   0.00139665 
+  669          715.80755    707.07776   0.00149477 
+  688          715.03147    705.74279   0.00145349 
+  713          714.40212    704.41062   0.00140252 
+  790          713.97308    703.08127   0.00126582 
+  691          713.82847    701.75471   0.00144718 
+  732          714.10547    700.43095   0.00136612 
+  724          715.04494    699.10998   0.00138122 
+  683          717.11881    697.7918    0.00146413 
+  753          721.50556    696.47639   0.00132802 
+  854          731.59923    695.16376   0.00117096 
+  1043         755.16728    693.85389   0.00095877 
+  1288         801.22221    692.54679   0.0007764 
+  1372         854.61896    691.24244   0.00072886 
+  1214         854.82676    689.94085   0.00082372 
+  1055         828.82344    688.642     0.00094787 
+  891          796.19479    687.34589   0.00112233 
+  696          755.6269     686.05252   0.00143678 
+  641          729.35775    684.76188   0.00156006 
+  623          716.28955    683.47397   0.00160514 
+  679          710.16229    682.18877   0.00147275 
+  643          707.18099    680.90629   0.00155521 
+  658          705.86733    679.62651   0.00151976 
+  642          705.76605    678.34944   0.00155763 
+  660          706.80336    677.07507   0.00151515 
+  693          709.12294    675.8034    0.001443  
+  697          713.17344    674.5344    0.00143472 
+  672          719.4666     673.2681    0.0014881 
+  704          729.30815    672.00447   0.00142045 
+  747          745.09476    670.74351   0.00133869 
+  802          772.27135    669.48521   0.00124688 
+  943          826.74323    668.22958   0.00106045 
+  1183         948.72245    666.97661   0.00084531 
+  1646         1198.80979   665.72628   0.00060753 
+  2540         1554.27564   664.4786    0.0003937 
+  2771         1667.29153   663.23357   0.00036088 
+  2231         1512.92517   661.99116   0.00044823 
+  1776         1347.66793   660.75139   0.00056306 
+  1189         1096.8599    659.51424   0.00084104 
+  781          902.26154    658.27971   0.00128041 
+  722          798.94835    657.0478    0.00138504 
+  652          748.96611    655.81849   0.00153374 
+  661          722.51966    654.59179   0.00151286 
+  610          706.15838    653.36769   0.00163934 
+  612          694.92248    652.14618   0.00163399 
+  658          686.72767    650.92727   0.00151976 
+  683          680.48993    649.71093   0.00146413 
+  632          675.58007    648.49717   0.00158228 
+  628          671.61129    647.28599   0.00159236 
+  640          668.3379     646.07737   0.0015625 
+  629          665.60641    644.87132   0.00158983 
+  565          663.31663    643.66783   0.00176991 
+  588          661.41558    642.46689   0.00170068 
+  673          659.88562    641.26849   0.00148588 
+  661          658.74921    640.07264   0.00151286 
+  692          658.08332    638.87933   0.00144509 
+  713          658.05976    637.68855   0.00140252 
+  693          659.07925    636.5003    0.001443  
+  762          662.26266    635.31457   0.00131234 
+  880          670.60041    634.13136   0.00113636 
+  1030         689.29882    632.95066   0.00097087 
+  1127         719.68196    631.77247   0.00088731 
+  1209         737.73188    630.59678   0.00082713 
+  1336         729.33993    629.42359   0.0007485 
+  1508         724.77019    628.2529    0.00066313 
+  1649         722.07263    627.08469   0.00060643 
+  1512         731.87204    625.91896   0.00066138 
+  1455         750.55475    624.75571   0.00068729 
+  1226         778.8956     623.59494   0.00081566 
+  940          800.28605    622.43663   0.00106383 
+  822          772.11518    621.28078   0.00121655 
+  683          741.52359    620.1274    0.00146413 
+  655          708.12724    618.97646   0.00152672 
+  629          674.88804    617.82798   0.00158983 
+  578          654.92564    616.68194   0.0017301 
+  603          645.11035    615.53834   0.00165837 
+  586          640.83412    614.39717   0.00170648 
+  562          639.5764     613.25843   0.00177936 
+  600          639.30618    612.12211   0.00166667 
+  584          638.08519    610.98822   0.00171233 
+  638          637.43955    609.85673   0.0015674 
+  574          638.70118    608.72766   0.00174216 
+  608          642.54084    607.60099   0.00164474 
+  609          647.20792    606.47672   0.00164204 
+  626          645.9974     605.35485   0.00159744 
+  630          640.78368    604.23537   0.0015873 
+  623          634.67635    603.11827   0.00160514 
+  568          627.1169     602.00356   0.00176056 
+  620          620.83437    600.89121   0.0016129 
+  581          616.58099    599.78124   0.00172117 
+  596          613.71516    598.67364   0.00167785 
+  574          611.62592    597.5684    0.00174216 
+  593          609.95005    596.46552   0.00168634 
+  593          608.50914    595.36498   0.00168634 
+  590          607.2193     594.2668    0.00169492 
+  554          606.03752    593.17095   0.00180505 
+  548          604.93948    592.07745   0.00182482 
+  574          603.91096    590.98628   0.00174216 
+  628          602.94396    589.89744   0.00159236 
+  602          602.03486    588.81092   0.00166113 
+  618          601.18357    587.72672   0.00161812 
+  588          600.39309    586.64483   0.00170068 
+  618          599.66981    585.56526   0.00161812 
+  633          599.02404    584.48799   0.00157978 
+  645          598.47141    583.41302   0.00155039 
+  695          598.03489    582.34034   0.00143885 
+  661          597.74839    581.26996   0.00151286 
+  662          597.66301    580.20186   0.00151057 
+  669          597.85768    579.13605   0.00149477 
+  711          598.45864    578.07251   0.00140647 
+  759          599.67799    577.01125   0.00131752 
+  817          601.89926    575.95225   0.00122399 
+  789          605.93754    574.89552   0.00126743 
+  764          614.01129    573.84105   0.0013089 
+  739          632.26494    572.78883   0.00135318 
+  857          672.40089    571.73886   0.00116686 
+  777          740.92794    570.69114   0.001287  
+  744          791.13843    569.64566   0.00134409 
+  672          766.46114    568.60241   0.0014881 
+  620          737.45277    567.5614    0.0016129 
+  660          698.97525    566.52261   0.00151515 
+  551          651.38432    565.48604   0.00181488 
+  595          622.11703    564.4517    0.00168067 
+  584          609.81561    563.41956   0.00171233 
+  604          607.41222    562.38964   0.00165563 
+  621          606.43259    561.36192   0.00161031 
+  597          601.24478    560.3364    0.00167504 
+  562          596.83076    559.31308   0.00177936 
+  574          592.08858    558.29195   0.00174216 
+  563          587.0693     557.273     0.0017762 
+  559          583.69522    556.25624   0.00178891 
+  586          581.68237    555.24166   0.00170648 
+  555          580.4186     554.22924   0.0018018 
+  541          579.54776    553.219     0.00184843 
+  574          578.92878    552.21092   0.00174216 
+  604          578.51684    551.20501   0.00165563 
+  605          578.31621    550.20125   0.00165289 
+  622          578.38236    549.19964   0.00160772 
+  656          578.82785    548.20017   0.00152439 
+  645          579.76389    547.20285   0.00155039 
+  631          580.97757    546.20767   0.00158479 
+  622          581.58177    545.21462   0.00160772 
+  572          581.64549    544.2237    0.00174825 
+  577          581.81767    543.23491   0.0017331 
+  589          581.96769    542.24824   0.00169779 
+  565          582.42165    541.26368   0.00176991 
+  543          583.47582    540.28124   0.00184162 
+  537          585.20614    539.3009    0.0018622 
+  552          587.74077    538.32267   0.00181159 
+  554          591.32156    537.34653   0.00180505 
+  539          596.11522    536.3725    0.00185529 
+  618          601.73179    535.40055   0.00161812 
+  576          608.40495    534.43069   0.00173611 
+  575          616.75629    533.46291   0.00173913 
+  543          624.24059    532.49721   0.00184162 
+  587          630.8555     531.53358   0.00170358 
+  518          640.35232    530.57202   0.0019305 
+  576          654.0658     529.61253   0.00173611 
+  645          676.6456     528.6551    0.00155039 
+  613          720.51222    527.69972   0.00163132 
+  635          811.3577     526.7464    0.0015748 
+  752          978.45427    525.79512   0.00132979 
+  825          1172.18125   524.84589   0.00121212 
+  857          1193.97423   523.8987    0.00116686 
+  826          1147.91257   522.95354   0.00121065 
+  906          1139.29148   522.01042   0.00110375 
+  1021         1104.18729   521.06932   0.00097943 
+  1286         1125.69608   520.13025   0.0007776 
+  1549         1241.04159   519.19319   0.00064558 
+  1873         1494.33388   518.25815   0.0005339 
+  2564         2140.94483   517.32512   0.00039002 
+  4289         3700.54841   516.3941    0.00023315 
+  7269         6092.91786   515.46508   0.00013757 
+  8389         7312.92917   514.53805   0.0001192 
+  5759         6020.22726   513.61302   0.00017364 
+  4763         5056.50353   512.68998   0.00020995 
+  3574         3926.54702   511.76893   0.0002798 
+  1587         2361.14009   510.84986   0.00063012 
+  848          1452.69058   509.93277   0.00117925 
+  704          1072.28725   509.01765   0.00142045 
+  640          905.8589     508.10449   0.0015625 
+  672          813.62433    507.19331   0.0014881 
+  661          754.79577    506.28408   0.00151286 
+  646          714.8844     505.37682   0.00154799 
+  665          686.69765    504.4715    0.00150376 
+  591          666.25928    503.56814   0.00169205 
+  551          651.19708    502.66672   0.00181488 
+  593          640.06365    501.76724   0.00168634 
+  559          631.99932    500.8697    0.00178891 
+  568          626.5946     499.97409   0.00176056 
+  562          623.8668     499.08041   0.00177936 
+  568          624.12061    498.18866   0.00176056 
+  593          627.09171    497.29882   0.00168634 
+  560          629.49088    496.41091   0.00178571 
+  528          628.0723     495.52491   0.00189394 
+  566          626.39034    494.64081   0.00176678 
+  568          624.99091    493.75862   0.00176056 
+  583          623.3747     492.87834   0.00171527 
+  545          623.36604    491.99995   0.00183486 
+  582          625.35583    491.12345   0.00171821 
+  563          628.99118    490.24884   0.0017762 
+  604          633.98504    489.37612   0.00165563 
+  613          640.21067    488.50528   0.00163132 
+  617          647.67209    487.63632   0.00162075 
+  627          656.46287    486.76923   0.0015949 
+  605          666.72981    485.90401   0.00165289 
+  610          678.674      485.04066   0.00163934 
+  631          692.55579    484.17917   0.00158479 
+  616          708.7068     483.31953   0.00162338 
+  669          727.54857    482.46175   0.00149477 
+  628          749.626      481.60583   0.00159236 
+  686          775.63914    480.75175   0.00145773 
+  689          806.51426    479.89951   0.00145138 
+  684          843.49898    479.04911   0.00146199 
+  707          888.30739    478.20054   0.00141443 
+  758          943.40974    477.35381   0.00131926 
+  824          1012.61419   476.5089    0.00121359 
+  838          1102.60771   475.66582   0.00119332 
+  927          1227.24525   474.82456   0.00107875 
+  1007         1413.60017   473.98511   0.00099305 
+  1176         1694.01573   473.14747   0.00085034 
+  1377         2045.73213   472.31165   0.00072622 
+  1557         2330.88922   471.47763   0.00064226 
+  2090         2660.15692   470.6454    0.00047847 
+  2893         3223.93291   469.81498   0.00034566 
+  4074         4137.80677   468.98635   0.00024546 
+  6116         5981.26469   468.15951   0.00016351 
+  10498        10170.40174  467.33445   0.00009526 
+  20357        18852.46069  466.51118   0.00004912 
+  44300        31590.30517  465.68968   0.00002257 
+  68184        36228.90377  464.86996   0.00001467 
+  52647        29933.06639  464.05201   0.00001899 
+  47193        26115.17958  463.23583   0.00002119 
+  39383        20246.59493  462.42141   0.00002539 
+  20615        12244.76794  461.60875   0.00004851 
+  11195        7089.87013   460.79785   0.00008933 
+  5113         4484.39913   459.9887    0.00019558 
+  2625         3212.27108   459.18129   0.00038095 
+  2172         2539.00519   458.37564   0.00046041 
+  2545         2140.9533    457.57172   0.00039293 
+  1966         1833.47108   456.76954   0.00050865 
+  1685         1585.70929   455.9691    0.00059347 
+  1686         1410.03597   455.17038   0.00059312 
+  1363         1259.39957   454.37339   0.00073368 
+  1163         1138.84822   453.57813   0.00085985 
+  1280         1061.53464   452.78458   0.00078125 
+  1564         1026.73081   451.99275   0.00063939 
+  1421         1026.02638   451.20264   0.00070373 
+  1254         1013.97837   450.41423   0.00079745 
+  1225         975.03445    449.62753   0.00081633 
+  1127         959.64465    448.84252   0.00088731 
+  1080         958.58605    448.05922   0.00092593 
+  1331         983.49964    447.27761   0.00075131 
+  1648         1107.78929   446.49769   0.0006068 
+  2119         1500.86939   445.71946   0.00047192 
+  3639         2442.59582   444.94291   0.0002748 
+  5361         3716.79524   444.16804   0.00018653 
+  4400         3969.77065   443.39485   0.00022727 
+  2929         3165.50823   442.62333   0.00034141 
+  2862         2809.27222   441.85348   0.00034941 
+  1873         2270.23823   441.08529   0.0005339 
+  913          1464.98035   440.31877   0.00109529 
+  736          997.30476    439.5539    0.0013587 
+  579          799.24844    438.7907    0.00172712 
+  559          709.37924    438.02914   0.00178891 
+  583          657.10565    437.26923   0.00171527 
+  536          621.87441    436.51097   0.00186567 
+  568          596.35644    435.75435   0.00176056 
+  560          576.93462    434.99936   0.00178571 
+  623          561.57706    434.24601   0.00160514 
+  619          549.0596     433.49429   0.00161551 
+  560          538.60357    432.7442    0.00178571 
+  567          529.69357    431.99573   0.00176367 
+  608          521.97452    431.24888   0.00164474 
+  532          515.19353    430.50365   0.0018797 
+  535          509.16693    429.76004   0.00186916 
+  509          503.75748    429.01803   0.00196464 
+  521          498.86       428.27763   0.00191939 
+  537          494.39348    427.53883   0.0018622 
+  503          490.29392    426.80164   0.00198807 
+  478          486.50973    426.06604   0.00209205 
+  447          482.99957    425.33203   0.00223714 
+  440          479.72948    424.59961   0.00227273 
+  480          476.66584    423.86878   0.00208333 
+  458          473.79584    423.13953   0.00218341 
+  448          471.09187    422.41187   0.00223214 
+  403          468.54231    421.68577   0.00248139 
+  404          466.13047    420.96126   0.00247525 
+  406          463.84418    420.23831   0.00246305 
+  428          461.67479    419.51692   0.00233645 
+  430          459.60997    418.7971    0.00232558 
+  432          457.6439     418.07884   0.00231481 
+  453          455.77098    417.36214   0.00220751 
+  441          453.98414    416.64699   0.00226757 
+  462          452.27978    415.93339   0.0021645 
+  505          450.65429    415.22133   0.0019802 
+  472          449.10505    414.51082   0.00211864 
+  402          447.63022    413.80185   0.00248756 
+  407          446.22881    413.09441   0.002457  
+  417          444.9013     412.38851   0.00239808 
+  408          443.64801    411.68413   0.00245098 
+  410          442.47166    410.98129   0.00243902 
+  406          441.37615    410.27996   0.00246305 
+  398          440.36732    409.58016   0.00251256 
+  423          439.45301    408.88187   0.00236407 
+  398          438.64389    408.1851    0.00251256 
+  394          437.95513    407.48984   0.00253807 
+  405          437.40715    406.79608   0.00246914 
+  382          437.02757    406.10383   0.0026178 
+  417          436.85489    405.41308   0.00239808 
+  387          436.94307    404.72383   0.00258398 
+  410          437.36954    404.03607   0.00243902 
+  420          438.24804    403.3498    0.00238095 
+  389          439.75052    402.66502   0.00257069 
+  427          442.14983    401.98172   0.00234192 
+  442          445.91231    401.29991   0.00226244 
+  443          451.93004    400.61957   0.00225734 
+  496          462.07096    399.94071   0.00201613 
+  450          480.10507    399.26332   0.00222222 
+  484          512.42127    398.5874    0.00206612 
+  507          565.84704    397.91295   0.00197239 
+  614          633.62405    397.23996   0.00162866 
+  745          691.19175    396.56842   0.00134228 
+  726          727.33397    395.89835   0.00137741 
+  696          711.17549    395.22972   0.00143678 
+  879          668.45611    394.56255   0.00113766 
+  973          636.70286    393.89682   0.00102775 
+  1040         610.02664    393.23254   0.00096154 
+  1139         600.08728    392.5697    0.00087796 
+  860          585.83425    391.90829   0.00116279 
+  787          551.60208    391.24832   0.00127065 
+  746          541.04056    390.58978   0.00134048 
+  627          545.34947    389.93267   0.0015949 
+  497          533.88523    389.27699   0.00201207 
+  471          502.80514    388.62272   0.00212314 
+  449          480.81328    387.96988   0.00222717 
+  433          470.08298    387.31845   0.00230947 
+  438          454.14716    386.66843   0.00228311 
+  434          440.76597    386.01983   0.00230415 
+  422          434.68457    385.37263   0.00236967 
+  447          434.31798    384.72683   0.00223714 
+  545          440.56473    384.08244   0.00183486 
+  638          459.55649    383.43944   0.0015674 
+  838          501.0833     382.79784   0.00119332 
+  965          562.54943    382.15763   0.00103627 
+  865          589.81263    381.51881   0.00115607 
+  802          577.63994    380.88137   0.00124688 
+  722          562.23844    380.24532   0.00138504 
+  574          531.55183    379.61065   0.00174216 
+  457          492.32895    378.97735   0.00218818 
+  370          458.57615    378.34543   0.0027027 
+  366          431.92578    377.71488   0.00273224 
+  377          416.21335    377.08569   0.00265252 
+  353          407.67439    376.45787   0.00283286 
+  382          402.67026    375.83141   0.0026178 
+  327          399.3178     375.20632   0.0030581 
+  379          396.83339    374.58257   0.00263852 
+  359          394.88338    373.96018   0.00278552 
+  357          393.29572    373.33915   0.00280112 
+  369          391.97328    372.71945   0.00271003 
+  386          390.85899    372.10111   0.00259067 
+  346          389.92307    371.4841    0.00289017 
+  360          389.15817    370.86843   0.00277778 
+  345          388.58898    370.2541    0.00289855 
+  342          388.29163    369.6411    0.00292398 
+  384          388.40987    369.02943   0.00260417 
+  357          389.1081     368.41909   0.00280112 
+  346          390.25733    367.81007   0.00289017 
+  348          390.8297     367.20237   0.00287356 
+  352          390.58869    366.59599   0.00284091 
+  333          390.81548    365.99093   0.003003  
+  343          391.37578    365.38718   0.00291545 
+  371          391.84318    364.78474   0.00269542 
+  409          393.41962    364.1836    0.00244499 
+  465          397.52954    363.58377   0.00215054 
+  415          406.91478    362.98524   0.00240964 
+  454          428.50703    362.38801   0.00220264 
+  582          471.26578    361.79208   0.00171821 
+  639          525.60483    361.19743   0.00156495 
+  629          530.81205    360.60408   0.00158983 
+  585          499.31341    360.01202   0.0017094 
+  466          488.92014    359.42124   0.00214592 
+  489          476.30689    358.83174   0.00204499 
+  406          449.44777    358.24351   0.00246305 
+  425          430.79323    357.65657   0.00235294 
+  432          418.12659    357.0709    0.00231481 
+  485          408.97681    356.4865    0.00206186 
+  436          404.21185    355.90336   0.00229358 
+  416          401.92181    355.32149   0.00240385 
+  455          401.87067    354.74089   0.0021978 
+  427          400.45348    354.16154   0.00234192 
+  406          393.20313    353.58345   0.00246305 
+  375          388.04711    353.00661   0.00266667 
+  405          385.27228    352.43102   0.00246914 
+  362          380.24604    351.85669   0.00276243 
+  373          375.46848    351.2836    0.00268097 
+  345          372.48817    350.71175   0.00289855 
+  357          370.7518     350.14114   0.00280112 
+  339          369.63544    349.57177   0.00294985 
+  319          368.81987    349.00363   0.0031348 
+  328          368.18242    348.43673   0.00304878 
+  368          367.67119    347.87105   0.00271739 
+  322          367.26009    347.3066    0.00310559 
+  316          366.93424    346.74338   0.00316456 
+  387          366.68708    346.18138   0.00258398 
+  363          366.51715    345.62059   0.00275482 
+  321          366.42794    345.06102   0.00311526 
+  342          366.42841    344.50267   0.00292398 
+  365          366.53576    343.94553   0.00273973 
+  339          366.78061    343.38959   0.00294985 
+  348          367.22714    342.83486   0.00287356 
+  326          368.01188    342.28133   0.00306748 
+  297          369.38159    341.72901   0.003367  
+  306          371.63822    341.17788   0.00326797 
+  322          374.91306    340.62794   0.00310559 
+  357          380.96213    340.0792    0.00280112 
+  346          392.29556    339.53165   0.00289017 
+  346          406.39516    338.98528   0.00289017 
+  332          407.55964    338.4401    0.00301205 
+  371          401.17501    337.8961    0.00269542 
+  380          398.52939    337.35328   0.00263158 
+  365          394.62143    336.81164   0.00273973 
+  370          387.17856    336.27117   0.0027027 
+  355          381.59174    335.73187   0.0028169 
+  306          378.70107    335.19374   0.00326797 
+  328          377.93561    334.65678   0.00304878 
+  342          378.38698    334.12098   0.00292398 
+  362          379.55766    333.58634   0.00276243 
+  357          381.28824    333.05287   0.00280112 
+  355          383.62411    332.52054   0.0028169 
+  362          386.77128    331.98937   0.00276243 
+  355          391.03602    331.45936   0.0028169 
+  352          396.45877    330.93049   0.00284091 
+  386          401.62649    330.40277   0.00259067 
+  403          404.81847    329.87619   0.00248139 
+  380          408.01405    329.35075   0.00263158 
+  386          412.37893    328.82645   0.00259067 
+  388          416.92034    328.30329   0.00257732 
+  383          422.04067    327.78126   0.00261097 
+  371          428.74177    327.26036   0.00269542 
+  379          437.19132    326.74059   0.00263852 
+  430          447.82207    326.22194   0.00232558 
+  439          460.90326    325.70442   0.0022779 
+  403          477.01347    325.18802   0.00248139 
+  398          496.93865    324.67274   0.00251256 
+  438          520.40007    324.15858   0.00228311 
+  471          546.79758    323.64553   0.00212314 
+  493          579.07086    323.13359   0.0020284 
+  486          620.78604    322.62275   0.00205761 
+  620          674.53291    322.11303   0.0016129 
+  675          745.57518    321.60441   0.00148148 
+  876          843.16556    321.09689   0.00114155 
+  1047         981.6715     320.59047   0.00095511 
+  1470         1186.38115   320.08515   0.00068027 
+  1905         1506.97806   319.58092   0.00052493 
+  2974         2069.44368   319.07778   0.00033625 
+  4604         3334.63412   318.57573   0.0002172 
+  8861         6764.09419   318.07477   0.00011285 
+  17339        14304.54196  317.5749    0.00005767 
+  31571        21789.02016  317.0761    0.00003167 
+  31561        17566.66158  316.57839   0.00003168 
+  16176        12621.40207  316.08175   0.00006182 
+  14974        12967.14411  315.58619   0.00006678 
+  16489        10754.5315   315.0917    0.00006065 
+  7982         5856.75481   314.59828   0.00012528 
+  2540         2997.37496   314.10593   0.0003937 
+  1442         1837.23373   313.61465   0.00069348 
+  1163         1343.10193   313.12443   0.00085985 
+  953          1071.23735   312.63527   0.00104932 
+  820          897.40381    312.14717   0.00121951 
+  697          778.56403    311.66012   0.00143472 
+  640          693.72684    311.17413   0.0015625 
+  658          630.70862    310.68919   0.00151976 
+  573          581.95847    310.2053    0.0017452 
+  503          543.81247    309.72245   0.00198807 
+  488          513.63768    309.24065   0.00204918 
+  450          489.03768    308.7599    0.00222222 
+  450          468.73312    308.28018   0.00222222 
+  460          452.00418    307.8015    0.00217391 
+  414          438.16477    307.32386   0.00241546 
+  416          426.63499    306.84724   0.00240385 
+  386          417.02572    306.37166   0.00259067 
+  387          409.07798    305.89711   0.00258398 
+  369          402.67432    305.42359   0.00271003 
+  368          397.83887    304.95109   0.00271739 
+  329          394.61986    304.47961   0.00303951 
+  384          392.57155    304.00915   0.00260417 
+  345          391.27708    303.5397    0.00289855 
+  349          392.34537    303.07128   0.00286533 
+  354          397.57419    302.60386   0.00282486 
+  417          408.93431    302.13746   0.00239808 
+  378          429.39067    301.67206   0.0026455 
+  376          457.65203    301.20767   0.00265957 
+  431          478.52064    300.74428   0.00232019 
+  447          492.05544    300.2819    0.00223714 
+  472          527.7329     299.82051   0.00211864 
+  533          596.33146    299.36012   0.00187617 
+  694          675.15169    298.90073   0.00144092 
+  798          705.67889    298.44233   0.00125313 
+  978          699.08089    297.98492   0.00102249 
+  2149         723.90464    297.5285    0.00046533 
+  2582         726.06111    297.07306   0.0003873 
+  1395         690.16185    296.61861   0.00071685 
+  1243         694.70342    296.16514   0.00080451 
+  1684         715.12351    295.71265   0.00059382 
+  1311         685.80609    295.26113   0.00076278 
+  1145         625.11173    294.8106    0.00087336 
+  1079         571.55327    294.36103   0.00092678 
+  719          527.96695    293.91244   0.00139082 
+  602          479.10428    293.46481   0.00166113 
+  650          427.70213    293.01815   0.00153846 
+  485          389.3068     292.57246   0.00206186 
+  393          365.12566    292.12773   0.00254453 
+  379          350.20121    291.68396   0.00263852 
+  375          340.49885    291.24114   0.00266667 
+  345          333.66502    290.79928   0.00289855 
+  352          328.50786    290.35838   0.00284091 
+  324          324.42736    289.91843   0.00308642 
+  310          321.08954    289.47942   0.00322581 
+  292          318.28837    289.04137   0.00342466 
+  295          315.8882     288.60426   0.00338983 
+  321          313.79572    288.16809   0.00311526 
+  280          311.94526    287.73287   0.00357143 
+  288          310.22515    287.29858   0.00347222 
+  284          308.74096    286.86523   0.00352113 
+  305          307.37432    286.43282   0.00327869 
+  305          306.08717    286.00133   0.00327869 
+  310          304.92658    285.57078   0.00322581 
+  294          303.85564    285.14116   0.00340136 
+  295          302.85072    284.71247   0.00338983 
+  322          301.91134    284.2847    0.00310559 
+  289          301.03195    283.85785   0.00346021 
+  315          300.20855    283.43192   0.0031746 
+  274          299.43865    283.00691   0.00364964 
+  279          298.7216     282.58282   0.00358423 
+  295          298.05818    282.15964   0.00338983 
+  303          297.45121    281.73737   0.00330033 
+  317          296.8991     281.31601   0.00315457 
+  300          296.42761    280.89557   0.00333333 
+  282          296.04488    280.47602   0.0035461 
+  298          295.77255    280.05739   0.0033557 
+  328          295.66133    279.63965   0.00304878 
+  334          295.7801     279.22281   0.00299401 
+  325          296.2641     278.80688   0.00307692 
+  350          297.41694    278.39184   0.00285714 
+  436          300.08685    277.97769   0.00229358 
+  517          305.78559    277.56444   0.00193424 
+  947          319.42337    277.15207   0.00105597 
+  1433         339.92139    276.74059   0.00069784 
+  1057         348.59125    276.33      0.00094607 
+  795          335.28256    275.9203    0.00125786 
+  845          327.1005     275.51148   0.00118343 
+  831          327.63159    275.10353   0.00120337 
+  513          321.70076    274.69647   0.00194932 
+  409          313.53219    274.29028   0.00244499 
+  327          312.29901    273.88497   0.0030581 
+  292          315.86907    273.48053   0.00342466 
+  298          315.3912     273.07696   0.0033557 
+  299          309.79256    272.67425   0.00334448 
+  267          306.10873    272.27242   0.00374532 
+  313          304.22491    271.87145   0.00319489 
+  293          300.67492    271.47134   0.00341297 
+  289          297.78865    271.0721    0.00346021 
+  279          297.10928    270.67371   0.00358423 
+  279          294.73056    270.27618   0.00358423 
+  257          290.86531    269.8795    0.00389105 
+  302          288.9474     269.48368   0.00331126 
+  284          288.04197    269.08871   0.00352113 
+  276          285.81301    268.69459   0.00362319 
+  277          283.53643    268.30132   0.00361011 
+  268          282.09264    267.90889   0.00373134 
+  275          281.27152    267.51731   0.00363636 
+  311          280.79779    267.12657   0.00321543 
+  273          280.53953    266.73667   0.003663  
+  306          280.48071    266.3476    0.00326797 
+  257          280.68208    265.95938   0.00389105 
+  257          281.34663    265.57199   0.00389105 
+  293          283.07899    265.18543   0.00341297 
+  269          287.20265    264.7997    0.00371747 
+  285          295.05961    264.4148    0.00350877 
+  265          303.35866    264.03073   0.00377358 
+  273          301.25391    263.64748   0.003663  
+  311          295.05095    263.26506   0.00321543 
+  267          293.58297    262.88345   0.00374532 
+  241          293.38994    262.50267   0.00414938 
+  270          288.67031    262.12271   0.0037037 
+  294          284.32304    261.74356   0.00340136 
+  270          282.29376    261.36522   0.0037037 
+  280          282.23009    260.9877    0.00357143 
+  313          284.29253    260.61099   0.00319489 
+  289          288.49739    260.23509   0.00346021 
+  297          292.96159    259.86      0.003367  
+  285          291.8581     259.48571   0.00350877 
+  309          288.87918    259.11222   0.00323625 
+  324          288.59473    258.73954   0.00308642 
+  266          288.89282    258.36765   0.0037594 
+  290          287.04329    257.99656   0.00344828 
+  288          285.54757    257.62627   0.00347222 
+  320          285.49261    257.25678   0.003125  
+  292          286.70036    256.88808   0.00342466 
+  289          288.95851    256.52016   0.00346021 
+  271          291.7223     256.15304   0.00369004 
+  287          294.3081     255.78671   0.00348432 
+  313          298.02572    255.42116   0.00319489 
+  305          304.10576    255.05639   0.00327869 
+  294          313.02758    254.69241   0.00340136 
+  277          325.57877    254.32921   0.00361011 
+  317          342.38183    253.96679   0.00315457 
+  306          359.72594    253.60514   0.00326797 
+  312          370.415      253.24427   0.00320513 
+  388          375.9848     252.88417   0.00257732 
+  425          381.65423    252.52485   0.00235294 
+  402          387.40287    252.16629   0.00248756 
+  393          403.94846    251.8085    0.00254453 
+  460          462.70689    251.45148   0.00217391 
+  553          617.44353    251.09523   0.00180832 
+  723          845.58867    250.73974   0.00138313 
+  672          832.65034    250.38501   0.0014881 
+  539          647.53627    250.03104   0.00185529 
+  590          603.86018    249.67782   0.00169492 
+  560          647.33627    249.32537   0.00178571 
+  459          564.18192    248.97367   0.00217865 
+  463          453.07101    248.62272   0.00215983 
+  438          401.03596    248.27253   0.00228311 
+  428          389.16386    247.92308   0.00233645 
+  442          397.31395    247.57438   0.00226244 
+  437          419.238      247.22643   0.00228833 
+  444          443.90486    246.87922   0.00225225 
+  408          453.00727    246.53276   0.00245098 
+  465          464.35894    246.18704   0.00215054 
+  438          492.24221    245.84206   0.00228311 
+  534          530.57736    245.49782   0.00187266 
+  605          575.06804    245.15431   0.00165289 
+  730          641.69097    244.81154   0.00136986 
+  1020         746.061      244.4695    0.00098039 
+  1411         909.93598    244.12819   0.00070872 
+  2263         1178.58531   243.78761   0.00044189 
+  2771         1689.57827   243.44777   0.00036088 
+  3922         2980.49868   243.10865   0.00025497 
+  7279         6326.25848   242.77025   0.00013738 
+  13854        12072.7241   242.43258   0.00007218 
+  19767        13649.22901  242.09563   0.00005059 
+  11424        8965.0948    241.7594    0.00008754 
+  6671         6910.91023   241.42389   0.0001499 
+  8296         8018.19627   241.08909   0.00012054 
+  8936         6881.10908   240.75501   0.00011191 
+  3941         3786.10235   240.42165   0.00025374 
+  1514         1955.2636    240.089     0.0006605 
+  984          1212.08842   239.75706   0.00101626 
+  658          898.33111    239.42582   0.00151976 
+  542          727.83787    239.0953    0.00184502 
+  507          621.62728    238.76548   0.00197239 
+  495          553.32016    238.43637   0.0020202 
+  451          506.01427    238.10796   0.00221729 
+  415          463.46944    237.78025   0.00240964 
+  425          428.66577    237.45324   0.00235294 
+  363          406.09459    237.12693   0.00275482 
+  327          389.46709    236.80132   0.0030581 
+  319          368.87051    236.4764    0.0031348 
+  328          349.60342    236.15217   0.00304878 
+  322          335.95802    235.82864   0.00310559 
+  305          325.89566    235.5058    0.00327869 
+  262          316.37984    235.18365   0.00381679 
+  297          308.43746    234.86218   0.003367  
+  309          303.14096    234.5414    0.00323625 
+  276          300.74692    234.22131   0.00362319 
+  293          300.16874    233.90189   0.00341297 
+  279          298.1494     233.58316   0.00358423 
+  285          295.50057    233.26511   0.00350877 
+  264          291.42875    232.94774   0.00378788 
+  270          287.66486    232.63105   0.0037037 
+  323          285.70173    232.31503   0.00309598 
+  279          286.25774    231.99968   0.00358423 
+  269          286.44027    231.68501   0.00371747 
+  262          283.97175    231.37101   0.00381679 
+  276          283.69403    231.05767   0.00362319 
+  276          287.14075    230.74501   0.00362319 
+  237          287.88167    230.43301   0.00421941 
+  234          282.45637    230.12168   0.0042735 
+  214          276.61476    229.81101   0.0046729 
+  247          272.72835    229.501     0.00404858 
+  247          268.55387    229.19166   0.00404858 
+  247          263.39068    228.88297   0.00404858 
+  226          258.63741    228.57494   0.00442478 
+  215          254.96581    228.26757   0.00465116 
+  223          252.34529    227.96085   0.0044843 
+  227          250.51977    227.65478   0.00440529 
+  243          249.32883    227.34937   0.00411523 
+  221          248.80203    227.04461   0.00452489 
+  216          249.13941    226.74049   0.00462963 
+  267          250.50788    226.43703   0.00374532 
+  265          252.14477    226.13421   0.00377358 
+  256          251.59783    225.83203   0.00390625 
+  215          249.22273    225.5305    0.00465116 
+  243          247.54978    225.22961   0.00411523 
+  270          246.64525    224.92937   0.0037037 
+  222          245.04019    224.62976   0.0045045 
+  260          242.83326    224.33078   0.00384615 
+  232          241.01157    224.03245   0.00431034 
+  227          239.75726    223.73475   0.00440529 
+  206          238.96635    223.43768   0.00485437 
+  220          238.52842    223.14124   0.00454545 
+  282          238.50988    222.84544   0.0035461 
+  240          239.21213    222.55026   0.00416667 
+  215          240.98749    222.25572   0.00465116 
+  225          243.39205    221.9618    0.00444444 
+  245          244.34845    221.6685    0.00408163 
+  244          244.16064    221.37583   0.00409836 
+  252          244.21818    221.08378   0.00396825 
+  252          245.18804    220.79235   0.00396825 
+  258          245.05469    220.50154   0.00387597 
+  244          242.36045    220.21135   0.00409836 
+  260          239.8458     219.92178   0.00384615 
+  234          238.78907    219.63282   0.0042735 
+  264          238.20253    219.34448   0.00378788 
+  253          237.18028    219.05675   0.00395257 
+  229          237.13995    218.76963   0.00436681 
+  251          239.32271    218.48312   0.00398406 
+  301          245.47702    218.19722   0.00332226 
+  318          257.34601    217.91192   0.00314465 
+  332          269.51511    217.62724   0.00301205 
+  315          266.60142    217.34316   0.0031746 
+  311          258.15913    217.05968   0.00321543 
+  362          254.7343     216.7768    0.00276243 
+  299          254.56539    216.49453   0.00334448 
+  322          249.09119    216.21285   0.00310559 
+  296          241.79037    215.93177   0.00337838 
+  275          236.36952    215.65129   0.00363636 
+  275          232.73505    215.37141   0.00363636 
+  240          231.07201    215.09212   0.00416667 
+  232          230.24855    214.81342   0.00431034 
+  224          229.67081    214.53532   0.00446429 
+  212          229.5549     214.2578    0.00471698 
+  256          229.64558    213.98088   0.00390625 
+  213          229.92609    213.70454   0.00469484 
+  221          230.40323    213.42879   0.00452489 
+  237          231.10532    213.15362   0.00421941 
+  242          232.07922    212.87904   0.00413223 
+  247          233.3991     212.60504   0.00404858 
+  264          235.18013    212.33162   0.00378788 
+  252          237.59976    212.05878   0.00396825 
+  230          240.94308    211.78652   0.00434783 
+  260          245.68723    211.51484   0.00384615 
+  245          252.68406    211.24373   0.00408163 
+  283          263.65415    210.9732    0.00353357 
+  327          283.35043    210.70325   0.0030581 
+  467          328.89977    210.43386   0.00214133 
+  674          444.42732    210.16505   0.00148368 
+  952          660.66329    209.89681   0.00105042 
+  1177         788.46391    209.62914   0.00084962 
+  935          661.56669    209.36203   0.00106952 
+  665          625.60654    209.09549   0.00150376 
+  654          751.26101    208.82952   0.00152905 
+  649          777.96703    208.56411   0.00154083 
+  573          595.1643     208.29926   0.0017452 
+  311          467.87299    208.03497   0.00321543 
+  298          436.96619    207.77125   0.0033557 
+  282          401.8089     207.50808   0.0035461 
+  288          336.95012    207.24547   0.00347222 
+  226          290.11197    206.98342   0.00442478 
+  207          265.10629    206.72192   0.00483092 
+  262          252.43588    206.46098   0.00381679 
+  258          245.34785    206.20059   0.00387597 
+  238          240.96044    205.94075   0.00420168 
+  241          238.22856    205.68146   0.00414938 
+  241          236.61167    205.42272   0.00414938 
+  208          235.31089    205.16453   0.00480769 
+  235          233.97743    204.90689   0.00425532 
+  247          233.17239    204.64979   0.00404858 
+  283          232.98944    204.39324   0.00353357 
+  233          233.09392    204.13723   0.00429185 
+  246          233.30427    203.88176   0.00406504 
+  243          233.96943    203.62684   0.00411523 
+  262          235.22705    203.37245   0.00381679 
+  235          236.87051    203.1186    0.00425532 
+  260          238.43719    202.86529   0.00384615 
+  267          240.40833    202.61252   0.00374532 
+  267          243.91303    202.36028   0.00374532 
+  275          249.66182    202.10858   0.00363636 
+  272          256.64181    201.85741   0.00367647 
+  272          261.17458    201.60677   0.00367647 
+  253          265.37658    201.35666   0.00395257 
+  293          275.14218    201.10708   0.00341297 
+  363          299.89515    200.85803   0.00275482 
+  431          358.82805    200.6095    0.00232019 
+  682          462.00363    200.36151   0.00146628 
+  858          507.05608    200.11403   0.0011655 
+  679          424.90839    199.86708   0.00147275 
+  528          375.18504    199.62066   0.00189394 
+  509          394.46947    199.37475   0.00196464 
+  551          416.33055    199.12937   0.00181488 
+  471          375.02092    198.8845    0.00212314 
+  391          339.2518     198.64016   0.00255754 
+  345          330.31814    198.39633   0.00289855 
+  322          337.69555    198.15301   0.00310559 
+  382          354.09453    197.91022   0.0026178 
+  363          376.36761    197.66793   0.00275482 
+  408          402.71038    197.42616   0.00245098 
+  506          438.27307    197.1849    0.00197628 
+  561          489.15601    196.94415   0.00178253 
+  578          561.54182    196.70391   0.0017301 
+  677          665.77976    196.46417   0.0014771 
+  946          826.19599    196.22495   0.00105708 
+  1413         1098.5023    195.98623   0.00070771 
+  2223         1668.25212   195.74801   0.00044984 
+  4219         3176.41687   195.5103    0.00023702 
+  8313         6786.88915   195.27309   0.00012029 
+  14596        11712.96236  195.03639   0.00006851 
+  15115        10864.03349  194.80018   0.00006616 
+  7874         6559.36543   194.56448   0.000127  
+  5514         5224.80667   194.32927   0.00018136 
+  7094         6583.24308   194.09456   0.00014096 
+  7686         6316.77673   193.86035   0.00013011 
+  3959         3649.13217   193.62663   0.00025259 
+  1492         1864.92444   193.3934    0.00067024 
+  797          1112.08823   193.16067   0.00125471 
+  586          803.51887    192.92843   0.00170648 
+  466          642.99873    192.69669   0.00214592 
+  395          542.10573    192.46543   0.00253165 
+  372          471.72676    192.23466   0.00268817 
+  365          421.34317    192.00438   0.00273973 
+  318          385.30571    191.77459   0.00314465 
+  299          359.77514    191.54528   0.00334448 
+  294          342.50725    191.31646   0.00340136 
+  242          332.29899    191.08812   0.00413223 
+  292          328.14008    190.86026   0.00342466 
+  330          328.28568    190.63289   0.0030303 
+  335          330.4694     190.406     0.00298507 
+  395          335.28877    190.17958   0.00253165 
+  382          335.55109    189.95365   0.0026178 
+  370          320.59929    189.72819   0.0027027 
+  351          307.44191    189.50321   0.002849  
+  317          298.78229    189.27871   0.00315457 
+  287          287.79436    189.05468   0.00348432 
+  287          271.26283    188.83112   0.00348432 
+  263          256.76923    188.60804   0.00380228 
+  245          247.18377    188.38543   0.00408163 
+  245          238.32723    188.16329   0.00408163 
+  240          231.11765    187.94162   0.00416667 
+  234          226.08683    187.72041   0.0042735 
+  214          222.52454    187.49968   0.0046729 
+  247          219.81936    187.27941   0.00404858 
+  219          217.65542    187.05961   0.00456621 
+  186          215.90793    186.84027   0.00537634 
+  238          214.55332    186.6214    0.00420168 
+  196          213.65724    186.40299   0.00510204 
+  209          213.43387    186.18504   0.00478469 
+  204          214.28085    185.96755   0.00490196 
+  241          216.63994    185.75052   0.00414938 
+  212          220.10047    185.53395   0.00471698 
+  251          221.35491    185.31784   0.00398406 
+  211          218.50738    185.10219   0.00473934 
+  231          215.70567    184.88699   0.004329  
+  242          215.13783    184.67225   0.00413223 
+  200          215.6785     184.45796   0.005     
+  227          215.60762    184.24412   0.00440529 
+  225          216.94442    184.03074   0.00444444 
+  245          222.46795    183.81781   0.00408163 
+  224          233.12233    183.60532   0.00446429 
+  238          243.38979    183.39329   0.00420168 
+  255          239.91749    183.18171   0.00392157 
+  231          229.07027    182.97057   0.004329  
+  213          224.1698     182.75988   0.00469484 
+  232          224.40102    182.54964   0.00431034 
+  208          221.70985    182.33984   0.00480769 
+  205          213.65057    182.13048   0.00487805 
+  216          207.03426    181.92157   0.00462963 
+  226          203.20822    181.7131    0.00442478 
+  200          201.20736    181.50507   0.005     
+  241          200.31025    181.29748   0.00414938 
+  224          200.09985    181.09033   0.00446429 
+  228          200.43628    180.88361   0.00438596 
+  221          201.37817    180.67734   0.00452489 
+  227          203.15176    180.4715    0.00440529 
+  238          206.02161    180.2661    0.00420168 
+  232          209.83668    180.06113   0.00431034 
+  265          214.38535    179.85659   0.00377358 
+  255          220.91708    179.65249   0.00392157 
+  255          230.7871     179.44882   0.00392157 
+  280          244.89849    179.24558   0.00357143 
+  371          273.20424    179.04278   0.00269542 
+  523          341.9371     178.8404    0.00191205 
+  953          489.60224    178.63845   0.00104932 
+  1479         681.10583    178.43692   0.00067613 
+  1987         676.27782    178.23583   0.00050327 
+  2749         508.84512    178.03516   0.00036377 
+  3495         443.26881    177.83491   0.00028612 
+  2807         493.17948    177.63509   0.00035625 
+  1809         514.27528    177.43569   0.00055279 
+  1665         412.80775    177.23671   0.0006006 
+  1787         320.98239    177.03816   0.0005596 
+  1546         278.59984    176.84002   0.00064683 
+  909          260.42955    176.64231   0.00110011 
+  641          248.3539     176.44501   0.00156006 
+  652          242.29975    176.24813   0.00153374 
+  564          242.69737    176.05167   0.00177305 
+  505          240.83512    175.85563   0.0019802 
+  461          230.24643    175.66      0.0021692 
+  436          221.82209    175.46478   0.00229358 
+  470          217.42386    175.26998   0.00212766 
+  378          214.5439     175.07559   0.0026455 
+  318          207.99193    174.88162   0.00314465 
+  288          200.95984    174.68805   0.00347222 
+  228          196.25592    174.49489   0.00438596 
+  221          192.3558     174.30215   0.00452489 
+  218          189.53615    174.10981   0.00458716 
+  205          187.74533    173.91788   0.00487805 
+  202          186.59605    173.72636   0.0049505 
+  190          185.82738    173.53524   0.00526316 
+  220          185.34092    173.34453   0.00454545 
+  184          184.88312    173.15423   0.00543478 
+  174          184.93762    172.96432   0.00574713 
+  175          184.93178    172.77482   0.00571429 
+  185          184.54934    172.58573   0.00540541 
+  209          184.02359    172.39703   0.00478469 
+  200          183.93671    172.20873   0.005     
+  175          184.1515     172.02084   0.00571429 
+  189          184.51142    171.83334   0.00529101 
+  233          185.33569    171.64624   0.00429185 
+  238          187.51715    171.45953   0.00420168 
+  283          191.89466    171.27323   0.00353357 
+  257          197.0111     171.08732   0.00389105 
+  211          196.59714    170.9018    0.00473934 
+  212          192.62108    170.71668   0.00471698 
+  244          190.88638    170.53195   0.00409836 
+  229          191.98929    170.34761   0.00436681 
+  203          192.94149    170.16367   0.00492611 
+  213          191.25634    169.98011   0.00469484 
+  203          189.73575    169.79695   0.00492611 
+  222          189.61503    169.61417   0.0045045 
+  203          190.78887    169.43179   0.00492611 
+  207          193.29471    169.24979   0.00483092 
+  218          197.98247    169.06818   0.00458716 
+  200          206.67796    168.88695   0.005     
+  226          220.49777    168.70611   0.00442478 
+  201          232.52279    168.52565   0.00497512 
+  211          232.37853    168.34558   0.00473934 
+  189          233.77718    168.16589   0.00529101 
+  211          248.00494    167.98659   0.00473934 
+  237          278.26637    167.80766   0.00421941 
+  273          321.15825    167.62912   0.003663  
+  267          368.24461    167.45095   0.00374532 
+  313          385.92817    167.27317   0.00319489 
+  389          365.95716    167.09576   0.00257069 
+  399          358.90814    166.91873   0.00250627 
+  349          390.72907    166.74208   0.00286533 
+  345          457.4811     166.5658    0.00289855 
+  385          535.71049    166.3899    0.0025974 
+  390          587.50937    166.21438   0.0025641 
+  365          546.97802    166.03923   0.00273973 
+  280          469.69572    165.86445   0.00357143 
+  301          434.63425    165.69004   0.00332226 
+  288          442.5018     165.51601   0.00347222 
+  297          440.55369    165.34234   0.003367  
+  270          406.01272    165.16905   0.0037037 
+  265          387.77475    164.99613   0.00377358 
+  290          415.19179    164.82357   0.00344828 
+  322          490.56756    164.65139   0.00310559 
+  429          575.32814    164.47957   0.002331  
+  456          582.25825    164.30812   0.00219298 
+  333          541.55544    164.13703   0.003003  
+  296          542.27995    163.96631   0.00337838 
+  321          569.54831    163.79595   0.00311526 
+  369          544.8467     163.62596   0.00271003 
+  315          463.43688    163.45633   0.0031746 
+  223          392.47658    163.28706   0.0044843 
+  212          354.75266    163.11816   0.00471698 
+  204          322.35511    162.94961   0.00490196 
+  242          280.94619    162.78143   0.00413223 
+  174          246.55162    162.61361   0.00574713 
+  181          223.81565    162.44614   0.00552486 
+  188          209.67612    162.27903   0.00531915 
+  193          200.76783    162.11228   0.00518135 
+  227          194.88794    161.94589   0.00440529 
+  175          190.9326     161.77985   0.00571429 
+  175          188.59217    161.61417   0.00571429 
+  164          188.29294    161.44884   0.00609756 
+  188          190.97679    161.28387   0.00531915 
+  182          196.22332    161.11925   0.00549451 
+  195          197.01035    160.95498   0.00512821 
+  167          190.30671    160.79107   0.00598802 
+  184          185.03476    160.6275    0.00543478 
+  177          183.91704    160.46429   0.00564972 
+  184          184.87878    160.30143   0.00543478 
+  190          182.758      160.13891   0.00526316 
+  176          178.64002    159.97675   0.00568182 
+  188          175.67042    159.81493   0.00531915 
+  172          173.84085    159.65346   0.00581395 
+  184          172.83007    159.49233   0.00543478 
+  167          172.42929    159.33156   0.00598802 
+  168          172.54582    159.17112   0.00595238 
+  165          173.21824    159.01104   0.00606061 
+  171          174.83208    158.85129   0.00584795 
+  186          177.96033    158.69189   0.00537634 
+  200          182.36469    158.53283   0.005     
+  189          184.95489    158.37411   0.00529101 
+  194          183.40093    158.21574   0.00515464 
+  177          181.90859    158.0577    0.00564972 
+  213          183.41944    157.90001   0.00469484 
+  194          187.57254    157.74265   0.00515464 
+  203          191.05002    157.58564   0.00492611 
+  190          191.36976    157.42896   0.00526316 
+  204          188.39961    157.27262   0.00490196 
+  182          183.70801    157.11661   0.00549451 
+  197          180.98756    156.96094   0.00507614 
+  202          180.31211    156.80561   0.0049505 
+  172          180.23367    156.65061   0.00581395 
+  206          179.60418    156.49595   0.00485437 
+  194          179.05327    156.34162   0.00515464 
+  218          177.47058    156.18762   0.00458716 
+  200          175.04586    156.03395   0.005     
+  207          174.40266    155.88062   0.00483092 
+  207          176.42691    155.72762   0.00483092 
+  235          180.94946    155.57495   0.00425532 
+  204          186.04079    155.4226    0.00490196 
+  226          189.58624    155.27059   0.00442478 
+  235          193.22177    155.11891   0.00425532 
+  231          193.87124    154.96755   0.004329  
+  298          193.56864    154.81652   0.0033557 
+  391          200.06558    154.66582   0.00255754 
+  506          216.35093    154.51544   0.00197628 
+  607          240.41804    154.36539   0.00164745 
+  628          245.92049    154.21566   0.00159236 
+  523          225.65332    154.06626   0.00191205 
+  403          211.46484    153.91718   0.00248139 
+  407          212.33678    153.76843   0.002457  
+  448          222.10371    153.62      0.00223214 
+  342          224.02415    153.47189   0.00292398 
+  322          220.06348    153.3241    0.00310559 
+  237          224.53563    153.17663   0.00421941 
+  218          244.18571    153.02948   0.00458716 
+  222          291.86427    152.88265   0.0045045 
+  231          394.07974    152.73614   0.004329  
+  214          571.99967    152.58995   0.0046729 
+  300          740.99013    152.44407   0.00333333 
+  328          749.77472    152.29852   0.00304878 
+  407          686.51064    152.15327   0.002457  
+  359          570.65857    152.00835   0.00278552 
+  295          534.36404    151.86374   0.00338983 
+  267          533.63609    151.71945   0.00374532 
+  255          486.87845    151.57547   0.00392157 
+  322          412.26596    151.4318    0.00310559 
+  273          314.55113    151.28845   0.003663  
+  240          251.66739    151.1454    0.00416667 
+  213          221.27154    151.00267   0.00469484 
+  201          207.6476     150.86026   0.00497512 
+  214          200.01242    150.71815   0.0046729 
+  203          192.18748    150.57635   0.00492611 
+  192          185.34236    150.43487   0.00520833 
+  190          180.52434    150.29369   0.00526316 
+  184          178.2303     150.15282   0.00543478 
+  196          176.8636     150.01226   0.00510204 
+  221          174.79577    149.872     0.00452489 
+  241          173.47658    149.73205   0.00414938 
+  480          173.70892    149.59241   0.00208333 
+  513          174.7389     149.45308   0.00194932 
+  321          173.3566     149.31405   0.00311526 
+  235          171.30338    149.17532   0.00425532 
+  269          171.18035    149.0369    0.00371747 
+  305          172.63176    148.89878   0.00327869 
+  302          173.21041    148.76096   0.00331126 
+  227          171.37807    148.62345   0.00440529 
+  193          169.7954     148.48624   0.00518135 
+  173          170.05056    148.34933   0.00578035 
+  190          171.93609    148.21272   0.00526316 
+  167          174.31694    148.07641   0.00598802 
+  186          175.19769    147.9404    0.00537634 
+  208          173.26423    147.80469   0.00480769 
+  168          170.99319    147.66928   0.00595238 
+  198          170.24333    147.53417   0.00505051 
+  169          170.89501    147.39935   0.00591716 
+  160          171.58123    147.26483   0.00625   
+  157          171.57909    147.13061   0.00636943 
+  190          172.13002    146.99668   0.00526316 
+  180          173.03387    146.86305   0.00555556 
+  174          173.4457     146.72971   0.00574713 
+  192          175.25388    146.59667   0.00520833 
+  197          179.76915    146.46392   0.00507614 
+  165          186.64673    146.33147   0.00606061 
+  215          191.12879    146.19931   0.00465116 
+  174          188.84849    146.06744   0.00574713 
+  217          184.84372    145.93586   0.00460829 
+  170          183.6428     145.80457   0.00588235 
+  218          185.09469    145.67358   0.00458716 
+  187          186.59061    145.54287   0.00534759 
+  179          185.60386    145.41246   0.00558659 
+  191          184.28206    145.28233   0.0052356 
+  193          184.23842    145.15249   0.00518135 
+  177          185.48571    145.02294   0.00564972 
+  186          187.74272    144.89368   0.00537634 
+  183          190.82873    144.7647    0.00546448 
+  211          194.71396    144.63601   0.00473934 
+  183          199.49375    144.50761   0.00546448 
+  196          205.37896    144.3795    0.00510204 
+  214          212.79004    144.25166   0.0046729 
+  243          222.71124    144.12412   0.00411523 
+  284          237.14652    143.99685   0.00352113 
+  324          258.49642    143.86988   0.00308642 
+  296          284.54137    143.74318   0.00337838 
+  295          300.96917    143.61677   0.00338983 
+  318          311.75342    143.49064   0.00314465 
+  358          334.14373    143.36479   0.0027933 
+  362          373.55903    143.23922   0.00276243 
+  361          430.44573    143.11393   0.00277008 
+  355          501.30635    142.98892   0.0028169 
+  477          601.79815    142.8642    0.00209644 
+  613          772.88735    142.73975   0.00163132 
+  877          1111.72904   142.61558   0.00114025 
+  1299         1961.85101   142.49169   0.00076982 
+  2539         4123.68671   142.36807   0.00039386 
+  5363         7880.21203   142.24474   0.00018646 
+  7624         9143.57878   142.12168   0.00013116 
+  4397         5748.60924   141.9989    0.00022743 
+  2111         3333.11994   141.87639   0.00047371 
+  2057         3192.02605   141.75416   0.00048614 
+  3153         4594.90025   141.6322    0.00031716 
+  3701         4917.69244   141.51052   0.0002702 
+  2122         3001.94986   141.38911   0.00047125 
+  975          1524.39434   141.26798   0.00102564 
+  527          872.54337    141.14712   0.00189753 
+  393          611.72872    141.02653   0.00254453 
+  335          481.48928    140.90621   0.00298507 
+  263          401.64481    140.78617   0.00380228 
+  256          347.99292    140.66639   0.00390625 
+  233          310.01864    140.54689   0.00429185 
+  209          282.09643    140.42766   0.00478469 
+  210          260.96062    140.3087    0.0047619 
+  207          244.60724    140.19      0.00483092 
+  209          231.76705    140.07158   0.00478469 
+  174          221.6168     139.95342   0.00574713 
+  196          213.59336    139.83554   0.00510204 
+  194          207.18743    139.71792   0.00515464 
+  191          202.01582    139.60056   0.0052356 
+  201          198.31044    139.48348   0.00497512 
+  203          196.88497    139.36666   0.00492611 
+  183          199.31815    139.2501    0.00546448 
+  189          207.32864    139.13381   0.00529101 
+  193          217.70312    139.01779   0.00518135 
+  190          215.82091    138.90203   0.00526316 
+  194          205.50988    138.78653   0.00515464 
+  202          201.79162    138.6713    0.0049505 
+  255          208.9219     138.55633   0.00392157 
+  333          229.03963    138.44163   0.003003  
+  451          264.18798    138.32718   0.00221729 
+  473          323.79039    138.213     0.00211416 
+  433          382.73597    138.09908   0.00230947 
+  389          352.81662    137.98542   0.00257069 
+  303          284.3748     137.87202   0.00330033 
+  321          250.66895    137.75888   0.00311526 
+  322          256.95768    137.646     0.00310559 
+  276          277.79095    137.53338   0.00362319 
+  225          259.73644    137.42102   0.00444444 
+  188          218.01791    137.30892   0.00531915 
+  190          188.87378    137.19707   0.00526316 
+  172          173.51655    137.08549   0.00581395 
+  164          165.66036    136.97416   0.00609756 
+  186          161.07237    136.86308   0.00537634 
+  153          157.96631    136.75226   0.00653595 
+  143          155.68398    136.6417    0.00699301 
+  148          153.91504    136.5314    0.00675676 
+  156          152.49351    136.42135   0.00641026 
+  175          151.32048    136.31155   0.00571429 
+  147          150.32711    136.20201   0.00680272 
+  157          149.47255    136.09272   0.00636943 
+  145          148.72702    135.98368   0.00689655 
+  157          148.06959    135.8749    0.00636943 
+  178          147.48524    135.76637   0.00561798 
+  175          146.96568    135.65809   0.00571429 
+  150          146.4976     135.55006   0.00666667 
+  142          146.07825    135.44229   0.00704225 
+  130          145.70426    135.33477   0.00769231 
+  166          145.37456    135.22749   0.0060241 
+  152          145.0912     135.12047   0.00657895 
+  171          144.86125    135.01369   0.00584795 
+  162          144.70498    134.90717   0.00617284 
+  137          144.67453    134.80089   0.00729927 
+  131          144.87393    134.69487   0.00763359 
+  168          145.41538    134.58909   0.00595238 
+  137          146.14041    134.48356   0.00729927 
+  190          146.50314    134.37827   0.00526316 
+  171          146.35724    134.27323   0.00584795 
+  140          145.74822    134.16844   0.00714286 
+  141          145.286      134.0639    0.0070922 
+  160          145.25068    133.9596    0.00625   
+  170          145.35316    133.85555   0.00588235 
+  137          145.41695    133.75174   0.00729927 
+  171          145.41657    133.64817   0.00584795 
+  158          145.65543    133.54485   0.00632911 
+  149          146.50858    133.44178   0.00671141 
+  183          148.28609    133.33894   0.00546448 
+  171          151.48342    133.23635   0.00584795 
+  250          157.01032    133.134     0.004     
+  244          167.14134    133.0319    0.00409836 
+  283          183.5016     132.93003   0.00353357 
+  265          193.70044    132.82841   0.00377358 
+  233          182.49975    132.72703   0.00429185 
+  223          169.00437    132.62589   0.0044843 
+  215          164.11623    132.52499   0.00465116 
+  227          167.59767    132.42433   0.00440529 
+  215          172.84413    132.32391   0.00465116 
+  190          168.56274    132.22373   0.00526316 
+  204          160.61225    132.12378   0.00490196 
+  181          156.00754    132.02408   0.00552486 
+  162          155.28126    131.92461   0.00617284 
+  185          158.25431    131.82538   0.00540541 
+  212          163.05616    131.72639   0.00471698 
+  220          162.06581    131.62764   0.00454545 
+  175          156.61893    131.52912   0.00571429 
+  171          153.26505    131.43084   0.00584795 
+  174          153.06144    131.33279   0.00574713 
+  222          155.14893    131.23498   0.0045045 
+  205          155.81718    131.1374    0.00487805 
+  218          153.91711    131.04006   0.00458716 
+  212          153.07794    130.94296   0.00471698 
+  190          154.47852    130.84608   0.00526316 
+  198          158.13119    130.74945   0.00505051 
+  225          163.31404    130.65304   0.00444444 
+  223          170.18551    130.55687   0.0044843 
+  225          184.87156    130.46093   0.00444444 
+  199          213.79595    130.36522   0.00502513 
+  218          249.57843    130.26974   0.00458716 
+  219          255.24908    130.1745    0.00456621 
+  218          231.21205    130.07948   0.00458716 
+  248          211.86446    129.9847    0.00403226 
+  276          213.10954    129.89015   0.00362319 
+  289          233.76169    129.79583   0.00346021 
+  332          256.11119    129.70173   0.00301205 
+  295          262.93773    129.60787   0.00338983 
+  293          255.33992    129.51424   0.00341297 
+  270          251.41006    129.42083   0.0037037 
+  301          253.90881    129.32765   0.00332226 
+  418          273.89727    129.2347    0.00239234 
+  451          336.84919    129.14198   0.00221729 
+  596          497.62381    129.04949   0.00167785 
+  776          836.92393    128.95722   0.00128866 
+  1278         1184.76452   128.86518   0.00078247 
+  1491         979.08264    128.77336   0.00067069 
+  953          611.46782    128.68178   0.00104932 
+  608          461.99129    128.59041   0.00164474 
+  497          519.50584    128.49927   0.00201207 
+  652          686.20205    128.40836   0.00153374 
+  760          665.52459    128.31767   0.00131579 
+  598          455.67624    128.22721   0.00167224 
+  343          318.20573    128.13697   0.00291545 
+  249          261.37338    128.04695   0.00401606 
+  212          240.27962    127.95716   0.00471698 
+  197          234.66212    127.86758   0.00507614 
+  195          240.06953    127.77824   0.00512821 
+  185          258.53175    127.68911   0.00540541 
+  223          303.70786    127.60021   0.0044843 
+  271          409.08015    127.51152   0.00369004 
+  388          585.36084    127.42306   0.00257732 
+  455          669.88328    127.33482   0.0021978 
+  349          616.31349    127.2468    0.00286533 
+  337          698.98962    127.159     0.00296736 
+  357          1053.2635    127.07142   0.00280112 
+  438          1682.95839   126.98406   0.00228311 
+  595          2068.66287   126.89692   0.00168067 
+  465          1610.88957   126.80999   0.00215054 
+  391          1060.37917   126.72329   0.00255754 
+  361          840.81378    126.6368    0.00277008 
+  342          924.84795    126.55054   0.00292398 
+  334          1105.89822   126.46449   0.00299401 
+  303          978.04042    126.37865   0.00330033 
+  259          660.64797    126.29304   0.003861  
+  205          436.53306    126.20764   0.00487805 
+  185          320.33567    126.12245   0.00540541 
+  183          263.97319    126.03749   0.00546448 
+  171          234.06853    125.95274   0.00584795 
+  155          215.66002    125.8682    0.00645161 
+  158          202.22664    125.78388   0.00632911 
+  156          192.67802    125.69977   0.00641026 
+  164          186.76552    125.61588   0.00609756 
+  148          183.8856     125.5322    0.00675676 
+  164          183.57111    125.44874   0.00609756 
+  168          185.28666    125.36549   0.00595238 
+  166          189.83563    125.28245   0.0060241 
+  155          199.76049    125.19963   0.00645161 
+  146          220.21368    125.11702   0.00684932 
+  197          264.84787    125.03462   0.00507614 
+  199          361.06964    124.95243   0.00502513 
+  190          533.08984    124.87045   0.00526316 
+  199          704.58947    124.78869   0.00502513 
+  205          643.62031    124.70714   0.00487805 
+  185          465.43655    124.62579   0.00540541 
+  184          365.97402    124.54466   0.00543478 
+  188          366.41356    124.46374   0.00531915 
+  199          431.31       124.38303   0.00502513 
+  164          444.55272    124.30252   0.00609756 
+  148          348.35302    124.22223   0.00675676 
+  147          257.22469    124.14214   0.00680272 
+  164          205.51474    124.06227   0.00609756 
+  142          179.9196     123.9826    0.00704225 
+  153          166.41348    123.90314   0.00653595 
+  137          158.12612    123.82389   0.00729927 
+  139          152.51809    123.74484   0.00719424 
+  124          148.54231    123.66601   0.00806452 
+  162          145.66523    123.58737   0.00617284 
+  152          143.58517    123.50895   0.00657895 
+  150          142.09613    123.43073   0.00666667 
+  154          141.05659    123.35272   0.00649351 
+  150          140.61842    123.27491   0.00666667 
+  149          141.0903     123.19731   0.00671141 
+  170          142.28575    123.11992   0.00588235 
+  147          143.46236    123.04272   0.00680272 
+  163          145.46919    122.96574   0.00613497 
+  180          147.91693    122.88895   0.00555556 
+  158          148.1833     122.81237   0.00632911 
+  179          145.20052    122.736     0.00558659 
+  188          142.71608    122.65983   0.00531915 
+  189          141.91661    122.58386   0.00529101 
+  194          143.13796    122.50809   0.00515464 
+  197          144.27408    122.43253   0.00507614 
+  198          142.32411    122.35717   0.00505051 
+  195          138.8317     122.28201   0.00512821 
+  214          136.6689     122.20705   0.0046729 
+  245          136.0738     122.13229   0.00408163 
+  240          136.61438    122.05773   0.00416667 
+  265          137.28045    121.98338   0.00377358 
+  291          138.00286    121.90922   0.00343643 
+  377          140.5453     121.83527   0.00265252 
+  409          144.88264    121.76151   0.00244499 
+  434          146.2747     121.68796   0.00230415 
+  422          143.55127    121.6146    0.00236967 
+  321          142.36747    121.54145   0.00311526 
+  320          145.13964    121.46849   0.003125  
+  338          154.1406     121.39573   0.00295858 
+  335          171.10604    121.32317   0.00298507 
+  315          189.77997    121.2508    0.0031746 
+  286          188.60077    121.17864   0.0034965 
+  261          168.85725    121.10667   0.00383142 
+  215          154.67132    121.0349    0.00465116 
+  222          151.29725    120.96333   0.0045045 
+  191          156.67553    120.89195   0.0052356 
+  181          162.94309    120.82077   0.00552486 
+  205          157.80332    120.74978   0.00487805 
+  184          148.80687    120.67899   0.00543478 
+  166          142.35713    120.6084    0.0060241 
+  161          138.8495     120.538     0.00621118 
+  192          137.14628    120.46779   0.00520833 
+  166          135.52704    120.39778   0.0060241 
+  143          134.83058    120.32797   0.00699301 
+  181          135.07801    120.25835   0.00552486 
+  182          135.9799     120.18892   0.00549451 
+  174          138.90889    120.11969   0.00574713 
+  158          144.43998    120.05065   0.00632911 
+  155          150.37553    119.9818    0.00645161 
+  166          148.63047    119.91314   0.0060241 
+  170          141.69933    119.84468   0.00588235 
+  169          137.40175    119.77641   0.00591716 
+  162          136.88056    119.70833   0.00617284 
+  164          139.20751    119.64045   0.00609756 
+  190          141.20218    119.57275   0.00526316 
+  166          138.8681     119.50525   0.0060241 
+  152          135.6549     119.43794   0.00657895 
+  172          134.01738    119.37082   0.00581395 
+  159          133.799      119.30389   0.00628931 
+  160          134.61326    119.23714   0.00625   
+  163          136.67149    119.17059   0.00613497 
+  162          141.09258    119.10423   0.00617284 
+  183          149.66734    119.03806   0.00546448 
+  158          162.0225     118.97208   0.00632911 
+  186          167.22883    118.90628   0.00537634 
+  177          158.84965    118.84068   0.00564972 
+  143          151.10986    118.77526   0.00699301 
+  195          149.43518    118.71003   0.00512821 
+  216          153.34997    118.64499   0.00462963 
+  193          160.03216    118.58013   0.00518135 
+  212          162.01235    118.51547   0.00471698 
+  250          160.06035    118.45099   0.004     
+  343          161.00451    118.38669   0.00291545 
+  530          166.46743    118.32259   0.00188679 
+  680          177.28076    118.25867   0.00147059 
+  580          196.63198    118.19493   0.00172414 
+  469          231.88335    118.13138   0.0021322 
+  622          293.31284    118.06802   0.00160772 
+  697          381.28241    118.00484   0.00143472 
+  942          469.02993    117.94185   0.00106157 
+  1106         511.82088    117.87904   0.00090416 
+  943          482.53376    117.81642   0.00106045 
+  755          458.74163    117.75398   0.0013245 
+  629          478.93701    117.69173   0.00158983 
+  592          492.63398    117.62966   0.00168919 
+  611          469.38028    117.56777   0.00163666 
+  604          423.17604    117.50606   0.00165563 
+  532          363.02243    117.44454   0.0018797 
+  402          326.34294    117.3832    0.00248756 
+  310          313.20739    117.32205   0.00322581 
+  288          294.3386     117.26108   0.00347222 
+  242          271.5087     117.20028   0.00413223 
+  236          261.01325    117.13967   0.00423729 
+  192          258.80092    117.07925   0.00520833 
+  183          251.38196    117.019     0.00546448 
+  180          233.7629     116.95893   0.00555556 
+  184          215.52493    116.89905   0.00543478 
+  200          204.10137    116.83934   0.005     
+  181          199.83333    116.77982   0.00552486 
+  196          197.78967    116.72048   0.00510204 
+  208          190.96269    116.66131   0.00480769 
+  199          178.96265    116.60233   0.00502513 
+  189          166.99776    116.54352   0.00529101 
+  195          157.89819    116.48489   0.00512821 
+  177          151.80316    116.42645   0.00564972 
+  201          148.08326    116.36818   0.00497512 
+  171          146.15996    116.31009   0.00584795 
+  230          145.84725    116.25218   0.00434783 
+  222          147.41829    116.19444   0.0045045 
+  206          151.85597    116.13689   0.00485437 
+  209          161.12776    116.07951   0.00478469 
+  208          179.16771    116.0223    0.00480769 
+  212          213.94229    115.96528   0.00471698 
+  230          262.40516    115.90843   0.00434783 
+  225          274.06906    115.85176   0.00444444 
+  239          232.00039    115.79526   0.0041841 
+  223          195.3105     115.73895   0.0044843 
+  209          181.88762    115.6828    0.00478469 
+  229          189.50973    115.62683   0.00436681 
+  220          207.43987    115.57104   0.00454545 
+  222          204.29659    115.51542   0.0045045 
+  247          179.03541    115.45998   0.00404858 
+  221          159.12655    115.40471   0.00452489 
+  232          149.29678    115.34962   0.00431034 
+  245          146.22253    115.2947    0.00408163 
+  213          146.74802    115.23995   0.00469484 
+  231          147.82872    115.18538   0.004329  
+  255          147.41553    115.13098   0.00392157 
+  304          147.78561    115.07676   0.00328947 
+  332          152.12056    115.0227    0.00301205 
+  277          164.39681    114.96882   0.00361011 
+  276          190.75919    114.91512   0.00362319 
+  253          233.01152    114.86158   0.00395257 
+  237          262.21298    114.80822   0.00421941 
+  230          235.39746    114.75503   0.00434783 
+  233          196.22023    114.70201   0.00429185 
+  233          176.92827    114.64916   0.00429185 
+  175          178.13856    114.59648   0.00571429 
+  212          194.00967    114.54398   0.00471698 
+  196          204.25201    114.49164   0.00510204 
+  210          188.61507    114.43948   0.0047619 
+  216          170.59877    114.38748   0.00462963 
+  234          163.22812    114.33566   0.0042735 
+  207          164.17415    114.284     0.00483092 
+  179          167.41001    114.23252   0.00558659 
+  208          169.83335    114.1812    0.00480769 
+  204          172.21742    114.13005   0.00490196 
+  231          172.92048    114.07908   0.004329  
+  207          171.25741    114.02827   0.00483092 
+  174          170.24326    113.97763   0.00574713 
+  199          171.31013    113.92715   0.00502513 
+  213          175.38529    113.87685   0.00469484 
+  245          186.05723    113.82671   0.00408163 
+  301          212.23754    113.77674   0.00332226 
+  275          275.16703    113.72694   0.00363636 
+  366          385.76751    113.6773    0.00273224 
+  441          440.96356    113.62783   0.00226757 
+  361          336.89619    113.57853   0.00277008 
+  270          242.20957    113.5294    0.0037037 
+  249          209.93062    113.48043   0.00401606 
+  252          226.83046    113.43163   0.00396825 
+  254          278.79108    113.38299   0.00393701 
+  306          306.64088    113.33452   0.00326797 
+  265          263.80166    113.28621   0.00377358 
+  221          235.85247    113.23807   0.00452489 
+  219          231.93984    113.19009   0.00456621 
+  211          212.28816    113.14228   0.00473934 
+  210          185.05434    113.09463   0.0047619 
+  183          169.67485    113.04715   0.00546448 
+  193          167.25357    112.99983   0.00518135 
+  196          174.68771    112.95267   0.00510204 
+  168          183.24122    112.90568   0.00595238 
+  190          178.34886    112.85885   0.00526316 
+  173          168.69526    112.81218   0.00578035 
+  187          167.25309    112.76568   0.00534759 
+  222          181.80669    112.71934   0.0045045 
+  288          222.01663    112.67316   0.00347222 
+  357          272.78637    112.62715   0.00280112 
+  346          256.64       112.58129   0.00289017 
+  283          205.08821    112.5356    0.00353357 
+  211          177.47272    112.49007   0.00473934 
+  199          174.53979    112.4447    0.00502513 
+  233          191.03514    112.39949   0.00429185 
+  266          215.9199     112.35445   0.0037594 
+  253          209.83268    112.30956   0.00395257 
+  225          186.09535    112.26484   0.00444444 
+  201          176.45025    112.22027   0.00497512 
+  190          180.54403    112.17587   0.00526316 
+  174          186.45989    112.13162   0.00574713 
+  167          181.45004    112.08753   0.00598802 
+  174          174.35743    112.04361   0.00574713 
+  186          172.50356    111.99984   0.00537634 
+  166          175.52582    111.95623   0.0060241 
+  167          181.27       111.91278   0.00598802 
+  181          186.36255    111.86949   0.00552486 
+  163          186.02699    111.82636   0.00613497 
+  202          184.75553    111.78338   0.0049505 
+  163          186.37216    111.74057   0.00613497 
+  206          190.37549    111.69791   0.00485437 
+  186          195.46937    111.65541   0.00537634 
+  184          201.29767    111.61306   0.00543478 
+  202          208.45887    111.57088   0.0049505 
+  231          217.67504    111.52885   0.004329  
+  231          229.54737    111.48697   0.004329  
+  244          244.76263    111.44526   0.00409836 
+  271          262.69116    111.40369   0.00369004 
+  270          279.22943    111.36229   0.0037037 
+  312          296.16842    111.32104   0.00320513 
+  329          319.02824    111.27995   0.00303951 
+  325          350.0694     111.23901   0.00307692 
+  374          391.21314    111.19823   0.0026738 
+  371          445.05806    111.1576    0.00269542 
+  390          514.37741    111.11712   0.0025641 
+  415          607.23775    111.07681   0.00240964 
+  523          739.6411     111.03664   0.00191205 
+  756          937.78711    110.99663   0.00132275 
+  1036         1254.1861    110.95677   0.00096525 
+  1715         1833.66148   110.91707   0.00058309 
+  2906         3184.66121   110.87752   0.00034412 
+  5424         6623.67649   110.83813   0.00018437 
+  9806         13299.25725  110.79888   0.00010198 
+  12859        18155.77002  110.75979   0.00007777 
+  9073         12843.61636  110.72086   0.00011022 
+  4936         6720.07319   110.68207   0.00020259 
+  3237         4139.50088   110.64344   0.00030893 
+  3540         4387.99935   110.60496   0.00028249 
+  4840         6929.19641   110.56663   0.00020661 
+  6214         9624.3789    110.52845   0.00016093 
+  5000         7410.69638   110.49043   0.0002    
+  2528         3884.31904   110.45255   0.00039557 
+  1304         1981.59393   110.41483   0.00076687 
+  751          1206.96518   110.37726   0.00133156 
+  597          865.67574    110.33983   0.00167504 
+  489          674.31947    110.30256   0.00204499 
+  368          550.6773     110.26544   0.00271739 
+  295          465.18191    110.22847   0.00338983 
+  296          403.33131    110.19165   0.00337838 
+  255          356.97677    110.15497   0.00392157 
+  204          321.24523    110.11845   0.00490196 
+  230          293.06169    110.08208   0.00434783 
+  209          270.40883    110.04585   0.00478469 
+  215          251.91644    110.00977   0.00465116 
+  199          236.63134    109.97385   0.00502513 
+  196          223.86163    109.93807   0.00510204 
+  204          213.08363    109.90243   0.00490196 
+  175          203.95324    109.86695   0.00571429 
+  180          196.28133    109.83162   0.00555556 
+  184          189.89724    109.79643   0.00543478 
+  168          184.4717     109.76139   0.00595238 
+  177          179.31617    109.72649   0.00564972 
+  153          174.25194    109.69174   0.00653595 
+  194          169.78132    109.65714   0.00515464 
+  169          166.06679    109.62269   0.00591716 
+  185          162.91259    109.58838   0.00540541 
+  150          160.15374    109.55422   0.00666667 
+  168          157.64059    109.5202    0.00595238 
+  169          155.27101    109.48633   0.00591716 
+  176          153.34514    109.45261   0.00568182 
+  184          152.08983    109.41903   0.00543478 
+  187          151.51406    109.38559   0.00534759 
+  167          151.40058    109.3523    0.00598802 
+  161          151.39921    109.31916   0.00621118 
+  177          152.14619    109.28616   0.00564972 
+  219          155.94683    109.2533    0.00456621 
+  236          165.12472    109.22059   0.00423729 
+  245          176.67563    109.18802   0.00408163 
+  228          176.73539    109.15559   0.00438596 
+  230          167.07208    109.12331   0.00434783 
+  228          158.6723     109.09117   0.00438596 
+  207          155.12967    109.05918   0.00483092 
+  189          157.45112    109.02733   0.00529101 
+  203          165.12156    108.99562   0.00492611 
+  205          171.90925    108.96405   0.00487805 
+  239          173.23236    108.93262   0.0041841 
+  227          168.79343    108.90134   0.00440529 
+  213          160.33224    108.8702    0.00469484 
+  219          153.74506    108.8392    0.00456621 
+  162          151.15034    108.80834   0.00617284 
+  186          152.28424    108.77762   0.00537634 
+  210          156.18441    108.74704   0.0047619 
+  212          160.31969    108.71661   0.00471698 
+  204          163.20036    108.68631   0.00490196 
+  202          168.63292    108.65616   0.0049505 
+  219          181.68399    108.62614   0.00456621 
+  269          209.92993    108.59627   0.00371747 
+  374          267.10142    108.56653   0.0026738 
+  647          365.112      108.53694   0.0015456 
+  840          474.23569    108.50748   0.00119048 
+  827          472.1668     108.47816   0.00120919 
+  675          364.52923    108.44898   0.00148148 
+  609          283.43525    108.41994   0.00164204 
+  772          257.02712    108.39104   0.00129534 
+  909          274.56162    108.36228   0.00110011 
+  881          317.43649    108.33366   0.00113507 
+  732          333.15293    108.30517   0.00136612 
+  608          278.56555    108.27682   0.00164474 
+  413          217.89606    108.24861   0.00242131 
+  427          181.88496    108.22054   0.00234192 
+  464          164.0073     108.1926    0.00215517 
+  393          154.2461     108.1648    0.00254453 
+  332          147.69597    108.13714   0.00301205 
+  251          142.23868    108.10961   0.00398406 
+  256          138.38425    108.08222   0.00390625 
+  196          136.79203    108.05497   0.00510204 
+  168          137.90892    108.02785   0.00595238 
+  178          142.48233    108.00086   0.00561798 
+  172          149.64537    107.97402   0.00581395 
+  172          152.40806    107.94731   0.00581395 
+  165          149.89557    107.92073   0.00606061 
+  141          148.9342     107.89429   0.0070922 
+  151          146.03377    107.86798   0.00662252 
+  141          141.81948    107.84181   0.0070922 
+  167          140.85851    107.81577   0.00598802 
+  183          141.33071    107.78987   0.00546448 
+  171          139.48632    107.7641    0.00584795 
+  176          138.03476    107.73846   0.00568182 
+  175          137.20676    107.71296   0.00571429 
+  183          135.15321    107.68759   0.00546448 
+  189          134.29844    107.66235   0.00529101 
+  183          135.08097    107.63725   0.00546448 
+  167          134.66897    107.61228   0.00598802 
+  172          132.64163    107.58744   0.00581395 
+  185          131.51049    107.56274   0.00540541 
+  152          131.82209    107.53816   0.00657895 
+  156          133.4855     107.51372   0.00641026 
+  147          136.44466    107.48941   0.00680272 
+  172          140.13685    107.46523   0.00581395 
+  187          143.97979    107.44119   0.00534759 
+  214          149.98737    107.41727   0.0046729 
+  245          160.33501    107.39349   0.00408163 
+  275          176.50951    107.36983   0.00363636 
+  326          201.92905    107.34631   0.00306748 
+  520          243.72127    107.32291   0.00192308 
+  578          286.35418    107.29965   0.0017301 
+  418          274.26164    107.27652   0.00239234 
+  329          232.23367    107.25351   0.00303951 
+  251          207.32274    107.23064   0.00398406 
+  300          204.13888    107.2079    0.00333333 
+  321          218.81696    107.18528   0.00311526 
+  393          245.74149    107.16279   0.00254453 
+  361          260.19262    107.14043   0.00277008 
+  292          249.73391    107.11821   0.00342466 
+  270          244.96497    107.0961    0.0037037 
+  292          260.13965    107.07413   0.00342466 
+  328          298.88038    107.05229   0.00304878 
+  447          375.50671    107.03057   0.00223714 
+  772          550.28952    107.00898   0.00129534 
+  1440         995.92808    106.98752   0.00069444 
+  2286         1912.05043   106.96618   0.00043745 
+  2962         2790.21666   106.94497   0.00033761 
+  2014         2204.55386   106.92389   0.00049652 
+  994          1229.54237   106.90293   0.00100604 
+  743          739.44539    106.88211   0.0013459 
+  793          650.82448    106.8614    0.00126103 
+  1109         874.88248    106.84083   0.00090171 
+  1398         1352.33072   106.82037   0.00071531 
+  1382         1486.46893   106.80005   0.00072359 
+  779          978.52848    106.77985   0.0012837 
+  539          571.03102    106.75977   0.00185529 
+  385          391.65658    106.73982   0.0025974 
+  351          309.46242    106.72      0.002849  
+  257          253.26901    106.7003    0.00389105 
+  229          216.57581    106.68072   0.00436681 
+  224          195.48239    106.66127   0.00446429 
+  197          186.19869    106.64194   0.00507614 
+  210          185.00023    106.62273   0.0047619 
+  186          183.37667    106.60365   0.00537634 
+  186          171.96551    106.58469   0.00537634 
+  176          158.56994    106.56586   0.00568182 
+  164          149.12679    106.54714   0.00609756 
+  147          143.31346    106.52855   0.00680272 
+  153          139.72645    106.51009   0.00653595 
+  164          137.17143    106.49174   0.00609756 
+  143          135.10898    106.47352   0.00699301 
+  144          133.67814    106.45542   0.00694444 
+  156          133.17168    106.43744   0.00641026 
+  129          133.85465    106.41958   0.00775194 
+  145          135.71536    106.40185   0.00689655 
+  136          137.20888    106.38423   0.00735294 
+  149          136.30815    106.36674   0.00671141 
+  134          134.59977    106.34936   0.00746269 
+  147          133.82426    106.33211   0.00680272 
+  177          134.46869    106.31498   0.00564972 
+  144          136.58176    106.29796   0.00694444 
+  148          140.02362    106.28107   0.00675676 
+  139          143.92084    106.2643    0.00719424 
+  141          148.32949    106.24764   0.0070922 
+  160          155.31427    106.23111   0.00625   
+  161          167.61154    106.21469   0.00621118 
+  196          191.22046    106.1984    0.00510204 
+  256          246.77286    106.18222   0.00390625 
+  320          385.46025    106.16616   0.003125  
+  452          653.81602    106.15022   0.00221239 
+  583          861.94948    106.1344    0.00171527 
+  596          658.4919     106.11869   0.00167785 
+  483          400.68901    106.1031    0.00207039 
+  386          279.36058    106.08763   0.00259067 
+  287          261.87897    106.07228   0.00348432 
+  298          326.27364    106.05705   0.0033557 
+  346          458.41336    106.04193   0.00289017 
+  366          498.20377    106.02693   0.00273224 
+  349          356.72191    106.01204   0.00286533 
+  272          238.40816    105.99727   0.00367647 
+  216          183.49387    105.98262   0.00462963 
+  192          161.81451    105.96808   0.00520833 
+  166          152.0338     105.95366   0.0060241 
+  175          146.48187    105.93935   0.00571429 
+  189          143.31722    105.92516   0.00529101 
+  171          142.30849    105.91108   0.00584795 
+  158          143.8339     105.89712   0.00632911 
+  180          148.09137    105.88328   0.00555556 
+  181          152.62445    105.86954   0.00552486 
+  188          152.37466    105.85593   0.00531915 
+  152          150.92157    105.84242   0.00657895 
+  185          152.46834    105.82903   0.00540541 
+  232          157.89616    105.81576   0.00431034 
+  226          168.35903    105.80259   0.00442478 
+  238          185.91057    105.78954   0.00420168 
+  200          208.22181    105.77661   0.005     
+  203          223.60536    105.76378   0.00492611 
+  183          237.46015    105.75107   0.00546448 
+  201          274.61974    105.73847   0.00497512 
+  223          364.73002    105.72598   0.0044843 
+  288          552.43978    105.71361   0.00347222 
+  381          860.90085    105.70135   0.00262467 
+  307          1104.33642   105.68919   0.00325733 
+  270          937.96505    105.67715   0.0037037 
+  238          631.70571    105.66522   0.00420168 
+  226          445.79923    105.65341   0.00442478 
+  193          390.94836    105.6417    0.00518135 
+  234          442.85662    105.6301    0.0042735 
+  229          572.91556    105.61862   0.00436681 
+  198          643.59844    105.60724   0.00505051 
+  192          515.79949    105.59597   0.00520833 
+  182          357.06539    105.58482   0.00549451 
+  181          259.24632    105.57377   0.00552486 
+  172          209.83294    105.56283   0.00581395 
+  170          184.22969    105.552     0.00588235 
+  164          168.7728     105.54128   0.00609756 
+  169          158.46278    105.53067   0.00591716 
+  159          151.38836    105.52017   0.00628931 
+  188          146.66468    105.50978   0.00531915 
+  149          143.65119    105.49949   0.00671141 
+  179          141.65127    105.48931   0.00558659 
+  168          139.78693    105.47924   0.00595238 
+  146          138.25135    105.46928   0.00684932 
+  149          137.52178    105.45942   0.00671141 
+  172          137.64509    105.44967   0.00581395 
+  168          138.52489    105.44003   0.00595238 
+  189          139.81116    105.4305    0.00529101 
+  181          141.22244    105.42107   0.00552486 
+  145          142.66963    105.41175   0.00689655 
+  160          143.28875    105.40253   0.00625   
+  158          144.08617    105.39342   0.00632911 
+  176          146.1939     105.38441   0.00568182 
+  179          149.67566    105.37551   0.00558659 
+  194          154.54575    105.36672   0.00515464 
+  178          162.11176    105.35803   0.00561798 
+  185          174.19484    105.34945   0.00540541 
+  193          189.05654    105.34097   0.00518135 
+  184          195.69052    105.33259   0.00543478 
+  227          192.17549    105.32432   0.00440529 
+  206          191.80212    105.31615   0.00485437 
+  246          198.63847    105.30809   0.00406504 
+  241          213.3158     105.30013   0.00414938 
+  262          236.99563    105.29227   0.00381679 
+  266          268.77135    105.28452   0.0037594 
+  275          300.4828     105.27687   0.00363636 
+  337          337.46188    105.26932   0.00296736 
+  377          400.5402     105.26187   0.00265252 
+  556          514.31728    105.25453   0.00179856 
+  806          748.95848    105.24729   0.00124069 
+  1282         1332.04647   105.24015   0.00078003 
+  2423         2683.35871   105.23311   0.00041271 
+  3449         4703.53432   105.22618   0.00028994 
+  3046         4887.07058   105.21934   0.0003283 
+  1823         2943.14848   105.21261   0.00054855 
+  1217         1572.55602   105.20597   0.00082169 
+  1051         1065.57746   105.19944   0.00095147 
+  1105         1110.18213   105.19301   0.00090498 
+  1484         1664.73319   105.18668   0.00067385 
+  1799         2592.50226   105.18045   0.00055586 
+  1624         2598.20239   105.17432   0.00061576 
+  1077         1572.69026   105.16828   0.00092851 
+  634          843.17645    105.16235   0.00157729 
+  456          519.61944    105.15652   0.00219298 
+  381          385.78276    105.15078   0.00262467 
+  307          317.61598    105.14515   0.00325733 
+  271          278.03915    105.13961   0.00369004 
+  225          249.43344    105.13417   0.00444444 
+  215          222.01024    105.12883   0.00465116 
+  211          200.28477    105.12359   0.00473934 
+  179          185.15527    105.11844   0.00558659 
+  197          174.68576    105.11339   0.00507614 
+  155          167.94519    105.10844   0.00645161 
+  183          164.30919    105.10359   0.00546448 
+  184          160.72053    105.09883   0.00543478 
+  159          154.97248    105.09417   0.00628931 
+  167          149.80132    105.08961   0.00598802 
+  174          145.95663    105.08514   0.00574713 
+  142          143.51937    105.08077   0.00704225 
+  163          141.99454    105.0765    0.00613497 
+  150          141.10901    105.07232   0.00666667 
+  161          139.48886    105.06823   0.00621118 
+  125          138.00293    105.06424   0.008     
+  157          137.70896    105.06035   0.00636943 
+  136          138.86095    105.05655   0.00735294 
+  157          140.23608    105.05284   0.00636943 
+  161          139.17518    105.04923   0.00621118 
+  130          135.82827    105.04571   0.00769231 
+  145          132.02494    105.04229   0.00689655 
+  123          128.83707    105.03896   0.00813008 
+  159          127.06788    105.03573   0.00628931 
+  144          126.70366    105.03258   0.00694444 
+  149          126.8613     105.02954   0.00671141 
+  133          126.04816    105.02658   0.0075188 
+  143          124.23075    105.02371   0.00699301 
+  169          122.42741    105.02094   0.00591716 
+  163          121.47776    105.01826   0.00613497 
+  163          121.61625    105.01568   0.00613497 
+  163          122.40007    105.01318   0.00613497 
+  144          122.16876    105.01078   0.00694444 
+  152          120.94611    105.00846   0.00657895 
+  151          120.27609    105.00624   0.00662252 
+  185          119.90828    105.00411   0.00540541 
+  155          119.33044    105.00207   0.00645161 
+  161          119.20177    105.00012   0.00621118 
+  142          119.67863    104.99826   0.00704225 
+  163          120.16942    104.99649   0.00613497 
+  180          120.70701    104.99482   0.00555556 
+  177          122.13013    104.99323   0.00564972 
+  189          123.35105    104.99172   0.00529101 
+  175          122.3055     104.99031   0.00571429 
+  210          120.35181    104.98899   0.0047619 
+  161          119.16098    104.98776   0.00621118 
+  169          119.05042    104.98661   0.00591716 
+  159          120.01667    104.98556   0.00628931 
+  161          121.90203    104.98459   0.00621118 
+  161          123.83874    104.98371   0.00621118 
+  177          124.01293    104.98292   0.00564972 
+  149          122.31923    104.98221   0.00671141 
+  141          120.68392    104.98159   0.0070922 
+  137          120.04286    104.98106   0.00729927 
+  139          120.48363    104.98062   0.00719424 
+  160          121.91587    104.98026   0.00625   
+  153          123.96972    104.97999   0.00653595 
+  160          125.70809    104.9798    0.00625   
+  176          126.25929    104.9797    0.00568182 
+  185          126.40811    104.97969   0.00540541 
+  186          126.53366    104.97976   0.00537634 
+  158          125.22395    104.97992   0.00632911 
+  179          123.7971     104.98016   0.00558659 
+  159          123.5472     104.98049   0.00628931 
+  150          124.23626    104.9809    0.00666667 
+  181          125.35272    104.9814    0.00552486 
+  209          126.89094    104.98198   0.00478469 
+  184          129.40203    104.98264   0.00543478 
+  154          132.76613    104.98339   0.00649351 
+  187          136.92492    104.98422   0.00534759 
+  185          139.78071    104.98514   0.00540541 
+  190          143.1118     104.98614   0.00526316 
+  184          151.00375    104.98722   0.00543478 
+  206          157.42077    104.98838   0.00485437 
+  177          152.83064    104.98963   0.00564972 
+  168          145.47005    104.99096   0.00595238 
+  188          142.54945    104.99237   0.00531915 
+  175          142.97124    104.99386   0.00571429 
+  205          144.60816    104.99544   0.00487805 
+  192          148.55734    104.99709   0.00520833 
+  167          154.45935    104.99883   0.00598802 
+  199          158.14831    105.00065   0.00502513 
+  173          163.83244    105.00254   0.00578035 
+  184          179.09394    105.00452   0.00543478 
+  216          201.38336    105.00658   0.00462963 
+  205          206.27915    105.00872   0.00487805 
+  199          188.1096     105.01094   0.00502513 
+  201          172.67454    105.01324   0.00497512 
+  274          167.53488    105.01562   0.00364964 
+  223          171.96413    105.01808   0.0044843 
+  222          185.68062    105.02061   0.0045045 
+  248          206.79785    105.02323   0.00403226 
+  256          220.24593    105.02592   0.00390625 
+  245          215.7001     105.02869   0.00408163 
+  246          214.84147    105.03154   0.00406504 
+  303          234.62855    105.03447   0.00330033 
+  359          285.0378     105.03747   0.00278552 
+  357          348.00856    105.04056   0.00280112 
+  337          347.25043    105.04372   0.00296736 
+  278          315.75002    105.04695   0.00359712 
+  305          309.78192    105.05027   0.00327869 
+  330          334.1846     105.05366   0.0030303 
+  376          388.505      105.05712   0.00265957 
+  405          482.49298    105.06067   0.00246914 
+  595          637.20016    105.06429   0.00168067 
+  909          888.78865    105.06798   0.00110011 
+  1518         1446.84525   105.07175   0.00065876 
+  2627         2831.43612   105.07559   0.00038066 
+  4971         5276.63786   105.07951   0.00020117 
+  5749         6498.83041   105.08351   0.00017394 
+  3609         4356.61537   105.08758   0.00027709 
+  1950         2294.36211   105.09172   0.00051282 
+  1205         1358.59929   105.09594   0.00082988 
+  1157         1149.59937   105.10023   0.0008643 
+  1409         1466.70633   105.10459   0.00070972 
+  2248         2404.1389    105.10903   0.00044484 
+  2914         3457.17022   105.11354   0.00034317 
+  2309         2872.38429   105.11813   0.00043309 
+  1308         1608.65925   105.12278   0.00076453 
+  914          866.56801    105.12751   0.00109409 
+  633          550.13897    105.13232   0.00157978 
+  450          414.1335     105.13719   0.00222222 
+  340          342.79298    105.14214   0.00294118 
+  290          300.19344    105.14715   0.00344828 
+  284          273.32708    105.15224   0.00352113 
+  277          253.5193     105.1574    0.00361011 
+  324          234.5107     105.16263   0.00308642 
+  308          217.20529    105.16793   0.00324675 
+  311          203.99808    105.17331   0.00321543 
+  346          193.9709     105.17875   0.00289017 
+  423          189.14189    105.18426   0.00236407 
+  367          190.97654    105.18984   0.0027248 
+  308          198.07602    105.1955    0.00324675 
+  299          202.91646    105.20122   0.00334448 
+  253          197.50862    105.20701   0.00395257 
+  273          187.23686    105.21287   0.003663  
+  277          180.56867    105.2188    0.00361011 
+  282          177.51689    105.22479   0.0035461 
+  265          171.86537    105.23086   0.00377358 
+  245          165.99626    105.23699   0.00408163 
+  232          163.66668    105.24319   0.00431034 
+  194          161.31719    105.24946   0.00515464 
+  252          156.63869    105.25579   0.00396825 
+  212          153.06459    105.2622    0.00471698 
+  218          152.74055    105.26867   0.00458716 
+  212          153.55392    105.2752    0.00471698 
+  200          154.64097    105.28181   0.005     
+  205          161.68321    105.28848   0.00487805 
+  247          178.80892    105.29521   0.00404858 
+  257          201.44474    105.30201   0.00389105 
+  228          212.80509    105.30888   0.00438596 
+  255          215.83681    105.31581   0.00392157 
+  239          203.81312    105.32281   0.0041841 
+  232          180.04986    105.32987   0.00431034 
+  207          165.07426    105.33699   0.00483092 
+  223          162.52084    105.34418   0.0044843 
+  221          170.48886    105.35144   0.00452489 
+  202          181.54617    105.35876   0.0049505 
+  189          188.82184    105.36614   0.00529101 
+  204          189.36061    105.37358   0.00490196 
+  183          175.7173     105.38109   0.00546448 
+  175          162.56447    105.38867   0.00571429 
+  177          158.56418    105.3963    0.00564972 
+  203          164.64015    105.404     0.00492611 
+  218          182.13175    105.41176   0.00458716 
+  283          209.3486     105.41958   0.00353357 
+  467          229.67101    105.42746   0.00214133 
+  407          225.37342    105.43541   0.002457  
+  313          204.90438    105.44342   0.00319489 
+  201          184.29583    105.45149   0.00497512 
+  221          169.69824    105.45961   0.00452489 
+  194          164.86784    105.4678    0.00515464 
+  210          169.81354    105.47605   0.0047619 
+  241          179.8759     105.48437   0.00414938 
+  294          184.31039    105.49274   0.00340136 
+  264          179.70949    105.50117   0.00378788 
+  220          172.9696     105.50966   0.00454545 
+  162          170.94313    105.51821   0.00617284 
+  184          177.68436    105.52682   0.00543478 
+  159          190.52248    105.53548   0.00628931 
+  220          194.80712    105.54421   0.00454545 
+  198          180.74305    105.553     0.00505051 
+  199          169.22468    105.56184   0.00502513 
+  192          168.0655     105.57074   0.00520833 
+  177          175.53668    105.5797    0.00564972 
+  171          191.2145     105.58872   0.00584795 
+  169          216.39566    105.59779   0.00591716 
+  189          250.36684    105.60692   0.00529101 
+  199          294.49495    105.61611   0.00502513 
+  227          376.7732     105.62535   0.00440529 
+  251          554.1116     105.63465   0.00398406 
+  254          869.13508    105.64401   0.00393701 
+  268          1208.33448   105.65342   0.00373134 
+  238          1157.36725   105.66289   0.00420168 
+  216          806.22956    105.67242   0.00462963 
+  174          535.65654    105.682     0.00574713 
+  190          405.41906    105.69163   0.00526316 
+  173          383.14239    105.70132   0.00578035 
+  179          452.25974    105.71106   0.00558659 
+  205          602.36772    105.72086   0.00487805 
+  201          717.78734    105.73071   0.00497512 
+  193          608.48953    105.74062   0.00518135 
+  143          420.27914    105.75058   0.00699301 
+  159          292.55268    105.76059   0.00628931 
+  145          224.20801    105.77066   0.00689655 
+  130          189.2196     105.78078   0.00769231 
+  140          169.72514    105.79095   0.00714286 
+  119          157.60613    105.80117   0.00840336 
+  131          149.63938    105.81145   0.00763359 
+  120          144.28207    105.82178   0.00833333 
+  158          141.06819    105.83216   0.00632911 
+  132          140.28385    105.84259   0.00757576 
+  153          140.66967    105.85307   0.00653595 
+  176          137.8787     105.86361   0.00568182 
+  163          132.50608    105.87419   0.00613497 
+  148          128.33626    105.88483   0.00675676 
+  118          125.91237    105.89552   0.00847458 
+  136          124.65905    105.90625   0.00735294 
+  131          124.26039    105.91704   0.00763359 
+  160          124.78265    105.92788   0.00625   
+  151          125.42588    105.93876   0.00662252 
+  144          124.28261    105.9497    0.00694444 
+  151          122.69036    105.96068   0.00662252 
+  127          122.27663    105.97171   0.00787402 
+  138          122.25923    105.98279   0.00724638 
+  135          120.86255    105.99392   0.00740741 
+  123          118.95929    106.0051    0.00813008 
+  147          117.61682    106.01633   0.00680272 
+  114          116.89553    106.0276    0.00877193 
+  154          116.65316    106.03892   0.00649351 
+  123          116.83291    106.05029   0.00813008 
+  138          117.36178    106.0617    0.00724638 
+  133          117.66103    106.07316   0.0075188 
+  132          117.14073    106.08467   0.00757576 
+  136          116.54774    106.09623   0.00735294 
+  129          116.34819    106.10783   0.00775194 
+  139          116.54866    106.11947   0.00719424 
+  117          117.03746    106.13116   0.00854701 
+  131          117.60471    106.1429    0.00763359 
+  112          118.15085    106.15468   0.00892857 
+  106          119.17583    106.16651   0.00943396 
+  128          121.36753    106.17838   0.0078125 
+  136          125.55775    106.19029   0.00735294 
+  139          132.28253    106.20225   0.00719424 
+  152          139.16334    106.21426   0.00657895 
+  137          142.95215    106.2263    0.00729927 
+  155          148.01662    106.23839   0.00645161 
+  155          151.25568    106.25053   0.00645161 
+  146          146.81145    106.2627    0.00684932 
+  136          140.00595    106.27492   0.00735294 
+  166          135.96123    106.28719   0.0060241 
+  177          136.22777    106.29949   0.00564972 
+  149          137.86067    106.31184   0.00671141 
+  156          139.20155    106.32422   0.00641026 
+  177          142.78152    106.33665   0.00564972 
+  202          146.50765    106.34913   0.0049505 
+  176          148.04413    106.36164   0.00568182 
+  187          150.61248    106.37419   0.00534759 
+  162          156.74068    106.38678   0.00617284 
+  167          164.09411    106.39942   0.00598802 
+  172          167.94883    106.41209   0.00581395 
+  151          167.65365    106.42481   0.00662252 
+  173          165.42068    106.43756   0.00578035 
+  177          161.8816     106.45035   0.00564972 
+  154          156.72157    106.46319   0.00649351 
+  161          154.53819    106.47606   0.00621118 
+  185          157.06523    106.48897   0.00540541 
+  181          162.39185    106.50192   0.00552486 
+  185          168.59574    106.51491   0.00540541 
+  159          176.58531    106.52793   0.00628931 
+  193          190.98028    106.54099   0.00518135 
+  253          223.45291    106.5541    0.00395257 
+  350          302.34414    106.56723   0.00285714 
+  565          460.62647    106.58041   0.00176991 
+  792          612.80204    106.59362   0.00126263 
+  928          515.62447    106.60687   0.00107759 
+  761          341.20439    106.62016   0.00131406 
+  508          247.65735    106.63348   0.0019685 
+  357          221.37212    106.64684   0.00280112 
+  296          237.83944    106.66023   0.00337838 
+  303          298.92015    106.67366   0.00330033 
+  391          404.27599    106.68712   0.00255754 
+  466          473.6388     106.70062   0.00214592 
+  533          394.28462    106.71416   0.00187617 
+  425          285.00649    106.72773   0.00235294 
+  315          230.8732     106.74133   0.0031746 
+  240          223.97575    106.75497   0.00416667 
+  222          249.89435    106.76864   0.0045045 
+  205          294.94821    106.78234   0.00487805 
+  219          319.5745     106.79608   0.00456621 
+  212          309.94947    106.80985   0.00471698 
+  302          321.97674    106.82366   0.00331126 
+  366          421.4091     106.8375    0.00273224 
+  581          628.29907    106.85137   0.00172117 
+  630          744.71155    106.86527   0.0015873 
+  615          571.26428    106.8792    0.00162602 
+  470          400.93579    106.89317   0.00212766 
+  369          320.91393    106.90716   0.00271003 
+  328          301.3497     106.92119   0.00304878 
+  335          352.74861    106.93525   0.00298507 
+  446          511.94707    106.94934   0.00224215 
+  547          745.82944    106.96347   0.00182815 
+  714          766.51076    106.97762   0.00140056 
+  561          528.77863    106.9918    0.00178253 
+  450          333.17587    107.00601   0.00222222 
+  312          241.30155    107.02025   0.00320513 
+  270          211.03418    107.03453   0.0037037 
+  281          217.65601    107.04883   0.00355872 
+  264          261.71501    107.06316   0.00378788 
+  264          325.84433    107.07751   0.00378788 
+  254          311.76398    107.0919    0.00393701 
+  246          234.44765    107.10632   0.00406504 
+  220          180.80274    107.12076   0.00454545 
+  176          154.92008    107.13523   0.00568182 
+  188          143.11908    107.14973   0.00531915 
+  174          137.09782    107.16426   0.00574713 
+  174          133.41572    107.17881   0.00574713 
+  182          130.81232    107.19339   0.00549451 
+  163          129.32268    107.208     0.00613497 
+  176          129.19662    107.22263   0.00568182 
+  179          130.7779     107.23729   0.00558659 
+  202          134.65959    107.25198   0.0049505 
+  217          141.25003    107.26669   0.00460829 
+  214          146.28231    107.28143   0.0046729 
+  208          143.40101    107.29619   0.00480769 
+  178          139.07731    107.31098   0.00561798 
+  192          139.29451    107.32579   0.00520833 
+  174          144.46845    107.34063   0.00574713 
+  169          153.48907    107.35549   0.00591716 
+  184          159.24512    107.37037   0.00543478 
+  225          154.2305     107.38528   0.00444444 
+  203          146.99237    107.40022   0.00492611 
+  210          139.70135    107.41518   0.0047619 
+  221          134.07065    107.43016   0.00452489 
+  219          132.19396    107.44516   0.00456621 
+  223          133.61692    107.46019   0.0044843 
+  199          137.41747    107.47523   0.00502513 
+  193          140.74733    107.4903    0.00518135 
+  177          138.66361    107.5054    0.00564972 
+  175          135.25062    107.52051   0.00571429 
+  163          134.42967    107.53565   0.00613497 
+  199          135.0395     107.55081   0.00502513 
+  187          134.35685    107.56599   0.00534759 
+  181          133.71398    107.58119   0.00552486 
+  187          134.60124    107.59641   0.00534759 
+  171          137.33995    107.61165   0.00584795 
+  195          142.86851    107.62691   0.00512821 
+  205          153.02206    107.64219   0.00487805 
+  242          173.05882    107.6575    0.00413223 
+  335          214.68963    107.67282   0.00298507 
+  442          280.52953    107.68816   0.00226244 
+  549          305.08238    107.70352   0.00182149 
+  476          248.21149    107.7189    0.00210084 
+  311          199.46259    107.73429   0.00321543 
+  240          178.59231    107.74971   0.00416667 
+  220          173.93548    107.76514   0.00454545 
+  201          180.16382    107.78059   0.00497512 
+  307          200.31537    107.79606   0.00325733 
+  329          240.29911    107.81155   0.00303951 
+  377          281.46283    107.82706   0.00265252 
+  367          282.60461    107.84258   0.0027248 
+  329          271.47197    107.85812   0.00303951 
+  271          273.6927     107.87367   0.00369004 
+  332          304.8915     107.88924   0.00301205 
+  435          384.59674    107.90483   0.00229885 
+  673          553.61232    107.92044   0.00148588 
+  804          863.94028    107.93606   0.00124378 
+  904          1267.46839   107.95169   0.00110619 
+  732          1372.12419   107.96734   0.00136612 
+  527          1028.44983   107.98301   0.00189753 
+  400          678.03979    107.99869   0.0025    
+  324          477.09445    108.01438   0.00308642 
+  295          398.33599    108.03009   0.00338983 
+  372          408.23481    108.04581   0.00268817 
+  454          503.50238    108.06155   0.00220264 
+  495          676.92083    108.0773    0.0020202 
+  444          793.08671    108.09307   0.00225225 
+  350          663.80097    108.10884   0.00285714 
+  255          461.55662    108.12464   0.00392157 
+  196          327.46546    108.14044   0.00510204 
+  166          260.49173    108.15626   0.0060241 
+  173          236.30811    108.17208   0.00578035 
+  122          236.69499    108.18792   0.00819672 
+  151          239.17493    108.20378   0.00662252 
+  129          218.01467    108.21964   0.00775194 
+  130          188.93656    108.23552   0.00769231 
+  116          168.73573    108.2514    0.00862069 
+  144          157.38766    108.2673    0.00694444 
+  127          151.85005    108.28321   0.00787402 
+  140          151.57778    108.29913   0.00714286 
+  118          157.04042    108.31506   0.00847458 
+  103          164.99247    108.331     0.00970874 
+  139          163.0275     108.34695   0.00719424 
+  136          150.65155    108.36291   0.00735294 
+  116          139.77043    108.37888   0.00862069 
+  123          133.09009    108.39486   0.00813008 
+  136          129.03835    108.41084   0.00735294 
+  118          126.31997    108.42684   0.00847458 
+  120          124.47978    108.44284   0.00833333 
+  153          123.09514    108.45886   0.00653595 
+  139          122.27551    108.47488   0.00719424 
+  148          121.73797    108.49091   0.00675676 
+  132          121.48522    108.50694   0.00757576 
+  114          121.55941    108.52299   0.00877193 
+  150          122.10537    108.53904   0.00666667 
+  131          123.48431    108.5551    0.00763359 
+  135          126.34577    108.57116   0.00740741 
+  114          131.68708    108.58723   0.00877193 
+  113          138.97576    108.60331   0.00884956 
+  122          142.90863    108.6194    0.00819672 
+  113          139.38002    108.63549   0.00884956 
+  141          135.5153     108.65158   0.0070922 
+  134          134.19662    108.66768   0.00746269 
+  119          132.21055    108.68379   0.00840336 
+  145          130.1988     108.6999    0.00689655 
+  111          130.76967    108.71602   0.00900901 
+  130          134.40384    108.73214   0.00769231 
+  112          139.53858    108.74827   0.00892857 
+  122          141.92777    108.7644    0.00819672 
+  119          140.07063    108.78053   0.00840336 
+  131          137.15637    108.79667   0.00763359 
+  116          135.64742    108.81281   0.00862069 
+  110          135.34261    108.82895   0.00909091 
+  137          137.13733    108.8451    0.00729927 
+  132          140.8551     108.86125   0.00757576 
+  161          147.78335    108.87741   0.00621118 
+  156          161.26523    108.89356   0.00641026 
+  161          184.17817    108.90972   0.00621118 
+  177          218.12434    108.92588   0.00564972 
+  194          251.26129    108.94204   0.00515464 
+  191          244.04424    108.9582    0.0052356 
+  143          207.89965    108.97437   0.00699301 
+  140          180.40065    108.99054   0.00714286 
+  148          168.19308    109.0067    0.00675676 
+  151          168.5221     109.02287   0.00662252 
+  154          177.57656    109.03904   0.00649351 
+  158          189.80834    109.05521   0.00632911 
+  177          202.17045    109.07138   0.00564972 
+  175          205.91684    109.08755   0.00571429 
+  174          188.8832     109.10371   0.00574713 
+  157          168.87939    109.11988   0.00636943 
+  143          157.47224    109.13605   0.00699301 
+  154          153.30666    109.15222   0.00649351 
+  175          153.74981    109.16838   0.00571429 
+  143          157.49896    109.18455   0.00699301 
+  180          163.00577    109.20071   0.00555556 
+  169          171.56342    109.21687   0.00591716 
+  179          182.42404    109.23303   0.00558659 
+  201          187.77295    109.24918   0.00497512 
+  212          182.90006    109.26534   0.00471698 
+  202          175.31916    109.28149   0.0049505 
+  167          174.05017    109.29764   0.00598802 
+  148          178.56238    109.31378   0.00675676 
+  156          179.17871    109.32993   0.00641026 
+  147          175.8182     109.34607   0.00680272 
+  177          177.76542    109.3622    0.00564972 
+  182          179.69594    109.37833   0.00549451 
+  187          175.44337    109.39446   0.00534759 
+  207          168.98492    109.41058   0.00483092 
+  170          167.11954    109.4267    0.00588235 
+  208          173.56392    109.44282   0.00480769 
+  210          186.30666    109.45893   0.0047619 
+  199          198.45733    109.47503   0.00502513 
+  202          211.10924    109.49113   0.0049505 
+  244          224.02823    109.50722   0.00409836 
+  278          227.03563    109.52331   0.00359712 
+  245          230.73298    109.53939   0.00408163 
+  246          257.03997    109.55547   0.00406504 
+  266          331.00064    109.57154   0.0037594 
+  453          481.06629    109.5876    0.00220751 
+  554          637.81398    109.60366   0.00180505 
+  475          557.13581    109.61971   0.00210526 
+  362          379.15478    109.63575   0.00276243 
+  265          272.85039    109.65178   0.00377358 
+  215          224.91464    109.66781   0.00465116 
+  210          208.03097    109.68383   0.0047619 
+  233          214.43324    109.69984   0.00429185 
+  254          251.69975    109.71585   0.00393701 
+  311          328.40537    109.73184   0.00321543 
+  323          380.98621    109.74783   0.00309598 
+  255          308.54296    109.76381   0.00392157 
+  222          220.62908    109.77978   0.0045045 
+  217          172.57766    109.79574   0.00460829 
+  184          150.99921    109.81169   0.00543478 
+  164          140.63468    109.82763   0.00609756 
+  171          134.92268    109.84356   0.00584795 
+  161          131.54864    109.85948   0.00621118 
+  158          129.06647    109.87539   0.00632911 
+  174          127.01423    109.8913    0.00574713 
+  169          125.87278    109.90719   0.00591716 
+  156          125.62984    109.92307   0.00641026 
+  150          125.92527    109.93894   0.00666667 
+  177          126.74283    109.9548    0.00564972 
+  146          128.22686    109.97064   0.00684932 
+  140          130.12989    109.98648   0.00714286 
+  159          130.44565    110.0023    0.00628931 
+  147          127.56354    110.01812   0.00680272 
+  147          123.95429    110.03392   0.00680272 
+  134          121.4222     110.0497    0.00746269 
+  151          120.11279    110.06548   0.00662252 
+  125          119.70408    110.08124   0.008     
+  153          119.98577    110.09699   0.00653595 
+  152          120.71758    110.11273   0.00657895 
+  131          121.58292    110.12846   0.00763359 
+  134          121.48972    110.14417   0.00746269 
+  125          120.11911    110.15986   0.008     
+  137          118.73659    110.17555   0.00729927 
+  122          117.85031    110.19122   0.00819672 
+  146          117.31639    110.20687   0.00684932 
+  145          117.31499    110.22251   0.00689655 
+  127          118.13494    110.23814   0.00787402 
+  150          119.76316    110.25375   0.00666667 
+  136          121.00026    110.26935   0.00735294 
+  136          120.29804    110.28493   0.00735294 
+  144          118.74328    110.3005    0.00694444 
+  124          117.6213     110.31605   0.00806452 
+  132          117.2367     110.33159   0.00757576 
+  130          117.26085    110.34711   0.00769231 
+  111          117.46399    110.36261   0.00900901 
+  120          117.94935    110.3781    0.00833333 
+  113          118.9118     110.39357   0.00884956 
+  113          119.62432    110.40903   0.00884956 
+  111          119.06961    110.42447   0.00900901 
+  112          117.91428    110.43989   0.00892857 
+  106          117.11078    110.45529   0.00943396 
+  127          116.94156    110.47068   0.00787402 
+  133          117.22338    110.48605   0.0075188 
+  124          117.67852    110.50141   0.00806452 
+  108          118.09183    110.51674   0.00925926 
+  128          118.18124    110.53206   0.0078125 
+  120          117.67659    110.54736   0.00833333 
+  119          116.99712    110.56264   0.00840336 
+  125          116.49576    110.5779    0.008     
+  129          116.2956     110.59314   0.00775194 
+  132          116.38885    110.60837   0.00757576 
+  147          116.74348    110.62357   0.00680272 
+  114          117.33572    110.63876   0.00877193 
+  125          118.09426    110.65393   0.008     
+  134          118.69169    110.66907   0.00746269 
+  113          118.72629    110.6842    0.00884956 
+  153          118.69821    110.69931   0.00653595 
+  125          119.05193    110.7144    0.008     
+  113          119.8745     110.72947   0.00884956 
+  144          121.23553    110.74451   0.00694444 
+  145          123.1957     110.75954   0.00689655 
+  131          126.04651    110.77455   0.00763359 
+  127          130.11098    110.78953   0.00787402 
+  147          134.61012    110.8045    0.00680272 
+  139          137.97579    110.81944   0.00719424 
+  130          141.73064    110.83436   0.00769231 
+  165          151.49858    110.84926   0.00606061 
+  155          177.55431    110.86414   0.00645161 
+  144          233.75788    110.879     0.00694444 
+  158          309.60484    110.89383   0.00632911 
+  140          311.50474    110.90864   0.00714286 
+  144          239.95773    110.92343   0.00694444 
+  141          188.00012    110.9382    0.0070922 
+  141          163.13191    110.95294   0.0070922 
+  133          152.15292    110.96767   0.0075188 
+  153          149.71224    110.98236   0.00653595 
+  154          157.69035    110.99704   0.00649351 
+  155          182.00075    111.01169   0.00645161 
+  146          219.72645    111.02632   0.00684932 
+  156          227.49399    111.04092   0.00641026 
+  156          196.30821    111.05551   0.00641026 
+  155          175.38383    111.07006   0.00645161 
+  122          167.85085    111.0846    0.00819672 
+  155          159.87019    111.0991    0.00645161 
+  139          151.0567     111.11359   0.00719424 
+  130          145.74723    111.12805   0.00769231 
+  134          142.3824     111.14248   0.00746269 
+  154          140.53411    111.15689   0.00649351 
+  163          140.7155     111.17128   0.00613497 
+  157          141.90781    111.18563   0.00636943 
+  159          144.64513    111.19997   0.00628931 
+  167          148.3925     111.21428   0.00598802 
+  181          149.04885    111.22856   0.00552486 
+  227          148.097      111.24282   0.00440529 
+  252          150.21299    111.25705   0.00396825 
+  275          155.46017    111.27125   0.00363636 
+  292          161.81357    111.28543   0.00342466 
+  292          165.34894    111.29958   0.00342466 
+  205          166.43683    111.3137    0.00487805 
+  215          170.39792    111.3278    0.00465116 
+  209          179.43401    111.34187   0.00478469 
+  269          199.49187    111.35592   0.00371747 
+  363          244.7973     111.36994   0.00275482 
+  484          337.56124    111.38393   0.00206612 
+  544          481.91157    111.39789   0.00183824 
+  482          577.6782     111.41182   0.00207469 
+  388          485.52748    111.42573   0.00257732 
+  397          343.18861    111.43961   0.00251889 
+  307          265.1659     111.45346   0.00325733 
+  369          245.93245    111.46728   0.00271003 
+  474          265.45873    111.48107   0.0021097 
+  485          303.73806    111.49484   0.00206186 
+  465          330.21164    111.50858   0.00215054 
+  462          360.18345    111.52228   0.0021645 
+  419          390.57263    111.53596   0.00238663 
+  333          345.95999    111.54961   0.003003  
+  296          260.28688    111.56323   0.00337838 
+  239          205.58323    111.57683   0.0041841 
+  249          184.32757    111.59039   0.00401606 
+  259          184.28664    111.60392   0.003861  
+  243          193.47752    111.61742   0.00411523 
+  252          191.86558    111.6309    0.00396825 
+  218          174.41445    111.64434   0.00458716 
+  222          157.8217     111.65775   0.0045045 
+  177          147.22327    111.67113   0.00564972 
+  153          142.12329    111.68449   0.00653595 
+  169          141.07656    111.69781   0.00591716 
+  174          142.80712    111.7111    0.00574713 
+  139          145.76251    111.72436   0.00719424 
+  169          147.63235    111.73759   0.00591716 
+  152          149.87057    111.75078   0.00657895 
+  142          157.09414    111.76395   0.00704225 
+  131          174.40448    111.77709   0.00763359 
+  168          208.06582    111.79019   0.00595238 
+  156          259.42946    111.80326   0.00641026 
+  169          302.14309    111.8163    0.00591716 
+  168          304.16406    111.82931   0.00595238 
+  182          270.75728    111.84229   0.00549451 
+  164          222.51701    111.85524   0.00609756 
+  173          186.24727    111.86815   0.00578035 
+  139          167.32559    111.88103   0.00719424 
+  155          162.353      111.89388   0.00645161 
+  141          169.47133    111.90669   0.0070922 
+  165          188.57659    111.91947   0.00606061 
+  137          211.8634     111.93222   0.00729927 
+  145          218.98341    111.94494   0.00689655 
+  145          206.64146    111.95763   0.00689655 
+  139          181.55894    111.97028   0.00719424 
+  139          158.41323    111.9829    0.00719424 
+  145          143.56929    111.99548   0.00689655 
+  137          135.26469    112.00803   0.00729927 
+  129          130.74578    112.02055   0.00775194 
+  143          128.21572    112.03303   0.00699301 
+  127          126.80425    112.04548   0.00787402 
+  146          126.0813     112.0579    0.00684932 
+  134          125.60675    112.07028   0.00746269 
+  146          125.0469     112.08263   0.00684932 
+  150          124.38411    112.09494   0.00666667 
+  135          123.8301     112.10722   0.00740741 
+  156          123.68751    112.11947   0.00641026 
+  159          124.14441    112.13168   0.00628931 
+  208          125.42784    112.14385   0.00480769 
+  221          127.93325    112.15599   0.00452489 
+  229          132.03354    112.1681    0.00436681 
+  221          136.80843    112.18017   0.00452489 
+  246          138.8032     112.1922    0.00406504 
+  246          137.33537    112.20421   0.00406504 
+  258          136.18984    112.21617   0.00387597 
+  260          136.22589    112.2281    0.00384615 
+  255          136.17694    112.24      0.00392157 
+  317          137.27396    112.25185   0.00315457 
+  324          140.63643    112.26368   0.00308642 
+  317          147.23952    112.27547   0.00315457 
+  347          159.88793    112.28722   0.00288184 
+  350          186.09044    112.29893   0.00285714 
+  308          241.0487     112.31061   0.00324675 
+  312          333.68338    112.32226   0.00320513 
+  324          390.86161    112.33386   0.00308642 
+  349          323.70637    112.34544   0.00286533 
+  363          247.95231    112.35697   0.00275482 
+  294          207.59412    112.36847   0.00340136 
+  254          183.30446    112.37993   0.00393701 
+  252          168.05329    112.39135   0.00396825 
+  227          164.02483    112.40274   0.00440529 
+  233          175.32566    112.41409   0.00429185 
+  219          207.99098    112.42541   0.00456621 
+  216          252.59469    112.43669   0.00462963 
+  210          249.58337    112.44793   0.0047619 
+  218          205.37859    112.45913   0.00458716 
+  179          174.98727    112.4703    0.00558659 
+  191          158.24458    112.48142   0.0052356 
+  130          146.25888    112.49252   0.00769231 
+  142          138.03835    112.50357   0.00704225 
+  122          133.2065     112.51459   0.00819672 
+  130          130.50421    112.52556   0.00769231 
+  141          128.81677    112.5365    0.0070922 
+  136          127.76009    112.54741   0.00735294 
+  125          127.34216    112.55827   0.008     
+  121          127.54104    112.5691    0.00826446 
+  119          128.16234    112.57989   0.00840336 
+  134          128.74521    112.59064   0.00746269 
+  144          128.75204    112.60135   0.00694444 
+  155          128.4464     112.61203   0.00645161 
+  137          128.45702    112.62266   0.00729927 
+  129          129.04987    112.63326   0.00775194 
+  133          130.35055    112.64382   0.0075188 
+  131          132.55752    112.65434   0.00763359 
+  142          135.87901    112.66482   0.00704225 
+  130          140.02448    112.67527   0.00769231 
+  132          143.24811    112.68567   0.00757576 
+  128          144.05215    112.69604   0.0078125 
+  136          144.44069    112.70637   0.00735294 
+  141          146.22813    112.71666   0.0070922 
+  137          149.52418    112.72691   0.00729927 
+  125          154.27243    112.73712   0.008     
+  141          161.25721    112.74729   0.0070922 
+  165          171.3178     112.75742   0.00606061 
+  176          185.7795     112.76752   0.00568182 
+  198          206.99206    112.77757   0.00505051 
+  229          239.37845    112.78759   0.00436681 
+  260          297.40145    112.79756   0.00384615 
+  412          425.83068    112.8075    0.00242718 
+  697          718.80594    112.8174    0.00143472 
+  1130         1250.06478   112.82725   0.00088496 
+  1421         1684.49301   112.83707   0.00070373 
+  1240         1335.86623   112.84685   0.00080645 
+  831          788.14577    112.85659   0.00120337 
+  527          473.64138    112.86629   0.00189753 
+  379          341.56102    112.87595   0.00263852 
+  364          296.39953    112.88557   0.00274725 
+  332          298.21049    112.89515   0.00301205 
+  403          357.6995     112.90469   0.00248139 
+  507          520.36342    112.91419   0.00197239 
+  728          798.37248    112.92365   0.00137363 
+  803          934.65659    112.93307   0.00124533 
+  640          693.27346    112.94245   0.0015625 
+  433          445.03458    112.95179   0.00230947 
+  310          319.46703    112.96109   0.00322581 
+  249          260.89782    112.97035   0.00401606 
+  220          222.06639    112.97957   0.00454545 
+  180          195.68445    112.98875   0.00555556 
+  170          177.58657    112.9979    0.00588235 
+  166          166.0506     113.007     0.0060241 
+  140          159.79064    113.01606   0.00714286 
+  148          156.3257     113.02507   0.00675676 
+  158          155.06021    113.03405   0.00632911 
+  152          156.85749    113.04299   0.00657895 
+  145          160.04068    113.05189   0.00689655 
+  163          157.3545     113.06075   0.00613497 
+  137          149.65529    113.06957   0.00729927 
+  145          142.99336    113.07835   0.00689655 
+  141          137.81106    113.08708   0.0070922 
+  142          134.40113    113.09578   0.00704225 
+  122          132.77412    113.10444   0.00819672 
+  139          132.20376    113.11305   0.00719424 
+  132          131.66697    113.12163   0.00757576 
+  99           130.78418    113.13016   0.01010101 
+  118          129.8238     113.13866   0.00847458 
+  106          128.93461    113.14711   0.00943396 
+  149          128.63199    113.15553   0.00671141 
+  137          129.32775    113.1639    0.00729927 
+  128          130.95968    113.17223   0.0078125 
+  121          132.22404    113.18052   0.00826446 
+  119          132.24927    113.18878   0.00840336 
+  132          132.59502    113.19699   0.00757576 
+  132          133.9236     113.20516   0.00757576 
+  122          134.8345     113.21329   0.00819672 
+  126          133.95581    113.22138   0.00793651 
+  128          132.43589    113.22943   0.0078125 
+  147          131.83449    113.23743   0.00680272 
+  149          132.81677    113.2454    0.00671141 
+  141          135.54652    113.25333   0.0070922 
+  149          139.85196    113.26121   0.00671141 
+  139          147.04887    113.26906   0.00719424 
+  146          162.51044    113.27687   0.00684932 
+  164          195.45827    113.28463   0.00609756 
+  170          251.18487    113.29236   0.00588235 
+  146          292.95335    113.30004   0.00684932 
+  177          262.78062    113.30768   0.00564972 
+  165          214.06019    113.31529   0.00606061 
+  147          180.53224    113.32285   0.00680272 
+  150          159.87424    113.33037   0.00666667 
+  165          149.24265    113.33785   0.00606061 
+  172          146.00917    113.34529   0.00581395 
+  148          149.88439    113.3527    0.00675676 
+  144          163.89948    113.36006   0.00694444 
+  150          190.5328     113.36738   0.00666667 
+  165          211.84648    113.37466   0.00606061 
+  157          198.74163    113.3819    0.00636943 
+  176          178.31074    113.38909   0.00568182 
+  162          168.85694    113.39625   0.00617284 
+  150          169.38499    113.40337   0.00666667 
+  160          171.40205    113.41045   0.00625   
+  180          162.04298    113.41749   0.00555556 
+  169          148.20448    113.42449   0.00591716 
+  153          138.49487    113.43145   0.00653595 
+  171          133.28252    113.43836   0.00584795 
+  173          131.06588    113.44524   0.00578035 
+  161          130.68971    113.45208   0.00621118 
+  182          132.01243    113.45888   0.00549451 
+  189          135.77973    113.46564   0.00529101 
+  182          142.32444    113.47236   0.00549451 
+  178          148.61822    113.47903   0.00561798 
+  153          149.16075    113.48567   0.00653595 
+  149          147.56119    113.49227   0.00671141 
+  159          147.91014    113.49883   0.00628931 
+  147          148.42467    113.50535   0.00680272 
+  172          146.15756    113.51183   0.00581395 
+  185          145.73852    113.51827   0.00540541 
+  163          151.57012    113.52467   0.00613497 
+  152          164.23206    113.53103   0.00657895 
+  167          175.59296    113.53736   0.00598802 
+  137          170.22004    113.54364   0.00729927 
+  148          156.23759    113.54988   0.00675676 
+  150          146.61949    113.55609   0.00666667 
+  148          142.30942    113.56225   0.00675676 
+  163          140.55822    113.56838   0.00613497 
+  142          138.40536    113.57447   0.00704225 
+  153          137.22247    113.58051   0.00653595 
+  146          139.25916    113.58652   0.00684932 
+  145          144.98198    113.59249   0.00689655 
+  140          151.25313    113.59842   0.00714286 
+  153          149.94764    113.60432   0.00653595 
+  161          142.82813    113.61017   0.00621118 
+  165          137.13024    113.61599   0.00606061 
+  150          134.20247    113.62176   0.00666667 
+  138          133.26256    113.6275    0.00724638 
+  170          133.54991    113.6332    0.00588235 
+  150          134.68546    113.63887   0.00666667 
+  180          136.60796    113.64449   0.00555556 
+  232          139.42621    113.65007   0.00431034 
+  223          143.18278    113.65562   0.0044843 
+  242          147.37765    113.66113   0.00413223 
+  212          151.79185    113.6666    0.00471698 
+  209          157.75682    113.67204   0.00478469 
+  205          166.61569    113.67743   0.00487805 
+  218          179.88054    113.68279   0.00458716 
+  277          200.26119    113.68811   0.00361011 
+  304          233.12634    113.6934    0.00328947 
+  413          290.97464    113.69864   0.00242131 
+  619          406.16901    113.70385   0.00161551 
+  989          649.82238    113.70903   0.00101112 
+  1601         1095.15446   113.71416   0.00062461 
+  2264         1507.31288   113.71926   0.0004417 
+  1963         1258.3705    113.72432   0.00050942 
+  1322         764.5618     113.72934   0.00075643 
+  800          462.80219    113.73433   0.00125   
+  537          330.14829    113.73928   0.0018622 
+  410          280.60805    113.7442    0.00243902 
+  412          270.38389    113.74908   0.00242718 
+  432          294.79484    113.75392   0.00231481 
+  567          376.73304    113.75873   0.00176367 
+  774          557.07947    113.7635    0.00129199 
+  1123         795.02493    113.76823   0.00089047 
+  1200         778.04038    113.77293   0.00083333 
+  851          523.34439    113.77759   0.00117509 
+  569          333.26834    113.78222   0.00175747 
+  359          240.00503    113.78681   0.00278552 
+  275          199.12644    113.79137   0.00363636 
+  235          179.18054    113.79589   0.00425532 
+  207          167.14076    113.80037   0.00483092 
+  182          157.89973    113.80483   0.00549451 
+  161          150.81478    113.80924   0.00621118 
+  157          146.01604    113.81362   0.00636943 
+  173          142.91382    113.81797   0.00578035 
+  164          140.66284    113.82228   0.00609756 
+  145          138.63678    113.82656   0.00689655 
+  153          136.9228     113.83081   0.00653595 
+  150          136.09574    113.83502   0.00666667 
+  165          136.6138     113.83919   0.00606061 
+  150          138.72159    113.84334   0.00666667 
+  144          142.45194    113.84745   0.00694444 
+  143          148.2263     113.85152   0.00699301 
+  150          153.52937    113.85556   0.00666667 
+  128          151.48167    113.85957   0.0078125 
+  135          144.98947    113.86355   0.00740741 
+  145          140.01939    113.86749   0.00689655 
+  152          137.38234    113.8714    0.00657895 
+  149          136.04588    113.87528   0.00671141 
+  155          135.33115    113.87913   0.00645161 
+  135          135.91027    113.88294   0.00740741 
+  139          138.36476    113.88672   0.00719424 
+  128          142.9425     113.89047   0.0078125 
+  137          149.19855    113.89419   0.00729927 
+  122          154.74046    113.89787   0.00819672 
+  144          160.16689    113.90153   0.00694444 
+  172          174.29466    113.90515   0.00581395 
+  228          211.08168    113.90874   0.00438596 
+  261          285.59982    113.91231   0.00383142 
+  324          376.1342     113.91584   0.00308642 
+  356          365.07957    113.91934   0.00280899 
+  331          273.06494    113.92281   0.00302115 
+  287          208.16549    113.92624   0.00348432 
+  225          180.57477    113.92965   0.00444444 
+  196          177.01108    113.93303   0.00510204 
+  170          191.35856    113.93638   0.00588235 
+  204          222.17272    113.9397    0.00490196 
+  187          249.31467    113.94299   0.00534759 
+  212          254.2468     113.94625   0.00471698 
+  232          271.97084    113.94948   0.00431034 
+  253          284.71186    113.95269   0.00395257 
+  233          243.2456     113.95586   0.00429185 
+  219          196.31022    113.95901   0.00456621 
+  200          169.27029    113.96213   0.005     
+  163          157.16075    113.96522   0.00613497 
+  158          155.3541     113.96828   0.00632911 
+  153          162.4577     113.97131   0.00653595 
+  141          174.27435    113.97432   0.0070922 
+  153          172.74265    113.9773    0.00653595 
+  142          158.18803    113.98025   0.00704225 
+  123          146.51651    113.98318   0.00813008 
+  155          140.36504    113.98608   0.00645161 
+  130          137.7551     113.98895   0.00769231 
+  138          136.77699    113.9918    0.00724638 
+  153          136.19132    113.99462   0.00653595 
+  142          136.11979    113.99741   0.00704225 
+  153          136.80952    114.00018   0.00653595 
+  147          136.70356    114.00292   0.00680272 
+  133          136.09935    114.00564   0.0075188 
+  144          136.65949    114.00834   0.00694444 
+  127          136.47312    114.01101   0.00787402 
+  124          133.81914    114.01365   0.00806452 
+  137          130.9066     114.01627   0.00729927 
+  127          129.11736    114.01887   0.00787402 
+  125          128.49434    114.02144   0.008     
+  151          128.70673    114.02399   0.00662252 
+  162          129.46357    114.02651   0.00617284 
+  140          130.34836    114.02902   0.00714286 
+  149          130.57559    114.0315    0.00671141 
+  141          130.90818    114.03395   0.0070922 
+  163          131.80214    114.03639   0.00613497 
+  142          132.02217    114.0388    0.00704225 
+  135          131.522      114.04119   0.00740741 
+  150          131.26373    114.04356   0.00666667 
+  139          131.14073    114.04591   0.00719424 
+  156          130.90465    114.04823   0.00641026 
+  148          130.7754     114.05054   0.00675676 
+  137          130.91038    114.05283   0.00729927 
+  152          131.43206    114.05509   0.00657895 
+  143          132.35494    114.05733   0.00699301 
+  174          133.6718     114.05956   0.00574713 
+  187          135.42948    114.06176   0.00534759 
+  152          137.74429    114.06395   0.00657895 
+  141          140.67463    114.06612   0.0070922 
+  149          144.13588    114.06827   0.00671141 
+  158          147.59682    114.07039   0.00632911 
+  146          150.8552     114.07251   0.00684932 
+  166          154.06529    114.0746    0.0060241 
+  168          157.76494    114.07667   0.00595238 
+  173          162.83398    114.07873   0.00578035 
+  161          170.29803    114.08077   0.00621118 
+  215          181.75205    114.0828    0.00465116 
+  220          201.0843     114.0848    0.00454545 
+  312          237.7555     114.0868    0.00320513 
+  423          306.41429    114.08877   0.00236407 
+  594          405.15624    114.09073   0.0016835 
+  659          451.67238    114.09267   0.00151745 
+  584          411.15366    114.0946    0.00171233 
+  549          397.29851    114.09652   0.00182149 
+  679          465.6206     114.09842   0.00147275 
+  887          679.82972    114.1003    0.0011274 
+  1519         1159.70783   114.10217   0.00065833 
+  2556         1927.95388   114.10403   0.00039124 
+  2839         2312.24114   114.10587   0.00035224 
+  2279         1697.12142   114.1077    0.00043879 
+  1449         1039.91157   114.10952   0.00069013 
+  1025         709.18798    114.11133   0.00097561 
+  793          562.6916     114.11312   0.00126103 
+  692          488.99338    114.1149    0.00144509 
+  581          501.84353    114.11667   0.00172117 
+  612          599.55535    114.11843   0.00163399 
+  750          713.44915    114.12018   0.00133333 
+  1035         871.24803    114.12192   0.00096618 
+  1374         1175.01882   114.12365   0.0007278 
+  1591         1265.76707   114.12536   0.00062854 
+  1087         899.88267    114.12707   0.00091996 
+  759          555.31548    114.12877   0.00131752 
+  497          371.47014    114.13046   0.00201207 
+  399          292.38136    114.13214   0.00250627 
+  271          266.53662    114.13382   0.00369004 
+  265          275.06232    114.13548   0.00377358 
+  250          304.23414    114.13714   0.004     
+  264          300.21021    114.13879   0.00378788 
+  208          252.50131    114.14043   0.00480769 
+  206          214.63923    114.14207   0.00485437 
+  230          197.90384    114.1437    0.00434783 
+  196          198.0243     114.14533   0.00510204 
+  183          211.80658    114.14695   0.00546448 
+  171          235.93087    114.14856   0.00584795 
+  162          252.4497     114.15017   0.00617284 
+  140          236.27397    114.15178   0.00714286 
+  146          207.50802    114.15338   0.00684932 
+  136          187.85918    114.15498   0.00735294 
+  151          176.4767     114.15657   0.00662252 
+  131          168.41831    114.15816   0.00763359 
+  146          163.52017    114.15975   0.00684932 
+  128          162.77523    114.16134   0.0078125 
+  143          167.42304    114.16292   0.00699301 
+  141          178.59254    114.16451   0.0070922 
+  146          195.17249    114.16609   0.00684932 
+  147          207.31649    114.16767   0.00680272 
+  146          202.06767    114.16925   0.00684932 
+  129          189.88607    114.17083   0.00775194 
+  126          184.11936    114.17242   0.00793651 
+  141          188.65658    114.174     0.0070922 
+  137          202.77845    114.17558   0.00729927 
+  121          217.52083    114.17717   0.00826446 
+  130          213.63405    114.17876   0.00769231 
+  118          200.14727    114.18035   0.00847458 
+  138          197.18478    114.18194   0.00724638 
+  133          209.50763    114.18354   0.0075188 
+  153          231.80721    114.18514   0.00653595 
+  148          240.95564    114.18674   0.00675676 
+  129          219.73097    114.18835   0.00775194 
+  129          193.13721    114.18996   0.00775194 
+  143          178.3628     114.19158   0.00699301 
+  123          176.10108    114.19321   0.00813008 
+  140          179.71524    114.19484   0.00714286 
+  115          177.01198    114.19647   0.00869565 
+  118          169.22871    114.19812   0.00847458 
+  132          166.80209    114.19977   0.00757576 
+  148          173.35532    114.20143   0.00675676 
+  145          187.99392    114.2031    0.00689655 
+  139          200.97156    114.20477   0.00719424 
+  142          198.8728     114.20646   0.00704225 
+  146          186.39698    114.20815   0.00684932 
+  127          170.19733    114.20986   0.00787402 
+  147          156.86232    114.21157   0.00680272 
+  134          148.58543    114.2133    0.00746269 
+  143          144.18107    114.21504   0.00699301 
+  113          142.51262    114.21679   0.00884956 
+  145          142.31674    114.21855   0.00689655 
+  114          142.35704    114.22032   0.00877193 
+  164          142.9501     114.22211   0.00609756 
+  174          145.29947    114.22391   0.00574713 
+  145          149.37571    114.22573   0.00689655 
+  174          153.10469    114.22756   0.00574713 
+  161          154.12065    114.2294    0.00621118 
+  166          152.90589    114.23126   0.0060241 
+  134          150.0229     114.23314   0.00746269 
+  186          148.47525    114.23503   0.00537634 
+  182          150.91775    114.23694   0.00549451 
+  196          158.58815    114.23886   0.00510204 
+  211          171.77063    114.24081   0.00473934 
+  227          186.32369    114.24277   0.00440529 
+  227          188.48225    114.24475   0.00440529 
+  205          177.02465    114.24675   0.00487805 
+  188          166.49773    114.24877   0.00531915 
+  184          162.36998    114.25081   0.00543478 
+  167          163.49655    114.25287   0.00598802 
+  186          167.70851    114.25495   0.00537634 
+  165          176.27624    114.25706   0.00606061 
+  154          193.57074    114.25918   0.00649351 
+  201          226.32921    114.26133   0.00497512 
+  186          283.62942    114.26351   0.00537634 
+  246          368.21148    114.2657    0.00406504 
+  238          444.94236    114.26792   0.00420168 
+  240          465.15249    114.27017   0.00416667 
+  222          466.14864    114.27244   0.0045045 
+  199          441.30432    114.27473   0.00502513 
+  179          363.68719    114.27705   0.00558659 
+  172          287.96477    114.2794    0.00581395 
+  179          241.08995    114.28178   0.00558659 
+  161          218.49982    114.28418   0.00621118 
+  187          212.76153    114.28662   0.00534759 
+  167          223.03717    114.28908   0.00598802 
+  205          250.51768    114.29157   0.00487805 
+  186          286.55872    114.29409   0.00537634 
+  189          304.80639    114.29664   0.00529101 
+  162          307.31613    114.29922   0.00617284 
+  201          305.48505    114.30184   0.00497512 
+  190          277.25997    114.30448   0.00526316 
+  188          238.26106    114.30716   0.00531915 
+  183          212.17352    114.30987   0.00546448 
+  198          200.65959    114.31262   0.00505051 
+  199          199.20567    114.3154    0.00502513 
+  188          203.60081    114.31822   0.00531915 
+  204          210.03717    114.32107   0.00490196 
+  210          221.84533    114.32395   0.0047619 
+  252          248.9776     114.32688   0.00396825 
+  329          311.95561    114.32984   0.00303951 
+  507          456.01244    114.33284   0.00197239 
+  750          737.72612    114.33587   0.00133333 
+  814          1090.41514   114.33895   0.0012285 
+  795          1083.6434    114.34206   0.00125786 
+  593          733.24849    114.34522   0.00168634 
+  457          462.60219    114.34842   0.00218818 
+  352          329.69918    114.35165   0.00284091 
+  291          277.89028    114.35493   0.00343643 
+  278          267.97214    114.35826   0.00359712 
+  244          294.2154     114.36162   0.00409836 
+  293          360.29476    114.36503   0.00341297 
+  339          436.06064    114.36848   0.00294985 
+  400          490.84771    114.37198   0.0025    
+  527          602.33516    114.37552   0.00189753 
+  509          688.29229    114.37911   0.00196464 
+  415          553.07273    114.38275   0.00240964 
+  322          372.06143    114.38643   0.00310559 
+  255          263.95763    114.39016   0.00392157 
+  218          213.42411    114.39394   0.00458716 
+  193          192.70334    114.39777   0.00518135 
+  190          189.76978    114.40165   0.00526316 
+  182          203.37246    114.40558   0.00549451 
+  167          226.67382    114.40955   0.00598802 
+  164          224.20226    114.41359   0.00609756 
+  158          192.68566    114.41767   0.00632911 
+  169          166.74591    114.42181   0.00591716 
+  153          151.93351    114.426     0.00653595 
+  151          143.79142    114.43024   0.00662252 
+  156          138.87686    114.43454   0.00641026 
+  168          135.58761    114.4389    0.00595238 
+  153          133.04216    114.44331   0.00653595 
+  133          130.95587    114.44777   0.0075188 
+  136          129.43391    114.4523    0.00735294 
+  133          128.43933    114.45688   0.0075188 
+  128          127.83315    114.46153   0.0078125 
+  120          127.45664    114.46623   0.00833333 
+  124          127.18434    114.47099   0.00806452 
+  135          126.98982    114.47581   0.00740741 
+  121          126.88669    114.4807    0.00826446 
+  123          127.13536    114.48564   0.00813008 
+  128          127.97365    114.49065   0.0078125 
+  125          129.00552    114.49572   0.008     
+  101          128.97743    114.50086   0.00990099 
+  138          127.82776    114.50606   0.00724638 
+  136          126.69822    114.51133   0.00735294 
+  140          126.00819    114.51666   0.00714286 
+  136          126.05437    114.52206   0.00735294 
+  125          127.08209    114.52753   0.008     
+  118          129.10239    114.53307   0.00847458 
+  135          131.60608    114.53868   0.00740741 
+  130          132.39302    114.54435   0.00769231 
+  144          131.09456    114.5501    0.00694444 
+  145          129.82382    114.55591   0.00689655 
+  133          128.94281    114.5618    0.0075188 
+  114          127.98401    114.56777   0.00877193 
+  143          127.19621    114.5738    0.00699301 
+  137          127.05097    114.57991   0.00729927 
+  113          127.73907    114.58609   0.00884956 
+  124          129.68309    114.59235   0.00806452 
+  115          133.60791    114.59869   0.00869565 
+  147          140.67938    114.6051    0.00680272 
+  128          152.066      114.61159   0.0078125 
+  127          166.97465    114.61816   0.00787402 
+  132          178.1224     114.62481   0.00757576 
+  133          172.42517    114.63154   0.0075188 
+  128          156.95209    114.63835   0.0078125 
+  123          144.86129    114.64524   0.00813008 
+  113          138.80438    114.65221   0.00884956 
+  159          138.31304    114.65927   0.00628931 
+  151          143.31596    114.66641   0.00662252 
+  171          152.4684     114.67363   0.00584795 
+  164          156.87505    114.68094   0.00609756 
+  160          152.67133    114.68834   0.00625   
+  152          150.83617    114.69582   0.00657895 
+  161          154.38201    114.70339   0.00621118 
+  122          158.16273    114.71105   0.00819672 
+  148          154.90199    114.7188    0.00675676 
+  141          148.00758    114.72664   0.0070922 
+  140          142.70207    114.73457   0.00714286 
+  136          140.84529    114.74259   0.00735294 
+  148          142.52148    114.7507    0.00675676 
+  153          146.85155    114.75891   0.00653595 
+  150          149.73039    114.76721   0.00666667 
+  132          146.15877    114.7756    0.00757576 
+  148          138.32169    114.78409   0.00675676 
+  173          132.346      114.79268   0.00578035 
+  125          129.12238    114.80136   0.008     
+  150          127.93439    114.81015   0.00666667 
+  167          128.09532    114.81903   0.00598802 
+  152          128.82215    114.82801   0.00657895 
+  162          129.96902    114.83709   0.00617284 
+  145          132.21585    114.84627   0.00689655 
+  170          135.91861    114.85555   0.00588235 
+  165          140.67719    114.86494   0.00606061 
+  161          143.15903    114.87443   0.00621118 
+  170          140.90725    114.88403   0.00588235 
+  171          136.8379     114.89373   0.00584795 
+  160          132.06438    114.90354   0.00625   
+  130          127.76991    114.91346   0.00769231 
+  165          124.97259    114.92348   0.00606061 
+  149          123.39836    114.93361   0.00671141 
+  155          122.68074    114.94385   0.00645161 
+  141          122.63969    114.95421   0.0070922 
+  156          123.19574    114.96467   0.00641026 
+  169          124.24791    114.97525   0.00591716 
+  190          126.00319    114.98594   0.00526316 
+  159          127.56113    114.99674   0.00628931 
+  158          127.63058    115.00766   0.00632911 
+  150          126.79591    115.0187    0.00666667 
+  139          125.4197     115.02985   0.00719424 
+  151          124.22109    115.04112   0.00662252 
+  168          123.91158    115.05251   0.00595238 
+  181          124.39545    115.06401   0.00552486 
+  160          125.19474    115.07564   0.00625   
+  206          125.31518    115.08739   0.00485437 
+  201          124.81222    115.09926   0.00497512 
+  221          124.60759    115.11126   0.00452489 
+  221          124.74483    115.12338   0.00452489 
+  216          125.38965    115.13562   0.00462963 
+  178          126.43801    115.14799   0.00561798 
+  194          127.40834    115.16048   0.00515464 
+  181          128.82819    115.17311   0.00552486 
+  172          129.76593    115.18586   0.00581395 
+  161          128.34577    115.19874   0.00621118 
+  152          126.1011     115.21176   0.00657895 
+  181          124.6211     115.2249    0.00552486 
+  192          123.63018    115.23818   0.00520833 
+  186          122.79666    115.25159   0.00537634 
+  208          122.3457     115.26513   0.00480769 
+  201          122.23263    115.27881   0.00497512 
+  173          122.44177    115.29262   0.00578035 
+  178          122.96006    115.30658   0.00561798 
+  189          123.49955    115.32067   0.00529101 
+  171          124.28627    115.3349    0.00584795 
+  188          125.12639    115.34927   0.00531915 
+  189          125.00231    115.36378   0.00529101 
+  196          124.51344    115.37843   0.00510204 
+  176          124.89929    115.39322   0.00568182 
+  205          126.28886    115.40816   0.00487805 
+  172          127.56328    115.42325   0.00581395 
+  166          127.56591    115.43848   0.0060241 
+  191          126.7107     115.45385   0.0052356 
+  167          125.68998    115.46938   0.00598802 
+  155          125.08118    115.48505   0.00645161 
+  177          124.89605    115.50088   0.00564972 
+  160          125.0305     115.51685   0.00625   
+  163          125.59926    115.53298   0.00613497 
+  177          126.57452    115.54925   0.00564972 
+  144          127.88458    115.56569   0.00694444 
+  170          129.765      115.58228   0.00588235 
+  188          132.50163    115.59902   0.00531915 
+  151          136.14284    115.61592   0.00662252 
+  146          141.20444    115.63298   0.00684932 
+  170          147.34154    115.6502    0.00588235 
+  176          149.79597    115.66758   0.00568182 
+  166          144.85733    115.68511   0.0060241 
+  161          137.88294    115.70282   0.00621118 
+  159          132.66474    115.72068   0.00628931 
+  160          129.67137    115.73871   0.00625   
+  164          128.39582    115.7569    0.00609756 
+  141          128.21177    115.77526   0.0070922 
+  152          128.72227    115.79379   0.00657895 
+  171          129.87632    115.81249   0.00584795 
+  154          131.9329     115.83135   0.00649351 
+  172          135.66171    115.85039   0.00581395 
+  181          141.05511    115.8696    0.00552486 
+  149          144.46699    115.88898   0.00671141 
+  168          141.64541    115.90853   0.00595238 
+  166          135.99254    115.92826   0.0060241 
+  119          131.56226    115.94817   0.00840336 
+  145          128.97175    115.96825   0.00689655 
+  138          127.65973    115.98851   0.00724638 
+  151          127.0793     116.00895   0.00662252 
+  135          127.03693    116.02957   0.00740741 
+  133          127.49448    116.05038   0.0075188 
+  158          128.51197    116.07136   0.00632911 
+  124          130.21046    116.09253   0.00806452 
+  151          132.57175    116.11388   0.00662252 
+  155          135.06212    116.13542   0.00645161 
+  155          136.68358    116.15715   0.00645161 
+  136          137.88346    116.17906   0.00735294 
+  150          139.58974    116.20117   0.00666667 
+  131          141.27905    116.22346   0.00763359 
+  137          142.32051    116.24595   0.00729927 
+  132          143.69287    116.26863   0.00757576 
+  161          146.57005    116.2915    0.00621118 
+  143          152.46644    116.31457   0.00699301 
+  126          163.89869    116.33783   0.00793651 
+  127          184.99178    116.36129   0.00787402 
+  114          220.64366    116.38495   0.00877193 
+  148          269.79116    116.40881   0.00675676 
+  189          304.4351     116.43288   0.00529101 
+  147          284.55128    116.45714   0.00680272 
+  112          237.33989    116.4816    0.00892857 
+  148          200.10011    116.50628   0.00675676 
+  147          177.91353    116.53115   0.00680272 
+  133          166.61278    116.55623   0.0075188 
+  150          162.23919    116.58152   0.00666667 
+  149          161.57562    116.60702   0.00671141 
+  152          164.39274    116.63274   0.00657895 
+  145          174.59565    116.65866   0.00689655 
+  162          195.52096    116.68479   0.00617284 
+  132          222.75646    116.71114   0.00757576 
+  153          241.9709     116.7377    0.00653595 
+  132          241.43388    116.76448   0.00757576 
+  148          219.74263    116.79148   0.00675676 
+  138          197.47668    116.8187    0.00724638 
+  121          180.20689    116.84614   0.00826446 
+  149          165.75956    116.87379   0.00671141 
+  154          156.18923    116.90167   0.00649351 
+  157          150.98815    116.92978   0.00636943 
+  153          148.01871    116.95811   0.00653595 
+  150          147.10808    116.98666   0.00666667 
+  135          148.97678    117.01545   0.00740741 
+  175          152.34623    117.04446   0.00571429 
+  141          152.5442     117.0737    0.0070922 
+  189          147.92325    117.10317   0.00529101 
+  181          144.42409    117.13288   0.00552486 
+  193          144.1602     117.16282   0.00518135 
+  152          145.5534     117.19299   0.00657895 
+  174          145.70738    117.22341   0.00574713 
+  159          145.18181    117.25405   0.00628931 
+  143          145.42132    117.28494   0.00699301 
+  156          144.75164    117.31607   0.00641026 
+  168          142.84783    117.34744   0.00595238 
+  160          141.61358    117.37905   0.00625   
+  149          141.4936     117.41091   0.00671141 
+  166          142.11681    117.44301   0.0060241 
+  170          143.85636    117.47536   0.00588235 
+  183          147.48682    117.50796   0.00546448 
+  172          153.88331    117.5408    0.00581395 
+  191          163.75076    117.5739    0.0052356 
+  153          175.04361    117.60725   0.00653595 
+  190          179.74132    117.64085   0.00526316 
+  180          175.77175    117.67471   0.00555556 
+  177          171.22985    117.70882   0.00564972 
+  188          169.18609    117.74319   0.00531915 
+  183          170.12488    117.77782   0.00546448 
+  173          174.53975    117.81271   0.00578035 
+  161          182.66665    117.84786   0.00621118 
+  208          195.19782    117.88327   0.00480769 
+  219          213.79147    117.91895   0.00456621 
+  263          241.70227    117.95489   0.00380228 
+  336          285.33207    117.9911    0.00297619 
+  407          359.61074    118.02758   0.002457  
+  586          501.24386    118.06433   0.00170648 
+  838          781.35839    118.10135   0.00119332 
+  1434         1270.6307    118.13864   0.00069735 
+  1980         1779.19249   118.1762    0.00050505 
+  1954         1634.55235   118.21404   0.00051177 
+  1549         1068.00838   118.25216   0.00064558 
+  1160         654.34902    118.29055   0.00086207 
+  860          439.69815    118.32923   0.00116279 
+  623          340.29519    118.36818   0.00160514 
+  516          294.3924     118.40742   0.00193798 
+  452          275.33808    118.44694   0.00221239 
+  368          275.4642     118.48674   0.00271739 
+  399          297.72764    118.52683   0.00250627 
+  489          359.17091    118.56721   0.00204499 
+  603          496.07009    118.60788   0.00165837 
+  900          741.6589     118.64884   0.00111111 
+  1047         987.58816    118.69009   0.00095511 
+  1092         898.00299    118.73164   0.00091575 
+  867          614.84319    118.77348   0.0011534 
+  673          413.05388    118.81562   0.00148588 
+  482          309.52514    118.85805   0.00207469 
+  393          261.47232    118.90079   0.00254453 
+  282          236.10563    118.94382   0.0035461 
+  283          218.28496    118.98716   0.00353357 
+  253          204.25783    119.0308    0.00395257 
+  237          195.38961    119.07475   0.00421941 
+  218          192.2622     119.119     0.00458716 
+  193          193.69292    119.16357   0.00518135 
+  219          196.64255    119.20844   0.00456621 
+  177          195.73031    119.25362   0.00564972 
+  196          189.12865    119.29912   0.00510204 
+  197          181.07422    119.34493   0.00507614 
+  177          174.88551    119.39106   0.00564972 
+  184          171.00707    119.4375    0.00543478 
+  193          167.89568    119.48426   0.00518135 
+  203          164.43959    119.53135   0.00492611 
+  171          160.3263     119.57875   0.00584795 
+  144          156.13511    119.62648   0.00694444 
+  160          153.27056    119.67453   0.00625   
+  167          152.68786    119.72291   0.00598802 
+  157          154.18078    119.77162   0.00636943 
+  161          156.51841    119.82066   0.00621118 
+  180          156.87744    119.87003   0.00555556 
+  154          153.91497    119.91973   0.00649351 
+  160          149.7031     119.96976   0.00625   
+  150          146.17005    120.02014   0.00666667 
+  136          143.61511    120.07085   0.00735294 
+  148          141.44481    120.12189   0.00675676 
+  156          139.64316    120.17328   0.00641026 
+  142          138.66578    120.22501   0.00704225 
+  139          138.58501    120.27709   0.00719424 
+  162          139.40729    120.32951   0.00617284 
+  145          141.32408    120.38228   0.00689655 
+  130          144.66847    120.43539   0.00769231 
+  142          149.79855    120.48886   0.00704225 
+  134          157.08508    120.54267   0.00746269 
+  133          166.17348    120.59684   0.0075188 
+  147          173.7639     120.65137   0.00680272 
+  142          174.52227    120.70625   0.00704225 
+  148          168.59825    120.76149   0.00675676 
+  157          161.44386    120.81709   0.00636943 
+  149          156.36097    120.87306   0.00671141 
+  139          153.60811    120.92938   0.00719424 
+  147          152.2268     120.98607   0.00680272 
+  144          151.25315    121.04313   0.00694444 
+  161          150.52959    121.10055   0.00621118 
+  150          150.74084    121.15835   0.00666667 
+  180          152.82838    121.21651   0.00555556 
+  177          157.71697    121.27505   0.00564972 
+  172          166.04201    121.33396   0.00581395 
+  160          176.29073    121.39325   0.00625   
+  167          182.15565    121.45292   0.00598802 
+  163          178.59419    121.51297   0.00613497 
+  153          170.23347    121.5734    0.00653595 
+  154          163.77402    121.63421   0.00649351 
+  179          161.75369    121.69541   0.00558659 
+  148          164.05099    121.75699   0.00675676 
+  159          169.87711    121.81896   0.00628931 
+  196          177.53218    121.88133   0.00510204 
+  162          182.56429    121.94408   0.00617284 
+  170          179.87495    122.00723   0.00588235 
+  201          171.48088    122.07077   0.00497512 
+  179          163.53303    122.13471   0.00558659 
+  169          158.9373     122.19905   0.00591716 
+  169          156.78339    122.26379   0.00591716 
+  160          154.12117    122.32893   0.00625   
+  168          150.20611    122.39447   0.00595238 
+  182          146.5986     122.46042   0.00549451 
+  156          144.53899    122.52678   0.00641026 
+  152          144.55471    122.59354   0.00657895 
+  187          146.68937    122.66072   0.00534759 
+  148          150.60032    122.72831   0.00675676 
+  163          154.67566    122.79632   0.00613497 
+  171          155.62404    122.86474   0.00584795 
+  169          152.28585    122.93358   0.00591716 
+  154          147.62001    123.00283   0.00649351 
+  156          144.22892    123.07252   0.00641026 
+  148          143.01857    123.14262   0.00675676 
+  137          144.30631    123.21315   0.00729927 
+  153          148.11334    123.2841    0.00653595 
+  136          152.69696    123.35549   0.00735294 
+  142          152.90557    123.4273    0.00704225 
+  151          147.64391    123.49955   0.00662252 
+  152          141.97753    123.57224   0.00657895 
+  163          138.18897    123.64535   0.00613497 
+  163          136.12915    123.71891   0.00613497 
+  130          135.18227    123.79291   0.00769231 
+  144          134.80395    123.86735   0.00694444 
+  146          134.81248    123.94223   0.00684932 
+  147          135.12153    124.01755   0.00680272 
+  140          135.61391    124.09333   0.00714286 
+  151          136.58219    124.16955   0.00662252 
+  129          138.48496    124.24623   0.00775194 
+  172          141.34267    124.32335   0.00581395 
+  144          143.68214    124.40094   0.00694444 
+  153          143.15813    124.47898   0.00653595 
+  122          140.98536    124.55747   0.00819672 
+  130          139.40754    124.63643   0.00769231 
+  125          138.92711    124.71585   0.008     
+  172          139.40514    124.79574   0.00581395 
+  138          140.71008    124.87609   0.00724638 
+  124          142.85931    124.9569    0.00806452 
+  135          146.01615    125.03819   0.00740741 
+  165          150.50304    125.11995   0.00606061 
+  142          157.1275     125.20219   0.00704225 
+  144          168.19311    125.2849    0.00694444 
+  138          189.66026    125.36809   0.00724638 
+  157          233.05192    125.45175   0.00636943 
+  190          310.1978     125.5359    0.00526316 
+  165          399.33283    125.62054   0.00606061 
+  167          396.53866    125.70566   0.00598802 
+  166          308.85785    125.79126   0.0060241 
+  178          237.68112    125.87736   0.00561798 
+  177          200.76092    125.96394   0.00564972 
+  145          186.4836     126.05102   0.00689655 
+  182          185.17607    126.1386    0.00549451 
+  172          194.45857    126.22667   0.00581395 
+  207          219.19204    126.31525   0.00483092 
+  177          270.20652    126.40432   0.00564972 
+  198          355.30782    126.4939    0.00505051 
+  258          441.67352    126.58398   0.00387597 
+  278          436.67283    126.67457   0.00359712 
+  275          387.64214    126.76567   0.00363636 
+  280          359.55555    126.85728   0.00357143 
+  234          307.19779    126.94941   0.0042735 
+  232          243.68938    127.04205   0.00431034 
+  230          202.0704     127.13521   0.00434783 
+  205          180.43935    127.22888   0.00487805 
+  195          170.68324    127.32308   0.00512821 
+  187          167.83925    127.41781   0.00534759 
+  182          170.96954    127.51305   0.00549451 
+  194          182.75947    127.60883   0.00515464 
+  188          208.38186    127.70514   0.00531915 
+  179          249.44281    127.80198   0.00558659 
+  176          281.44367    127.89935   0.00568182 
+  195          258.08354    127.99726   0.00512821 
+  203          212.738      128.09571   0.00492611 
+  194          181.39083    128.19469   0.00515464 
+  208          164.49778    128.29422   0.00480769 
+  213          155.37405    128.3943    0.00469484 
+  185          149.74788    128.49492   0.00540541 
+  183          146.12337    128.59609   0.00546448 
+  198          143.85648    128.69781   0.00505051 
+  178          142.57676    128.80009   0.00561798 
+  177          142.07713    128.90292   0.00564972 
+  161          142.21386    129.0063    0.00621118 
+  172          142.72322    129.11025   0.00581395 
+  158          143.12129    129.21476   0.00632911 
+  144          143.17163    129.31983   0.00694444 
+  139          143.07567    129.42547   0.00719424 
+  153          143.03822    129.53167   0.00653595 
+  144          143.2281     129.63845   0.00694444 
+  128          143.71522    129.7458    0.0078125 
+  148          144.28406    129.85372   0.00675676 
+  134          144.75492    129.96222   0.00746269 
+  157          145.28436    130.0713    0.00636943 
+  141          146.45989    130.18096   0.0070922 
+  166          148.26004    130.29121   0.0060241 
+  150          149.21245    130.40203   0.00666667 
+  151          148.5952     130.51345   0.00662252 
+  136          147.70967    130.62546   0.00735294 
+  139          147.51069    130.73806   0.00719424 
+  149          147.16435    130.85125   0.00671141 
+  152          145.64254    130.96504   0.00657895 
+  142          143.89168    131.07943   0.00704225 
+  158          142.89956    131.19442   0.00632911 
+  168          142.82314    131.31002   0.00595238 
+  148          143.57121    131.42622   0.00675676 
+  129          144.95164    131.54303   0.00775194 
+  154          146.77708    131.66044   0.00649351 
+  146          148.92333    131.77848   0.00684932 
+  164          150.85596    131.89712   0.00609756 
+  129          151.3296     132.01638   0.00775194 
+  152          149.84794    132.13627   0.00657895 
+  130          148.1434     132.25677   0.00769231 
+  103          147.7123     132.3779    0.00970874 
+  130          148.59315    132.49965   0.00769231 
+  134          150.24804    132.62203   0.00746269 
+  145          152.48539    132.74505   0.00689655 
+  142          153.49135    132.86869   0.00704225 
+  142          151.31463    132.99298   0.00704225 
+  146          148.13381    133.1179    0.00684932 
+  155          146.01136    133.24346   0.00645161 
+  143          145.15569    133.36966   0.00699301 
+  154          145.13511    133.49651   0.00649351 
+  132          145.39256    133.624     0.00757576 
+  142          145.46932    133.75215   0.00704225 
+  130          145.16131    133.88094   0.00769231 
+  143          144.91618    134.01039   0.00699301 
+  171          145.23907    134.1405    0.00584795 
+  168          146.34468    134.27127   0.00595238 
+  157          148.36132    134.40269   0.00636943 
+  155          151.2171     134.53479   0.00645161 
+  152          153.97743    134.66754   0.00657895 
+  162          155.22143    134.80097   0.00617284 
+  173          155.49961    134.93507   0.00578035 
+  143          155.75105    135.06984   0.00699301 
+  146          155.75819    135.20529   0.00684932 
+  160          155.21847    135.34141   0.00625   
+  160          154.34387    135.47822   0.00625   
+  153          153.57672    135.61571   0.00653595 
+  148          153.17031    135.75388   0.00675676 
+  164          153.07998    135.89275   0.00609756 
+  165          153.26151    136.0323    0.00606061 
+  156          153.98132    136.17255   0.00641026 
+  147          155.55903    136.31349   0.00680272 
+  180          158.11742    136.45513   0.00555556 
+  195          161.7093     136.59747   0.00512821 
+  157          166.90149    136.74051   0.00636943 
+  192          174.78719    136.88426   0.00520833 
+  183          184.93616    137.02872   0.00546448 
+  159          191.70998    137.17388   0.00628931 
+  175          188.49042    137.31976   0.00571429 
+  176          180.38473    137.46636   0.00568182 
+  177          174.50458    137.61367   0.00564972 
+  176          172.7565     137.76171   0.00568182 
+  205          175.26954    137.91046   0.00487805 
+  179          182.23852    138.05994   0.00558659 
+  168          193.60824    138.21015   0.00595238 
+  198          206.21967    138.3611    0.00505051 
+  185          211.03282    138.51277   0.00540541 
+  222          204.81924    138.66518   0.0045045 
+  209          196.27853    138.81833   0.00478469 
+  222          191.57197    138.97221   0.0045045 
+  223          192.4276     139.12685   0.0044843 
+  212          198.3093     139.28222   0.00471698 
+  241          206.30937    139.43835   0.00414938 
+  239          215.92469    139.59523   0.0041841 
+  239          228.25691    139.75286   0.0041841 
+  227          232.8771     139.91125   0.00440529 
+  249          220.32273    140.07039   0.00401606 
+  232          208.99622    140.2303    0.00431034 
+  280          208.32273    140.39097   0.00357143 
+  262          217.74321    140.55241   0.00381679 
+  235          235.05695    140.71462   0.00425532 
+  273          262.27858    140.8776    0.003663  
+  304          315.13966    141.04135   0.00328947 
+  286          412.56045    141.20589   0.0034965 
+  358          529.20592    141.3712    0.0027933 
+  331          532.41801    141.53729   0.00302115 
+  302          418.14816    141.70417   0.00331126 
+  289          320.45722    141.87184   0.00346021 
+  260          268.31408    142.0403    0.00384615 
+  237          245.42163    142.20955   0.00421941 
+  241          229.81936    142.3796    0.00414938 
+  208          215.08132    142.55045   0.00480769 
+  236          206.94888    142.7221    0.00423729 
+  191          205.35914    142.89455   0.0052356 
+  242          208.98772    143.06781   0.00413223 
+  202          218.83422    143.24188   0.0049505 
+  205          237.26998    143.41677   0.00487805 
+  244          269.49065    143.59246   0.00409836 
+  248          322.48647    143.76898   0.00403226 
+  225          370.35252    143.94631   0.00444444 
+  252          347.6782     144.12447   0.00396825 
+  229          291.23535    144.30346   0.00436681 
+  225          253.34283    144.48327   0.00444444 
+  210          232.31457    144.66392   0.0047619 
+  219          215.08999    144.8454    0.00456621 
+  198          199.85332    145.02771   0.00505051 
+  205          189.48261    145.21087   0.00487805 
+  189          183.5792     145.39487   0.00529101 
+  193          180.46559    145.57972   0.00518135 
+  160          179.10882    145.76541   0.00625   
+  195          178.79307    145.95195   0.00512821 
+  174          177.85895    146.13935   0.00574713 
+  162          175.40707    146.32761   0.00617284 
+  190          173.1016     146.51672   0.00526316 
+  180          172.44515    146.7067    0.00555556 
+  167          173.74469    146.89755   0.00598802 
+  167          176.52434    147.08926   0.00598802 
+  197          179.43611    147.28184   0.00507614 
+  195          180.01061    147.4753    0.00512821 
+  187          176.59388    147.66963   0.00534759 
+  176          171.97346    147.86484   0.00568182 
+  197          168.43462    148.06094   0.00507614 
+  165          165.83169    148.25792   0.00606061 
+  164          163.9592     148.45579   0.00609756 
+  177          162.82568    148.65455   0.00564972 
+  153          162.13805    148.8542    0.00653595 
+  157          161.64771    149.05475   0.00636943 
+  192          161.44963    149.25621   0.00520833 
+  185          161.65956    149.45856   0.00540541 
+  174          162.26175    149.66182   0.00574713 
+  144          162.9273     149.86599   0.00694444 
+  171          163.08368    150.07107   0.00584795 
+  185          162.769      150.27706   0.00540541 
+  176          162.52389    150.48398   0.00568182 
+  168          162.61284    150.69181   0.00595238 
+  166          163.06146    150.90057   0.0060241 
+  180          163.74076    151.11025   0.00555556 
+  171          164.42549    151.32086   0.00584795 
+  173          165.05422    151.53241   0.00578035 
+  157          165.32333    151.74489   0.00636943 
+  197          164.97695    151.95831   0.00507614 
+  165          164.48292    152.17267   0.00606061 
+  176          164.25743    152.38798   0.00568182 
+  153          164.38048    152.60423   0.00653595 
+  182          164.78319    152.82143   0.00549451 
+  186          165.29496    153.03959   0.00537634 
+  169          165.72697    153.2587    0.00591716 
+  178          166.15442    153.47878   0.00561798 
+  165          166.74683    153.69981   0.00606061 
+  185          167.58313    153.92181   0.00540541 
+  187          168.72587    154.14478   0.00534759 
+  187          170.27333    154.36873   0.00534759 
+  214          172.36243    154.59364   0.0046729 
+  184          175.11466    154.81954   0.00543478 
+  164          178.44692    155.04642   0.00609756 
+  179          181.91945    155.27428   0.00558659 
+  212          184.63658    155.50313   0.00471698 
+  204          186.43553    155.73296   0.00490196 
+  181          188.59828    155.9638    0.00552486 
+  191          191.29593    156.19563   0.0052356 
+  206          193.44716    156.42845   0.00485437 
+  189          194.37325    156.66229   0.00529101 
+  192          195.18665    156.89712   0.00520833 
+  192          196.81031    157.13297   0.00520833 
+  191          198.43716    157.36983   0.0052356 
+  204          198.39114    157.60771   0.00490196 
+  237          196.78637    157.8466    0.00421941 
+  238          195.45924    158.08652   0.00420168 
+  264          195.75617    158.32746   0.00378788 
+  225          198.12722    158.56943   0.00444444 
+  228          202.43922    158.81243   0.00438596 
+  226          207.75172    159.05646   0.00442478 
+  217          212.48495    159.30154   0.00460829 
+  224          215.39429    159.54765   0.00446429 
+  222          216.53804    159.79481   0.0045045 
+  228          217.49256    160.04302   0.00438596 
+  230          219.48444    160.29228   0.00434783 
+  239          223.0261     160.54259   0.0041841 
+  257          227.99712    160.79396   0.00389105 
+  254          236.28552    161.04639   0.00393701 
+  231          253.16353    161.29988   0.004329  
+  309          284.92457    161.55444   0.00323625 
+  307          330.4088     161.81007   0.00325733 
+  311          352.89928    162.06677   0.00321543 
+  299          320.28994    162.32456   0.00334448 
+  337          278.73138    162.58342   0.00296736 
+  327          253.97354    162.84336   0.0030581 
+  328          243.44102    163.1044    0.00304878 
+  299          240.14916    163.36652   0.00334448 
+  285          239.84155    163.62973   0.00350877 
+  299          241.81112    163.89405   0.00334448 
+  242          246.11613    164.15946   0.00413223 
+  298          251.47223    164.42598   0.0033557 
+  264          255.83294    164.6936    0.00378788 
+  308          259.69318    164.96233   0.00324675 
+  280          267.16615    165.23218   0.00357143 
+  289          282.8938     165.50314   0.00346021 
+  308          309.3533     165.77523   0.00324675 
+  349          337.66751    166.04844   0.00286533 
+  362          342.93538    166.32277   0.00276243 
+  351          333.62696    166.59824   0.002849  
+  375          331.12749    166.87484   0.00266667 
+  409          337.67038    167.15257   0.00244499 
+  429          351.84108    167.43145   0.002331  
+  432          374.57819    167.71147   0.00231481 
+  489          409.51758    167.99264   0.00204499 
+  558          462.9603     168.27496   0.00179211 
+  632          535.86302    168.55844   0.00158228 
+  736          604.05803    168.84307   0.0013587 
+  854          646.7592     169.12887   0.00117096 
+  1053         702.01928    169.41583   0.00094967 
+  1281         806.74698    169.70395   0.00078064 
+  1693         997.9423     169.99325   0.00059067 
+  2324         1357.70718   170.28373   0.00043029 
+  3402         2065.25908   170.57538   0.00029394 
+  5433         3394.16639   170.86822   0.00018406 
+  8527         5458.76254   171.16224   0.00011727 
+  11779        7125.94593   171.45745   0.0000849 
+  12522        6199.26077   171.75386   0.00007986 
+  10422        4047.03439   172.05146   0.00009595 
+  7934         2473.97119   172.35026   0.00012604 
+  5815         1607.41544   172.65026   0.00017197 
+  4232         1178.63333   172.95148   0.00023629 
+  3089         967.14045    173.2539    0.00032373 
+  2454         845.72147    173.55753   0.0004075 
+  1981         767.6221     173.86239   0.0005048 
+  1745         733.42384    174.16846   0.00057307 
+  1649         747.7046     174.47576   0.00060643 
+  1736         825.79595    174.78429   0.00057604 
+  1962         1015.79636   175.09405   0.00050968 
+  2513         1421.07255   175.40505   0.00039793 
+  3510         2178.02858   175.71729   0.0002849 
+  4910         3249.69732   176.03077   0.00020367 
+  6085         3785.46096   176.34549   0.00016434 
+  6192         3006.29488   176.66147   0.0001615 
+  5056         1969.94128   176.9787    0.00019778 
+  3799         1301.93765   177.29718   0.00026323 
+  2834         967.3465     177.61693   0.00035286 
+  2124         838.78978    177.93795   0.00047081 
+  1548         835.7626     178.26023   0.00064599 
+  1126         918.48759    178.58378   0.0008881 
+  894          1022.52517   178.90861   0.00111857 
+  795          1012.6       179.23472   0.00125786 
+  646          855.95824    179.56212   0.00154799 
+  547          676.46662    179.8908    0.00182815 
+  460          542.32088    180.22077   0.00217391 
+  434          454.88111    180.55204   0.00230415 
+  397          400.58386    180.8846    0.00251889 
+  327          367.63856    181.21846   0.0030581 
+  364          348.39207    181.55364   0.00274725 
+  330          337.94217    181.89012   0.0030303 
+  307          332.87091    182.22791   0.00325733 
+  319          333.64349    182.56702   0.0031348 
+  295          344.48063    182.90746   0.00338983 
+  279          371.23392    183.24921   0.00358423 
+  262          420.44834    183.5923    0.00381679 
+  263          493.19753    183.93671   0.00380228 
+  251          562.78359    184.28247   0.00398406 
+  288          564.19835    184.62956   0.00347222 
+  260          491.03602    184.978     0.00384615 
+  240          408.10832    185.32778   0.00416667 
+  199          347.27969    185.67892   0.00502513 
+  249          308.52947    186.03141   0.00401606 
+  211          284.91863    186.38525   0.00473934 
+  230          270.67394    186.74047   0.00434783 
+  242          262.38911    187.09705   0.00413223 
+  218          257.78745    187.45499   0.00458716 
+  238          254.90256    187.81432   0.00420168 
+  230          253.06365    188.17502   0.00434783 
+  238          253.05869    188.5371    0.00420168 
+  236          257.05879    188.90058   0.00423729 
+  223          268.86573    189.26544   0.0044843 
+  211          293.84812    189.63169   0.00473934 
+  236          336.18777    189.99934   0.00423729 
+  234          380.59579    190.3684    0.0042735 
+  228          374.95499    190.73886   0.00438596 
+  232          326.37557    191.11073   0.00431034 
+  221          284.8121     191.48401   0.00452489 
+  224          260.64602    191.85871   0.00446429 
+  208          248.52629    192.23483   0.00480769 
+  199          242.98835    192.61238   0.00502513 
+  191          241.223      192.99136   0.0052356 
+  213          242.25197    193.37177   0.00469484 
+  215          245.98057    193.75362   0.00465116 
+  200          252.83072    194.13691   0.005     
+  198          264.17231    194.52164   0.00505051 
+  176          283.92261    194.90783   0.00568182 
+  201          320.90533    195.29547   0.00497512 
+#--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--#
+
+
+# start Validation Reply Form
+_vrf_PLAT741_QPABAT1ug3_phase_1 # for all atoms in 1_quartz
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT741_QPABAT1ug3_phase_3 # for all atoms in 3_pyrrhotite
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT741_QPABAT1ug3_phase_4 # for all atoms in 4_rutile
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT741_QPABAT1ug3_phase_2 # for all atoms in 2_albite
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT155_QPABAT1ug3_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT141_QPABAT1ug3_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT142_QPABAT1ug3_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT143_QPABAT1ug3_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT144_QPABAT1ug3_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT145_QPABAT1ug3_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT146_QPABAT1ug3_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT148_QPABAT1ug3_phase_3 # 3_pyrrhotite
+;
+PROBLEM: s.u. on the a-Axis and b-Axis is (Too) Large 
+RESPONSE: untreated sample, s.u. expected to be high
+;
+_vrf_PLAT151_QPABAT1ug3_phase_2
+;
+PROBLEM: No s.u. (esd) Given on Volume ..................     Please Do !  
+RESPONSE: unit cell not refined
+;
+# end Validation Reply Form

--- a/data/hamish/fixed/vb5042sup5.cif
+++ b/data/hamish/fixed/vb5042sup5.cif
@@ -1,0 +1,6675 @@
+
+data_NEW1minmill_publ
+_audit_creation_method  "created in GSAS-II"
+_audit_creation_date  2021-08-04T18:19
+_audit_author_name  "McDougall, Hamish"
+_audit_update_record
+   "2021-08-04T18:19  Initial software-generated CIF"
+_pd_block_id  2021-08-04T18:19|NEW1minmill|McDougallHamish|Overall
+# GSAS-II edited template follows Publication_Template
+#=============================================================================
+# this information describes the project, paper etc. for the CIF             #
+# Acta Cryst. Section C papers and editorial correspondence is generated     #
+# from the information in this section                                       #
+#                                                                            #
+#   (from)   CIF submission form for Rietveld refinements (Acta Cryst. C)    #
+#                                                 Version 14 December 1998   #
+#=============================================================================
+# 1. SUBMISSION DETAILS
+
+_publ_contact_author_name            "Suzanne Neville, Vanessa Peterson, Christophe Didier"   # Name of author for correspondence
+_publ_contact_author_address             # Address of author for correspondence
+; ?
+;
+_publ_contact_author_email           "s.neville@unsw.edu.au; vanessa.peterson@ansto.gov.au; drchristophedidier@gmail.com"
+_publ_contact_author_fax             ?
+_publ_contact_author_phone           ?
+
+_publ_contact_letter
+; ?
+;
+   
+_publ_requested_journal              ?
+_publ_requested_coeditor_name        ?
+_publ_requested_category             ?   # Acta C: one of CI/CM/CO/FI/FM/FO
+
+#==============================================================================
+
+# 2. PROCESSING SUMMARY (IUCr Office Use Only)
+
+_journal_data_validation_number      ?
+
+_journal_date_recd_electronic        ?
+_journal_date_to_coeditor            ?
+_journal_date_from_coeditor          ?
+_journal_date_accepted               ?
+_journal_date_printers_first         ?
+_journal_date_printers_final         ?
+_journal_date_proofs_out             ?
+_journal_date_proofs_in              ?
+_journal_coeditor_name               ?
+_journal_coeditor_code               ?
+_journal_coeditor_notes
+; ?
+;
+_journal_techeditor_code             ?
+_journal_techeditor_notes
+; ?
+;
+_journal_coden_ASTM                  ?
+_journal_name_full                   ?
+_journal_year                        ?
+_journal_volume                      ?
+_journal_issue                       ?
+_journal_page_first                  ?
+_journal_page_last                   ?
+_journal_paper_category              ?
+_journal_suppl_publ_number           ?
+_journal_suppl_publ_pages            ?
+
+#==============================================================================
+
+# 3. TITLE AND AUTHOR LIST
+
+_publ_section_title
+; ?
+;
+_publ_section_title_footnote
+; ?
+;         
+ 
+# The loop structure below should contain the names and addresses of all 
+# authors, in the required order of publication. Repeat as necessary.
+
+loop_
+	_publ_author_name
+        _publ_author_footnote
+	_publ_author_address
+ ?                                   #<--'Last name, first name' 
+; ?
+;
+; ?
+;
+
+#==============================================================================
+
+# 4. TEXT
+
+_publ_section_synopsis
+;  ?
+;
+_publ_section_abstract                         
+; ?
+;          
+_publ_section_comment                          
+; ?
+;
+_publ_section_exptl_prep      # Details of the preparation of the sample(s)
+                              # should be given here. 
+; ?
+;
+_publ_section_exptl_refinement                  
+; ?
+;
+_publ_section_references
+; ?
+;
+_publ_section_figure_captions
+; ?
+;
+_publ_section_acknowledgements
+; ?
+;
+
+#=============================================================================
+# 5. OVERALL REFINEMENT & COMPUTING DETAILS
+
+_refine_special_details
+; ?
+;
+_pd_proc_ls_special_details
+; ?
+;
+
+# The following items are used to identify the programs used.
+_computing_molecular_graphics     ?
+_computing_publication_material   ?
+
+_refine_ls_weighting_scheme       ?        
+_refine_ls_weighting_details      ?
+_refine_ls_hydrogen_treatment     ?        
+_refine_ls_extinction_method      ?        
+_refine_ls_extinction_coef        ?         
+_refine_ls_number_constraints     ?        
+
+_refine_ls_restrained_S_all       ?        
+_refine_ls_restrained_S_obs       ?
+
+#==============================================================================
+# 6. SAMPLE PREPARATION DATA
+
+# (In the unusual case where multiple samples are used in a single
+#  Rietveld study, this information should be moved into the phase
+#  blocks)
+
+# The following three fields describe the preparation of the material.
+# The cooling rate is in K/min.  The pressure at which the sample was  
+# prepared is in kPa.  The temperature of preparation is in K.
+               
+_pd_prep_cool_rate                N/A        
+_pd_prep_pressure                 101.3        
+_pd_prep_temperature              298          
+
+_pd_char_colour                   ?       # use ICDD colour descriptions
+
+data_NEW1minmill_overall
+_pd_proc_info_datetime  2021-08-04T18:19
+_pd_calc_method  "Rietveld Refinement"
+_computing_structure_refinement
+   "GSAS-II (Toby & Von Dreele, J. Appl. Cryst. 46, 544-549, 2013)"
+_refine_ls_number_parameters  27
+_refine_ls_goodness_of_fit_all  3.078
+_refine_ls_shift/su_max  4.0766
+
+# OVERALL WEIGHTED R-FACTOR
+_refine_ls_wR_factor_obs  0.13200
+_refine_ls_matrix_type  full
+# POINTERS TO PHASE AND HISTOGRAM BLOCKS
+loop_   _pd_phase_block_id
+  2021-08-04T18:19|NEW1minmill|phase_0|McDougallHamish
+  2021-08-04T18:19|NEW1minmill|phase_2|McDougallHamish
+  2021-08-04T18:19|NEW1minmill|phase_4|McDougallHamish
+  2021-08-04T18:19|NEW1minmill|phase_1|McDougallHamish
+  2021-08-04T18:19|NEW1minmill|phase_3|McDougallHamish
+_pd_block_diffractogram_id
+;
+2021-08-04T18:19|NEW1minmill|McDougallHamish|PANalytical,Co-EmpyreanII_hist_0
+;
+
+data_NEW1minmill_phase_0
+# Information for phase 0
+_pd_block_id  2021-08-04T18:19|NEW1minmill|phase_0|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for FeS2 follows
+_pd_phase_name  FeS2
+_cell_length_a  5.41977(4)
+_cell_length_b  5.41977(4)
+_cell_length_c  5.41977(4)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  90
+_cell_volume  159.200(4)
+_exptl_crystal_density_diffrn  5.0053
+_symmetry_cell_setting  cubic
+_symmetry_space_group_name_H-M  "P a -3"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  z,x,y
+     3  y,z,x
+     4  1/2+x,y,1/2-z
+     5  1/2-z,1/2+x,y
+     6  y,1/2-z,1/2+x
+     7  -z,1/2+x,1/2-y
+     8  1/2-y,-z,1/2+x
+     9  1/2+y,1/2-z,-x
+    10  -x,1/2+y,1/2-z
+    11  1/2-z,-x,1/2+y
+    12  1/2+x,1/2-y,-z
+    13  -x,-y,-z
+    14  -z,-x,-y
+    15  -y,-z,-x
+    16  1/2-x,-y,1/2+z
+    17  1/2+z,1/2-x,-y
+    18  -y,1/2+z,1/2-x
+    19  z,1/2-x,1/2+y
+    20  1/2+y,z,1/2-x
+    21  1/2-y,1/2+z,x
+    22  x,1/2-y,1/2+z
+    23  1/2+z,x,1/2-y
+    24  1/2-x,1/2+y,z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Fe1    Fe   0.00000     0.00000     0.00000     1.000      Uiso 0.010      4   
+S2     S    0.38589     0.38589     0.38589     1.000      Uiso 0.010      8   
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Fe   4      11.7695    7.3573     3.5222     2.3045     4.7611     0.3072     15.3535    76.8805    1.0369     0.945
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S    8      6.9053     5.2034     1.4379     1.5863     1.4679     22.2151    0.2536     56.172     0.8669     0.2847
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Fe S2"
+_chemical_formula_weight  119.97
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Fe1    S2     2.26694      1_555    4_455 yes
+  Fe1    S2     2.26694      1_555    5_545 yes
+  Fe1    S2     2.26694      1_555    6_554 yes
+  Fe1    S2     2.26694      1_555    7_545 yes
+  Fe1    S2     2.26694      1_555    8_554 yes
+  Fe1    S2     2.26694      1_555    9_455 yes
+  S2     Fe1    2.26694      1_555    4_555 yes
+  S2     Fe1    2.26694      1_555    5_555 yes
+  S2     Fe1    2.26694      1_555    6_555 yes
+  S2     S2     2.14245      1_555   13_666 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.2413(26), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW1minmill_phase_2
+# Information for phase 2
+_pd_block_id  2021-08-04T18:19|NEW1minmill|phase_2|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for NaAlSi3O8 follows
+_pd_phase_name  NaAlSi3O8
+_cell_length_a  8.137
+_cell_length_b  12.785
+_cell_length_c  7.1583
+_cell_angle_alpha  94.26
+_cell_angle_beta   116.6
+_cell_angle_gamma  87.71
+_cell_volume  664.008
+_exptl_crystal_density_diffrn  2.6230
+_symmetry_cell_setting  triclinic
+_symmetry_space_group_name_H-M  "C -1"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -x,-y,-z
+     3  1/2+x,1/2+y,z
+     4  1/2-x,1/2-y,-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Al1    Al3+ 0.00887     0.16846     0.20805     1.000      Uani 0.007      4   
+Si1    Si4+ 0.00375     0.82051     0.23737     1.000      Uani 0.006      4   
+Si2    Si4+ 0.69162     0.11021     0.31466     1.000      Uani 0.006      4   
+Si3    Si4+ 0.68129     0.88190     0.36076     1.000      Uani 0.006      4   
+Na1    Na1+ 0.26799     0.98865     0.14650     1.000      Uani 0.031      4   
+O1     O2-  0.00490     0.13103     0.96660     1.000      Uani 0.012      4   
+O2     O2-  0.59176     0.99756     0.28040     1.000      Uani 0.008      4   
+O3     O2-  0.81230     0.10966     0.19010     1.000      Uani 0.014      4   
+O4     O2-  0.82000     0.85101     0.25870     1.000      Uani 0.018      4   
+O5     O2-  0.01288     0.30238     0.27060     1.000      Uani 0.011      4   
+O6     O2-  0.02329     0.69368     0.22910     1.000      Uani 0.011      4   
+O7     O2-  0.20780     0.10896     0.38900     1.000      Uani 0.011      4   
+O8     O2-  0.18400     0.86817     0.43620     1.000      Uani 0.012      4   
+
+loop_
+   _atom_site_aniso_label
+   _atom_site_aniso_U_11
+   _atom_site_aniso_U_22
+   _atom_site_aniso_U_33
+   _atom_site_aniso_U_12
+   _atom_site_aniso_U_13
+   _atom_site_aniso_U_23
+Al1    0.0074      0.0068      0.0061      -0.0009     0.0031      0.0004      
+Si1    0.0068      0.0065      0.0055      0.0011      0.0030      0.0008      
+Si2    0.0061      0.0055      0.0073      -0.0002     0.0025      0.0004      
+Si3    0.0060      0.0055      0.0074      0.0006      0.0028      0.0009      
+Na1    0.0136      0.0471      0.0315      -0.0050     0.0084      -0.0219     
+O1     0.0164      0.0122      0.0074      -0.0002     0.0067      0.0014      
+O2     0.0074      0.0056      0.0119      0.0003      0.0033      0.0020      
+O3     0.0117      0.0130      0.0162      -0.0040     0.0093      -0.0017     
+O4     0.0134      0.0179      0.0216      0.0046      0.0129      0.0020      
+O5     0.0103      0.0076      0.0150      -0.0020     0.0052      -0.0009     
+O6     0.0101      0.0071      0.0145      0.0022      0.0034      0.0012      
+O7     0.0120      0.0129      0.0080      0.0024      0.0013      0.0015      
+O8     0.0140      0.0140      0.0084      -0.0026     -0.0002     -0.0006     
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Al   4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Na   4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  O    32     ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si   12     ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Al Na O8 Si3"
+_chemical_formula_weight  262.22
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Al1    O1     1.74519      1_555    1_554 yes
+  Al1    O3     1.7429       1_555    1_455 yes
+  Al1    O5     1.73509      1_555    1_555 yes
+  Al1    O7     1.74556      1_555    1_555 yes
+  Si1    O1     1.59985      1_555    2_566 yes
+  Si1    O4     1.59997      1_555    1_455 yes
+  Si1    O6     1.62225      1_555    1_555 yes
+  Si1    O8     1.61907      1_555    1_555 yes
+  Si2    O2     1.63011      1_555    1_545 yes
+  Si2    O3     1.59435      1_555    1_555 yes
+  Si2    O6     1.61836      1_555    3_545 yes
+  Si2    O8     1.6168       1_555    2_666 yes
+  Si3    O2     1.64718      1_555    1_555 yes
+  Si3    O4     1.61975      1_555    1_555 yes
+  Si3    O5     1.59682      1_555    3_555 yes
+  Si3    O7     1.60203      1_555    2_666 yes
+  Na1    O1     2.66887      1_555    1_564 yes
+  Na1    O1     2.53079      1_555    2_566 yes
+  Na1    O2     2.3704       1_555    1_555 yes
+  Na1    O3     2.45321      1_555    2_665 yes
+  Na1    O7     2.43384      1_555    1_565 yes
+  O1     Al1    1.74519      1_555    1_556 yes
+  O1     Si1    1.59985      1_555    2_566 yes
+  O1     Na1    2.66887      1_555    1_546 yes
+  O1     Na1    2.53079      1_555    2_566 yes
+  O2     Si2    1.63011      1_555    1_565 yes
+  O2     Si3    1.64718      1_555    1_555 yes
+  O2     Na1    2.3704       1_555    1_555 yes
+  O3     Al1    1.7429       1_555    1_655 yes
+  O3     Si2    1.59435      1_555    1_555 yes
+  O3     Na1    2.45321      1_555    2_665 yes
+  O4     Si1    1.59997      1_555    1_655 yes
+  O4     Si3    1.61975      1_555    1_555 yes
+  O5     Al1    1.73509      1_555    1_555 yes
+  O5     Si3    1.59682      1_555    3_445 yes
+  O6     Si1    1.62225      1_555    1_555 yes
+  O6     Si2    1.61836      1_555    3_455 yes
+  O7     Al1    1.74556      1_555    1_555 yes
+  O7     Si3    1.60203      1_555    2_666 yes
+  O7     Na1    2.43384      1_555    1_545 yes
+  O8     Si1    1.61907      1_555    1_555 yes
+  O8     Si2    1.6168       1_555    2_666 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Al1    O3     102.836       1_554  1_555    1_455 yes
+  O1     Al1    O5     116.047       1_554  1_555    1_555 yes
+  O3     Al1    O5     112.215       1_455  1_555    1_555 yes
+  O1     Al1    O7     104.004       1_554  1_555    1_555 yes
+  O3     Al1    O7     111.151       1_455  1_555    1_555 yes
+  O5     Al1    O7     110.14        1_555  1_555    1_555 yes
+  O1     Si1    O4     109.433       2_566  1_555    1_455 yes
+  O1     Si1    O6     112.47        2_566  1_555    1_555 yes
+  O4     Si1    O6     108.187       1_455  1_555    1_555 yes
+  O1     Si1    O8     107.176       2_566  1_555    1_555 yes
+  O4     Si1    O8     111.446       1_455  1_555    1_555 yes
+  O6     Si1    O8     108.16        1_555  1_555    1_555 yes
+  O2     Si2    O3     111.144       1_545  1_555    1_555 yes
+  O2     Si2    O6     104.24        1_545  1_555    3_545 yes
+  O3     Si2    O6     112.114       1_555  1_555    3_545 yes
+  O2     Si2    O8     106.97        1_545  1_555    2_666 yes
+  O3     Si2    O8     111.591       1_555  1_555    2_666 yes
+  O6     Si2    O8     110.422       3_545  1_555    2_666 yes
+  O2     Si3    O4     107.269       1_555  1_555    1_555 yes
+  O2     Si3    O5     105.914       1_555  1_555    3_555 yes
+  O4     Si3    O5     110.224       1_555  1_555    3_555 yes
+  O2     Si3    O7     108.565       1_555  1_555    2_666 yes
+  O4     Si3    O7     110.208       1_555  1_555    2_666 yes
+  O5     Si3    O7     114.328       3_555  1_555    2_666 yes
+  Al1    O1     Si1    141.397       1_556  1_555    2_566 yes
+  Si2    O2     Si3    130.019       1_565  1_555    1_555 yes
+  Si2    O2     Na1    120.351       1_565  1_555    1_555 yes
+  Si3    O2     Na1    108.811       1_555  1_555    1_555 yes
+  Al1    O3     Si2    139.461       1_655  1_555    1_555 yes
+  Si1    O4     Si3    161.151       1_655  1_555    1_555 yes
+  Al1    O5     Si3    129.689       1_555  1_555    3_445 yes
+  Si1    O6     Si2    135.676       1_555  1_555    3_455 yes
+  Al1    O7     Si3    133.943       1_555  1_555    2_666 yes
+  Si1    O8     Si2    151.747       1_555  1_555    2_666 yes
+_pd_proc_ls_pref_orient_corr  none
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.177(14), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW1minmill_phase_4
+# Information for phase 4
+_pd_block_id  2021-08-04T18:19|NEW1minmill|phase_4|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Pyrrhotite 4M follows
+_pd_phase_name  "Pyrrhotite 4M"
+_cell_length_a  11.904(12)
+_cell_length_b  6.8784(21)
+_cell_length_c  12.814(15)
+_cell_angle_alpha  90
+_cell_angle_beta   117.119(25)
+_cell_angle_gamma  90
+_cell_volume  933.92(25)
+_exptl_crystal_density_diffrn  4.6045
+_symmetry_cell_setting  monoclinic
+_symmetry_space_group_name_H-M  "C 2/c"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -x,y,1/2-z
+     3  -x,-y,-z
+     4  x,-y,1/2+z
+     5  1/2+x,1/2+y,z
+     6  1/2-x,1/2+y,1/2-z
+     7  1/2-x,1/2-y,-z
+     8  1/2+x,1/2-y,1/2+z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+S1     S    0.01800     0.38330     0.11960     1.000      Uiso 0.010      8   
+S2     S    0.02910     0.11420     0.63900     1.000      Uiso 0.010      8   
+Fe3    Fe   0.10860     0.10250     0.49980     1.000      Uiso 0.010      8   
+S4     S    0.23410     0.13550     0.38260     1.000      Uiso 0.010      8   
+Fe5    Fe   0.24180     0.36600     0.24680     1.000      Uiso 0.010      8   
+S6     S    0.26790     0.13400     0.12360     1.000      Uiso 0.010      8   
+Fe7    Fe   0.38720     0.15000     0.01260     1.000      Uiso 0.010      8   
+Fe8    Fe   0.00000     0.14720     0.25000     1.000      Uiso 0.010      4   
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Fe   28     11.7695    7.3573     3.5222     2.3045     4.7611     0.3072     15.3535    76.8805    1.0369     0.945
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S    32     6.9053     5.2034     1.4379     1.5863     1.4679     22.2151    0.2536     56.172     0.8669     0.2847
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Fe7 S8"
+_chemical_formula_weight  647.41
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  S1     Fe3    2.49812      1_555    2_555 yes
+  S1     Fe5    2.41036      1_555    1_555 yes
+  S1     Fe7    2.39236      1_555    5_455 yes
+  S1     Fe7    2.43697      1_555    7_555 yes
+  S1     Fe8    2.40872      1_555    1_555 yes
+  S2     Fe3    2.37128      1_555    1_555 yes
+  S2     Fe3    2.32686      1_555    3_556 yes
+  S2     Fe5    2.44121      1_555    7_556 yes
+  S2     Fe7    2.36923      1_555    8_456 yes
+  S2     Fe8    2.41356      1_555    3_556 yes
+  Fe3    S1     2.49812      1_555    2_555 yes
+  Fe3    S2     2.37128      1_555    1_555 yes
+  Fe3    S2     2.32686      1_555    3_556 yes
+  Fe3    S6     2.45285      1_555    4_556 yes
+  S4     Fe5    2.38659      1_555    1_555 yes
+  Fe5    S1     2.41036      1_555    1_555 yes
+  Fe5    S2     2.44121      1_555    7_556 yes
+  Fe5    S4     2.38659      1_555    1_555 yes
+  Fe5    S6     2.36277      1_555    1_555 yes
+  S6     Fe3    2.45285      1_555    4_555 yes
+  S6     Fe5    2.36277      1_555    1_555 yes
+  S6     Fe7    2.42773      1_555    1_555 yes
+  S6     Fe7    2.39264      1_555    7_555 yes
+  Fe7    S1     2.39236      1_555    5_545 yes
+  Fe7    S1     2.43697      1_555    7_555 yes
+  Fe7    S2     2.36923      1_555    8_555 yes
+  Fe7    S6     2.42773      1_555    1_555 yes
+  Fe7    S6     2.39264      1_555    7_555 yes
+  Fe8    S1     2.40872      1_555    1_555 yes
+  Fe8    S1     2.40872      1_555    2_555 yes
+  Fe8    S2     2.41356      1_555    3_556 yes
+  Fe8    S2     2.41356      1_555    4_555 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.071(6), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW1minmill_phase_1
+# Information for phase 1
+_pd_block_id  2021-08-04T18:19|NEW1minmill|phase_1|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for SiO2 follows
+_pd_phase_name  SiO2
+_cell_length_a  4.9162(4)
+_cell_length_b  4.9162(4)
+_cell_length_c  5.4061(4)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  120
+_cell_volume  113.154(10)
+_exptl_crystal_density_diffrn  2.6452
+_symmetry_cell_setting  trigonal
+_symmetry_space_group_name_H-M  "P 32 2 1"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -y,x-y,2/3+z
+     3  y-x,-x,1/3+z
+     4  y,x,-z
+     5  -x,y-x,2/3-z
+     6  x-y,-y,1/3-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Si1    Si4+ 0.47000     0.00000     0.66670     1.000      Uani 0.006      3   
+O1     O2-  0.41460     0.26780     0.78543     1.000      Uani 0.011      6   
+
+loop_
+   _atom_site_aniso_label
+   _atom_site_aniso_U_11
+   _atom_site_aniso_U_22
+   _atom_site_aniso_U_33
+   _atom_site_aniso_U_12
+   _atom_site_aniso_U_13
+   _atom_site_aniso_U_23
+Si1    0.0073      0.0059      0.0053      0.0029      0.0003      0.0006      
+O1     0.0120      0.0105      0.0118      0.0065      -0.0029     -0.0040     
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  O    6      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si   3      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  3
+_chemical_formula_sum  "O2 Si"
+_chemical_formula_weight  60.08
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Si1    O1     1.60563      1_555    1_555 yes
+  Si1    O1     1.61187      1_555    2_654 yes
+  Si1    O1     1.61161      1_555    5_656 yes
+  Si1    O1     1.60577      1_555    6_556 yes
+  O1     Si1    1.60563      1_555    1_555 yes
+  O1     Si1    1.61187      1_555    3_665 yes
+  O1     Si1    1.61161      1_555    5_666 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Si1    O1     110.252       1_555  1_555    2_654 yes
+  O1     Si1    O1     108.754       1_555  1_555    5_656 yes
+  O1     Si1    O1     109.677       2_654  1_555    5_656 yes
+  O1     Si1    O1     109.158       1_555  1_555    6_556 yes
+  O1     Si1    O1     108.734       2_654  1_555    6_556 yes
+  O1     Si1    O1     110.258       5_656  1_555    6_556 yes
+  Si1    O1     Si1    143.831       1_555  1_555    3_665 yes
+  Si1    O1     Si1    143.835       1_555  1_555    5_666 yes
+  Si1    O1     Si1    0.009         3_665  1_555    5_666 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.220(14), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW1minmill_phase_3
+# Information for phase 3
+_pd_block_id  2021-08-04T18:19|NEW1minmill|phase_3|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for TiO2 follows
+_pd_phase_name  TiO2
+_cell_length_a  4.5994(25)
+_cell_length_b  4.5994(25)
+_cell_length_c  2.9601(22)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  90
+_cell_volume  62.62(5)
+_exptl_crystal_density_diffrn  4.2373
+_symmetry_cell_setting  tetragonal
+_symmetry_space_group_name_H-M  "P 42/m n m"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  1/2-y,1/2+x,1/2+z
+     3  -x,-y,z
+     4  1/2+y,1/2-x,1/2+z
+     5  1/2-x,1/2+y,1/2+z
+     6  -y,-x,z
+     7  1/2+x,1/2-y,1/2+z
+     8  y,x,z
+     9  -x,-y,-z
+    10  1/2+y,1/2-x,1/2-z
+    11  x,y,-z
+    12  1/2-y,1/2+x,1/2-z
+    13  1/2+x,1/2-y,1/2-z
+    14  y,x,-z
+    15  1/2-x,1/2+y,1/2-z
+    16  -y,-x,-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Ti1    Ti4+ 0.00000     0.00000     0.00000     1.000      Uani 0.006      2   
+O1     O2-  0.30493     0.30493     0.00000     1.000      Uani 0.006      4   
+
+loop_
+   _atom_site_aniso_label
+   _atom_site_aniso_U_11
+   _atom_site_aniso_U_22
+   _atom_site_aniso_U_33
+   _atom_site_aniso_U_12
+   _atom_site_aniso_U_13
+   _atom_site_aniso_U_23
+Ti1    0.0070      0.0070      0.0047      -0.0002     0.0000      0.0000      
+O1     0.0060      0.0060      0.0045      -0.0019     0.0000      0.0000      
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  O    4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Ti   2      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  2
+_chemical_formula_sum  "O2 Ti"
+_chemical_formula_weight  79.9
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Ti1    O1     1.98345      1_555    1_555 yes
+  Ti1    O1     1.94951      1_555    2_544 yes
+  Ti1    O1     1.94951      1_555    2_545 yes
+  Ti1    O1     1.98345      1_555    3_555 yes
+  Ti1    O1     1.94951      1_555    4_454 yes
+  Ti1    O1     1.94951      1_555    4_455 yes
+  O1     Ti1    1.98345      1_555    1_555 yes
+  O1     Ti1    1.94951      1_555    2_554 yes
+  O1     Ti1    1.94951      1_555    2_555 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Ti1    O1     90            1_555  1_555    2_544 yes
+  O1     Ti1    O1     90            1_555  1_555    2_545 yes
+  O1     Ti1    O1     98.787        2_544  1_555    2_545 yes
+  O1     Ti1    O1     180           1_555  1_555    3_555 yes
+  O1     Ti1    O1     90            2_544  1_555    3_555 yes
+  O1     Ti1    O1     90            2_545  1_555    3_555 yes
+  O1     Ti1    O1     90            1_555  1_555    4_454 yes
+  O1     Ti1    O1     81.213        2_544  1_555    4_454 yes
+  O1     Ti1    O1     180           2_545  1_555    4_454 yes
+  O1     Ti1    O1     90            3_555  1_555    4_454 yes
+  O1     Ti1    O1     90            1_555  1_555    4_455 yes
+  O1     Ti1    O1     180           2_544  1_555    4_455 yes
+  O1     Ti1    O1     81.213        2_545  1_555    4_455 yes
+  O1     Ti1    O1     90            3_555  1_555    4_455 yes
+  O1     Ti1    O1     98.787        4_454  1_555    4_455 yes
+  Ti1    O1     Ti1    130.606       1_555  1_555    2_554 yes
+  Ti1    O1     Ti1    130.606       1_555  1_555    2_555 yes
+  Ti1    O1     Ti1    98.787        2_554  1_555    2_555 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.100, 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW1minmill_pwd_0
+_pd_proc_ls_profile_function
+;
+Finger-Cox-Jephcoat function parameters U, V, W, X, Y, SH/L:
+  peak variance(Gauss) = Utan(Th)^2^+Vtan(Th)+W:
+  peak HW(Lorentz) = X/cos(Th)+Ytan(Th); SH/L = S/L+H/L
+  U, V, W in (centideg)^2^, X & Y in centideg
+    0.000, 0.000, 1.089, 0.882, 1.689, 0.058, 
+;
+# Information for histogram 0: PWDR BAT3_1min_milla_30mm_MonicaHamish_Ruoming_step size 0_1_min_mill_a.xrdml Scan 1
+_pd_block_id
+;
+2021-08-04T18:19|NEW1minmill|McDougallHamish|PANalytical,Co-EmpyreanII_hist_0
+;
+# GSAS-II edited template follows Instrument_Template
+#==============================================================================
+# 9. INSTRUMENT CHARACTERIZATION
+
+_exptl_special_details
+; ?
+;
+
+# if regions of the data are excluded, the reason(s) are supplied here:
+_pd_proc_info_excluded_regions
+; ?
+;
+
+# The following item is used to identify the equipment used to record 
+# the powder pattern when the diffractogram was measured at a laboratory 
+# other than the authors' home institution, e.g. when neutron or synchrotron
+# radiation is used.
+
+_pd_instr_location
+; ?
+;
+_pd_calibration_special_details           # description of the method used
+                                          # to calibrate the instrument
+; ?
+;
+
+_diffrn_source                    Co-Ka       
+_diffrn_source_target             Co
+_diffrn_source_type               Graded_Flat
+_diffrn_measurement_device_type   Panalytical_Reflection_Transmission       
+_diffrn_detector                  PIXcel1D       
+_diffrn_detector_type             Empyrean_II       # make or model of detector
+
+_pd_meas_scan_method              ?       # options are 'step', 'cont',
+                                          # 'tof', 'fixed' or
+                                          # 'disp' (= dispersive)
+_pd_meas_special_details
+;  ?
+;
+
+# The following two items identify the program(s) used (if appropriate).
+_computing_data_collection        ?        
+_computing_data_reduction         ?                   
+
+# Describe any processing performed on the data, prior to refinement.
+# For example: a manual Lp correction or a precomputed absorption correction
+_pd_proc_info_data_reduction      ?
+
+# The following item is used for angular dispersive measurements only.
+
+_diffrn_radiation_monochromator   ?        
+
+# The following items are used to define the size of the instrument.
+# Not all distances are appropriate for all instrument types.
+
+_pd_instr_dist_src/mono           ?
+_pd_instr_dist_mono/spec          ?
+_pd_instr_dist_src/spec           ?
+_pd_instr_dist_spec/anal          ?
+_pd_instr_dist_anal/detc          ?
+_pd_instr_dist_spec/detc          ?
+
+# 10. Specimen size and mounting information
+
+# The next three fields give the specimen dimensions in mm.  The equatorial 
+# plane contains the incident and diffracted beam.
+
+_pd_spec_size_axial               ?       # perpendicular to 
+                                          # equatorial plane
+
+_pd_spec_size_equat               ?       # parallel to 
+                                          # scattering vector 
+                                          # in transmission
+
+_pd_spec_size_thick               ?       # parallel to 
+                                          # scattering vector 
+                                          # in reflection
+
+_pd_spec_mounting                         # This field should be
+                                          # used to give details of the 
+                                          # container.
+; ?
+;
+
+_pd_spec_mount_mode               ?       # options are 'reflection' 
+                                          # or 'transmission'
+    
+_pd_spec_shape                    ?       # options are 'cylinder' 
+                                          # 'flat_sheet' or 'irregular'
+
+
+loop_
+     _atom_type_symbol
+     _atom_type_scat_dispersion_real
+     _atom_type_scat_dispersion_imag
+     _atom_type_scat_dispersion_source
+  Al        0.255   0.328   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Fe       -3.332   0.490   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Na        0.167   0.167   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  O         0.063   0.044   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S         0.371   0.733   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si        0.298   0.438   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Ti       -0.063   2.321   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+_diffrn_radiation_type  K\a~1,2~
+loop_
+   _diffrn_radiation_wavelength
+   _diffrn_radiation_wavelength_wt
+   _diffrn_radiation_wavelength_id
+  1.78892         1.0             1     
+  1.79278         0.5000          2     
+
+# PHASE TABLE
+loop_
+   _pd_phase_id
+   _pd_phase_block_id
+   _pd_phase_mass_%
+  0  2021-08-04T18:19|NEW1minmill|phase_0|McDougallHamish  0.731(4)
+  2  2021-08-04T18:19|NEW1minmill|phase_2|McDougallHamish  0.133(3)
+  4  2021-08-04T18:19|NEW1minmill|phase_4|McDougallHamish  0.0539(16)
+  1  2021-08-04T18:19|NEW1minmill|phase_1|McDougallHamish  0.0754(13)
+  3  2021-08-04T18:19|NEW1minmill|phase_3|McDougallHamish  0.0072(8)
+loop_
+   _gsas_proc_phase_R_F_factor
+   _gsas_proc_phase_R_Fsqd_factor
+   _gsas_proc_phase_id
+   _gsas_proc_phase_block_id
+    0.06473  0.11770  0  2021-08-04T18:19|NEW1minmill|phase_0|McDougallHamish
+    0.13114  0.28099  2  2021-08-04T18:19|NEW1minmill|phase_2|McDougallHamish
+    0.11500  0.24264  4  2021-08-04T18:19|NEW1minmill|phase_4|McDougallHamish
+    0.08345  0.16213  1  2021-08-04T18:19|NEW1minmill|phase_1|McDougallHamish
+    0.11629  0.33088  3  2021-08-04T18:19|NEW1minmill|phase_3|McDougallHamish
+_pd_proc_ls_prof_R_factor     0.09508
+_pd_proc_ls_prof_wR_factor    0.13200
+_gsas_proc_ls_prof_R_B_factor   0.12376
+_gsas_proc_ls_prof_wR_B_factor  0.16147
+_pd_proc_ls_prof_wR_expected  0.04302
+_diffrn_radiation_probe  x-ray
+_diffrn_radiation_polarisn_ratio  0.7000
+_pd_proc_ls_background_function
+;
+Background function: "chebyschev-1" function with 7 terms:
+    416.1(17), -490.8(28), 375.8(27), -195.5(24), 98.2(22), -36.4(17), 
+    8.9(15), 
+;
+_diffrn_ambient_temperature  300
+_diffrn_ambient_pressure  100
+
+# STRUCTURE FACTOR TABLE
+loop_
+   _pd_refln_phase_id
+   _refln_index_h
+   _refln_index_k
+   _refln_index_l
+   _refln_F_squared_meas
+   _refln_F_squared_calc
+   _refln_phase_calc
+   _refln_d_spacing
+   _gsas_i100_meas
+  0  1    1    1    837.5122   818.8476   0.0     3.12911  20.97  
+  0  2    0    0    6987.0490  6378.4820  -0.0    2.70989  97.00  
+  0  2    1    0    2890.4973  3259.8770  0.0     2.42380  63.39  
+  0  2    1    1    1787.6568  1674.1551  -180.0  2.21261  64.62  
+  0  2    2    0    2676.8059  3256.8520  -0.0    1.91618  35.71  
+  0  2    2    1    39.3829    43.0663    -0.0    1.80659  0.93   
+  0  3    1    1    5184.8362  5012.3659  -0.0    1.63412  100.00 
+  0  2    2    2    2016.4784  2253.0940  0.0     1.56455  11.92  
+  0  3    0    2    2996.0845  2977.7832  -0.0    1.50317  24.69  
+  0  3    1    2    493.5363   526.6229   0.0     1.44850  7.62   
+  0  3    2    1    1511.5200  1612.8522  180.0   1.44850  23.35  
+  0  4    0    0    480.1350   344.3256   -180.0  1.35494  1.67   
+  0  3    2    2    38.0741    46.4103    -0.0    1.31449  0.51   
+  0  4    1    0    94.0183    114.6032   -0.0    1.31449  0.63   
+  0  4    1    1    69.3979    62.6129    180.0   1.27745  0.90   
+  0  3    3    1    500.5286   561.9376   -0.0    1.24338  6.30   
+  0  4    0    2    894.5422   793.3344   0.0     1.21190  5.53   
+  0  4    2    0    894.5422   793.3344   0.0     1.21190  5.53   
+  0  4    1    2    2.1639     1.8357     -0.0    1.18269  0.03   
+  0  4    2    1    1450.0778  1230.1866  -180.0  1.18269  17.69  
+  0  3    3    2    716.5935   623.9322   0.0     1.15550  8.69   
+  0  4    2    2    1374.1670  928.6766   0.0     1.10631  16.82  
+  0  4    3    0    106.5321   139.6802   -0.0    1.08395  0.66   
+  0  4    1    3    60.0496    76.8277    -180.0  1.06291  0.76   
+  0  4    3    1    19.6072    25.0855    0.0     1.06291  0.25   
+  0  3    3    3    1699.4442  1375.9176  -0.0    1.04304  7.42   
+  0  5    1    1    3700.3894  2995.9389  -0.0    1.04304  48.48  
+  1  1    0    0    307.0577   242.5267   180.0   4.25752  1.16   
+  1  1    0    -1   1497.8281  1509.4485  -120.0  3.34480  3.44   
+  1  1    0    1    629.6147   634.4994   120.0   3.34480  1.44   
+  1  1    1    0    496.0535   343.8890   -155.6  2.45808  0.60   
+  1  1    0    2    417.8839   298.8520   -120.0  2.28199  0.43   
+  1  1    0    -2   120.5196   86.1903    -60.0   2.28199  0.12   
+  1  1    1    1    92.7349    96.0660    82.9    2.23764  0.18   
+  1  2    0    0    399.2701   308.9201   -0.0    2.12876  0.35   
+  1  2    0    -1   90.1319    77.2268    60.0    1.98073  0.07   
+  1  2    0    1    216.0015   185.0743   -60.0   1.98073  0.16   
+  1  1    1    2    613.3117   602.8883   9.8     1.81858  0.78   
+  1  0    0    3    70.9394    94.4539    0.0     1.80204  0.01   
+  1  2    0    -2   395.4825   364.2694   120.0   1.67240  0.21   
+  1  2    0    2    89.1277    82.0934    60.0    1.67240  0.05   
+  1  1    0    -3   260.0211   203.8550   180.0   1.65951  0.14   
+  1  1    0    3    3.2974     2.5852     0.0     1.65951  0.00   
+  1  2    1    0    23.2728    14.6471    -38.9   1.60919  0.02   
+  1  2    1    -1   499.6835   356.4103   95.9    1.54231  0.46   
+  1  2    1    1    430.0605   306.7502   -109.6  1.54231  0.39   
+  1  1    1    3    136.9561   142.5823   117.5   1.45333  0.11   
+  1  3    0    0    71.2590    76.3725    180.0   1.41917  0.03   
+  1  2    1    -2   385.2836   413.8478   -123.3  1.38272  0.29   
+  1  2    1    2    119.6259   128.4947   143.4   1.38272  0.09   
+  1  2    0    -3   273.8589   292.6715   -0.0    1.37540  0.10   
+  1  2    0    3    964.2463   1030.4844  0.0     1.37540  0.36   
+  1  3    0    -1   671.0310   815.9932   -120.0  1.37266  0.25   
+  1  3    0    1    0.8360     1.0166     -60.0   1.37266  0.00   
+  1  1    0    -4   120.7667   120.2826   -120.0  1.28818  0.04   
+  1  1    0    4    398.0481   396.4524   120.0   1.28818  0.14   
+  1  3    0    -2   136.8918   208.3560   120.0   1.25652  0.05   
+  1  3    0    2    312.0759   474.9945   -120.0  1.25652  0.11   
+  1  2    2    0    387.8696   371.1299   -16.5   1.22904  0.13   
+  1  2    1    -3   63.9821    71.0165    179.1   1.20028  0.04   
+  1  2    1    3    271.5908   301.4501   -134.8  1.20028  0.18   
+  1  2    2    1    107.9721   105.6120   88.6    1.19846  0.07   
+  1  1    1    4    471.9220   334.1867   -14.4   1.18432  0.31   
+  1  3    1    0    415.4680   361.6404   121.4   1.18082  0.27   
+  1  3    1    -1   209.9201   189.9632   -18.5   1.15362  0.14   
+  1  3    1    1    70.0690    63.4076    16.4    1.15362  0.05   
+  1  2    0    4    72.7203    70.6840    120.0   1.14099  0.02   
+  1  2    0    -4   1.5160     1.4735     -120.0  1.14099  0.00   
+  1  2    2    2    1.8381     3.3522     -9.9    1.11882  0.00   
+  1  3    0    3    71.0156    62.7375    -180.0  1.11493  0.02   
+  1  3    0    -3   7.5716     6.6890     -0.0    1.11493  0.00   
+  1  3    1    -2   219.6848   304.4168   -8.9    1.08208  0.15   
+  1  3    1    2    89.7569    124.3760   59.1    1.08208  0.06   
+  1  4    0    0    108.8167   168.2196   0.0     1.06438  0.04   
+  1  1    0    -5   415.9661   346.2831   120.0   1.04796  0.14   
+  1  1    0    5    156.0583   129.9153   -120.0  1.04796  0.05   
+  1  4    0    -1   38.0175    31.4137    60.0    1.04433  0.01   
+  1  4    0    1    350.6909   289.7750   120.0   1.04433  0.12   
+  1  2    1    -4   9.3276     10.8630    51.2    1.03493  0.01   
+  1  2    1    4    206.8612   240.9124   -129.5  1.03493  0.15   
+  2  0    0    1    1760.7694  685.7541   180.0   6.38786  0.16   
+  2  0    2    0    969.6625   396.3962   180.0   6.37466  0.03   
+  2  1    1    0    549.2777   238.2363   -0.0    6.33955  0.02   
+  2  1    -1   0    827.9147   287.4879   -0.0    6.29869  0.03   
+  2  1    1    -1   1037.1224  406.2352   180.0   5.91009  0.03   
+  2  1    -1   -1   482.5490   415.6378   -180.0  5.58552  0.02   
+  2  0    2    -1   4.7377     16.5792    0.0     4.66174  0.00   
+  2  0    2    1    3.1232     1.8371     180.0   4.37623  0.00   
+  2  2    0    -1   19310.5322 21037.4763 -0.0    4.02732  0.24   
+  2  1    -1   1    6489.2494  3767.3897  -0.0    3.85265  0.12   
+  2  1    1    1    8852.8737  10390.3834 0.0     3.77565  0.20   
+  2  1    3    0    9361.7579  5886.9121  180.0   3.68167  0.11   
+  2  1    3    -1   7390.9539  4505.3267  0.0     3.66562  0.07   
+  2  1    -3   0    15591.2561 11675.3013 180.0   3.65766  0.15   
+  2  2    0    0    1.9047     2.5781     0.0     3.63776  0.00   
+  2  1    1    -2   5696.9384  4328.5159  0.0     3.50520  0.10   
+  2  2    2    -1   4111.8691  1650.0035  180.0   3.48122  0.04   
+  2  1    -3   -1   79.2330    12.1276    0.0     3.43616  0.00   
+  2  1    -1   -2   7147.1650  5251.4578  0.0     3.37264  0.14   
+  2  2    -2   -1   267.5771   364.8637   0.0     3.33313  0.00   
+  2  2    0    -2   24784.6770 26655.4799 -180.0  3.21484  0.26   
+  2  0    0    2    38362.8902 37071.8044 -180.0  3.19393  0.86   
+  2  0    4    0    24744.5220 25362.8195 180.0   3.18733  0.19   
+  2  2    2    0    12022.7512 13873.6743 180.0   3.16977  0.11   
+  2  2    -2   0    13241.1477 14946.6082 -180.0  3.14934  0.10   
+  2  1    -3   1    15844.7178 11175.2497 -180.0  2.96418  0.12   
+  2  2    2    -2   7506.1613  7187.5067  0.0     2.95504  0.06   
+  2  0    2    -2   6874.2343  5310.5610  0.0     2.93060  0.08   
+  2  0    4    -1   9624.6592  8585.7945  0.0     2.92677  0.06   
+  2  1    3    1    9253.0085  6897.0276  180.0   2.86133  0.10   
+  2  1    3    -2   2137.1464  1923.0466  -0.0    2.83885  0.02   
+  2  2    -2   -2   222.0723   183.4547   -0.0    2.79276  0.00   
+  2  0    2    2    208.0175   191.6414   0.0     2.78600  0.00   
+  2  0    4    1    430.9781   387.5360   -0.0    2.78271  0.00   
+  2  2    0    1    102.2844   109.5836   -0.0    2.68712  0.00   
+  2  3    1    -1   346.3515   431.0071   -180.0  2.66293  0.00   
+  2  1    -3   -2   5704.0184  6171.6319  -0.0    2.63839  0.05   
+  2  3    -1   -1   28.8078    33.5476    -180.0  2.62530  0.00   
+  2  2    4    -1   17379.1647 12550.4891 -180.0  2.55995  0.08   
+  2  3    1    -2   2870.9062  1812.0722  180.0   2.53704  0.01   
+  2  1    -1   2    1086.1077  667.2869   180.0   2.51139  0.01   
+  2  2    -2   1    2608.9500  1686.7859  -180.0  2.49495  0.02   
+  2  3    -1   -2   485.9393   451.5613   180.0   2.48043  0.00   
+  2  1    1    2    133.4148   110.2849   180.0   2.46610  0.00   
+  2  2    2    1    1990.1671  1367.0046  -180.0  2.45771  0.01   
+  2  2    -4   -1   15395.1790 10453.7459 -180.0  2.44277  0.07   
+  2  1    5    -1   4043.1245  4093.1663  -0.0    2.42941  0.02   
+  2  1    5    0    48.2766    64.0884    180.0   2.41202  0.00   
+  2  2    4    0    3172.4144  3944.1458  -0.0    2.40628  0.02   
+  2  1    -5   0    1870.3275  2230.8323  180.0   2.40074  0.01   
+  2  2    -4   0    2063.1379  2079.3222  -0.0    2.38844  0.01   
+  2  3    1    0    1536.8965  1565.2946  -0.0    2.38575  0.01   
+  2  3    -1   0    1728.6479  2090.0863  -0.0    2.37918  0.01   
+  2  2    0    -3   6.3833     7.3701     180.0   2.35133  0.00   
+  2  2    4    -2   2.3964     2.9331     0.0     2.34729  0.00   
+  2  1    1    -3   109.6612   110.8373   -0.0    2.33656  0.00   
+  2  0    4    -2   1262.8542  884.3144   -180.0  2.33087  0.01   
+  2  3    3    -1   26675.1237 9809.7794  180.0   2.31766  0.10   
+  2  1    -5   -1   2726.0455  1044.9800  0.0     2.31526  0.01   
+  2  1    -1   -3   2954.9525  2291.2470  -0.0    2.27750  0.03   
+  2  2    2    -3   215.9273   155.6865   -0.0    2.26146  0.00   
+  2  3    3    -2   19.6002    15.9172    0.0     2.25070  0.00   
+  2  3    -3   -1   2793.7510  2703.2457  -180.0  2.24518  0.01   
+  2  1    -3   2    820.3354   824.7896   -0.0    2.22556  0.00   
+  2  0    4    2    5400.0899  2085.0250  0.0     2.18812  0.04   
+  2  2    -4   -2   3719.8426  1431.8638  0.0     2.18799  0.02   
+  2  1    -5   1    9636.3483  4194.8986  180.0   2.18493  0.03   
+  2  2    -2   -3   2139.1206  1851.4932  0.0     2.15451  0.01   
+  2  1    5    -2   339.4683   312.7232   -180.0  2.15169  0.00   
+  2  3    1    -3   152.1173   204.6119   0.0     2.13824  0.00   
+  2  3    -3   -2   385.6241   512.1941   180.0   2.13724  0.00   
+  2  1    3    2    168.2470   174.4523   -180.0  2.13433  0.00   
+  2  0    0    3    576.5051   454.6548   -0.0    2.12929  0.01   
+  2  0    6    0    13533.0831 11042.6256 -0.0    2.12489  0.04   
+  2  1    3    -3   660.2374   674.2906   -180.0  2.11876  0.00   
+  2  1    5    1    4358.4702  4734.7647  180.0   2.11595  0.02   
+  2  3    3    0    1381.7339  1496.6439  -180.0  2.11318  0.01   
+  2  3    -3   0    80.2897    182.7827   -180.0  2.09956  0.00   
+  2  3    -1   -3   1203.8373  2416.5634  0.0     2.08973  0.01   
+  2  2    -4   1    7304.8953  8370.0925  180.0   2.07604  0.03   
+  2  0    2    -3   253.6244   286.8930   -180.0  2.05903  0.00   
+  2  0    6    -1   68.0970    83.9001    -0.0    2.05549  0.00   
+  2  2    4    1    1904.3692  2723.1302  180.0   2.03350  0.01   
+  2  4    0    -2   1088.3778  1673.8545  -0.0    2.01366  0.00   
+  2  1    -5   -2   583.0932   976.2191   -0.0    2.00557  0.00   
+  2  4    0    -1   2197.0104  3207.5402  -0.0    2.00025  0.01   
+  2  2    0    2    638.5652   914.6787   0.0     1.99827  0.00   
+  2  1    -3   -3   1767.2984  2006.9284  -0.0    1.99351  0.01   
+  2  0    2    3    1379.0888  1320.4879  0.0     1.98235  0.01   
+  2  0    6    1    5915.4139  4760.1395  0.0     1.97919  0.02   
+  2  3    -1   1    1331.2757  1778.1424  0.0     1.97162  0.01   
+  2  3    3    -3   494.7831   747.2487   -180.0  1.97003  0.00   
+  2  3    1    1    634.2055   1049.8991  0.0     1.96352  0.00   
+  2  2    4    -3   126.4250   210.6125   -180.0  1.96339  0.00   
+  2  4    2    -2   936.0749   1505.1300  0.0     1.94723  0.00   
+  2  2    -2   2    3436.3799  4434.5615  -0.0    1.92633  0.02   
+  2  4    2    -1   149.1592   195.3738   0.0     1.92397  0.00   
+  2  2    6    -1   20.8308    25.7092    -0.0    1.91781  0.00   
+  2  4    -2   -2   9686.3336  14612.2943 -0.0    1.89414  0.02   
+  2  4    -2   -1   54.5080    83.9894    180.0   1.89341  0.00   
+  2  3    5    -1   2206.0979  3253.1319  -180.0  1.88804  0.01   
+  2  2    2    2    7589.6442  11147.4650 -0.0    1.88782  0.04   
+  2  3    -3   -3   84.1629    242.1347   -0.0    1.86184  0.00   
+  2  3    5    -2   54.1500    151.7748   -180.0  1.86122  0.00   
+  2  4    0    -3   13837.8559 17227.6438 -180.0  1.84958  0.04   
+  2  2    -6   -1   492.8976   630.1904   -180.0  1.84310  0.00   
+  2  1    -5   2    25.6544    32.7906    -180.0  1.84286  0.00   
+  2  2    6    0    4799.7629  5973.8074  -0.0    1.84084  0.01   
+  2  2    6    -2   2800.9960  2234.4122  -180.0  1.83281  0.01   
+  2  1    -1   3    3172.1808  2403.8627  -180.0  1.82957  0.02   
+  2  2    -6   0    13760.5854 11170.3478 0.0     1.82883  0.03   
+  2  2    -4   -3   419.3468   351.5785   -0.0    1.82817  0.00   
+  2  0    4    -3   7311.1450  6600.1943  180.0   1.82454  0.03   
+  2  3    -5   -1   557.2685   547.0575   -180.0  1.82305  0.00   
+  2  0    6    -2   9547.7088  9376.7847  -180.0  1.82300  0.02   
+  2  4    0    0    16770.9319 16544.7345 -0.0    1.81888  0.04   
+  2  3    -3   1    1307.7873  1388.1619  -0.0    1.81269  0.00   
+  2  4    2    -3   1557.8336  1698.2109  -0.0    1.80678  0.00   
+  2  1    1    3    10327.4006 13204.6231 -180.0  1.80269  0.07   
+  2  3    3    1    642.9679   659.8672   -0.0    1.79396  0.00   
+  2  1    5    -3   34.3240    36.9138    180.0   1.79152  0.00   
+  2  1    7    -1   409.5504   370.2527   -180.0  1.78554  0.00   
+  2  2    0    -4   32342.2682 29304.7955 0.0     1.78457  0.16   
+  2  1    7    0    2215.3788  1186.7943  -0.0    1.76994  0.01   
+  2  3    5    0    562.8465   192.4714   -180.0  1.76391  0.00   
+  2  1    -7   0    5584.8832  1861.7091  0.0     1.76369  0.01   
+  2  1    5    2    5615.0030  1478.1411  -180.0  1.75728  0.02   
+  2  3    -5   -2   921.0621   292.8600   -180.0  1.75539  0.00   
+  2  2    2    -4   9647.4650  5374.4235  180.0   1.75260  0.04   
+  2  4    2    0    5768.0405  3240.2714  180.0   1.75255  0.01   
+  2  3    -5   0    1.0365     0.6787     -180.0  1.75073  0.00   
+  2  4    -2   -3   1998.8873  1498.9920  -180.0  1.74735  0.00   
+  2  4    -2   0    1869.5698  1478.3757  -180.0  1.74562  0.00   
+  2  4    4    -2   15518.7528 11156.5991 -180.0  1.74061  0.03   
+  2  3    1    -4   20.9640    11.6942    0.0     1.73791  0.00   
+  2  1    1    -4   1732.8634  931.5858   180.0   1.73044  0.01   
+  2  0    4    3    2049.6155  1649.4123  180.0   1.72108  0.01   
+  2  1    -7   -1   674.4483   544.5769   -0.0    1.72100  0.00   
+  2  2    -4   2    6253.0542  5111.9528  -180.0  1.72066  0.02   
+  2  0    6    2    4853.6006  4043.0244  180.0   1.71979  0.02   
+  2  2    -6   -2   6736.2056  5843.5104  180.0   1.71808  0.02   
+  2  1    -3   3    4406.7142  3889.7621  0.0     1.71755  0.02   
+  2  4    4    -1   3739.5915  3425.3612  -0.0    1.71605  0.01   
+  2  3    -1   -4   29.8187    26.3196    -0.0    1.70384  0.00   
+  2  3    5    -3   2212.7714  1781.5059  180.0   1.70048  0.00   
+  2  1    -1   -4   1371.2098  1087.2281  180.0   1.69839  0.01   
+  2  2    -2   -4   5513.8533  6607.2640  -0.0    1.68632  0.03   
+  2  2    -6   1    101.6055   111.8094   180.0   1.68403  0.00   
+  2  1    -7   1    1227.1499  1037.6002  0.0     1.67991  0.00   
+  2  1    7    -2   3448.9695  3014.1863  0.0     1.67337  0.01   
+  2  4    -4   -1   3530.1848  3113.5342  -0.0    1.67328  0.01   
+  2  1    -5   -3   327.4791   322.6770   -180.0  1.66739  0.00   
+  2  2    4    2    7088.4022  6980.1241  -180.0  1.66673  0.03   
+  2  4    -4   -2   3070.3211  2996.9232  -180.0  1.66656  0.01   
+  2  1    3    3    655.7614   605.4945   0.0     1.65314  0.00   
+  2  3    3    -4   500.7155   474.5918   180.0   1.65084  0.00   
+  2  2    6    1    15.3309    15.0623    180.0   1.64996  0.00   
+  2  4    4    -3   80.6696    81.5092    0.0     1.64497  0.00   
+  2  1    3    -4   1263.8168  1267.0308  -180.0  1.64299  0.00   
+  2  2    6    -3   408.5156   438.3802   0.0     1.63845  0.00   
+  2  1    7    1    995.0581   959.6711   0.0     1.63566  0.00   
+  2  5    1    -2   55.0153    62.3555    -180.0  1.62122  0.00   
+  2  2    4    -4   10.9534    6.6299     0.0     1.60885  0.00   
+  2  3    -1   2    430.0656   237.1891   -180.0  1.60779  0.00   
+  2  4    0    -4   46.1227    25.5451    0.0     1.60742  0.00   
+  2  5    -1   -2   172.2008   104.4782   -0.0    1.60481  0.00   
+  2  3    1    2    7.0268     3.3755     -180.0  1.59704  0.00   
+  2  0    0    4    3602.2208  1719.5025  -0.0    1.59697  0.02   
+  2  0    8    0    8512.1115  4104.7411  -0.0    1.59366  0.02   
+  2  3    -5   -3   7029.6008  7048.0684  -180.0  1.58673  0.02   
+  2  4    2    -4   5381.8867  5767.4424  -180.0  1.58523  0.01   
+  2  4    4    0    74.8888    80.5872    180.0   1.58489  0.00   
+  2  3    -5   1    3404.0118  3541.7994  0.0     1.57987  0.01   
+  2  1    -7   -2   97.3188    106.0592   180.0   1.57566  0.00   
+  2  4    -4   0    904.2432   972.7791   180.0   1.57467  0.00   
+  2  4    0    1    1227.0861  1313.3627  0.0     1.57405  0.00   
+  2  0    2    -4   6296.9019  6835.8768  -180.0  1.57267  0.03   
+  2  5    1    -1   1677.4923  1838.8969  0.0     1.57223  0.00   
+  2  5    1    -3   4.2398     4.5305     0.0     1.57056  0.00   
+  2  0    8    -1   4839.4193  5105.5113  -180.0  1.56971  0.01   
+  2  3    -3   -4   201.6155   222.0271   -180.0  1.56739  0.00   
+  2  1    -3   -4   1058.1254  1168.3240  -180.0  1.56437  0.00   
+  2  5    -1   -1   3249.7348  3532.8589  -0.0    1.56314  0.01   
+  2  3    5    1    5771.3101  6630.5027  -0.0    1.55930  0.01   
+  2  2    0    3    1534.8118  1763.6711  -180.0  1.55911  0.01   
+  2  4    -4   -3   577.0871   668.2938   0.0     1.55805  0.00   
+  2  0    6    -3   44.6343    50.4752    180.0   1.55391  0.00   
+  2  5    -1   -3   2988.8505  3177.9812  180.0   1.54983  0.01   
+  2  5    3    -2   2684.5311  1684.3120  0.0     1.53962  0.00   
+  2  3    7    -1   440.8410   255.3064   -0.0    1.53554  0.00   
+  2  4    -2   -4   6975.9522  4566.3850  180.0   1.53333  0.02   
+  2  4    -2   1    598.3388   360.2122   -0.0    1.53138  0.00   
+  2  2    -2   3    5526.2970  3884.5431  0.0     1.52972  0.02   
+  2  1    -5   3    170.0730   114.2358   180.0   1.52775  0.00   
+  2  0    2    4    2848.7309  1999.2534  180.0   1.52655  0.01   
+  2  3    7    -2   2019.3472  1417.6951  180.0   1.52649  0.00   
+  2  4    2    1    77.8726    55.0425    -0.0    1.52494  0.00   
+  2  0    8    1    73.0159    53.4117    0.0     1.52385  0.00   
+  2  3    -3   2    1013.6910  713.5252   0.0     1.52351  0.00   
+  2  2    -6   -3   1421.3891  972.3599   180.0   1.52111  0.00   
+  2  1    -7   2    2851.7517  2092.8268  180.0   1.51406  0.01   
+  2  2    -4   -4   4474.5733  3475.0688  -180.0  1.51008  0.01   
+  2  2    8    -1   9290.2363  8932.7653  0.0     1.50687  0.01   
+  2  5    3    -3   10907.9721 11216.4371 -0.0    1.50125  0.02   
+  2  2    2    3    239.2054   261.4234   0.0     1.49966  0.00   
+  2  5    -3   -2   1123.2703  1283.3165  0.0     1.49852  0.00   
+  2  4    6    -2   1418.5638  1643.4734  -180.0  1.49804  0.00   
+  2  3    3    2    2442.4667  2828.3266  0.0     1.49651  0.01   
+  2  5    3    -1   1321.6913  1375.8687  180.0   1.49230  0.00   
+  2  1    7    -3   970.8679   963.7100   -0.0    1.49138  0.00   
+  2  3    5    -4   1033.5989  976.7543   0.0     1.48741  0.00   
+  2  3    -7   -1   4.6341     4.1505     -180.0  1.48641  0.00   
+  2  2    -6   2    2309.5314  2225.9899  -180.0  1.48209  0.00   
+  2  1    5    -4   613.5251   569.2303   -0.0    1.48061  0.00   
+  2  4    4    -4   1027.9118  936.8644   -0.0    1.47752  0.00   
+  2  4    6    -1   2757.8799  2425.3077  -0.0    1.47727  0.00   
+  2  2    8    -2   2624.7372  2036.6290  -0.0    1.46947  0.00   
+  2  5    -3   -1   2862.8323  2250.7625  180.0   1.46932  0.00   
+  2  0    4    -4   2218.8515  1799.2981  0.0     1.46530  0.01   
+  2  2    8    0    21368.0253 17372.8918 180.0   1.46378  0.04   
+  2  0    8    -2   3244.2964  2670.5014  0.0     1.46338  0.01   
+  2  3    7    0    1634.1144  1344.4772  -0.0    1.46164  0.00   
+  2  0    6    3    9763.6158  9727.2084  -180.0  1.45874  0.03   
+  2  2    -8   -1   292.4753   277.6153   0.0     1.45806  0.00   
+  2  2    -8   0    14494.5185 14971.6548 -180.0  1.45572  0.02   
+  2  1    5    3    81.3642    84.4701    0.0     1.45352  0.00   
+  2  3    -7   0    1732.1670  1874.7884  -0.0    1.45113  0.00   
+  2  5    -3   -3   3782.2910  3973.0050  -0.0    1.44873  0.01   
+  2  1    7    2    317.4993   339.6716   180.0   1.44736  0.00   
+  2  5    1    0    437.2516   468.7582   0.0     1.44694  0.00   
+  2  5    -1   0    259.5964   282.6566   0.0     1.44450  0.00   
+  2  3    -7   -2   376.0626   407.5222   -180.0  1.44435  0.00   
+  2  5    1    -4   347.1225   376.0669   -0.0    1.44434  0.00   
+  2  4    6    -3   5276.4244  4799.2632  180.0   1.44037  0.01   
+  2  3    7    -3   2387.1639  2066.9126  0.0     1.43858  0.00   
+  2  4    -6   -1   17284.9119 13974.0377 -0.0    1.43651  0.02   
+  2  1    -1   4    2420.9450  1747.7612  -0.0    1.43156  0.01   
+  2  2    6    2    18876.1530 14127.5120 -180.0  1.43067  0.05   
+  2  4    -6   -2   14849.7124 11494.7453 -180.0  1.42772  0.02   
+  2  3    1    -5   71.2384    54.5453    0.0     1.42498  0.00   
+  2  2    -4   3    12149.7747 9304.7725  -0.0    1.42492  0.03   
+  2  5    -1   -4   7747.2791  6191.0063  0.0     1.42367  0.01   
+  2  2    0    -5   511.6541   530.6717   -0.0    1.41970  0.00   
+  2  2    6    -4   3899.0773  4109.1661  -0.0    1.41942  0.01   
+  2  4    -4   1    2152.8582  2328.2327  -180.0  1.41643  0.00   
+  2  1    1    4    7646.3313  9765.5200  -0.0    1.41417  0.03   
+  2  2    2    -5   136.6449   102.1798   180.0   1.40774  0.00   
+  2  4    4    1    4903.4700  4251.1055  -180.0  1.40628  0.01   
+  2  1    9    -1   477.6548   313.3806   180.0   1.40427  0.00   
+  2  3    -1   -5   969.6305   559.2035   180.0   1.40173  0.00   
+  2  5    5    -2   153.0620   121.8591   180.0   1.39689  0.00   
+  2  4    -4   -4   442.0674   333.7965   -180.0  1.39638  0.00   
+  2  5    3    -4   9984.7582  10290.7248 -180.0  1.39407  0.02   
+  2  0    4    4    552.8930   603.2489   180.0   1.39300  0.00   
+  2  1    9    0    5526.4004  6061.3448  -180.0  1.39244  0.01   
+  2  0    8    2    756.2924   841.8614   -0.0    1.39135  0.00   
+  2  1    -7   -3   7.8153     8.6161     0.0     1.39082  0.00   
+  2  2    -8   -2   320.8616   389.1003   0.0     1.38958  0.00   
+  2  1    -9   0    4278.6786  5032.6219  -180.0  1.38852  0.01   
+  2  3    -5   -4   608.6716   712.8918   180.0   1.38828  0.00   
+  2  1    -5   -4   10.7772    12.2841    -0.0    1.38705  0.00   
+  2  4    6    0    6052.2587  6881.9956  0.0     1.38694  0.01   
+  2  2    -8   1    2522.4586  2583.5813  -0.0    1.38353  0.00   
+  2  3    -5   2    118.4309   107.7060   180.0   1.38139  0.00   
+  2  1    -3   4    11083.8607 11498.8556 180.0   1.38001  0.03   
+  2  3    3    -5   573.2244   601.2645   -0.0    1.37984  0.00   
+  2  5    3    0    1966.2247  2064.1961  180.0   1.37983  0.00   
+  2  2    4    3    8041.1778  7682.9819  -0.0    1.37735  0.03   
+  2  4    -6   0    2901.0502  2929.6322  0.0     1.37669  0.00   
+  2  5    -3   0    1648.1636  1846.9850  -180.0  1.37349  0.00   
+  2  4    0    -5   8296.4238  9852.1453  -0.0    1.37263  0.02   
+  2  5    5    -3   887.1918   1000.1841  -0.0    1.37203  0.00   
+  2  1    1    -5   64.4621    51.8333    180.0   1.36876  0.00   
+  2  2    8    -3   1316.9898  897.0709   0.0     1.36740  0.00   
+  2  2    -2   -5   1043.0819  890.9937   -180.0  1.36475  0.00   
+  2  1    -9   -1   2470.1916  2521.2414  180.0   1.36346  0.00   
+  2  4    2    -5   10160.4102 11335.5971 180.0   1.36264  0.02   
+  2  2    8    1    3796.2855  3611.9875  -180.0  1.35827  0.01   
+  2  5    5    -1   978.3033   870.4892   -180.0  1.35737  0.00   
+  2  4    -6   -3   5714.3827  4126.3352  180.0   1.35385  0.01   
+  2  3    -7   1    827.4348   576.4772   0.0     1.35312  0.00   
+  2  1    9    -2   18690.9365 16147.0686 0.0     1.35152  0.02   
+  2  6    0    -2   18967.7606 16981.3924 180.0   1.35133  0.02   
+  2  1    -9   1    3894.2336  3741.5161  -0.0    1.35032  0.01   
+  2  1    -1   -5   9569.9916  10683.9602 -0.0    1.34891  0.04   
+  2  3    5    2    176.2864   209.3398   0.0     1.34817  0.00   
+  2  5    -5   -2   420.3341   568.7530   180.0   1.34647  0.00   
+  2  4    0    2    11299.7610 20266.7951 180.0   1.34356  0.02   
+  2  6    0    -3   270.5796   424.9852   0.0     1.34244  0.00   
+  2  3    -7   -3   667.9514   987.1236   180.0   1.34218  0.00   
+  2  5    -3   -4   13.5624    19.4544    -0.0    1.34037  0.00   
+  2  3    7    1    696.2972   545.2034   0.0     1.33504  0.00   
+  2  1    3    4    382.2474   303.9072   180.0   1.33473  0.00   
+  2  2    4    -5   2802.0935  2138.1647  -0.0    1.33359  0.01   
+  2  6    2    -2   9098.5199  7470.5514  0.0     1.33146  0.01   
+  2  3    -1   3    719.3095   551.6386   -0.0    1.32984  0.00   
+  2  5    -5   -1   3328.8024  3077.6343  -180.0  1.32879  0.00   
+  2  1    -7   3    801.8731   845.5145   -180.0  1.32789  0.00   
+  2  1    3    -5   12244.4150 12956.3684 180.0   1.32785  0.03   
+  2  4    6    -4   1129.8145  1219.1637  0.0     1.32754  0.00   
+  2  6    2    -3   5.6054     6.0091     -0.0    1.32656  0.00   
+  2  4    -2   -5   2593.3913  3146.4347  0.0     1.32203  0.01   
+  2  1    9    1    901.8577   1105.1306  -0.0    1.32057  0.00   
+  2  4    -2   2    1794.3869  2255.4357  0.0     1.32028  0.00   
+  2  3    1    3    2551.5223  3237.6008  0.0     1.32015  0.01   
+  2  2    -6   -4   90.9541    114.0134   0.0     1.31919  0.00   
+  2  3    -3   -5   1740.3097  2179.7868  180.0   1.31918  0.00   
+  2  0    6    -4   2846.0400  3685.3963  0.0     1.31717  0.01   
+  2  0    8    -3   3294.9948  4546.6333  -0.0    1.31636  0.00   
+  2  6    -2   -2   256.7691   330.6363   180.0   1.31265  0.00   
+  2  4    2    2    452.2541   505.4413   0.0     1.30914  0.00   
+  2  5    -5   -3   6978.2269  6208.9517  0.0     1.30653  0.01   
+  2  3    7    -4   12.3942    11.5530    -180.0  1.30602  0.00   
+  2  6    0    -1   594.3976   635.2341   -0.0    1.30261  0.00   
+  2  6    -2   -3   4231.8421  4797.6968  0.0     1.30107  0.01   
+  2  1    7    -4   688.9595   816.7390   180.0   1.30069  0.00   
+  2  4    4    -5   1068.7569  839.8412   -180.0  1.29576  0.00   
+  2  5    -1   1    696.6167   560.8179   -180.0  1.29287  0.00   
+  2  5    5    -4   111.6670   102.0732   -0.0    1.29210  0.00   
+  2  5    1    1    211.2422   213.0414   180.0   1.29128  0.00   
+  2  5    1    -5   1311.4962  1297.0866  -180.0  1.28850  0.00   
+  2  1    -9   -2   7102.3487  7594.2794  0.0     1.28440  0.01   
+  2  3    -3   3    3556.8795  3821.2749  180.0   1.28422  0.01   
+  2  2    -6   3    95.5573    97.9036    -0.0    1.28363  0.00   
+  2  3    5    -5   3063.3486  3037.5557  -0.0    1.28334  0.01   
+  2  6    2    -1   2241.8679  2446.8719  180.0   1.28151  0.00   
+  2  4    8    -2   15278.3675 16043.2073 -0.0    1.27998  0.02   
+  2  6    0    -4   5017.5940  4642.8182  0.0     1.27913  0.01   
+  2  1    -5   4    0.3060     0.2762     -0.0    1.27885  0.00   
+  2  0    0    5    1679.6469  1504.7953  0.0     1.27757  0.01   
+  2  2    -8   -3   1131.3748  969.8153   0.0     1.27578  0.00   
+  2  1    -3   -5   1895.8005  1649.0848  -180.0  1.27554  0.01   
+  2  0    10   0    6004.6070  5612.4673  -0.0    1.27493  0.01   
+  2  3    9    -1   596.1352   567.6734   180.0   1.27318  0.00   
+  2  3    9    -2   172.6538   209.3409   0.0     1.27118  0.00   
+  2  6    -2   -1   482.4271   604.9530   -180.0  1.27102  0.00   
+  2  5    -1   -5   2453.1505  3287.3648  -0.0    1.27057  0.00   
+  2  4    -6   1    1572.2276  2157.0193  180.0   1.27033  0.00   
+  2  2    0    4    3590.5598  5970.9564  -0.0    1.26862  0.01   
+  2  6    2    -4   1551.0154  2642.8907  -180.0  1.26852  0.00   
+  2  0    2    -5   2250.5465  4140.6925  180.0   1.26818  0.01   
+  2  2    -8   2    8314.3213  15669.9235 0.0     1.26800  0.01   
+  2  5    5    0    812.0420   1539.1640  -0.0    1.26791  0.00   
+  2  0    10   -1   482.1402   722.1628   -180.0  1.26570  0.00   
+  2  4    8    -1   86.1892    116.1733   180.0   1.26381  0.00   
+  2  2    -4   -5   27.1170    34.2839    180.0   1.26302  0.00   
+  2  1    -9   2    306.0296   407.6104   0.0     1.26267  0.00   
+  2  6    4    -2   2753.5652  4060.9393  -0.0    1.26012  0.00   
+  2  1    7    3    951.1672   1423.0605  -180.0  1.25993  0.00   
+  2  5    -5   0    817.8946   1251.7915  -0.0    1.25974  0.00   
+  2  4    6    1    22.4887    35.4122    180.0   1.25938  0.00   
+  2  6    4    -3   3731.9987  5742.7030  -180.0  1.25904  0.00   
+  2  3    3    3    24.1584    34.1056    0.0     1.25855  0.00   
+  2  2    -2   4    2037.0636  2630.4316  180.0   1.25569  0.01   
+  2  5    3    -5   6295.4246  7849.9862  180.0   1.25548  0.01   
+  2  1    9    -3   413.0759   446.4585   -180.0  1.25310  0.00   
+  2  4    -4   2    2882.5998  2913.1494  0.0     1.24747  0.00   
+  2  4    8    -3   1363.6103  1591.0184  -180.0  1.24643  0.00   
+  2  5    -3   1    144.4372   154.1169   -180.0  1.24419  0.00   
+  2  4    -6   -4   4005.5544  4649.8078  0.0     1.24074  0.01   
+  2  1    5    -5   17.7162    20.8490    -0.0    1.24058  0.00   
+  2  6    -2   -4   96.1606    116.0421   -0.0    1.24022  0.00   
+  2  5    3    1    699.2020   865.0651   -180.0  1.23993  0.00   
+  2  0    6    4    3454.0571  4402.8269  -0.0    1.23960  0.01   
+  2  0    8    3    1965.3681  2523.8232  0.0     1.23892  0.00   
+  2  5    7    -2   37.7928    48.4702    -180.0  1.23815  0.00   
+  2  0    2    5    4.7550     6.1649     -0.0    1.23770  0.00   
+  2  3    -9   -1   1401.5121  1878.7146  -180.0  1.23697  0.00   
+  2  0    10   1    52.1725    69.0195    180.0   1.23540  0.00   
+  2  2    8    -4   0.5364     0.6712     -0.0    1.23509  0.00   
+  2  2    2    4    204.9500   202.3679   180.0   1.23305  0.00   
+  2  2    10   -1   684.9399   674.5837   -0.0    1.23266  0.00   
+  2  2    6    3    610.9562   591.5126   -0.0    1.23202  0.00   
+  2  4    -8   -1   1822.6809  1660.8265  180.0   1.22975  0.00   
+  2  4    4    2    7727.5161  7216.8110  -0.0    1.22886  0.02   
+  2  6    -4   -2   8042.3766  7429.0559  0.0     1.22874  0.01   
+  2  4    -4   -5   6865.2271  5935.8119  180.0   1.22833  0.01   
+  2  3    9    0    276.4814   207.1256   180.0   1.22722  0.00   
+  2  2    8    2    27957.1486 16367.8700 -0.0    1.22501  0.05   
+  2  3    -7   2    7.6119     4.4310     -180.0  1.22493  0.00   
+  2  5    7    -3   1367.9329  701.3947   180.0   1.22357  0.00   
+  2  5    -5   -4   968.5345   527.2945   -180.0  1.22255  0.00   
+  2  2    6    -5   167.4875   93.3157    -0.0    1.22244  0.00   
+  2  3    9    -3   6137.1297  3989.5508  -0.0    1.22187  0.01   
+  2  4    -8   -2   20924.0546 15576.6760 0.0     1.22139  0.03   
+  2  1    5    4    3664.6259  2923.6151  -180.0  1.22003  0.01   
+  2  3    -9   0    71.3240    63.1939    -0.0    1.21922  0.00   
+  2  6    -4   -3   1.6819     1.6171     -180.0  1.21643  0.00   
+  2  6    4    -1   10.9130    10.2523    180.0   1.21473  0.00   
+  2  2    10   -2   3396.7562  3195.8904  -180.0  1.21471  0.00   
+  2  3    -7   -4   11.0695    9.5153     0.0     1.21279  0.00   
+  2  6    0    0    15258.4808 13100.2263 0.0     1.21259  0.02   
+  2  1    9    2    2038.0159  1749.7864  0.0     1.21259  0.00   
+  2  0    4    -5   59.8707    51.4047    -180.0  1.21258  0.00   
+  2  1    -7   -4   784.4688   673.8718   0.0     1.21254  0.00   
+  2  6    4    -4   225.3895   199.9465   0.0     1.21185  0.00   
+  2  0    10   -2   2637.9964  2393.1814  180.0   1.21068  0.00   
+  2  3    -9   -2   2.7061     2.4088     0.0     1.20966  0.00   
+  2  5    7    -1   983.4025   919.5910   -0.0    1.20764  0.00   
+  2  5    -3   -5   1786.0588  1669.4106  -180.0  1.20756  0.00   
+  2  2    10   0    14.0409    11.8619    180.0   1.20601  0.00   
+  2  3    -5   -5   5070.3363  5223.5291  -0.0    1.20426  0.01   
+  2  4    8    0    2060.1623  2036.1638  -180.0  1.20314  0.00   
+  2  2    -10  0    1104.4821  1234.3417  180.0   1.20037  0.00   
+  2  2    -10  -1   1901.9473  1881.5821  0.0     1.19900  0.00   
+  2  2    -4   4    0.0044     0.0043     180.0   1.19841  0.00   
+  2  3    -5   3    5361.9295  5149.8089  -180.0  1.19827  0.01   
+  2  6    -4   -1   4507.0951  4013.4094  180.0   1.19705  0.01   
+  2  4    -8   0    2238.9064  1701.7086  -180.0  1.19422  0.00   
+  2  4    6    -5   6895.0396  5356.2972  -0.0    1.19366  0.01   
+  2  6    2    0    8082.5129  6359.8747  -180.0  1.19287  0.01   
+  2  3    1    -6   219.2542   172.0799   180.0   1.19278  0.00   
+  2  3    7    2    272.6048   210.6961   180.0   1.19262  0.00   
+  2  6    -2   0    2471.9262  1825.4606  -180.0  1.18959  0.00   
+  2  5    -7   -2   329.2501   235.2689   -180.0  1.18926  0.00   
+  2  5    5    -5   761.9937   652.0282   -0.0    1.18202  0.00   
+  2  6    0    -5   2158.5311  1859.8386  -0.0    1.18139  0.00   
+  2  5    -7   -1   1265.3600  1170.6276  -0.0    1.17956  0.00   
+  2  3    -1   -6   9368.8067  10651.6340 0.0     1.17652  0.03   
+  2  1    -9   -3   2935.3041  3479.3329  -0.0    1.17569  0.01   
+  2  4    0    -6   586.5623   694.8770   -180.0  1.17567  0.00   
+  2  6    2    -5   585.8620   690.4314   180.0   1.17553  0.00   
+  2  4    8    -4   5177.5452  5262.2410  180.0   1.17365  0.01   
+  2  1    -1   5    43.3727    44.3347    0.0     1.17349  0.00   
+  2  2    0    -6   3478.0655  3262.2227  -180.0  1.17258  0.01   
+  2  4    2    -6   1052.0856  785.7923   0.0     1.17185  0.00   
+  2  4    -8   -3   707.1452   512.5086   -0.0    1.17167  0.00   
+  2  1    -5   -5   7383.5025  5414.4867  -180.0  1.17131  0.02   
+  2  3    3    -6   3544.6390  3178.6335  180.0   1.16840  0.01   
+  2  5    7    -4   6553.1135  5932.4007  0.0     1.16833  0.01   
+  2  2    2    -6   487.7904   444.4424   0.0     1.16828  0.00   
+  2  0    8    -4   9233.1938  6734.2463  -180.0  1.16544  0.01   
+  2  3    5    3    14854.2710 9033.3981  -180.0  1.16397  0.04   
+  2  6    -4   -4   2188.0553  1331.0105  -180.0  1.16381  0.00   
+  2  3    7    -5   1938.8102  1180.8749  180.0   1.16377  0.00   
+  2  3    -9   1    38.2328    24.5109    -0.0    1.16177  0.00   
+  2  1    1    5    3040.6333  1984.2370  0.0     1.16142  0.01   
+  2  2    -10  1    624.3338   408.7012   -180.0  1.16134  0.00   
+  2  0    4    5    5359.4939  3674.6390  -180.0  1.16082  0.02   
+  2  6    6    -3   791.3541   572.9928   0.0     1.16041  0.00   
+  2  5    -5   1    11.0498    8.2052     180.0   1.16017  0.00   
+  2  7    1    -3   432.9079   326.8856   180.0   1.15995  0.00   
+  2  2    4    4    442.1377   334.7388   180.0   1.15990  0.00   
+  2  0    10   2    2472.9016  1953.1670  -180.0  1.15916  0.00   
+  2  5    -7   -3   17.6552    13.9221    0.0     1.15905  0.00   
+  2  6    6    -2   1361.7415  1062.5954  180.0   1.15883  0.00   
+  2  2    -10  -2   1100.6983  927.1428   -180.0  1.15763  0.00   
+  2  2    10   -3   536.4940   456.9863   180.0   1.15752  0.00   
+  2  1    -7   4    8953.0651  7894.1741  -0.0    1.15699  0.01   
+  2  1    11   -1   200.4342   172.4013   -0.0    1.15488  0.00   
+  2  5    5    1    16.2911    14.5872    180.0   1.15443  0.00   
+  2  4    0    3    413.1377   372.8509   -0.0    1.15214  0.00   
+  2  7    -1   -3   210.1178   190.7937   -0.0    1.15103  0.00   
+  2  1    -9   3    432.0509   390.2848   -180.0  1.15086  0.00   
+  2  7    1    -2   425.6256   417.6649   180.0   1.14957  0.00   
+  2  6    -2   -5   3.3721     3.3422     180.0   1.14818  0.00   
+  2  2    -8   -4   998.4000   1241.1393  -0.0    1.14713  0.00   
+  2  3    9    1    690.2274   840.9132   -180.0  1.14703  0.00   
+  2  1    -3   5    111.7963   131.0137   -0.0    1.14691  0.00   
+  2  4    -6   2    891.8785   884.2580   -180.0  1.14653  0.00   
+  2  1    11   0    732.4588   673.8595   0.0     1.14593  0.00   
+  2  3    -9   -3   6325.4327  6842.7549  -0.0    1.14539  0.01   
+  2  1    -11  0    55.6444    56.5171    180.0   1.14326  0.00   
+  2  7    -1   -2   250.1368   258.5173   180.0   1.14319  0.00   
+  2  2    10   1    1858.9437  2221.3310  -180.0  1.14260  0.00   
+  2  2    -6   -5   6875.1586  8280.7099  -0.0    1.14253  0.02   
+  2  5    -1   2    0.2086     0.2523     -180.0  1.14237  0.00   
+  2  4    -2   -6   164.8864   159.9954   -0.0    1.14109  0.00   
+  2  5    7    0    1607.0134  1584.2307  0.0     1.14103  0.00   
+  2  3    9    -4   2593.3807  3452.1120  -180.0  1.13977  0.00   
+  2  4    -2   3    508.7556   675.3480   180.0   1.13965  0.00   
+  2  2    -8   3    683.1211   940.5804   180.0   1.13923  0.00   
+  2  5    1    2    104.1135   151.0052   180.0   1.13897  0.00   
+  2  2    -2   -6   296.8271   457.5743   180.0   1.13875  0.00   
+  2  5    1    -6   65.0031    92.8501    180.0   1.13644  0.00   
+  2  6    4    0    6460.3063  9886.1889  -180.0  1.13618  0.01   
+  2  1    9    -4   3989.2135  6387.1239  180.0   1.13575  0.01   
+  2  7    1    -4   56.4531    104.3489   0.0     1.13318  0.00   
+  2  5    -7   0    266.8549   561.3250   0.0     1.13270  0.00   
+  2  6    4    -5   1624.6620  3560.8356  -0.0    1.13225  0.00   
+  2  7    3    -3   900.6355   1752.7599  180.0   1.13164  0.00   
+  2  1    7    -5   943.3813   1876.4532  -0.0    1.13113  0.00   
+  2  4    4    -6   34.9941    74.0198    180.0   1.13073  0.00   
+  2  6    -4   0    4110.4912  8996.3605  -180.0  1.13052  0.01   
+  2  1    1    -6   5.7377     12.7255    180.0   1.13041  0.00   
+  2  4    2    3    13.5186    26.9687    0.0     1.12798  0.00   
+  2  1    11   -2   1866.6288  4054.5939  -180.0  1.12721  0.00   
+  2  2    4    -6   267.4159   617.9103   -180.0  1.12706  0.00   
+  2  1    -11  -1   33.0939    80.5660    180.0   1.12692  0.00   
+  2  0    6    -5   323.0845   825.3110   -0.0    1.12677  0.00   
+  2  0    10   -3   13.8070    25.1309    180.0   1.12560  0.00   
+  2  6    6    -4   601.7715   1116.6065  -0.0    1.12535  0.00   
+  2  4    -8   1    743.9145   1428.0735  -0.0    1.12500  0.00   
+  2  4    6    2    255.6920   491.6513   180.0   1.12497  0.00   
+  2  3    -3   -6   1279.3004  2679.1058  0.0     1.12421  0.00   
+  2  1    -11  1    246.5148   520.4388   180.0   1.12385  0.00   
+  2  3    -1   4    27.9122    62.3074    180.0   1.12290  0.00   
+  2  7    -1   -4   156.1336   340.7362   180.0   1.12266  0.00   
+  2  6    -6   -2   2.7253     5.8815     -0.0    1.12259  0.00   
+  2  5    -1   -6   1604.4130  3679.1020  -180.0  1.12188  0.00   
+  2  6    6    -1   7.5168     18.5196    -180.0  1.12105  0.00   
+  2  7    3    -2   194.2814   466.2613   -180.0  1.11981  0.00   
+  2  5    -5   -5   2206.5006  3254.1700  180.0   1.11710  0.00   
+  2  1    -1   -6   1095.3882  1573.1101  -180.0  1.11699  0.00   
+  2  4    -6   -5   14.1501    12.1624    -180.0  1.11621  0.00   
+  2  5    3    -6   4839.9209  3572.8767  0.0     1.11574  0.01   
+  2  3    1    4    626.2286   557.2568   180.0   1.11489  0.00   
+  2  4    8    1    3371.6581  3030.2470  -0.0    1.11486  0.01   
+  2  1    3    5    232.9346   208.8946   -180.0  1.11404  0.00   
+  2  2    -6   4    1985.9218  1626.0861  -0.0    1.11278  0.00   
+  2  6    -6   -3   9250.7123  9170.8262  180.0   1.11104  0.01   
+  2  5    -3   2    23.8784    23.9804    -180.0  1.11049  0.00   
+  2  3    5    -6   75.0815    75.3696    -0.0    1.11017  0.00   
+  2  1    3    -6   4318.7229  3749.4968  0.0     1.10915  0.01   
+  2  7    3    -4   1013.5392  851.8273   -0.0    1.10885  0.00   
+  2  7    -3   -3   10.9475    8.0510     -0.0    1.10731  0.00   
+  2  7    1    -1   749.4337   540.2195   -180.0  1.10485  0.00   
+  2  6    0    1    3829.6262  2851.2916  180.0   1.10441  0.01   
+  2  1    11   1    441.3254   353.4958   0.0     1.10278  0.00   
+  2  7    -3   -2   8.8107     7.6618     -0.0    1.10240  0.00   
+  2  4    10   -2   302.4037   293.9448   -180.0  1.10139  0.00   
+  2  7    -1   -1   577.2049   560.8360   -180.0  1.10125  0.00   
+  2  5    3    2    95.2954    92.4856    -180.0  1.10119  0.00   
+  2  2    8    -5   3833.9862  3728.5603  180.0   1.10077  0.01   
+  2  6    -6   -1   6.3073     6.2337     0.0     1.10033  0.00   
+  2  5    -7   -4   215.3223   136.6182   0.0     1.09716  0.00   
+  2  3    -3   4    234.9634   143.6453   -0.0    1.09706  0.00   
+  2  1    7    4    109.7248   57.0295    -0.0    1.09661  0.00   
+  2  0    8    4    8655.9391  2959.2417  180.0   1.09406  0.02   
+  2  4    -8   -4   10638.2939 3685.4545  -180.0  1.09399  0.02   
+  2  4    -4   3    6057.4403  2186.7268  180.0   1.09385  0.01   
+  2  3    -7   3    5015.0241  1814.2931  0.0     1.09384  0.01   
+  2  1    9    3    848.1665   308.2223   180.0   1.09383  0.00   
+  2  2    -10  2    6.8950     3.3265     -0.0    1.09247  0.00   
+  2  2    8    3    747.2794   379.8198   0.0     1.09126  0.00   
+  2  5    9    -2   2524.6140  1582.6840  -0.0    1.09021  0.00   
+  2  4    10   -1   2.3524     1.7369     -180.0  1.08903  0.00   
+  2  6    -2   1    2.0031     1.5406     -180.0  1.08894  0.00   
+  2  1    -5   5    7072.8998  5646.2565  0.0     1.08884  0.02   
+  2  6    2    1    306.5909   245.3481   -0.0    1.08745  0.00   
+  2  2    -10  -3   764.8691   617.4947   180.0   1.08733  0.00   
+  2  5    7    -5   102.4202   91.0318    -180.0  1.08704  0.00   
+  2  6    -4   -5   319.1093   422.0173   180.0   1.08477  0.00   
+  2  3    -7   -5   2224.3485  3180.2930  0.0     1.08232  0.00   
+  2  5    9    -3   26.4458    37.0056    -180.0  1.08217  0.00   
+  2  4    10   -3   397.1827   496.5346   180.0   1.08176  0.00   
+  2  4    8    -5   247.5107   416.8216   0.0     1.08002  0.00   
+  2  7    -3   -4   282.6006   475.9937   -180.0  1.08002  0.00   
+  2  3    11   -2   733.7743   1209.7235  180.0   1.07973  0.00   
+  2  3    -9   2    750.1734   1162.0253  -0.0    1.07952  0.00   
+  2  1    -11  -2   361.9161   505.5742   -0.0    1.07909  0.00   
+  2  3    11   -1   1812.3892  2531.9784  -180.0  1.07901  0.00   
+  2  4    -4   -6   27.5046    79.4879    0.0     1.07725  0.00   
+  2  7    3    -1   200.2969   517.9063   0.0     1.07642  0.00   
+  2  7    1    -5   8.4526     25.2106    -0.0    1.07626  0.00   
+  2  5    -3   -6   333.0889   1371.1187  180.0   1.07586  0.00   
+  2  2    10   -4   687.3779   2842.5457  0.0     1.07584  0.00   
+  2  2    -4   -6   43.9289    186.5753   0.0     1.07568  0.00   
+  2  3    3    4    179.1913   560.4316   180.0   1.07511  0.00   
+  2  1    -11  2    225.9118   558.2780   -180.0  1.07370  0.00   
+  2  7    5    -3   347.8482   928.6481   180.0   1.07351  0.00   
+  2  4    4    3    304.1275   818.8776   180.0   1.07348  0.00   
+  2  1    -3   -6   78.0009    135.6225   180.0   1.07233  0.00   
+  2  6    0    -6   2.4310     4.1780     -180.0  1.07161  0.00   
+  2  1    11   -3   223.5849   540.3856   180.0   1.07008  0.00   
+  2  6    2    -6   46.8842    107.8329   0.0     1.06912  0.00   
+  2  6    -6   -4   254.2975   552.9788   0.0     1.06862  0.00   
+  2  5    9    -1   649.1744   1026.4794  0.0     1.06732  0.00   
+  2  2    6    4    2553.7755  4143.5979  0.0     1.06716  0.01   
+  2  7    -3   -1   101.6994   173.9010   0.0     1.06652  0.00   
+  2  2    0    5    1156.2769  1937.9253  0.0     1.06580  0.00   
+  2  0    6    5    225.0566   358.8678   0.0     1.06561  0.00   
+  2  7    -1   -5   2128.1074  3288.8085  0.0     1.06535  0.00   
+  2  5    5    -6   294.9856   447.2840   -180.0  1.06509  0.00   
+  2  0    0    6    33.9348    53.4823    180.0   1.06464  0.00   
+  2  0    10   3    2078.2935  3276.3246  0.0     1.06463  0.00   
+  2  4    6    -6   24.2448    31.3322    -180.0  1.06282  0.00   
+  2  6    6    -5   334.0316   434.3157   -0.0    1.06260  0.00   
+  2  0    12   0    86.2128    112.6819   180.0   1.06244  0.00   
+  2  4    -10  -1   876.8758   1132.6677  180.0   1.06171  0.00   
+  2  7    5    -2   3594.4123  4496.3914  -180.0  1.06153  0.00   
+  2  0    2    -6   611.5662   748.1993   0.0     1.06104  0.00   
+  2  5    -7   1    763.1006   969.1237   180.0   1.06052  0.00   
+  2  1    -9   -4   1311.2170  1706.8793  -180.0  1.06015  0.00   
+  2  2    -2   5    2461.3995  3313.4198  -180.0  1.05994  0.01   
+  2  3    -9   -4   10.1196    13.6703    -180.0  1.05993  0.00   
+  2  2    6    -6   196.8348   288.6216   -180.0  1.05938  0.00   
+  2  0    12   -1   940.5158   1340.4500  -0.0    1.05892  0.00   
+  2  1    -7   -5   5.2920     7.5059     -180.0  1.05860  0.00   
+  2  1    5    -6   33.3647    47.4061    -180.0  1.05858  0.00   
+  2  2    10   2    734.2218   1237.1699  -0.0    1.05797  0.00   
+  2  3    7    3    7.4205     12.9031    -180.0  1.05758  0.00   
+  2  7    3    -5   1237.5176  2239.1302  -180.0  1.05718  0.00   
+  2  6    6    0    248.9941   461.7745   -0.0    1.05659  0.00   
+  2  7    5    -4   1009.7117  2051.4003  0.0     1.05581  0.00   
+  2  4    -10  -2   1430.1734  3145.7849  0.0     1.05450  0.00   
+  2  5    7    1    16.8834    37.2884    180.0   1.05440  0.00   
+  2  6    8    -3   5060.2109  8866.7538  -0.0    1.05196  0.01   
+  2  3    -11  -1   150.2793   261.5320   -0.0    1.05193  0.00   
+  2  5    -5   2    3820.2201  5387.0808  -180.0  1.05131  0.01   
+  2  3    9    2    662.4148   862.2832   -0.0    1.05108  0.00   
+  2  3    11   -3   552.4291   673.7850   180.0   1.05082  0.00   
+  2  6    -6   0    442.8817   488.9045   -0.0    1.04978  0.00   
+  2  6    8    -2   340.9901   331.3808   0.0     1.04899  0.00   
+  2  3    11   0    436.2634   407.0557   -0.0    1.04881  0.00   
+  2  3    -5   -6   1347.8230  1235.7557  -180.0  1.04872  0.00   
+  2  4    10   0    72.4698    61.4161    -0.0    1.04771  0.00   
+  2  5    -9   -2   2567.2854  2208.3085  -0.0    1.04729  0.00   
+  2  5    9    -4   266.5034   228.7958   -180.0  1.04516  0.00   
+  2  6    -2   -6   1517.4220  1293.5044  -0.0    1.04487  0.00   
+  2  6    -4   1    3709.5447  3160.5795  -0.0    1.04485  0.01   
+  2  3    -5   4    2883.5935  2301.6767  -0.0    1.04377  0.01   
+  2  3    9    -5   2272.6452  1817.7670  180.0   1.04328  0.00   
+  2  1    5    5    2006.7796  1623.2967  -0.0    1.04294  0.01   
+  2  3    -11  0    1732.0511  1387.3612  0.0     1.04270  0.00   
+  2  2    2    5    330.1885   264.3036   0.0     1.04269  0.00   
+  2  5    -9   -1   79.6058    62.5557    0.0     1.04240  0.00   
+  2  6    4    1    1306.3778  1021.8291  -0.0    1.04223  0.00   
+  2  4    -10  0    651.4159   554.7785   -0.0    1.04034  0.00   
+  2  2    12   -1   4545.1771  3828.0670  -180.0  1.03971  0.01   
+  2  0    2    6    1753.2908  1492.8101  0.0     1.03949  0.01   
+  2  7    -5   -3   4108.8070  3517.5593  180.0   1.03943  0.01   
+  2  5    5    2    4423.9374  4324.4718  -180.0  1.03825  0.01   
+  2  4    -8   2    302.0320   298.1823   -0.0    1.03802  0.00   
+  2  6    4    -6   1266.8519  1251.2761  -180.0  1.03798  0.00   
+  2  0    12   1    349.2113   335.8693   -0.0    1.03750  0.00   
+  2  7    -5   -2   1573.9806  1492.9651  -180.0  1.03709  0.00   
+  2  7    1    0    1273.9213  1264.8986  -0.0    1.03656  0.00   
+  2  1    -9   4    2.5847     2.8086     180.0   1.03594  0.00   
+  2  1    11   2    1514.1982  1702.3367  180.0   1.03580  0.00   
+  2  7    -1   0    1522.4168  1823.6465  -0.0    1.03529  0.00   
+  2  4    10   -4   7.9789     9.1218     0.0     1.03486  0.00   
+  2  3    -11  -2   1182.1710  1522.0493  -180.0  1.03326  0.00   
+  3  1    1    0    1093.8782  1272.1776  -0.0    3.25230  0.03   
+  3  1    0    1    671.5168   492.3011   -0.0    2.48917  0.02   
+  3  2    0    0    227.3732   149.2708   -0.0    2.29972  0.00   
+  3  1    1    1    800.9722   374.9784   180.0   2.18915  0.02   
+  3  2    1    0    129.7520   152.8703   0.0     2.05694  0.00   
+  3  2    1    1    847.7959   880.4203   -0.0    1.68916  0.03   
+  3  2    2    0    963.5094   1143.5960  -0.0    1.62615  0.01   
+  3  0    0    2    1535.0492  1417.8449  -0.0    1.48006  0.00   
+  3  3    1    0    346.8820   356.8940   -0.0    1.45447  0.00   
+  3  2    2    1    36.7387    28.2517    180.0   1.42525  0.00   
+  3  3    0    1    939.5432   1055.6715  -0.0    1.36139  0.01   
+  3  1    1    2    442.1448   541.6074   -0.0    1.34713  0.00   
+  3  3    1    1    37.5538    32.7691    0.0     1.30540  0.00   
+  3  3    2    0    16.8965    15.0349    180.0   1.27566  0.00   
+  3  2    0    2    131.9178   145.3422   -0.0    1.24459  0.00   
+  3  2    1    2    37.9946    42.1715    0.0     1.20138  0.00   
+  3  3    2    1    199.7072   154.5400   -0.0    1.17150  0.00   
+  3  4    0    0    435.9820   422.3977   -0.0    1.14986  0.00   
+  3  4    1    0    96.3191    78.7453    180.0   1.11553  0.00   
+  3  2    2    2    1444.0197  562.7763   -0.0    1.09457  0.01   
+  3  3    3    0    454.6558   592.6505   -0.0    1.08410  0.00   
+  3  4    1    1    333.4768   271.8535   -0.0    1.04387  0.01   
+  3  3    1    2    229.2504   220.8817   -0.0    1.03740  0.00   
+  4  1    1    0    8044.7648  5231.9807  0.0     5.76931  0.01   
+  4  1    1    -1   2237.9666  1404.8565  0.0     5.75562  0.00   
+  4  0    0    2    12790.2916 6634.9821  0.0     5.70281  0.01   
+  4  2    0    0    625.8682   777.2638   180.0   5.29777  0.00   
+  4  2    0    -2   8230.5686  11497.9523 0.0     5.25570  0.00   
+  4  1    1    1    3044.2609  5913.5157  -180.0  4.69973  0.00   
+  4  1    1    -2   198.2013   470.9294   -180.0  4.67759  0.00   
+  4  1    1    2    1584.8515  1808.3292  -180.0  3.63025  0.00   
+  4  1    1    -3   5521.1711  6211.9688  180.0   3.61325  0.00   
+  4  0    2    0    9958.2235  1740.1438  180.0   3.43920  0.00   
+  4  3    1    -1   2052.9785  1014.8005  -0.0    3.40289  0.00   
+  4  3    1    -2   5548.2637  3185.9766  180.0   3.39446  0.00   
+  4  0    2    1    4234.2242  5012.7687  -0.0    3.29276  0.00   
+  4  2    0    2    10721.6100 11585.4987 -0.0    3.21822  0.00   
+  4  2    0    -4   4985.1459  4993.6085  180.0   3.18996  0.00   
+  4  3    1    0    1994.9549  2136.8151  0.0     3.14187  0.00   
+  4  3    1    -3   2547.6759  2673.2736  180.0   3.12208  0.00   
+  4  4    0    -2   110074.2817 80809.4369 180.0   2.97592  0.02   
+  4  2    2    -1   98230.9176 75082.5724 -0.0    2.97781  0.04   
+  4  0    2    2    916.1500   793.6721   0.0     2.94509  0.00   
+  4  2    2    0    1879.0267  1811.0116  0.0     2.88466  0.00   
+  4  2    2    -2   547.8400   529.7071   -0.0    2.87781  0.00   
+  4  1    1    3    3094.1270  2485.3141  -0.0    2.86465  0.00   
+  4  1    1    -4   7283.0712  5798.6010  -0.0    2.85294  0.00   
+  4  0    0    4    12939.7422 10329.8968 -0.0    2.85141  0.00   
+  4  3    1    1    3777.3368  3752.3989  -180.0  2.75636  0.00   
+  4  3    1    -4   2739.6597  3259.7661  -0.0    2.73414  0.00   
+  4  4    0    0    64886.0291 70960.6376 0.0     2.64889  0.01   
+  4  2    2    1    125220.4531 133105.8360 0.0     2.64490  0.04   
+  4  2    2    -3   60743.9411 66299.3101 -180.0  2.63437  0.02   
+  4  4    0    -4   126099.1785 140270.1926 180.0   2.62785  0.02   
+  4  0    2    3    21810.8694 14193.3935 180.0   2.55049  0.01   
+  4  3    1    2    8335.5202  9771.8878  -180.0  2.37480  0.00   
+  4  3    1    -5   5232.1900  5854.1041  -0.0    2.35492  0.00   
+  4  2    2    2    128.6644   143.9167   -180.0  2.34986  0.00   
+  4  2    2    -4   865.5857   881.6893   180.0   2.33880  0.00   
+  4  1    1    4    3169.2885  2965.0251  -0.0    2.33627  0.00   
+  4  1    1    -5   494.9175   299.6305   -0.0    2.32809  0.00   
+  4  4    2    -2   1704.3586  1407.2856  -0.0    2.25040  0.00   
+  4  5    1    -2   2184.1979  2119.9402  180.0   2.24094  0.00   
+  4  5    1    -3   537.3547   538.2185   180.0   2.23692  0.00   
+  4  1    3    0    54.1638    52.5740    0.0     2.24093  0.00   
+  4  1    3    -1   4281.0219  4191.7021  -0.0    2.24013  0.00   
+  4  4    2    -1   964.2653   918.1472   0.0     2.21092  0.00   
+  4  4    2    -3   12890.3343 13289.7843 -0.0    2.20476  0.00   
+  4  0    2    4    1281.3101  967.7406   180.0   2.19509  0.00   
+  4  5    1    -1   17084.1284 11504.4667 -0.0    2.16275  0.00   
+  4  1    3    1    1472.8084  1033.7998  -0.0    2.15985  0.00   
+  4  1    3    -2   14818.7279 10989.5160 0.0     2.15769  0.00   
+  4  5    1    -4   789.7581   708.4659   -180.0  2.15197  0.00   
+  4  2    0    4    1382.7309  1631.2791  0.0     2.13699  0.00   
+  4  2    0    -6   8019.3622  7199.2402  0.0     2.12316  0.00   
+  4  4    2    0    390.7062   728.3368   -180.0  2.09858  0.00   
+  4  4    2    -4   320.7563   548.2406   -180.0  2.08808  0.00   
+  4  4    0    2    291024.5879 285615.0180 180.0   2.06893  0.02   
+  4  2    2    3    294379.9898 293002.6542 0.0     2.06451  0.05   
+  4  2    2    -5   248823.9919 297100.5659 0.0     2.05450  0.04   
+  4  4    0    -6   246483.5386 301606.5195 -180.0  2.04894  0.02   
+  4  3    1    3    873.5916   1081.2889  -180.0  2.04816  0.00   
+  4  3    1    -6   105.2136   154.5562   -0.0    2.03175  0.00   
+  4  5    1    0    459.3435   770.1564   180.0   2.02518  0.00   
+  4  1    3    2    9610.6323  14047.1698 -0.0    2.02043  0.00   
+  4  1    3    -3   874.3027   1240.8061  -0.0    2.01749  0.00   
+  4  5    1    -5   9303.3428  14125.1550 -0.0    2.01048  0.00   
+  4  3    3    -1   7662.1363  7033.5856  -0.0    1.97856  0.00   
+  4  3    3    -2   198.3810   188.4026   0.0     1.97690  0.00   
+  4  1    1    5    3056.5150  4614.7955  180.0   1.96139  0.00   
+  4  6    0    -2   637.2240   968.3799   180.0   1.95782  0.00   
+  4  1    1    -6   1058.2849  1560.8017  -0.0    1.95547  0.00   
+  4  6    0    -4   11152.5918 17212.7823 -180.0  1.95140  0.00   
+  4  4    2    1    13621.0692 20964.7061 -0.0    1.94284  0.00   
+  4  4    2    -5   56.7690    70.8523    180.0   1.93036  0.00   
+  4  3    3    0    7547.2947  9851.7693  180.0   1.92310  0.00   
+  4  3    3    -3   2206.8390  2772.7220  -0.0    1.91854  0.00   
+  4  0    0    6    1331.2590  1705.8756  -0.0    1.90094  0.00   
+  4  0    2    5    70.3815    90.1884    -180.0  1.90098  0.00   
+  4  5    1    1    1171.2150  2498.8683  -180.0  1.85943  0.00   
+  4  1    3    3    2211.5244  3430.5540  0.0     1.85393  0.00   
+  4  1    3    -4   395.5266   509.7607   -180.0  1.85074  0.00   
+  4  5    1    -6   2279.8444  2891.1577  -180.0  1.84353  0.00   
+  4  3    3    1    3554.6973  3301.2065  -0.0    1.82358  0.00   
+  4  3    3    -4   15472.2042 15091.0574 -180.0  1.81711  0.00   
+  4  2    2    4    1976.8066  2006.2475  180.0   1.81513  0.00   
+  4  2    2    -6   101.8955   110.8852   -0.0    1.80663  0.00   
+  4  3    1    4    1398.3718  1171.2955  -0.0    1.78224  0.00   
+  4  4    2    2    884.2266   570.0798   -0.0    1.77286  0.00   
+  4  3    1    -7   1409.4597  720.2705   -180.0  1.76902  0.00   
+  4  6    0    0    79564.4271 33062.0174 180.0   1.76592  0.00   
+  4  4    2    -6   4379.9099  1197.3043  -0.0    1.76023  0.00   
+  4  6    0    -6   3.8631     2.0530     0.0     1.75190  0.00   
+  4  6    2    -3   444665.0849 369463.6328 -180.0  1.71851  0.05   
+  4  0    4    0    433236.4610 349863.5489 -180.0  1.71960  0.02   
+  4  6    2    -2   460.0287   389.2193   -0.0    1.70144  0.00   
+  4  6    2    -4   2002.3442  1557.3296  180.0   1.69723  0.00   
+  4  0    4    1    3963.3672  3266.6769  -0.0    1.70038  0.00   
+  4  3    3    2    4474.2965  3605.3646  -0.0    1.69906  0.00   
+  4  3    3    -5   11499.0414 10541.7011 0.0     1.69173  0.00   
+  4  5    1    2    2621.1101  2565.7099  -180.0  1.69028  0.00   
+  4  1    1    6    685.4062   742.0669   -0.0    1.68540  0.00   
+  4  1    3    4    42.1339    45.0799    -0.0    1.68478  0.00   
+  4  1    1    -7   13517.0692 12424.5444 -180.0  1.68096  0.00   
+  4  1    3    -5   4885.9524  4687.0100  0.0     1.68171  0.00   
+  4  5    1    -7   340.2745   265.4106   -180.0  1.67494  0.00   
+  4  0    2    6    1159.0757  1004.4694  0.0     1.66371  0.00   
+  4  2    4    -1   3057.3681  2851.3584  180.0   1.65203  0.00   
+  4  6    2    -1   881.4406   864.7978   -180.0  1.64927  0.00   
+  4  7    1    -3   35.3354    35.3863    180.0   1.64764  0.00   
+  4  5    3    -2   337.2765   336.8162   -180.0  1.64796  0.00   
+  4  7    1    -4   553.2002   555.9037   -0.0    1.64540  0.00   
+  4  5    3    -3   1224.2191  1232.9682  -180.0  1.64636  0.00   
+  4  0    4    2    609.0628   613.4118   -180.0  1.64638  0.00   
+  4  6    2    -5   502.7451   504.1972   -180.0  1.64161  0.00   
+  4  2    4    0    769.0151   755.5233   -0.0    1.63560  0.00   
+  4  2    4    -2   4590.0127  4473.9753  180.0   1.63434  0.00   
+  4  7    1    -2   3654.1213  3561.9732  180.0   1.61641  0.00   
+  4  5    3    -1   1005.0415  967.0214   0.0     1.61610  0.00   
+  4  7    1    -5   1356.3496  914.2042   -0.0    1.61010  0.00   
+  4  5    3    -4   5258.8793  3834.7604  -180.0  1.61159  0.00   
+  4  4    0    4    100308.2785 64365.6929 180.0   1.60911  0.00   
+  4  4    2    3    44.8174    27.4278    180.0   1.60794  0.00   
+  4  2    2    5    59975.8467 37151.5471 -180.0  1.60584  0.01   
+  4  2    2    -7   119317.5287 66528.8930 0.0     1.59877  0.01   
+  4  4    2    -7   5208.7979  2578.9270  -0.0    1.59617  0.00   
+  4  4    0    -8   74957.8571 36898.8655 0.0     1.59498  0.00   
+  4  2    4    1    2441.6300  1930.1723  0.0     1.58794  0.00   
+  4  2    4    -3   1973.1031  1881.2909  0.0     1.58565  0.00   
+  4  2    0    6    27274.5693 28902.0696 -0.0    1.57545  0.00   
+  4  6    2    0    298.9117   317.2177   -0.0    1.57094  0.00   
+  4  2    0    -8   4626.8238  4970.9680  -180.0  1.56767  0.00   
+  4  3    1    5    1617.2618  1738.8731  180.0   1.56818  0.00   
+  4  3    3    3    456.0774   485.8360   0.0     1.56658  0.00   
+  4  0    4    3    2738.8489  2921.6975  -0.0    1.56679  0.00   
+  4  6    2    -6   1124.2948  1245.1059  -180.0  1.56104  0.00   
+  4  3    3    -6   1336.7271  1493.4630  -180.0  1.55920  0.00   
+  4  3    1    -8   1653.0306  1856.4706  0.0     1.55752  0.00   
+  4  7    1    -1   1816.0982  2038.2115  -0.0    1.55703  0.00   
+  4  5    3    0    3379.3290  3764.9574  180.0   1.55622  0.00   
+  4  7    1    -6   3913.0005  3771.5315  -180.0  1.54766  0.00   
+  4  5    3    -5   1382.2717  1406.9228  0.0     1.54952  0.00   
+  4  5    1    3    1231.5970  786.5305   0.0     1.53183  0.00   
+  4  1    3    5    10.6181    7.3706     -180.0  1.52671  0.00   
+  4  1    3    -6   1647.4680  1157.5408  0.0     1.52392  0.00   
+  4  5    1    -8   7.9286     5.3959     0.0     1.51787  0.00   
+  4  2    4    2    6154.1501  4268.8139  180.0   1.51666  0.00   
+  4  2    4    -4   3423.3683  2493.6843  -0.0    1.51368  0.00   
+  4  6    0    2    9252.3187  8920.3709  180.0   1.50424  0.00   
+  4  6    0    -8   4514.8939  4369.8954  -180.0  1.48983  0.00   
+  4  8    0    -4   21178.7319 19996.1970 0.0     1.48796  0.00   
+  4  4    4    -2   21465.7232 20545.4757 -0.0    1.48890  0.00   
+  4  7    1    0    557.5613   520.8465   0.0     1.47828  0.00   
+  4  6    2    1    562.9946   503.5585   180.0   1.47737  0.00   
+  4  5    3    1    1666.2466  1471.1042  180.0   1.47712  0.00   
+  4  4    4    -1   202.8609   180.7352   180.0   1.47730  0.00   
+  4  1    1    7    10780.5574 9080.5953  -0.0    1.47519  0.00   
+  4  4    4    -3   1976.7645  1670.8759  180.0   1.47546  0.00   
+  4  1    1    -8   9414.5139  7394.5831  0.0     1.47176  0.00   
+  4  0    2    7    3182.3455  2502.8143  180.0   1.47248  0.00   
+  4  0    4    4    750.1892   590.3690   180.0   1.47255  0.00   
+  4  5    3    -6   0.2235     0.1799     -180.0  1.46911  0.00   
+  4  7    1    -7   284.1084   230.9464   -180.0  1.46708  0.00   
+  4  6    2    -7   1320.3169  1071.6736  180.0   1.46642  0.00   
+  4  4    2    4    325.2109   309.2371   -180.0  1.45747  0.00   
+  4  4    2    -8   287.2153   302.2854   -180.0  1.44695  0.00   
+  4  8    0    -2   50756.0860 52191.8116 0.0     1.44319  0.00   
+  4  4    4    0    40386.7986 40462.2403 -180.0  1.44233  0.00   
+  4  8    0    -6   48834.6492 39406.4023 -180.0  1.43636  0.00   
+  4  4    4    -4   61959.6383 54182.6466 0.0     1.43890  0.01   
+  4  3    3    4    5578.5118  4626.4893  -180.0  1.43753  0.00   
+  4  2    2    6    1.1137     0.8090     -180.0  1.43232  0.00   
+  4  3    3    -7   1947.9614  1449.5464  0.0     1.43056  0.00   
+  4  2    4    3    3652.6873  2705.9280  180.0   1.43112  0.00   
+  4  2    2    -8   2379.4448  1820.4550  -0.0    1.42647  0.00   
+  4  2    4    -5   2191.4278  1676.3137  180.0   1.42778  0.00   
+  4  0    0    8    345923.3240 266682.9411 -0.0    1.42570  0.01   
+  4  3    1    6    1097.7223  938.8478   180.0   1.39505  0.00   
+  4  5    1    4    682.5362   766.3681   0.0     1.38984  0.00   
+  4  7    1    1    44.4115    50.1895    -180.0  1.38930  0.00   
+  4  3    1    -9   648.2171   706.6839   -0.0    1.38639  0.00   
+  4  4    4    1    3216.6946  3628.8070  -0.0    1.38867  0.00   
+  4  5    3    2    395.7154   443.1806   -180.0  1.38795  0.00   
+  4  1    3    6    3028.3971  3155.0437  0.0     1.38524  0.00   
+  4  4    4    -5   1215.2968  1225.7411  0.0     1.38410  0.00   
+  4  1    3    -7   482.0953   485.9616   -180.0  1.38278  0.00   
+  4  5    3    -7   1073.3447  1074.8978  180.0   1.37942  0.00   
+  4  7    1    -8   234.3600   230.7902   0.0     1.37736  0.00   
+  4  5    1    -9   3210.6143  3153.8678  -0.0    1.37751  0.00   
+  4  6    2    2    260.2225   255.4568   -180.0  1.37818  0.00   
+  4  0    4    5    336.9208   361.3752   -180.0  1.37315  0.00   
+  4  6    2    -8   3.8235     2.8810     0.0     1.36707  0.00   
+  4  8    2    -4   915.4945   736.5865   180.0   1.36563  0.00   
+  4  7    3    -3   3460.0946  3194.1659  -180.0  1.36405  0.00   
+  4  7    3    -4   449.5450   461.8667   -180.0  1.36278  0.00   
+  4  1    5    0    4835.7393  4390.0706  -180.0  1.36423  0.00   
+  4  1    5    -1   62.4662    57.6803    -0.0    1.36405  0.00   
+  4  8    2    -3   2174.1122  1916.8044  180.0   1.35737  0.00   
+  4  8    2    -5   18497.4332 14106.0917 180.0   1.35452  0.00   
+  4  7    3    -2   5409.8118  6964.4536  0.0     1.34617  0.00   
+  4  1    5    1    5565.3261  7469.3772  0.0     1.34529  0.00   
+  4  7    3    -5   1669.7288  2386.7429  180.0   1.34252  0.00   
+  4  1    5    -2   2046.7359  2814.0666  180.0   1.34477  0.00   
+  4  2    4    4    168.0656   205.1051   -180.0  1.33972  0.00   
+  4  2    4    -6   4984.5829  4283.2439  180.0   1.33629  0.00   
+  4  8    2    -2   231.6036   191.7748   0.0     1.33077  0.00   
+  4  8    2    -6   103.7081   116.3047   0.0     1.32541  0.00   
+  4  8    0    0    110915.0785 126382.7897 0.0     1.32444  0.00   
+  4  4    2    5    11233.8747 12817.6384 0.0     1.32439  0.00   
+  4  4    4    2    94782.9783 114087.3943 0.0     1.32245  0.01   
+  4  0    2    8    293.1319   368.5862   180.0   1.31702  0.00   
+  4  4    4    -6   96606.3673 120807.8853 0.0     1.31718  0.01   
+  4  3    3    5    1021.5421  1247.3478  -0.0    1.31793  0.00   
+  4  4    2    -9   4451.8002  5520.1830  180.0   1.31518  0.00   
+  4  8    0    -8   112636.6820 138633.6310 -0.0    1.31393  0.00   
+  4  3    3    -8   6120.1915  7102.5115  180.0   1.31158  0.00   
+  4  7    3    -1   899.3538   1031.0978  180.0   1.31129  0.00   
+  4  1    1    8    140.5640   157.0086   180.0   1.31039  0.00   
+  4  1    1    -9   782.2802   715.2756   180.0   1.30766  0.00   
+  4  1    5    2    1617.0087  1747.1162  180.0   1.30952  0.00   
+  4  1    5    -3   7309.6831  7354.0579  -0.0    1.30871  0.00   
+  4  7    3    -6   8418.5817  7526.8654  -0.0    1.30568  0.00   
+  4  6    4    -3   2271.5028  2359.0079  -0.0    1.29943  0.00   
+  4  9    1    -4   993.8937   837.5850   0.0     1.29744  0.00   
+  4  9    1    -5   322.2010   255.6466   0.0     1.29604  0.00   
+  4  7    1    2    4676.5624  3966.6339  -180.0  1.29754  0.00   
+  4  3    5    -1   715.6072   625.4942   0.0     1.29791  0.00   
+  4  3    5    -2   2611.2991  2200.0985  -0.0    1.29744  0.00   
+  4  5    3    3    422.1538   335.5917   180.0   1.29613  0.00   
+  4  6    4    -2   28.5102    25.6472    0.0     1.29200  0.00   
+  4  4    0    6    19418.1948 18456.6618 180.0   1.29066  0.00   
+  4  6    4    -4   7505.3606  7146.1392  -0.0    1.29015  0.00   
+  4  8    2    -1   9216.1752  8895.7730  180.0   1.28889  0.00   
+  4  5    3    -8   3666.0110  3483.3406  180.0   1.28764  0.00   
+  4  7    1    -9   141.7616   133.1010   180.0   1.28566  0.00   
+  4  2    2    7    16753.1829 16148.0723 -0.0    1.28836  0.00   
+  4  2    2    -9   19692.8814 19762.2271 0.0     1.28349  0.00   
+  4  8    2    -7   413.4276   427.8887   -180.0  1.28160  0.00   
+  4  9    1    -3   5422.2655  5483.9741  180.0   1.28233  0.00   
+  4  4    0    -10  19831.8607 20600.9233 -180.0  1.28092  0.00   
+  4  3    5    0    705.4383   724.7677   -0.0    1.28187  0.00   
+  4  9    1    -6   202.6249   185.4937   -0.0    1.27827  0.00   
+  4  6    2    3    0.3733     0.3796     180.0   1.28017  0.00   
+  4  3    5    -3   5889.4716  6070.8578  -0.0    1.28052  0.00   
+  4  0    4    6    129.1532   119.0527   180.0   1.27524  0.00   
+  4  6    2    -9   340.8846   464.1730   180.0   1.26949  0.00   
+  4  6    4    -1   325.9191   482.4167   -180.0  1.26870  0.00   
+  4  6    4    -5   394.1737   581.9483   -180.0  1.26521  0.00   
+  4  5    1    5    3125.0711  4609.6049  180.0   1.26532  0.00   
+  4  6    0    4    4912.3760  7252.6974  180.0   1.26520  0.00   
+  4  7    3    0    597.0087   802.1220   180.0   1.26320  0.00   
+  4  1    3    7    5872.0890  8434.1606  -0.0    1.26128  0.00   
+  4  1    5    3    24.7383    35.5210    180.0   1.26076  0.00   
+  4  1    3    -8   2159.3551  3100.1996  180.0   1.25913  0.00   
+  4  1    5    -4   2158.3097  3118.0662  180.0   1.25975  0.00   
+  4  7    3    -7   1818.8891  2417.3561  180.0   1.25619  0.00   
+  4  5    1    -10  5954.2315  7031.4223  -180.0  1.25458  0.00   
+  4  6    0    -10  110.6597   117.8504   180.0   1.25319  0.00   
+  4  3    1    7    1463.9864  1612.5904  -0.0    1.25354  0.00   
+  4  9    1    -2   371.5141   360.5869   0.0     1.25235  0.00   
+  4  3    5    1    9265.0817  8385.0852  0.0     1.25109  0.00   
+  4  4    4    3    18.2573    16.4474    0.0     1.24960  0.00   
+  4  9    1    -7   7789.9482  8689.1629  -180.0  1.24607  0.00   
+  4  3    5    -4   1229.6763  1097.1260  -0.0    1.24899  0.00   
+  4  3    1    -10  2715.4672  2985.7659  180.0   1.24641  0.00   
+  4  2    4    5    1285.7693  1155.1937  0.0     1.24861  0.00   
+  4  2    4    -7   708.0020   793.2047   0.0     1.24528  0.00   
+  4  4    4    -7   5981.2484  6550.3571  -0.0    1.24405  0.00   
+  4  2    0    8    24.8484    27.7535    -0.0    1.24197  0.00   
+  4  2    0    -10  1596.5486  2004.4109  180.0   1.23706  0.00   
+  4  8    2    0    593.4599   731.1716   180.0   1.23596  0.00   
+  4  6    4    0    14692.8900 14169.4044 -0.0    1.23199  0.00   
+  4  8    2    -8   821.9978   625.1878   180.0   1.22740  0.00   
+  4  6    4    -6   174.0768   129.7157   -180.0  1.22720  0.00   
+  4  9    1    -1   3038.4681  2729.5167  -0.0    1.21052  0.00   
+  4  3    3    6    948.7460   851.1980   0.0     1.21008  0.00   
+  4  4    2    6    459.1313   412.0139   -0.0    1.20837  0.00   
+  4  7    1    3    81.2715    73.3386    180.0   1.20806  0.00   
+  4  3    5    2    4208.0252  3760.4381  0.0     1.20861  0.00   
+  4  5    3    4    8523.9936  7539.6385  -180.0  1.20667  0.00   
+  4  7    3    1    3111.4862  2736.4548  180.0   1.20632  0.00   
+  4  3    5    -5   55.5542    48.9345    180.0   1.20597  0.00   
+  4  3    3    -9   983.4468   945.9331   -0.0    1.20442  0.00   
+  4  9    1    -8   2334.2278  2311.4455  0.0     1.20259  0.00   
+  4  1    5    4    3993.5331  3957.3115  180.0   1.20344  0.00   
+  4  4    2    -10  157.8938   165.3839   -0.0    1.20037  0.00   
+  4  1    5    -5   659.1539   659.9451   0.0     1.20232  0.00   
+  4  7    3    -8   5.7046     5.4194     0.0     1.19848  0.00   
+  4  5    3    -9   315.3304   300.8337   180.0   1.19858  0.00   
+  4  7    1    -10  9472.0336  8271.1701  -180.0  1.19674  0.00   
+  4  0    2    9    386.7348   269.5507   -0.0    1.18913  0.00   
+  4  5    5    -2   4286.9273  3037.7651  -0.0    1.18980  0.00   
+  4  5    5    -3   0.1460     0.1021     -0.0    1.18920  0.00   
+  4  6    2    4    392.3798   267.9044   180.0   1.18740  0.00   
+  4  10   0    -4   9288.7641  6762.8489  0.0     1.18513  0.00   
+  4  10   0    -6   13573.6235 11025.9166 0.0     1.18275  0.00   
+  4  6    4    1    1820.2853  1322.2815  0.0     1.18528  0.00   
+  4  0    4    7    352.5160   286.3541   180.0   1.18275  0.00   
+  4  6    4    -7   1939.3722  1786.9978  0.0     1.17960  0.00   
+  4  6    2    -10  2.2423     2.2486     -0.0    1.17746  0.00   
+  4  1    1    9    123.8397   122.6226   -0.0    1.17803  0.00   
+  4  8    0    2    30852.0403 31177.0851 180.0   1.17726  0.00   
+  4  5    5    -1   7361.0000  7344.2509  -180.0  1.17765  0.00   
+  4  1    1    -10  708.7808   763.0113   180.0   1.17581  0.00   
+  4  8    2    1    5462.0375  5820.5557  -180.0  1.17634  0.00   
+  4  5    5    -4   5180.5971  5578.1067  -0.0    1.17590  0.00   
+  4  4    4    4    32771.9070 33833.4889 0.0     1.17493  0.00   
+  4  4    4    -8   33526.7919 28622.9953 -180.0  1.16940  0.00   
+  4  8    2    -9   9987.6217  8385.4389  180.0   1.16713  0.00   
+  4  8    0    -10  48770.6673 38153.4334 0.0     1.16621  0.00   
+  4  2    2    8    115.0422   100.3620   0.0     1.16813  0.00   
+  4  2    2    -10  855.6298   559.6416   -0.0    1.16405  0.00   
+  4  2    4    6    20580.9262 13819.5238 180.0   1.16164  0.00   
+  4  9    1    0    241.9935   175.9402   180.0   1.16041  0.00   
+  4  2    4    -8   3048.2336  2422.3664  0.0     1.15851  0.00   
+  4  3    5    3    3878.1979  3145.9058  0.0     1.15806  0.00   
+  4  5    1    6    59.0567    50.4302    0.0     1.15711  0.00   
+  4  3    5    -6   59.8099    52.2732    -0.0    1.15507  0.00   
+  4  9    1    -9   611.3095   563.7453   180.0   1.15145  0.00   
+  4  1    3    8    3082.8641  2765.5276  0.0     1.15358  0.00   
+  4  5    5    0    7456.2351  6688.2411  -0.0    1.15386  0.00   
+  4  1    3    -9   1.4576     1.3388     -0.0    1.15172  0.00   
+  4  5    5    -5   9224.6662  8534.2396  -180.0  1.15112  0.00   
+  4  5    1    -11  1427.6473  1511.2943  0.0     1.14780  0.00   
+  4  9    3    -4   382.5908   425.5769   0.0     1.14472  0.00   
+  4  0    6    0    2556.4729  2626.6424  -0.0    1.14640  0.00   
+  4  9    3    -5   60.3998    64.6877    -0.0    1.14375  0.00   
+  4  7    3    2    4411.1622  4898.1563  -0.0    1.14478  0.00   
+  4  0    0    10   359.6922   424.1063   -0.0    1.14056  0.00   
+  4  1    5    5    4669.0087  5066.0483  -0.0    1.14168  0.00   
+  4  10   0    -2   11637.1657 15912.5149 0.0     1.13915  0.00   
+  4  1    5    -6   4479.7930  5328.6002  180.0   1.14051  0.00   
+  4  0    6    1    1427.1979  1658.5210  180.0   1.14065  0.00   
+  4  7    3    -9   3309.9498  4654.6447  180.0   1.13660  0.00   
+  4  3    1    8    47.8754    68.5418    180.0   1.13641  0.00   
+  4  10   0    -8   767.7368   1439.4845  0.0     1.13285  0.00   
+  4  9    3    -3   882.7041   1421.7922  -180.0  1.13430  0.00   
+  4  9    3    -6   943.2937   1849.0487  -0.0    1.13149  0.00   
+  4  3    1    -11  14.5459    30.9448    0.0     1.13047  0.00   
+  4  6    4    2    1445.7892  2830.3188  0.0     1.13219  0.00   
+  4  6    4    -8   1030.9424  2097.5313  -0.0    1.12601  0.00   
+  4  10   2    -5   3205.8646  6217.2778  0.0     1.12490  0.00   
+  4  8    4    -4   2155.0235  4152.8328  -180.0  1.12520  0.00   
+  4  2    6    -1   1831.0988  3598.0405  180.0   1.12571  0.00   
+  4  7    1    4    2442.5790  4920.7864  -0.0    1.12379  0.00   
+  4  0    6    2    689.8554   1385.4812  -180.0  1.12392  0.00   
+  4  5    3    5    953.9377   1971.7468  -180.0  1.12247  0.00   
+  4  10   2    -4   4.1792     9.0549     180.0   1.12047  0.00   
+  4  8    4    -3   1526.1802  3319.4383  -180.0  1.12057  0.00   
+  4  10   2    -6   113.4701   172.3151   180.0   1.11846  0.00   
+  4  5    5    1    329.0620   713.6507   0.0     1.12049  0.00   
+  4  8    4    -5   601.0722   1030.3969  180.0   1.11896  0.00   
+  4  2    6    0    2462.2406  5334.0481  180.0   1.12047  0.00   
+  4  2    6    -2   476.0666   997.1586   180.0   1.12006  0.00   
+  4  5    5    -6   2056.5584  2510.7097  0.0     1.11698  0.00   
+  4  5    3    -10  1793.2344  1594.6441  -0.0    1.11496  0.00   
+  4  7    1    -11  2404.4809  2075.3693  180.0   1.11327  0.00   
+  4  3    3    7    7949.9921  7170.6448  0.0     1.11422  0.00   
+  4  9    3    -2   2325.6027  2014.1740  0.0     1.11339  0.00   
+  4  8    2    2    136.2664   120.4664   0.0     1.11381  0.00   
+  4  9    3    -7   2036.1763  1744.1969  -180.0  1.10897  0.00   
+  4  3    3    -10  302.0077   264.2339   -0.0    1.10921  0.00   
+  4  4    2    7    11933.7861 9269.2326  0.0     1.10772  0.00   
+  4  8    2    -10  48.5523    36.3377    0.0     1.10444  0.00   
+  4  10   2    -3   49190.1442 35058.8019 -180.0  1.10556  0.00   
+  4  9    1    1    5319.6466  3795.6991  -180.0  1.10551  0.00   
+  4  8    4    -2   41071.8314 29350.7262 -180.0  1.10546  0.00   
+  4  2    6    1    37611.7107 27709.5445 -180.0  1.10478  0.00   
+  4  10   2    -7   38838.6374 34855.8200 0.0     1.10171  0.00   
+  4  8    4    -6   35546.7742 30117.1572 0.0     1.10238  0.00   
+  4  2    6    -3   39470.2807 29988.3819 0.0     1.10401  0.00   
+  4  4    2    -11  2345.9570  2171.0819  -0.0    1.10078  0.00   
+  4  3    5    4    88.2863    70.8198    0.0     1.10291  0.00   
+  4  6    2    5    148392.5477 132137.7368 -180.0  1.10183  0.01   
+  4  4    4    5    3027.0864  2701.2482  180.0   1.10180  0.00   
+  4  3    5    -7   3165.6798  2946.5109  0.0     1.09975  0.00   
+  4  9    1    -10  533.6385   278.2739   0.0     1.09606  0.00   
+  4  0    4    8    193350.0995 134162.4401 -180.0  1.09754  0.01   
+  4  4    4    -9   244.2672   134.2238   0.0     1.09647  0.00   
+  4  0    6    3    4872.9784  3417.0093  -0.0    1.09759  0.00   
+  4  6    2    -11  311618.7823 149486.2917 -180.0  1.09275  0.02   
+  4  9    3    -1   851.0714   1112.5481  0.0     1.08368  0.00   
+  4  0    2    10   98.6406    133.9402   0.0     1.08258  0.00   
+  4  10   2    -2   681.7972   877.0100   -0.0    1.08138  0.00   
+  4  7    3    3    4568.6708  5994.2685  180.0   1.08192  0.00   
+  4  8    4    -1   4.9980     6.5294     0.0     1.08110  0.00   
+  4  2    4    7    105.9594   144.1187   180.0   1.08079  0.00   
+  4  9    3    -8   8.3528     17.0104    180.0   1.07799  0.00   
+  4  5    5    2    3519.2311  5322.5321  0.0     1.08004  0.00   
+  4  2    6    2    315.4128   480.5787   0.0     1.07993  0.00   
+  4  2    4    -9   625.4760   1305.3409  -180.0  1.07791  0.00   
+  4  1    5    6    4641.7890  7519.7479  180.0   1.07876  0.00   
+  4  2    6    -4   1985.6419  3166.0314  -0.0    1.07885  0.00   
+  4  10   2    -8   110.5471   300.2563   0.0     1.07598  0.00   
+  4  8    4    -7   371.4595   885.2685   -0.0    1.07679  0.00   
+  4  1    5    -7   4995.7924  11225.7617 0.0     1.07759  0.00   
+  4  5    5    -7   6.0807     16.4677    0.0     1.07600  0.00   
+  4  6    4    3    556.3942   1520.7877  -180.0  1.07594  0.00   
+  4  7    3    -10  5633.5866  12239.5298 0.0     1.07376  0.00   
+  4  6    0    6    435.1676   878.9653   180.0   1.07274  0.00   
+  4  6    4    -9   387.1432   817.2868   -180.0  1.06958  0.00   
+  4  1    1    10   1233.9242  2600.7823  -180.0  1.06954  0.00   
+  4  11   1    -5   84.1190    156.1615   180.0   1.06831  0.00   
+  4  11   1    -6   3.3757     5.6244     -180.0  1.06735  0.00   
+  4  4    6    -2   1176.6070  2501.0589  -180.0  1.06977  0.00   
+  4  1    1    -11  24.8202    42.1353    0.0     1.06771  0.00   
+  4  7    5    -3   677.3376   1332.3819  -180.0  1.06866  0.00   
+  4  4    0    8    12278.2075 23540.6218 -0.0    1.06850  0.00   
+  4  7    5    -4   95.1684    168.7551   180.0   1.06805  0.00   
+  4  2    2    9    14614.0045 24399.9566 -0.0    1.06684  0.00   
+  4  6    0    -12  2166.4816  2924.7731  -180.0  1.06332  0.00   
+  4  4    6    -1   1.3163     2.0675     -0.0    1.06544  0.00   
+  4  2    2    -11  15510.5604 21011.1835 -180.0  1.06338  0.00   
+  4  4    6    -3   1873.9920  2839.1017  180.0   1.06475  0.00   
+  4  4    0    -12  21733.2698 28246.9030 -180.0  1.06158  0.00   
+  4  5    1    7    2424.2952  3264.8798  0.0     1.06327  0.00   
+  4  0    6    4    1216.8728  1681.5177  0.0     1.06365  0.00   
+  4  11   1    -4   3736.1708  5085.4725  0.0     1.06000  0.00   
+  4  1    3    9    1202.8215  1612.9219  0.0     1.06019  0.00   
+  4  10   0    0    577.0001   814.1249   0.0     1.05955  0.00   
+  4  7    5    -2   1.2094     1.6464     -0.0    1.06000  0.00   
+  4  11   1    -7   38.1606    65.5221    -180.0  1.05720  0.00   
+  4  1    3    -10  1585.2430  2359.9917  0.0     1.05857  0.00   
+  4  7    5    -5   2505.7984  3887.4922  -180.0  1.05821  0.00   
+  4  5    1    -12  1074.4873  2091.1612  -180.0  1.05519  0.00   
+  4  10   0    -10  3512.0281  4622.1342  0.0     1.05114  0.00   
+  4  4    6    0    1019.2939  1598.6611  0.0     1.05210  0.00   
+  4  8    2    3    16710.9754 22529.9236 180.0   1.05126  0.00   
+  4  10   2    -1   53276.8078 57768.9447 0.0     1.04971  0.00   
+  4  4    6    -4   957.0183   1175.6125  0.0     1.05076  0.00   
+  4  8    4    0    60231.7076 62127.9689 -180.0  1.04929  0.00   
+  4  9    1    2    138.1075   132.1767   -0.0    1.04876  0.00   
+  4  9    3    0    2672.4283  2352.9775  0.0     1.04729  0.00   
+  4  2    6    3    63414.2317 56115.4778 -180.0  1.04772  0.00   
+  4  7    1    5    1181.7548  1023.3072  0.0     1.04609  0.00   
+  4  2    6    -5   64806.6808 56409.7526 -180.0  1.04641  0.00   
+  4  3    5    5    4229.5955  3659.9420  -0.0    1.04604  0.00   
+  4  10   2    -9   81872.5048 66942.7235 0.0     1.04314  0.01   
+  4  8    4    -8   81283.3843 67443.7666 -180.0  1.04404  0.01   
+  4  5    3    6    1641.3423  1401.6133  -180.0  1.04487  0.00   
+  4  8    2    -11  5.9622     4.8366     0.0     1.04207  0.00   
+  4  11   1    -3   33.1865    27.1213    180.0   1.04304  0.00   
+  4  3    5    -8   469.7345   383.3221   -0.0    1.04286  0.00   
+  4  7    5    -1   5721.6693  4660.7467  -180.0  1.04272  0.00   
+  4  9    3    -9   578.0950   491.9475   -180.0  1.04069  0.00   
+  4  9    1    -11  5523.3576  4912.6119  180.0   1.03923  0.00   
+  4  11   1    -8   5691.4898  5299.0210  0.0     1.03860  0.00   
+  4  7    5    -6   23.8319    20.5777    180.0   1.03989  0.00   
+  4  5    3    -11  173.5421   166.7199   -0.0    1.03799  0.00   
+  4  7    1    -12  558.4325   562.7233   -180.0  1.03648  0.00   
+  4  3    1    9    1035.9546  984.7090   -180.0  1.03827  0.00   
+_reflns_number_total  1184
+_reflns_d_resolution_low    6.388
+_reflns_d_resolution_high   1.033
+
+# POWDER DATA TABLE
+_pd_meas_2theta_range_min  10.01313
+_pd_meas_2theta_range_max  119.99238
+_pd_meas_2theta_range_inc  0.02626
+_pd_proc_2theta_range_min  9.98829
+_pd_proc_2theta_range_max  119.96754
+_pd_proc_2theta_range_inc  0.02626
+_pd_proc_number_of_points  4189
+
+loop_
+   _pd_meas_intensity_total
+   _pd_calc_intensity_total
+   _pd_proc_intensity_bkg_calc
+   _pd_proc_ls_weight
+  2696         0            0           0         
+  2569         0            0           0         
+  2604         0            0           0         
+  2714         0            0           0         
+  2632         0            0           0         
+  2676         0            0           0         
+  2690         0            0           0         
+  2568         0            0           0         
+  2654         0            0           0         
+  2582         0            0           0         
+  2628         0            0           0         
+  2572         0            0           0         
+  2569         0            0           0         
+  2545         0            0           0         
+  2564         0            0           0         
+  2513         0            0           0         
+  2570         0            0           0         
+  2469         0            0           0         
+  2422         0            0           0         
+  2583         0            0           0         
+  2458         0            0           0         
+  2486         0            0           0         
+  2577         0            0           0         
+  2520         0            0           0         
+  2454         0            0           0         
+  2431         0            0           0         
+  2502         0            0           0         
+  2390         0            0           0         
+  2528         0            0           0         
+  2438         0            0           0         
+  2430         0            0           0         
+  2468         0            0           0         
+  2453         0            0           0         
+  2416         0            0           0         
+  2369         0            0           0         
+  2420         0            0           0         
+  2376         0            0           0         
+  2340         0            0           0         
+  2422         0            0           0         
+  2394         0            0           0         
+  2349         0            0           0         
+  2402         0            0           0         
+  2431         0            0           0         
+  2336         0            0           0         
+  2385         0            0           0         
+  2274         0            0           0         
+  2307         0            0           0         
+  2322         0            0           0         
+  2255         0            0           0         
+  2310         0            0           0         
+  2318         0            0           0         
+  2395         0            0           0         
+  2323         0            0           0         
+  2270         0            0           0         
+  2323         0            0           0         
+  2296         0            0           0         
+  2265         0            0           0         
+  2315         0            0           0         
+  2273         0            0           0         
+  2360         0            0           0         
+  2244         0            0           0         
+  2227         0            0           0         
+  2301         0            0           0         
+  2246         0            0           0         
+  2245         0            0           0         
+  2205         0            0           0         
+  2251         0            0           0         
+  2234         0            0           0         
+  2232         0            0           0         
+  2171         0            0           0         
+  2224         0            0           0         
+  2078         0            0           0         
+  2160         0            0           0         
+  2195         0            0           0         
+  2160         0            0           0         
+  2187         0            0           0         
+  2195         0            0           0         
+  2141         0            0           0         
+  2151         0            0           0         
+  2185         0            0           0         
+  2133         0            0           0         
+  2206         0            0           0         
+  2119         0            0           0         
+  2086         0            0           0         
+  2052         0            0           0         
+  2189         0            0           0         
+  2089         0            0           0         
+  2097         0            0           0         
+  2082         0            0           0         
+  2122         0            0           0         
+  2045         0            0           0         
+  2035         0            0           0         
+  2043         0            0           0         
+  2064         0            0           0         
+  2102         0            0           0         
+  2093         0            0           0         
+  2002         0            0           0         
+  2034         0            0           0         
+  2032         0            0           0         
+  2050         0            0           0         
+  2075         0            0           0         
+  1953         0            0           0         
+  2041         0            0           0         
+  2070         0            0           0         
+  2052         0            0           0         
+  1987         0            0           0         
+  2026         0            0           0         
+  2034         0            0           0         
+  2025         0            0           0         
+  2033         0            0           0         
+  2016         0            0           0         
+  1940         0            0           0         
+  1986         0            0           0         
+  1994         0            0           0         
+  1979         0            0           0         
+  1967         0            0           0         
+  1966         0            0           0         
+  1968         0            0           0         
+  1945         0            0           0         
+  2010         0            0           0         
+  1940         0            0           0         
+  1987         0            0           0         
+  1963         0            0           0         
+  1835         0            0           0         
+  1984         0            0           0         
+  1860         0            0           0         
+  1832         0            0           0         
+  1840         0            0           0         
+  1877         0            0           0         
+  1929         0            0           0         
+  1944         0            0           0         
+  1881         0            0           0         
+  1869         0            0           0         
+  1802         0            0           0         
+  1901         0            0           0         
+  1819         0            0           0         
+  1829         0            0           0         
+  1877         0            0           0         
+  1875         0            0           0         
+  1876         0            0           0         
+  1870         0            0           0         
+  1893         0            0           0         
+  1852         0            0           0         
+  1783         0            0           0         
+  1830         0            0           0         
+  1865         0            0           0         
+  1837         0            0           0         
+  1794         0            0           0         
+  1807         0            0           0         
+  1799         0            0           0         
+  1779         0            0           0         
+  1784         0            0           0         
+  1716         0            0           0         
+  1804         0            0           0         
+  1803         0            0           0         
+  1775         0            0           0         
+  1815         0            0           0         
+  1785         0            0           0         
+  1802         0            0           0         
+  1676         0            0           0         
+  1728         0            0           0         
+  1842         0            0           0         
+  1768         0            0           0         
+  1830         0            0           0         
+  1766         0            0           0         
+  1768         0            0           0         
+  1773         0            0           0         
+  1789         0            0           0         
+  1807         0            0           0         
+  1728         0            0           0         
+  1726         0            0           0         
+  1767         0            0           0         
+  1797         0            0           0         
+  1663         0            0           0         
+  1654         0            0           0         
+  1714         0            0           0         
+  1693         0            0           0         
+  1704         0            0           0         
+  1647         0            0           0         
+  1646         0            0           0         
+  1666         0            0           0         
+  1659         0            0           0         
+  1647         0            0           0         
+  1638         0            0           0         
+  1660         0            0           0         
+  1754         0            0           0         
+  1616         1622.1557    1621.67137  0.00061881 
+  1656         1618.90134   1618.39894  0.00060386 
+  1692         1615.65442   1615.13277  0.00059102 
+  1652         1612.41504   1611.87284  0.00060533 
+  1652         1609.18333   1608.61914  0.00060533 
+  1626         1605.95941   1605.37166  0.00061501 
+  1595         1602.74344   1602.13038  0.00062696 
+  1632         1599.5356    1598.89532  0.00061275 
+  1615         1596.33609   1595.66644  0.0006192 
+  1627         1593.14516   1592.44374  0.00061463 
+  1664         1589.96307   1589.22722  0.00060096 
+  1604         1586.79014   1586.01686  0.00062344 
+  1576         1583.62675   1582.81265  0.00063452 
+  1630         1580.47333   1579.61458  0.0006135 
+  1679         1577.33041   1576.42265  0.00059559 
+  1502         1574.19858   1573.23685  0.00066578 
+  1617         1571.0786    1570.05715  0.00061843 
+  1620         1567.97133   1566.88357  0.00061728 
+  1560         1564.87785   1563.71607  0.00064103 
+  1645         1561.79948   1560.55467  0.0006079 
+  1552         1558.73782   1557.39934  0.00064433 
+  1593         1555.6949    1554.25008  0.00062775 
+  1604         1552.67329   1551.10687  0.00062344 
+  1546         1549.67626   1547.96971  0.00064683 
+  1599         1546.70813   1544.8386   0.00062539 
+  1561         1543.7746    1541.71351  0.00064061 
+  1608         1540.8835    1538.59444  0.00062189 
+  1581         1538.04584   1535.48138  0.00063251 
+  1488         1535.27771   1532.37432  0.00067204 
+  1592         1532.60387   1529.27325  0.00062814 
+  1562         1530.06554   1526.17816  0.0006402 
+  1602         1527.74096   1523.08905  0.00062422 
+  1556         1525.80081   1520.0059   0.00064267 
+  1620         1524.59438   1516.9287   0.00061728 
+  1602         1524.44413   1513.85745  0.00062422 
+  1572         1524.74294   1510.79213  0.00063613 
+  1586         1526.48634   1507.73273  0.00063052 
+  1602         1530.13817   1504.67926  0.00062422 
+  1502         1533.70652   1501.63169  0.00066578 
+  1596         1540.24822   1498.59002  0.00062657 
+  1538         1547.95869   1495.55423  0.0006502 
+  1552         1558.89216   1492.52433  0.00064433 
+  1627         1573.79373   1489.50029  0.00061463 
+  1720         1594.27508   1486.48211  0.0005814 
+  1675         1620.40129   1483.46979  0.00059701 
+  1724         1644.77835   1480.46331  0.00058005 
+  1707         1637.11996   1477.46266  0.00058582 
+  1674         1599.20649   1474.46783  0.00059737 
+  1663         1557.20499   1471.47882  0.00060132 
+  1508         1530.01422   1468.49561  0.00066313 
+  1560         1515.74658   1465.5182   0.00064103 
+  1496         1504.19093   1462.54658  0.00066845 
+  1521         1494.59443   1459.58073  0.00065746 
+  1569         1487.94113   1456.62065  0.00063735 
+  1540         1483.07883   1453.66633  0.00064935 
+  1516         1474.70002   1450.71776  0.00065963 
+  1528         1464.63894   1447.77493  0.00065445 
+  1463         1455.91314   1444.83783  0.00068353 
+  1400         1449.71069   1441.90645  0.00071429 
+  1422         1445.01214   1438.98079  0.00070323 
+  1433         1441.01816   1436.06083  0.00069784 
+  1433         1437.3804    1433.14657  0.00069784 
+  1457         1433.95167   1430.23799  0.00068634 
+  1421         1430.65985   1427.3351   0.00070373 
+  1438         1427.46434   1424.43786  0.00069541 
+  1435         1424.34024   1421.54629  0.00069686 
+  1470         1421.27146   1418.66037  0.00068027 
+  1375         1418.24711   1415.78009  0.00072727 
+  1463         1415.25996   1412.90544  0.00068353 
+  1354         1412.30401   1410.03641  0.00073855 
+  1455         1409.37588   1407.173    0.00068729 
+  1364         1406.47251   1404.31519  0.00073314 
+  1453         1403.59218   1401.46298  0.00068823 
+  1360         1400.73476   1398.61636  0.00073529 
+  1442         1397.89744   1395.77531  0.00069348 
+  1454         1395.08179   1392.93984  0.00068776 
+  1383         1392.28725   1390.10992  0.00072307 
+  1444         1389.51557   1387.28556  0.00069252 
+  1370         1386.76884   1384.46674  0.00072993 
+  1419         1384.05049   1381.65345  0.00070472 
+  1414         1381.36598   1378.84569  0.00070721 
+  1404         1378.72469   1376.04344  0.00071225 
+  1398         1376.14461   1373.2467   0.00071531 
+  1413         1373.66461   1370.45546  0.00070771 
+  1389         1371.3601    1367.6697   0.00071994 
+  1382         1369.27944   1364.88943  0.00072359 
+  1375         1367.32485   1362.11463  0.00072727 
+  1392         1365.79133   1359.34529  0.00071839 
+  1376         1364.44774   1356.58141  0.00072674 
+  1417         1363.36696   1353.82297  0.00070572 
+  1433         1362.89507   1351.06997  0.00069784 
+  1354         1362.62103   1348.3224   0.00073855 
+  1409         1363.52587   1345.58024  0.00070972 
+  1430         1365.1025    1342.8435   0.0006993 
+  1364         1368.04886   1340.11216  0.00073314 
+  1381         1369.9404    1337.38621  0.00072411 
+  1400         1365.18843   1334.66564  0.00071429 
+  1352         1355.99183   1331.95045  0.00073964 
+  1299         1347.14155   1329.24063  0.00076982 
+  1318         1341.62798   1326.53617  0.00075873 
+  1346         1338.8764    1323.83705  0.00074294 
+  1347         1337.84239   1321.14328  0.00074239 
+  1334         1338.06965   1318.45484  0.00074963 
+  1362         1339.17379   1315.77172  0.00073421 
+  1405         1340.77669   1313.09391  0.00071174 
+  1304         1343.11184   1310.42142  0.00076687 
+  1281         1347.04692   1307.75422  0.00078064 
+  1412         1353.25195   1305.09231  0.00070822 
+  1312         1360.95721   1302.43568  0.0007622 
+  1383         1368.51196   1299.78432  0.00072307 
+  1341         1374.95776   1297.13823  0.00074571 
+  1352         1378.43723   1294.49739  0.00073964 
+  1320         1376.0271    1291.86179  0.00075758 
+  1399         1367.54583   1289.23144  0.0007148 
+  1379         1356.19065   1286.60631  0.00072516 
+  1355         1345.91584   1283.98641  0.00073801 
+  1459         1338.32082   1281.37171  0.0006854 
+  1380         1332.79152   1278.76222  0.00072464 
+  1334         1328.46513   1276.15793  0.00074963 
+  1336         1323.82948   1273.55882  0.0007485 
+  1365         1316.81792   1270.96489  0.0007326 
+  1380         1307.27993   1268.37614  0.00072464 
+  1331         1296.98188   1265.79254  0.00075131 
+  1294         1287.81768   1263.21409  0.0007728 
+  1310         1280.59511   1260.64079  0.00076336 
+  1258         1275.06854   1258.07263  0.00079491 
+  1337         1270.78065   1255.5096   0.00074794 
+  1257         1267.897     1252.95168  0.00079554 
+  1315         1265.56241   1250.39887  0.00076046 
+  1188         1264.06587   1247.85117  0.00084175 
+  1198         1263.67934   1245.30856  0.00083472 
+  1186         1263.76341   1242.77104  0.00084317 
+  1308         1265.83118   1240.2386   0.00076453 
+  1232         1268.33706   1237.71122  0.00081169 
+  1228         1269.22091   1235.18891  0.00081433 
+  1195         1262.17551   1232.67165  0.00083682 
+  1237         1251.32554   1230.15943  0.00080841 
+  1243         1240.95941   1227.65225  0.00080451 
+  1274         1233.83625   1225.1501   0.00078493 
+  1216         1229.0346    1222.65296  0.00082237 
+  1249         1225.29376   1220.16084  0.00080064 
+  1292         1222.03733   1217.67372  0.00077399 
+  1152         1219.03612   1215.1916   0.00086806 
+  1219         1216.18863   1212.71446  0.00082034 
+  1210         1213.44298   1210.24231  0.00082645 
+  1141         1210.76994   1207.77512  0.00087642 
+  1225         1208.15082   1205.31289  0.00081633 
+  1157         1205.57512   1202.85562  0.0008643 
+  1187         1203.0351    1200.40329  0.00084246 
+  1168         1200.5263    1197.9559   0.00085616 
+  1206         1198.04572   1195.51344  0.00082919 
+  1205         1195.5916    1193.0759   0.00082988 
+  1143         1193.16318   1190.64328  0.00087489 
+  1231         1190.76056   1188.21556  0.00081235 
+  1186         1188.38466   1185.79273  0.00084317 
+  1159         1186.03728   1183.3748   0.00086281 
+  1197         1183.72126   1180.96175  0.00083542 
+  1164         1181.44071   1178.55356  0.00085911 
+  1228         1179.20148   1176.15025  0.00081433 
+  1208         1177.01178   1173.75179  0.00082781 
+  1124         1174.88324   1171.35817  0.00088968 
+  1087         1172.8323    1168.9694   0.00091996 
+  1186         1170.88185   1166.58546  0.00084317 
+  1159         1169.06176   1164.20635  0.00086281 
+  1162         1167.40446   1161.83205  0.00086059 
+  1153         1165.93967   1159.46256  0.0008673 
+  1132         1164.72263   1157.09787  0.00088339 
+  1125         1163.88027   1154.73797  0.00088889 
+  1107         1163.58826   1152.38285  0.00090334 
+  1113         1163.98013   1150.03252  0.00089847 
+  1147         1165.02468   1147.68695  0.00087184 
+  1114         1166.47826   1145.34614  0.00089767 
+  1191         1168.11526   1143.01008  0.00083963 
+  1095         1170.22772   1140.67877  0.00091324 
+  1087         1173.47497   1138.3522   0.00091996 
+  1140         1177.79833   1136.03035  0.00087719 
+  1183         1181.93742   1133.71323  0.00084531 
+  1108         1184.80727   1131.40082  0.00090253 
+  1079         1184.87698   1129.09311  0.00092678 
+  1177         1179.8867    1126.7901   0.00084962 
+  1154         1170.14071   1124.49178  0.00086655 
+  1145         1158.2527    1122.19814  0.00087336 
+  1090         1146.99909   1119.90918  0.00091743 
+  1137         1137.79165   1117.62488  0.00087951 
+  1089         1130.60039   1115.34524  0.00091827 
+  1074         1124.90841   1113.07025  0.0009311 
+  1100         1120.23579   1110.7999   0.00090909 
+  1114         1116.24182   1108.53418  0.00089767 
+  1085         1112.70386   1106.2731   0.00092166 
+  1040         1109.47944   1104.01663  0.00096154 
+  1058         1106.47676   1101.76477  0.00094518 
+  1061         1103.63564   1099.51752  0.00094251 
+  1084         1100.91536   1097.27487  0.00092251 
+  1069         1098.28755   1095.0368   0.00093545 
+  1052         1095.74699   1092.80331  0.00095057 
+  1049         1093.24914   1090.5744   0.00095329 
+  1099         1090.80538   1088.35005  0.00090992 
+  1064         1088.39258   1086.13025  0.00093985 
+  1031         1086.01188   1083.91501  0.00096993 
+  1019         1083.65834   1081.70431  0.00098135 
+  1077         1081.32813   1079.49814  0.00092851 
+  1047         1079.01821   1077.2965   0.00095511 
+  1054         1076.72612   1075.09938  0.00094877 
+  1055         1074.44988   1072.90677  0.00094787 
+  1011         1072.18789   1070.71867  0.00098912 
+  1019         1069.93882   1068.53506  0.00098135 
+  1046         1067.70156   1066.35594  0.00095602 
+  1002         1065.4752    1064.1813   0.000998  
+  1051         1063.25897   1062.01113  0.00095147 
+  1017         1061.05224   1059.84543  0.00098328 
+  1041         1058.85527   1057.68419  0.00096061 
+  1060         1056.66597   1055.5274   0.0009434 
+  1009         1054.48478   1053.37505  0.00099108 
+  1063         1052.31174   1051.22714  0.00094073 
+  1026         1050.14579   1049.08366  0.00097466 
+  1047         1047.98707   1046.94459  0.00095511 
+  1087         1045.83538   1044.80994  0.00091996 
+  1093         1043.69055   1042.6797   0.00091491 
+  1041         1041.55244   1040.55385  0.00096061 
+  986          1039.42093   1038.43239  0.0010142 
+  988          1037.29593   1036.31532  0.00101215 
+  1009         1035.18191   1034.20262  0.00099108 
+  1065         1033.06974   1032.09429  0.00093897 
+  1025         1030.96392   1029.99032  0.00097561 
+  1001         1028.86671   1027.89071  0.000999  
+  1013         1026.77357   1025.79544  0.00098717 
+  1021         1024.68961   1023.70451  0.00097943 
+  1019         1022.60925   1021.61791  0.00098135 
+  943          1020.54389   1019.53564  0.00106045 
+  930          1018.47661   1017.45768  0.00107527 
+  984          1016.41598   1015.38403  0.00101626 
+  933          1014.36575   1013.31468  0.00107181 
+  941          1012.31894   1011.24962  0.0010627 
+  967          1010.27932   1009.18885  0.00103413 
+  980          1008.24714   1007.13237  0.00102041 
+  1001         1006.2227    1005.08015  0.000999  
+  966          1004.20636   1003.0322   0.0010352 
+  992          1002.19855   1000.98851  0.00100806 
+  974          1000.19979   998.94906   0.00102669 
+  1035         998.2107     996.91386   0.00096618 
+  934          996.23202    994.8829    0.00107066 
+  979          994.26493    992.85616   0.00102145 
+  974          992.30997    990.83365   0.00102669 
+  969          990.36875    988.81535   0.00103199 
+  1007         988.44308    986.80126   0.00099305 
+  972          986.53472    984.79136   0.00102881 
+  992          984.6464     982.78566   0.00100806 
+  972          982.78139    980.78414   0.00102881 
+  966          980.94389    978.7868    0.0010352 
+  947          979.13974    976.79364   0.00105597 
+  945          977.37542    974.80463   0.0010582 
+  979          975.66095    972.81978   0.00102145 
+  962          974.00979    970.83908   0.0010395 
+  957          972.44003    968.86252   0.00104493 
+  949          970.97852    966.8901    0.00105374 
+  937          969.66461    964.92181   0.00106724 
+  997          968.55747    962.95763   0.00100301 
+  955          967.74721    960.99757   0.00104712 
+  951          967.36909    959.04161   0.00105152 
+  940          967.61315    957.08976   0.00106383 
+  965          968.69468    955.14199   0.00103627 
+  962          970.67606    953.19831   0.0010395 
+  946          973.13677    951.25871   0.00105708 
+  963          975.49125    949.32318   0.00103842 
+  980          978.09886    947.39172   0.00102041 
+  967          981.85304    945.46431   0.00103413 
+  897          986.56931    943.54095   0.00111483 
+  947          989.4239     941.62163   0.00105597 
+  933          987.15772    939.70635   0.00107181 
+  938          980.16138    937.79509   0.0010661 
+  914          970.83046    935.88786   0.00109409 
+  930          961.5693     933.98465   0.00107527 
+  863          953.64919    932.08544   0.00115875 
+  912          947.11915    930.19023   0.00109649 
+  930          941.76559    928.29901   0.00107527 
+  918          937.20459    926.41178   0.00108932 
+  877          933.19597    924.52853   0.00114025 
+  928          929.69528    922.64926   0.00107759 
+  890          926.5757     920.77395   0.0011236 
+  931          923.80459    918.9026    0.00107411 
+  877          921.26939    917.0352    0.00114025 
+  862          918.89675    915.17174   0.00116009 
+  895          916.64051    913.31223   0.00111732 
+  901          914.46442    911.45664   0.00110988 
+  893          912.35202    909.60499   0.00111982 
+  904          910.29062    907.75724   0.00110619 
+  884          908.26856    905.91341   0.00113122 
+  851          906.27996    904.07348   0.00117509 
+  913          904.31842    902.23745   0.00109529 
+  889          902.3802     900.40531   0.00112486 
+  894          900.46205    898.57706   0.00111857 
+  859          898.56138    896.75268   0.00116414 
+  856          896.67615    894.93217   0.00116822 
+  887          894.80473    893.11552   0.0011274 
+  855          892.94579    891.30273   0.00116959 
+  857          891.09825    889.49379   0.00116686 
+  897          889.26124    887.68869   0.00111483 
+  893          887.43403    885.88742   0.00111982 
+  861          885.61603    884.08999   0.00116144 
+  865          883.80676    882.29638   0.00115607 
+  795          882.00582    880.50658   0.00125786 
+  845          880.21288    878.72059   0.00118343 
+  820          878.42769    876.93841   0.00121951 
+  866          876.65005    875.16002   0.00115473 
+  887          874.87979    873.38542   0.0011274 
+  844          873.11681    871.6146    0.00118483 
+  839          871.36104    869.84756   0.0011919 
+  897          869.61244    868.08428   0.00111483 
+  830          867.871      866.32477   0.00120482 
+  859          866.13678    864.56901   0.00116414 
+  843          864.40982    862.817     0.00118624 
+  879          862.69025    861.06874   0.00113766 
+  854          860.98711    859.32421   0.00117096 
+  910          859.2876     857.5834    0.0010989 
+  830          857.59122    855.84632   0.00120482 
+  839          855.90749    854.11296   0.0011919 
+  832          854.22616    852.38331   0.00120192 
+  810          852.55259    850.65735   0.00123457 
+  868          850.89083    848.9351    0.00115207 
+  812          849.23938    847.21653   0.00123153 
+  868          847.59794    845.50165   0.00115207 
+  816          845.96851    843.79044   0.00122549 
+  736          844.35792    842.0829    0.0013587 
+  851          842.75547    840.37902   0.00117509 
+  813          841.1682     838.6788    0.00123001 
+  853          839.60067    836.98224   0.00117233 
+  823          838.05104    835.28931   0.00121507 
+  825          836.52061    833.60002   0.00121212 
+  813          835.01892    831.91437   0.00123001 
+  810          833.54181    830.23233   0.00123457 
+  815          832.09278    828.55392   0.00122699 
+  822          830.64788    826.87911   0.00121655 
+  863          829.2155     825.20791   0.00115875 
+  797          827.82086    823.54031   0.00125471 
+  846          826.4747     821.8763    0.00118203 
+  802          825.19594    820.21588   0.00124688 
+  782          823.99279    818.55903   0.00127877 
+  798          822.87658    816.90576   0.00125313 
+  808          821.86503    815.25606   0.00123762 
+  838          820.9844     813.60991   0.00119332 
+  799          820.27144    811.96732   0.00125156 
+  820          819.77804    810.32827   0.00121951 
+  802          819.57983    808.69277   0.00124688 
+  811          819.79157    807.06079   0.00123305 
+  760          820.5957     805.43235   0.00131579 
+  864          822.30175    803.80743   0.00115741 
+  808          825.50548    802.18602   0.00123762 
+  826          831.60422    800.56813   0.00121065 
+  858          843.96114    798.95373   0.0011655 
+  879          867.07862    797.34283   0.00113766 
+  877          895.10228    795.73542   0.00114025 
+  912          945.82016    794.1315    0.00109649 
+  1020         1012.25752   792.53105   0.00098039 
+  1146         1094.72828   790.93408   0.0008726 
+  1222         1229.76177   789.34057   0.00081833 
+  1541         1377.93693   787.75051   0.00064893 
+  1640         1468.77692   786.16391   0.00060976 
+  1485         1336.33859   784.58076   0.0006734 
+  1283         1189.57505   783.00104   0.00077942 
+  898          1022.80233   781.42476   0.00111359 
+  859          906.10536    779.85191   0.00116414 
+  864          852.46672    778.28248   0.00115741 
+  817          826.48316    776.71646   0.00122399 
+  838          811.42211    775.15385   0.00119332 
+  810          801.45505    773.59465   0.00123457 
+  874          794.28209    772.03884   0.00114416 
+  843          788.78876    770.48642   0.00118624 
+  857          784.37154    768.93739   0.00116686 
+  813          780.67603    767.39173   0.00123001 
+  846          777.48658    765.84945   0.00118203 
+  837          774.66289    764.31053   0.00119474 
+  829          772.11124    762.77497   0.00120627 
+  809          769.76817    761.24276   0.00123609 
+  824          767.58766    759.7139    0.00121359 
+  827          765.53646    758.18839   0.00120919 
+  748          763.59127    756.66621   0.0013369 
+  809          761.73502    755.14735   0.00123609 
+  735          759.9533     753.63182   0.00136054 
+  780          758.23691    752.11961   0.00128205 
+  852          756.57865    750.61071   0.00117371 
+  727          754.9733     749.10511   0.00137552 
+  741          753.41738    747.60281   0.00134953 
+  765          751.92669    746.10381   0.00130719 
+  771          750.46487    744.60809   0.00129702 
+  793          749.05018    743.11565   0.00126103 
+  794          747.69334    741.62649   0.00125945 
+  767          746.3797     740.14059   0.00130378 
+  770          745.12296    738.65796   0.0012987 
+  749          743.92978    737.17859   0.00133511 
+  742          742.80929    735.70246   0.00134771 
+  702          741.82679    734.22958   0.0014245 
+  746          740.89291    732.75994   0.00134048 
+  724          740.08243    731.29354   0.00138122 
+  750          739.46452    729.83036   0.00133333 
+  783          739.00295    728.3704    0.00127714 
+  775          738.79566    726.91365   0.00129032 
+  746          738.935      725.46012   0.00134048 
+  768          739.53802    724.00978   0.00130208 
+  742          740.81561    722.56265   0.00134771 
+  773          743.11143    721.11871   0.00129366 
+  775          747.07445    719.67795   0.00129032 
+  786          754.06137    718.24037   0.00127226 
+  773          767.04087    716.80597   0.00129366 
+  760          790.59553    715.37473   0.00131579 
+  833          822.0773     713.94666   0.00120048 
+  893          864.32225    712.52174   0.00111982 
+  935          941.78171    711.09997   0.00106952 
+  1070         1020.99499   709.68135   0.00093458 
+  1138         1143.47629   708.26586   0.00087873 
+  1155         1259.63776   706.85351   0.0008658 
+  1087         1261.0343    705.44429   0.00091996 
+  958          1147.60608   704.03819   0.00104384 
+  876          1029.20676   702.6352    0.00114155 
+  726          899.30291    701.23532   0.00137741 
+  782          813.53235    699.83855   0.00127877 
+  709          769.96591    698.44487   0.00141044 
+  709          746.78184    697.05429   0.00141044 
+  723          732.74883    695.6668    0.00138313 
+  704          723.27205    694.28238   0.00142045 
+  726          716.37489    692.90104   0.00137741 
+  676          711.06758    691.52277   0.00147929 
+  709          706.79763    690.14757   0.00141044 
+  700          703.23525    688.77542   0.00142857 
+  698          700.17426    687.40632   0.00143266 
+  703          697.479      686.04027   0.00142248 
+  653          695.05855    684.67727   0.00153139 
+  659          692.84987    683.31729   0.00151745 
+  734          690.80754    681.96035   0.0013624 
+  695          688.89929    680.60643   0.00143885 
+  660          687.10132    679.25553   0.00151515 
+  705          685.39603    677.90764   0.00141844 
+  735          683.77056    676.56276   0.00136054 
+  691          682.21554    675.22089   0.00144718 
+  661          680.72444    673.882     0.00151286 
+  714          679.29318    672.54611   0.00140056 
+  657          677.92016    671.2132    0.00152207 
+  713          676.60491    669.88327   0.00140252 
+  681          675.3503     668.55632   0.00146843 
+  725          674.1617     667.23233   0.00137931 
+  735          673.04749    665.9113    0.00136054 
+  696          672.02133    664.59323   0.00143678 
+  693          671.1036     663.27811   0.001443  
+  640          670.32555    661.96594   0.0015625 
+  655          669.73614    660.65671   0.00152672 
+  663          669.41543    659.35041   0.0015083 
+  680          669.5054     658.04704   0.00147059 
+  675          670.2915     656.7466    0.00148148 
+  707          672.39795    655.44907   0.00141443 
+  722          677.14268    654.15445   0.00138504 
+  762          685.13426    652.86275   0.00131234 
+  775          695.10319    651.57394   0.00129032 
+  833          713.82253    650.28803   0.00120048 
+  887          737.7964     649.00501   0.0011274 
+  969          767.70599    647.72487   0.00103199 
+  901          804.36342    646.44762   0.00110988 
+  847          809.0912     645.17324   0.00118064 
+  833          779.45194    643.90172   0.00120048 
+  695          748.02276    642.63307   0.00143885 
+  686          712.16288    641.36728   0.00145773 
+  687          684.71652    640.10434   0.0014556 
+  683          670.49051    638.84425   0.00146413 
+  668          663.29343    637.587     0.00149701 
+  647          659.42428    636.33258   0.0015456 
+  602          657.39132    635.081     0.00166113 
+  688          656.67497    633.83224   0.00145349 
+  666          657.18177    632.5863    0.0015015 
+  688          659.12252    631.34318   0.00145349 
+  642          663.12755    630.10287   0.00155763 
+  665          670.7044     628.86536   0.00150376 
+  671          685.11771    627.63064   0.00149031 
+  684          710.98406    626.39872   0.00146199 
+  723          745.27874    625.16959   0.00138313 
+  759          798.28001    623.94325   0.00131752 
+  876          883.30368    622.71968   0.00114155 
+  944          974.35649    621.49888   0.00105932 
+  1068         1107.18308   620.28085   0.00093633 
+  1067         1162.96562   619.06557   0.00093721 
+  1016         1082.96903   617.85306   0.00098425 
+  841          979.30507    616.6433    0.00118906 
+  777          866.9569     615.43628   0.001287  
+  661          760.80556    614.232     0.00151286 
+  692          701.77221    613.03046   0.00144509 
+  647          671.7784     611.83165   0.0015456 
+  645          655.03302    610.63556   0.00155039 
+  582          644.47435    609.44219   0.00171821 
+  625          637.21328    608.25154   0.0016    
+  642          631.94484    607.06359   0.00155763 
+  601          627.953      605.87835   0.00166389 
+  621          624.85609    604.6958    0.00161031 
+  638          622.42961    603.51595   0.0015674 
+  607          620.5523     602.33879   0.00164745 
+  603          619.15716    601.16431   0.00165837 
+  606          618.24218    599.99251   0.00165017 
+  666          617.86018    598.82339   0.0015015 
+  601          618.17552    597.65692   0.00166389 
+  602          619.53943    596.49313   0.00166113 
+  654          622.73564    595.33198   0.00152905 
+  600          629.14634    594.1735    0.00166667 
+  661          639.25368    593.01765   0.00151286 
+  670          653.34257    591.86445   0.00149254 
+  718          678.51732    590.71389   0.00139276 
+  736          708.23239    589.56596   0.0013587 
+  838          751.7147     588.42065   0.00119332 
+  924          787.15649    587.27797   0.00108225 
+  996          789.02944    586.1379    0.00100402 
+  946          791.7599     585.00044   0.00105708 
+  1046         800.55716    583.86559   0.00095602 
+  1066         828.99394    582.73334   0.00093809 
+  1147         863.58705    581.60369   0.00087184 
+  1213         895.23368    580.47663   0.0008244 
+  1086         921.20964    579.35215   0.00092081 
+  864          879.9757     578.23026   0.00115741 
+  814          808.45964    577.11094   0.0012285 
+  655          749.7073     575.99419   0.00152672 
+  663          688.23879    574.88001   0.0015083 
+  626          648.20026    573.76839   0.00159744 
+  588          628.34281    572.65932   0.00170068 
+  580          618.76257    571.55281   0.00172414 
+  637          613.94406    570.44884   0.00156986 
+  559          611.24838    569.34742   0.00178891 
+  585          609.61383    568.24852   0.0017094 
+  630          608.74757    567.15216   0.0015873 
+  586          608.57076    566.05833   0.00170648 
+  594          608.00842    564.96702   0.0016835 
+  595          605.29229    563.87822   0.00168067 
+  565          600.43423    562.79194   0.00176991 
+  587          594.47231    561.70816   0.00170358 
+  553          588.06191    560.62688   0.00180832 
+  558          582.11622    559.5481    0.00179211 
+  596          577.23069    558.47181   0.00167785 
+  596          573.3847     557.39801   0.00167785 
+  563          570.32975    556.32669   0.0017762 
+  586          567.83138    555.25785   0.00170648 
+  574          565.72023    554.19148   0.00174216 
+  540          563.88324    553.12758   0.00185185 
+  552          562.24683    552.06613   0.00181159 
+  583          560.76323    551.00715   0.00171527 
+  589          559.40124    549.95062   0.00169779 
+  569          558.14066    548.89654   0.00175747 
+  579          556.96886    547.8449    0.00172712 
+  581          555.87888    546.7957    0.00172117 
+  564          554.87318    545.74893   0.00177305 
+  564          553.94472    544.70459   0.00177305 
+  571          553.10539    543.66268   0.00175131 
+  544          552.37206    542.62318   0.00183824 
+  557          551.75937    541.5861    0.00179533 
+  575          551.30529    540.55143   0.00173913 
+  540          551.06439    539.51916   0.00185185 
+  563          551.12712    538.4893    0.0017762 
+  564          551.64883    537.46182   0.00177305 
+  578          552.93421    536.43674   0.0017301 
+  596          555.65599    535.41405   0.00167785 
+  520          561.27161    534.39373   0.00192308 
+  585          571.90936    533.3758    0.0017094 
+  628          585.60379    532.36023   0.00159236 
+  632          603.61756    531.34703   0.00158228 
+  624          640.32012    530.33619   0.00160256 
+  666          674.90249    529.32771   0.0015015 
+  713          701.9833     528.32159   0.00140252 
+  714          690.0693     527.31781   0.00140056 
+  666          655.22264    526.31637   0.0015015 
+  647          630.4145     525.31727   0.0015456 
+  569          596.82909    524.32051   0.00175747 
+  581          576.02868    523.32608   0.00172117 
+  619          570.71392    522.33397   0.00161551 
+  658          570.51851    521.34418   0.00151976 
+  642          571.3283     520.35671   0.00155763 
+  619          565.31604    519.37155   0.00161551 
+  617          556.30183    518.38869   0.00162075 
+  613          549.34593    517.40813   0.00163132 
+  603          540.95379    516.42988   0.00165837 
+  612          535.22402    515.45391   0.00163399 
+  582          531.94783    514.48024   0.00171821 
+  610          529.94676    513.50884   0.00163934 
+  576          528.62336    512.53973   0.00173611 
+  629          527.73849    511.57289   0.00158983 
+  599          527.1759     510.60831   0.00166945 
+  593          526.84524    509.64601   0.00168634 
+  643          526.70056    508.68596   0.00155521 
+  711          526.70372    507.72817   0.00140647 
+  703          526.61557    506.77263   0.00142248 
+  678          526.2608     505.81934   0.00147493 
+  660          525.74033    504.86829   0.00151515 
+  626          525.19121    503.91948   0.00159744 
+  647          524.79941    502.9729    0.0015456 
+  587          524.68929    502.02855   0.00170358 
+  576          525.00919    501.08642   0.00173611 
+  567          525.84519    500.14652   0.00176367 
+  549          527.26502    499.20883   0.00182149 
+  559          529.35243    498.27334   0.00178891 
+  590          532.24487    497.34007   0.00169492 
+  552          536.14374    496.409     0.00181159 
+  608          540.9825     495.48012   0.00164474 
+  525          545.9562     494.55344   0.00190476 
+  558          549.96506    493.62895   0.00179211 
+  566          553.23345    492.70664   0.00176678 
+  577          557.42637    491.78651   0.0017331 
+  609          564.55722    490.86856   0.00164204 
+  564          577.85969    489.95277   0.00177305 
+  590          600.08694    489.03915   0.00169492 
+  644          627.08973    488.1277    0.0015528 
+  862          673.95743    487.2184    0.00116009 
+  905          741.46364    486.31126   0.00110497 
+  976          796.25595    485.40626   0.00102459 
+  876          824.48486    484.50341   0.00114155 
+  850          808.15709    483.6027    0.00117647 
+  889          819.81395    482.70412   0.00112486 
+  865          857.39813    481.80768   0.00115607 
+  953          971.35908    480.91336   0.00104932 
+  1239         1205.04916   480.02116   0.0008071 
+  1708         1545.17732   479.13109   0.00058548 
+  2305         2192.08056   478.24312   0.00043384 
+  3208         2948.05735   477.35727   0.00031172 
+  4100         3921.61284   476.47352   0.0002439 
+  4036         4022.72001   475.59188   0.00024777 
+  2938         3170.94285   474.71233   0.00034037 
+  2384         2689.51633   473.83487   0.00041946 
+  1679         1995.0244    472.9595    0.00059559 
+  945          1288.57211   472.08621   0.0010582 
+  653          937.69958    471.21501   0.00153139 
+  594          776.55097    470.34588   0.0016835 
+  583          690.76783    469.47882   0.00171527 
+  549          637.90583    468.61383   0.00182149 
+  525          603.18678    467.7509    0.00190476 
+  531          579.34616    466.89002   0.00188324 
+  533          562.47689    466.0312    0.00187617 
+  505          550.44849    465.17444   0.0019802 
+  478          542.09491    464.31971   0.00209205 
+  548          536.76245    463.46703   0.00182482 
+  518          533.85404    462.61639   0.0019305 
+  509          532.14505    461.76778   0.00196464 
+  535          529.71517    460.92119   0.00186916 
+  521          525.81249    460.07664   0.00191939 
+  530          521.23827    459.2341    0.00188679 
+  497          516.44718    458.39358   0.00201207 
+  486          511.93288    457.55507   0.00205761 
+  492          508.4653     456.71857   0.00203252 
+  461          506.42297    455.88407   0.0021692 
+  505          505.88001    455.05157   0.0019802 
+  474          506.95111    454.22107   0.0021097 
+  531          510.00272    453.39256   0.00188324 
+  515          515.83223    452.56603   0.00194175 
+  552          525.85822    451.74149   0.00181159 
+  526          542.01253    450.91893   0.00190114 
+  531          564.72429    450.09834   0.00188324 
+  542          590.33606    449.27972   0.00184502 
+  584          620.39067    448.46307   0.00171233 
+  651          655.62945    447.64838   0.0015361 
+  645          669.75753    446.83565   0.00155039 
+  638          653.59741    446.02488   0.0015674 
+  619          632.81986    445.21605   0.00161551 
+  585          608.34153    444.40917   0.0017094 
+  473          581.46432    443.60424   0.00211416 
+  544          564.02648    442.80124   0.00183824 
+  549          557.51085    442.00017   0.00182149 
+  513          561.37027    441.20104   0.00194932 
+  512          576.66066    440.40383   0.00195312 
+  589          608.9498     439.60854   0.00169779 
+  636          665.7326     438.81517   0.00157233 
+  734          739.0611     438.02372   0.0013624 
+  875          846.69127    437.23417   0.00114286 
+  1018         1018.51209   436.44653   0.00098232 
+  1152         1155.19677   435.66079   0.00086806 
+  1181         1200.16027   434.87695   0.00084674 
+  1014         1123.75494   434.09501   0.00098619 
+  993          1105.26644   433.31495   0.00100705 
+  984          1134.11725   432.53678   0.00101626 
+  1047         1211.74875   431.76049   0.00095511 
+  1381         1407.96551   430.98608   0.00072411 
+  1893         1856.52232   430.21354   0.00052826 
+  2379         2302.8542    429.44287   0.00042034 
+  3125         2551.96418   428.67407   0.00032   
+  2900         2375.50014   427.90714   0.00034483 
+  2289         2147.05492   427.14205   0.00043687 
+  1808         1891.11576   426.37883   0.0005531 
+  1326         1439.6858    425.61745   0.00075415 
+  1046         1149.18885   424.85792   0.00095602 
+  749          976.41621    424.10024   0.00133511 
+  744          872.45937    423.34439   0.00134409 
+  785          861.17436    422.59038   0.00127389 
+  785          871.48162    421.83819   0.00127389 
+  757          854.68158    421.08784   0.001321  
+  752          791.87268    420.33931   0.00132979 
+  707          752.152      419.59259   0.00141443 
+  736          719.77459    418.8477    0.0013587 
+  707          692.63524    418.10461   0.00141443 
+  755          700.09308    417.36333   0.0013245 
+  691          755.84405    416.62386   0.00144718 
+  711          826.84848    415.88618   0.00140647 
+  771          880.07292    415.15031   0.00129702 
+  819          889.14798    414.41622   0.001221  
+  865          932.84655    413.68392   0.00115607 
+  961          1072.05742   412.95341   0.00104058 
+  1325         1335.70686   412.22468   0.00075472 
+  1819         1747.64493   411.49773   0.00054975 
+  2786         2563.42136   410.77254   0.00035894 
+  4142         3595.22489   410.04913   0.00024143 
+  5255         4681.78017   409.32749   0.00019029 
+  4609         4310.9057    408.6076    0.00021697 
+  3339         3302.71274   407.88948   0.00029949 
+  2841         2919.99663   407.17311   0.00035199 
+  1945         2085.67985   406.45849   0.00051414 
+  1026         1274.76105   405.74561   0.00097466 
+  722          898.77515    405.03448   0.00138504 
+  642          730.31885    404.32509   0.00155763 
+  608          640.0142     403.61744   0.00164474 
+  479          584.18438    402.91152   0.00208768 
+  474          546.75565    402.20732   0.0021097 
+  502          520.22466    401.50485   0.00199203 
+  474          500.59771    400.8041    0.0021097 
+  452          485.57569    400.10507   0.00221239 
+  469          473.75233    399.40775   0.0021322 
+  434          464.22801    398.71215   0.00230415 
+  461          456.40703    398.01824   0.0021692 
+  449          449.8676     397.32604   0.00222717 
+  453          444.32155    396.63554   0.00220751 
+  475          439.55685    395.94674   0.00210526 
+  431          435.41821    395.25962   0.00232019 
+  460          431.78359    394.57419   0.00217391 
+  443          428.56451    393.89045   0.00225734 
+  438          425.69059    393.20839   0.00228311 
+  461          423.10687    392.528     0.0021692 
+  459          420.76969    391.84929   0.00217865 
+  451          418.64404    391.17225   0.00221729 
+  394          416.70167    390.49687   0.00253807 
+  411          414.92001    389.82316   0.00243309 
+  413          413.28046    389.1511    0.00242131 
+  414          411.7679     388.4807    0.00241546 
+  411          410.37093    387.81195   0.00243309 
+  402          409.07847    387.14485   0.00248756 
+  389          407.88334    386.47939   0.00257069 
+  416          406.77966    385.81558   0.00240385 
+  396          405.76334    385.1534    0.00252525 
+  410          404.82634    384.49286   0.00243902 
+  371          403.97657    383.83394   0.00269542 
+  353          403.20713    383.17665   0.00283286 
+  406          402.52389    382.52099   0.00246305 
+  409          401.92751    381.86694   0.00244499 
+  369          401.4226     381.21451   0.00271003 
+  454          401.01573    380.56369   0.00220264 
+  413          400.7158     379.91448   0.00242131 
+  405          400.53457    379.26688   0.00246914 
+  377          400.48718    378.62088   0.00265252 
+  416          400.59323    377.97648   0.00240385 
+  379          400.87794    377.33367   0.00263852 
+  403          401.37442    376.69245   0.00248139 
+  383          402.1241     376.05282   0.00261097 
+  381          403.18324    375.41478   0.00262467 
+  402          404.62579    374.77831   0.00248756 
+  364          406.55143    374.14342   0.00274725 
+  427          409.0961     373.51011   0.00234192 
+  446          412.45009    372.87837   0.00224215 
+  445          416.88442    372.24819   0.00224719 
+  455          422.79715    371.61958   0.0021978 
+  450          430.78673    370.99253   0.00222222 
+  430          441.75513    370.36703   0.00232558 
+  545          457.14791    369.74309   0.00183486 
+  486          479.0832     369.1207    0.00205761 
+  529          510.62297    368.49986   0.00189036 
+  563          555.35173    367.88055   0.0017762 
+  573          614.74728    367.26279   0.0017452 
+  653          680.52952    366.64656   0.00153139 
+  716          729.00173    366.03187   0.00139665 
+  824          741.07645    365.4187    0.00121359 
+  851          725.73558    364.80706   0.00117509 
+  901          699.52941    364.19695   0.00110988 
+  1042         669.88905    363.58835   0.00095969 
+  1089         643.89056    362.98127   0.00091827 
+  969          643.69881    362.3757    0.00103199 
+  876          663.31601    361.77164   0.00114155 
+  800          669.062      361.16909   0.00125   
+  731          635.72182    360.56804   0.00136799 
+  630          617.53293    359.96848   0.0015873 
+  568          619.5882     359.37043   0.00176056 
+  535          595.7243     358.77386   0.00186916 
+  521          548.52193    358.17879   0.00191939 
+  481          509.21069    357.5852    0.002079  
+  497          486.67436    356.99309   0.00201207 
+  478          460.93825    356.40247   0.00209205 
+  423          437.55121    355.81331   0.00236407 
+  479          427.46344    355.22563   0.00208768 
+  418          429.07733    354.63942   0.00239234 
+  474          441.90476    354.05468   0.0021097 
+  532          465.46043    353.4714    0.0018797 
+  688          508.53936    352.88958   0.00145349 
+  635          557.95564    352.30921   0.0015748 
+  745          595.4454     351.7303    0.00134228 
+  678          596.25274    351.15284   0.00147493 
+  588          577.51388    350.57682   0.00170068 
+  518          537.16732    350.00225   0.0019305 
+  471          493.82171    349.42911   0.00212314 
+  403          456.86533    348.85742   0.00248139 
+  389          420.80112    348.28715   0.00257069 
+  393          397.93669    347.71832   0.00254453 
+  378          385.50377    347.15091   0.0026455 
+  366          378.27267    346.58493   0.00273224 
+  353          373.58226    346.02037   0.00283286 
+  362          370.27889    345.45722   0.00276243 
+  377          367.84064    344.89549   0.00265252 
+  354          365.99962    344.33517   0.00282486 
+  358          364.61393    343.77626   0.0027933 
+  396          363.61554    343.21875   0.00252525 
+  363          362.9889     342.66265   0.00275482 
+  338          362.75303    342.10794   0.00295858 
+  348          362.93543    341.55463   0.00287356 
+  388          363.48785    341.00271   0.00257732 
+  384          364.10592    340.45217   0.00260417 
+  360          364.43639    339.90303   0.00277778 
+  349          364.56007    339.35526   0.00286533 
+  367          364.78133    338.80888   0.0027248 
+  350          365.13149    338.26387   0.00285714 
+  366          365.80695    337.72024   0.00273224 
+  369          367.3956     337.17797   0.00271003 
+  381          370.65736    336.63707   0.00262467 
+  371          376.82102    336.09754   0.00269542 
+  405          388.16798    335.55937   0.00246914 
+  391          406.81614    335.02255   0.00255754 
+  498          431.70738    334.48709   0.00200803 
+  563          471.59948    333.95298   0.0017762 
+  639          511.35719    333.42021   0.00156495 
+  559          519.95407    332.8888    0.00178891 
+  576          493.81657    332.35872   0.00173611 
+  512          478.67734    331.82999   0.00195312 
+  501          463.05123    331.30259   0.00199601 
+  429          430.9266     330.77652   0.002331  
+  422          405.45467    330.25178   0.00236967 
+  413          390.89749    329.72837   0.00242131 
+  402          382.68453    329.20629   0.00248756 
+  431          378.58742    328.68552   0.00232019 
+  402          378.88655    328.16607   0.00248756 
+  382          382.97002    327.64794   0.0026178 
+  398          384.1484     327.13112   0.00251256 
+  380          376.91399    326.6156    0.00263158 
+  364          369.98295    326.1014    0.00274725 
+  356          365.57703    325.58849   0.00280899 
+  342          358.96941    325.07689   0.00292398 
+  377          352.22366    324.56658   0.00265252 
+  337          348.17517    324.05756   0.00296736 
+  334          346.27929    323.54984   0.00299401 
+  364          344.81016    323.0434    0.00274725 
+  331          343.788      322.53825   0.00302115 
+  318          343.03248    322.03438   0.00314465 
+  333          342.67114    321.53179   0.003003  
+  334          342.24019    321.03048   0.00299401 
+  329          341.92145    320.53043   0.00303951 
+  338          341.70178    320.03166   0.00295858 
+  339          341.57217    319.53416   0.00294985 
+  355          341.53265    319.03792   0.0028169 
+  336          341.59299    318.54294   0.00297619 
+  339          341.77497    318.04921   0.00294985 
+  335          342.12963    317.55675   0.00298507 
+  373          342.75661    317.06553   0.00268097 
+  338          343.70973    316.57557   0.00295858 
+  363          344.86179    316.08685   0.00275482 
+  356          346.715      315.59938   0.00280899 
+  349          348.81313    315.11314   0.00286533 
+  383          350.22331    314.62815   0.00261097 
+  381          352.56602    314.14439   0.00262467 
+  325          356.07405    313.66186   0.00307692 
+  342          357.44875    313.18056   0.00292398 
+  374          357.92308    312.70048   0.0026738 
+  355          357.19461    312.22163   0.0028169 
+  370          355.98371    311.744     0.0027027 
+  359          355.56253    311.26759   0.00278552 
+  378          355.15971    310.7924    0.0026455 
+  370          355.02454    310.31841   0.0027027 
+  358          355.98324    309.84564   0.0027933 
+  378          357.75012    309.37407   0.0026455 
+  333          360.15899    308.9037    0.003003  
+  360          363.20675    308.43454   0.00277778 
+  350          366.97137    307.96657   0.00285714 
+  387          371.48283    307.4998    0.00258398 
+  407          376.47146    307.03422   0.002457  
+  381          381.23759    306.56984   0.00262467 
+  380          385.40238    306.10663   0.00263158 
+  382          389.50963    305.64461   0.0026178 
+  372          394.05036    305.18378   0.00268817 
+  409          399.09895    304.72412   0.00244499 
+  414          404.98557    304.26563   0.00241546 
+  405          412.23982    303.80832   0.00246914 
+  430          421.24661    303.35218   0.00232558 
+  416          432.31448    302.89721   0.00240385 
+  399          445.81077    302.4434    0.00250627 
+  420          462.17472    301.99075   0.00238095 
+  467          481.79152    301.53927   0.00214133 
+  442          504.87743    301.08893   0.00226244 
+  474          532.04079    300.63976   0.0021097 
+  484          565.16828    300.19173   0.00206612 
+  499          606.9665     299.74485   0.00200401 
+  564          660.85299    299.29912   0.00177305 
+  576          732.20432    298.85452   0.00173611 
+  771          829.91526    298.41107   0.00129702 
+  897          968.89514    297.96876   0.00111483 
+  1161         1176.72551   297.52758   0.00086133 
+  1527         1513.33808   297.08753   0.00065488 
+  2190         2133.71744   296.64861   0.00045662 
+  3355         3404.45872   296.21082   0.00029806 
+  5429         5664.53552   295.77415   0.0001842 
+  9393         8880.79627   295.3386    0.00010646 
+  14841        14538.13666  294.90417   0.00006738 
+  20573        18479.66319  294.47086   0.00004861 
+  20638        15364.38047  294.03866   0.00004845 
+  13984        11600.22546  293.60757   0.00007151 
+  11012        10870.9753   293.17759   0.00009081 
+  10378        8796.83093   292.74871   0.00009636 
+  6126         4840.01674   292.32094   0.00016324 
+  2506         2713.55757   291.89426   0.00039904 
+  1333         1790.89514   291.46868   0.00075019 
+  1161         1333.99976   291.0442    0.00086133 
+  917          1066.31434   290.62081   0.00109051 
+  789          893.53976    290.19851   0.00126743 
+  780          775.03147    289.77729   0.00128205 
+  659          690.16626    289.35716   0.00151745 
+  602          627.17801    288.93811   0.00166113 
+  535          578.41211    288.52014   0.00186916 
+  537          540.348      288.10324   0.0018622 
+  486          510.46588    287.68742   0.00205761 
+  523          486.30094    287.27267   0.00191205 
+  432          466.66771    286.85899   0.00231481 
+  480          450.9029     286.44637   0.00208333 
+  425          438.30886    286.03482   0.00235294 
+  381          428.38535    285.62433   0.00262467 
+  410          420.85322    285.2149    0.00243902 
+  403          415.63771    284.80652   0.00248139 
+  362          412.80399    284.39919   0.00276243 
+  358          412.20481    283.99292   0.0027933 
+  381          414.2458     283.58769   0.00262467 
+  412          418.96958    283.18351   0.00242718 
+  407          425.41558    282.78038   0.002457  
+  364          436.68242    282.37828   0.00274725 
+  416          455.43256    281.97722   0.00240385 
+  438          482.94389    281.57719   0.00228311 
+  489          522.13193    281.1782    0.00204499 
+  534          574.28641    280.78024   0.00187266 
+  588          635.23446    280.38331   0.00170068 
+  678          696.86399    279.9874    0.00147493 
+  681          744.82051    279.59252   0.00146843 
+  741          763.99409    279.19865   0.00134953 
+  779          764.60369    278.8058    0.0012837 
+  817          767.9286     278.41397   0.00122399 
+  826          773.93421    278.02315   0.00121065 
+  782          791.1552     277.63335   0.00127877 
+  683          778.05932    277.24454   0.00146413 
+  652          735.62244    276.85675   0.00153374 
+  686          712.10335    276.46996   0.00145773 
+  616          701.34493    276.08417   0.00162338 
+  572          670.90832    275.69937   0.00174825 
+  611          628.25728    275.31557   0.00163666 
+  541          580.09942    274.93277   0.00184843 
+  471          536.18983    274.55096   0.00212314 
+  449          497.07591    274.17013   0.00222717 
+  403          458.89376    273.79029   0.00248139 
+  414          423.87326    273.41143   0.00241546 
+  361          395.43771    273.03356   0.00277008 
+  352          373.82789    272.65666   0.00284091 
+  375          357.65008    272.28074   0.00266667 
+  356          345.47991    271.9058    0.00280899 
+  348          336.05521    271.53182   0.00287356 
+  314          328.63781    271.15882   0.00318471 
+  329          322.63917    270.78678   0.00303951 
+  310          317.68121    270.4157    0.00322581 
+  326          313.52151    270.04559   0.00306748 
+  320          309.97497    269.67643   0.003125  
+  293          306.91285    269.30824   0.00341297 
+  345          304.2336     268.941     0.00289855 
+  322          301.88143    268.57471   0.00310559 
+  311          299.79513    268.20937   0.00321543 
+  268          297.92974    267.84497   0.00373134 
+  281          296.26151    267.48153   0.00355872 
+  286          294.76155    267.11902   0.0034965 
+  303          293.41135    266.75746   0.00330033 
+  313          292.19689    266.39684   0.00319489 
+  295          291.10834    266.03715   0.00338983 
+  333          290.13266    265.67839   0.003003  
+  290          289.28193    265.32057   0.00344828 
+  284          288.55123    264.96367   0.00352113 
+  289          287.94426    264.60771   0.00346021 
+  301          287.48635    264.25266   0.00332226 
+  308          287.18907    263.89854   0.00324675 
+  325          287.09442    263.54534   0.00307692 
+  294          287.26374    263.19305   0.00340136 
+  301          287.79716    262.84168   0.00332226 
+  299          288.86241    262.49123   0.00334448 
+  309          290.77929    262.14168   0.00323625 
+  328          294.21648    261.79304   0.00304878 
+  322          300.6937     261.44531   0.00310559 
+  326          313.33736    261.09848   0.00306748 
+  336          335.44573    260.75256   0.00297619 
+  381          361.10553    260.40753   0.00262467 
+  458          394.51347    260.0634    0.00218341 
+  463          411.89476    259.72016   0.00215983 
+  404          386.61631    259.37782   0.00247525 
+  428          370.79831    259.03637   0.00233645 
+  434          373.25508    258.6958    0.00230415 
+  402          359.75979    258.35613   0.00248756 
+  370          337.28759    258.01733   0.0027027 
+  355          321.88988    257.67942   0.0028169 
+  363          312.28587    257.34238   0.00275482 
+  345          305.6186     257.00622   0.00289855 
+  328          299.79759    256.67094   0.00304878 
+  311          294.86171    256.33653   0.00321543 
+  337          291.99592    256.00299   0.00296736 
+  307          291.68032    255.67031   0.00325733 
+  360          292.68579    255.33851   0.00277778 
+  336          295.5566     255.00756   0.00297619 
+  311          293.90754    254.67748   0.00321543 
+  312          288.1571     254.34826   0.00320513 
+  287          285.47197    254.01989   0.00348432 
+  279          284.20395    253.69238   0.00358423 
+  283          280.17235    253.36572   0.00353357 
+  285          276.37073    253.03991   0.00350877 
+  263          274.18458    252.71495   0.00380228 
+  295          273.16776    252.39084   0.00338983 
+  279          272.47995    252.06757   0.00358423 
+  282          272.11604    251.74514   0.0035461 
+  294          272.03261    251.42356   0.00340136 
+  264          272.29302    251.10281   0.00378788 
+  259          273.11446    250.78289   0.003861  
+  283          274.92052    250.46381   0.00353357 
+  318          277.78195    250.14556   0.00314465 
+  284          281.01209    249.82814   0.00352113 
+  325          284.87098    249.51155   0.00307692 
+  307          284.0884     249.19578   0.00325733 
+  313          281.42798    248.88084   0.00319489 
+  298          281.09152    248.56671   0.0033557 
+  285          281.63957    248.2534    0.00350877 
+  288          280.41426    247.94091   0.00347222 
+  314          280.34014    247.62924   0.00318471 
+  342          282.59377    247.31837   0.00292398 
+  354          287.64259    247.00832   0.00282486 
+  401          295.79942    246.69908   0.00249377 
+  328          306.78188    246.39064   0.00304878 
+  352          322.13683    246.083     0.00284091 
+  343          335.41835    245.77617   0.00291545 
+  380          350.03082    245.47014   0.00263158 
+  423          361.05897    245.1649    0.00236407 
+  396          356.56435    244.86046   0.00252525 
+  391          343.94243    244.55681   0.00255754 
+  366          335.97644    244.25396   0.00273224 
+  345          327.96966    243.95189   0.00289855 
+  332          316.37232    243.65062   0.00301205 
+  288          306.41393    243.35012   0.00347222 
+  311          300.25302    243.05041   0.00321543 
+  266          295.50515    242.75149   0.0037594 
+  305          292.67801    242.45334   0.00327869 
+  286          292.00157    242.15597   0.0034965 
+  305          292.35115    241.85937   0.00327869 
+  302          292.98907    241.56355   0.00331126 
+  292          294.8821     241.2685    0.00342466 
+  307          298.35215    240.97422   0.00325733 
+  324          303.52859    240.68071   0.00308642 
+  319          311.0079     240.38796   0.0031348 
+  322          322.07949    240.09597   0.00310559 
+  361          340.27402    239.80475   0.00277008 
+  393          376.61331    239.51428   0.00254453 
+  469          441.25171    239.22458   0.0021322 
+  612          512.11494    238.93562   0.00163399 
+  788          610.62384    238.64743   0.00126904 
+  797          604.91184    238.35998   0.00125471 
+  670          524.33089    238.07328   0.00149254 
+  618          500.06089    237.78733   0.00161812 
+  628          517.30302    237.50213   0.00159236 
+  605          472.50048    237.21767   0.00165289 
+  569          426.81645    236.93395   0.00175747 
+  645          416.28801    236.65097   0.00155039 
+  834          430.17193    236.36873   0.00119904 
+  849          459.91971    236.08722   0.00117786 
+  720          498.32294    235.80645   0.00138889 
+  642          541.69479    235.52641   0.00155763 
+  717          556.11196    235.2471    0.0013947 
+  629          573.61891    234.96852   0.00158983 
+  604          617.91341    234.69067   0.00165563 
+  627          681.43957    234.41353   0.0015949 
+  709          756.02033    234.13713   0.00141044 
+  788          876.07891    233.86144   0.00126904 
+  1046         1074.05641   233.58647   0.00095602 
+  1393         1404.89026   233.31222   0.00071788 
+  2099         2024.74608   233.03868   0.00047642 
+  3598         3340.10311   232.76585   0.00027793 
+  5468         5986.05313   232.49374   0.00018288 
+  8845         9109.47575   232.22234   0.00011306 
+  12371        13525.18772  231.95164   0.00008083 
+  12154        14138.68957  231.68165   0.00008228 
+  8306         9629.48553   231.41236   0.00012039 
+  6666         7811.04444   231.14377   0.00015002 
+  6612         8557.05288   230.87589   0.00015124 
+  5111         6628.3426    230.6087    0.00019566 
+  2651         3545.33286   230.34221   0.00037722 
+  1312         2032.52682   230.07641   0.0007622 
+  893          1373.0619    229.8113    0.00111982 
+  792          1038.90736   229.54689   0.00126263 
+  641          842.86786    229.28316   0.00156006 
+  604          719.79877    229.02012   0.00165563 
+  547          638.50241    228.75776   0.00182815 
+  490          582.93041    228.49609   0.00204082 
+  472          530.74199    228.2351    0.00211864 
+  467          487.77343    227.97479   0.00214133 
+  408          459.3087     227.71516   0.00245098 
+  377          438.98754    227.4562    0.00265252 
+  353          410.12261    227.19792   0.00283286 
+  385          383.07631    226.94031   0.0025974 
+  337          364.7523     226.68337   0.00296736 
+  336          351.87415    226.4271    0.00297619 
+  325          339.17118    226.1715    0.00307692 
+  315          329.59446    225.91656   0.0031746 
+  329          324.83865    225.66228   0.00303951 
+  316          323.59099    225.40867   0.00316456 
+  323          325.1754     225.15572   0.00309598 
+  338          322.38495    224.90342   0.00295858 
+  331          318.61933    224.65178   0.00302115 
+  310          313.37206    224.4008    0.00322581 
+  325          309.57287    224.15047   0.00307692 
+  297          307.60378    223.90079   0.003367  
+  301          307.92599    223.65175   0.00332226 
+  292          307.68367    223.40337   0.00342466 
+  268          301.59697    223.15563   0.00373134 
+  290          295.53974    222.90854   0.00344828 
+  286          291.62406    222.66209   0.0034965 
+  258          287.64566    222.41627   0.00387597 
+  238          280.52984    222.1711    0.00420168 
+  256          273.81144    221.92657   0.00390625 
+  262          268.31313    221.68267   0.00381679 
+  266          263.56928    221.4394    0.0037594 
+  262          259.6649     221.19676   0.00381679 
+  268          256.63531    220.95476   0.00373134 
+  256          254.37537    220.71338   0.00390625 
+  253          252.77467    220.47263   0.00395257 
+  231          251.78068    220.23251   0.004329  
+  282          251.39527    219.99301   0.0035461 
+  219          251.61146    219.75413   0.00456621 
+  241          252.22033    219.51587   0.00414938 
+  275          252.57022    219.27823   0.00363636 
+  235          251.94583    219.04121   0.00425532 
+  223          250.53382    218.8048    0.0044843 
+  245          249.02257    218.569     0.00408163 
+  269          247.52707    218.33382   0.00371747 
+  236          245.74834    218.09924   0.00423729 
+  236          243.83344    217.86528   0.00423729 
+  225          242.16961    217.63192   0.00444444 
+  224          240.92053    217.39916   0.00446429 
+  257          240.08956    217.16701   0.00389105 
+  220          239.70178    216.93546   0.00454545 
+  260          239.78282    216.70451   0.00384615 
+  236          239.81299    216.47416   0.00423729 
+  207          240.73011    216.24441   0.00483092 
+  217          241.69705    216.01525   0.00460829 
+  223          242.43606    215.78668   0.0044843 
+  250          242.26195    215.55871   0.004     
+  261          242.41203    215.33132   0.00383142 
+  230          243.56805    215.10453   0.00434783 
+  275          245.18439    214.87832   0.00363636 
+  253          245.6698     214.65269   0.00395257 
+  224          242.82917    214.42765   0.00446429 
+  248          240.83968    214.2032    0.00403226 
+  242          240.7862     213.97932   0.00413223 
+  272          241.54984    213.75602   0.00367647 
+  276          242.15043    213.5333    0.00362319 
+  341          245.53163    213.31115   0.00293255 
+  323          254.5344     213.08958   0.00309598 
+  419          271.03676    212.86858   0.00238663 
+  477          291.05894    212.64816   0.00209644 
+  464          311.03289    212.4283    0.00215517 
+  496          304.23795    212.20901   0.00201613 
+  412          288.605      211.99028   0.00242718 
+  427          281.13363    211.77212   0.00234192 
+  450          279.27827    211.55453   0.00222222 
+  355          267.20068    211.33749   0.0028169 
+  303          252.60088    211.12101   0.00330033 
+  271          242.76774    210.9051    0.00369004 
+  282          237.05379    210.68974   0.0035461 
+  266          234.30428    210.47493   0.0037594 
+  271          233.34747    210.26068   0.00369004 
+  261          233.70478    210.04698   0.00383142 
+  262          235.16376    209.83383   0.00381679 
+  242          236.89886    209.62123   0.00413223 
+  216          237.15857    209.40918   0.00462963 
+  267          236.03878    209.19768   0.00374532 
+  227          235.32336    208.98671   0.00440529 
+  259          235.35829    208.7763    0.003861  
+  251          235.24002    208.56642   0.00398406 
+  235          234.91724    208.35708   0.00425532 
+  237          235.28221    208.14828   0.00421941 
+  257          236.85088    207.94002   0.00389105 
+  252          240.00455    207.73229   0.00396825 
+  243          245.56612    207.5251    0.00411523 
+  268          255.66629    207.31844   0.00373134 
+  296          275.92994    207.11231   0.00337838 
+  305          318.23193    206.90671   0.00327869 
+  396          385.93651    206.70164   0.00252525 
+  531          463.69888    206.4971    0.00188324 
+  736          512.12037    206.29308   0.0013587 
+  655          441.04022    206.08958   0.00152672 
+  510          406.16179    205.88661   0.00196078 
+  494          418.38263    205.68415   0.00202429 
+  500          420.27929    205.48222   0.002     
+  406          351.11416    205.2808    0.00246305 
+  335          301.65695    205.0799    0.00298507 
+  273          281.1418     204.87951   0.003663  
+  256          267.64311    204.67964   0.00390625 
+  246          253.01138    204.48028   0.00406504 
+  237          243.56131    204.28143   0.00421941 
+  219          238.36691    204.08308   0.00456621 
+  239          235.49424    203.88525   0.0041841 
+  247          233.91356    203.68792   0.00404858 
+  253          233.19995    203.4911    0.00395257 
+  233          233.11041    203.29478   0.00429185 
+  232          233.41474    203.09896   0.00431034 
+  252          233.69448    202.90364   0.00396825 
+  272          233.64918    202.70882   0.00367647 
+  261          234.02913    202.5145    0.00383142 
+  253          234.90738    202.32067   0.00395257 
+  234          236.03856    202.12734   0.0042735 
+  255          237.21906    201.9345    0.00392157 
+  211          238.85041    201.74215   0.00473934 
+  296          241.01658    201.55029   0.00337838 
+  269          243.64779    201.35893   0.00371747 
+  268          246.90349    201.16805   0.00373134 
+  247          251.49965    200.97765   0.00404858 
+  252          258.4545     200.78775   0.00396825 
+  241          267.278      200.59832   0.00414938 
+  282          277.00327    200.40938   0.0035461 
+  315          282.23276    200.22091   0.0031746 
+  284          286.72736    200.03293   0.00352113 
+  296          299.18892    199.84543   0.00337838 
+  298          323.8244     199.6584    0.0033557 
+  354          358.53748    199.47184   0.00282486 
+  399          395.67054    199.28576   0.00250627 
+  416          413.84602    199.10016   0.00240385 
+  369          377.90292    198.91502   0.00271003 
+  345          362.8233     198.73036   0.00289855 
+  345          370.95077    198.54616   0.00289855 
+  369          381.94435    198.36243   0.00271003 
+  320          366.37247    198.17916   0.003125  
+  363          359.11666    197.99636   0.00275482 
+  364          367.10863    197.81402   0.00274725 
+  386          385.52981    197.63215   0.00259067 
+  367          411.99973    197.45073   0.0027248 
+  425          446.36612    197.26978   0.00235294 
+  533          488.26811    197.08928   0.00187617 
+  574          545.19059    196.90923   0.00174216 
+  635          626.45983    196.72965   0.0015748 
+  723          744.44823    196.55051   0.00138313 
+  882          922.10385    196.37183   0.00113379 
+  1185         1213.7158    196.1936    0.00084388 
+  1810         1758.84825   196.01582   0.00055249 
+  2999         2923.69273   195.83849   0.00033344 
+  5474         5345.40419   195.66161   0.00018268 
+  9407         8568.37018   195.48517   0.0001063 
+  13490        12136.39564  195.30917   0.00007413 
+  12446        10493.98346  195.13362   0.00008035 
+  7468         6910.93002   194.95852   0.0001339 
+  6205         6160.7719    194.78385   0.00016116 
+  7094         6928.70941   194.60962   0.00014096 
+  6394         6046.26321   194.43583   0.0001564 
+  3387         3364.41199   194.26248   0.00029525 
+  1634         1893.62331   194.08956   0.000612  
+  876          1247.04142   193.91708   0.00114155 
+  679          928.15584    193.74503   0.00147275 
+  527          742.40197    193.57341   0.00189753 
+  451          622.1594     193.40222   0.00221729 
+  408          539.02856    193.23147   0.00245098 
+  405          479.37174    193.06114   0.00246914 
+  387          435.73679    192.89123   0.00258398 
+  347          403.65459    192.72175   0.00288184 
+  344          380.61977    192.5527    0.00290698 
+  341          365.73322    192.38407   0.00293255 
+  412          359.26882    192.21586   0.00242718 
+  402          361.30202    192.04808   0.00248756 
+  540          367.13237    191.88071   0.00185185 
+  799          368.3185     191.71376   0.00125156 
+  996          365.03117    191.54723   0.00100402 
+  724          352.92786    191.38111   0.00138122 
+  515          344.74257    191.2154    0.00194175 
+  534          336.31962    191.05012   0.00187266 
+  634          318.0501     190.88524   0.00157729 
+  523          297.45671    190.72077   0.00191205 
+  354          281.54617    190.55671   0.00282486 
+  315          271.14466    190.39307   0.0031746 
+  296          259.09963    190.22982   0.00337838 
+  267          248.70871    190.06699   0.00374532 
+  245          241.77724    189.90456   0.00408163 
+  246          237.04601    189.74253   0.00406504 
+  247          233.57254    189.58091   0.00404858 
+  260          230.91186    189.41968   0.00384615 
+  238          228.86493    189.25886   0.00420168 
+  231          227.35865    189.09844   0.004329  
+  233          226.39328    188.93841   0.00429185 
+  209          226.03666    188.77878   0.00478469 
+  219          226.40932    188.61954   0.00456621 
+  220          227.66257    188.4607    0.00454545 
+  269          229.83749    188.30225   0.00371747 
+  272          232.51829    188.1442    0.00367647 
+  283          234.66631    187.98653   0.00353357 
+  288          235.69067    187.82926   0.00347222 
+  265          236.47434    187.67237   0.00377358 
+  259          237.95106    187.51587   0.003861  
+  266          239.67206    187.35976   0.0037594 
+  303          240.67226    187.20403   0.00330033 
+  272          241.83205    187.04868   0.00367647 
+  253          244.49594    186.89372   0.00395257 
+  260          247.68503    186.73914   0.00384615 
+  228          244.7703     186.58494   0.00438596 
+  231          236.197      186.43111   0.004329  
+  243          230.96284    186.27767   0.00411523 
+  257          228.16577    186.1246    0.00389105 
+  209          225.01078    185.97191   0.00478469 
+  223          218.93779    185.8196    0.0044843 
+  231          214.11967    185.66765   0.004329  
+  200          211.02669    185.51608   0.005     
+  193          208.94728    185.36488   0.00518135 
+  195          207.75795    185.21405   0.00512821 
+  214          207.24131    185.06359   0.0046729 
+  192          207.32314    184.9135    0.00520833 
+  205          208.10496    184.76378   0.00487805 
+  202          209.76239    184.61442   0.0049505 
+  208          212.21342    184.46542   0.00480769 
+  191          215.1423     184.31679   0.0052356 
+  189          217.14051    184.16853   0.00529101 
+  198          219.52691    184.02062   0.00505051 
+  222          224.46717    183.87307   0.0045045 
+  227          232.77132    183.72588   0.00440529 
+  263          248.67482    183.57906   0.00380228 
+  302          281.87686    183.43258   0.00331126 
+  378          337.16373    183.28647   0.0026455 
+  471          399.0768     183.14071   0.00212314 
+  542          414.35546    182.9953    0.00184502 
+  535          372.48325    182.85025   0.00186916 
+  446          376.36939    182.70554   0.00224215 
+  424          381.77121    182.56119   0.00235849 
+  395          364.24633    182.41719   0.00253165 
+  365          317.56111    182.27353   0.00273973 
+  334          289.85441    182.13023   0.00299401 
+  293          279.42086    181.98727   0.00341297 
+  243          263.47711    181.84465   0.00411523 
+  246          253.73519    181.70238   0.00406504 
+  241          257.01119    181.56046   0.00414938 
+  262          263.96781    181.41887   0.00381679 
+  264          253.6469     181.27763   0.00378788 
+  246          243.64163    181.13673   0.00406504 
+  242          239.5452     180.99616   0.00413223 
+  220          237.28077    180.85594   0.00454545 
+  214          229.98063    180.71605   0.0046729 
+  196          219.70921    180.5765    0.00510204 
+  220          213.64193    180.43728   0.00454545 
+  204          208.13369    180.2984    0.00490196 
+  218          203.76429    180.15985   0.00458716 
+  206          201.21996    180.02163   0.00485437 
+  179          199.81557    179.88374   0.00558659 
+  187          199.06563    179.74619   0.00534759 
+  227          198.76148    179.60896   0.00440529 
+  176          198.86232    179.47206   0.00568182 
+  186          199.37305    179.33548   0.00537634 
+  158          199.91466    179.19924   0.00632911 
+  178          199.93186    179.06331   0.00561798 
+  201          200.00664    178.92772   0.00497512 
+  184          200.49884    178.79244   0.00543478 
+  189          201.42226    178.65749   0.00529101 
+  193          202.54345    178.52286   0.00518135 
+  179          204.20909    178.38855   0.00558659 
+  190          207.41714    178.25455   0.00526316 
+  181          213.55926    178.12088   0.00552486 
+  190          222.754      177.98752   0.00526316 
+  216          225.83631    177.85448   0.00462963 
+  197          220.42511    177.72175   0.00507614 
+  177          217.88339    177.58934   0.00564972 
+  191          220.12476    177.45724   0.0052356 
+  209          223.85683    177.32546   0.00478469 
+  214          223.18029    177.19398   0.0046729 
+  188          222.11693    177.06282   0.00531915 
+  209          223.59886    176.93196   0.00478469 
+  228          227.38842    176.80142   0.00438596 
+  241          233.50946    176.67118   0.00414938 
+  239          243.04334    176.54124   0.0041841 
+  286          258.76024    176.41162   0.0034965 
+  258          284.87771    176.2823    0.00387597 
+  287          316.15405    176.15328   0.00348432 
+  286          323.26313    176.02456   0.0034965 
+  301          322.29773    175.89615   0.00332226 
+  332          339.0297     175.76804   0.00301205 
+  329          375.19969    175.64022   0.00303951 
+  361          418.83104    175.51271   0.00277008 
+  442          458.69744    175.3855    0.00226244 
+  614          501.46694    175.25858   0.00162866 
+  665          541.15932    175.13196   0.00150376 
+  674          580.3441     175.00563   0.00148368 
+  693          630.06773    174.8796    0.001443  
+  690          683.80854    174.75386   0.00144928 
+  745          710.97415    174.62842   0.00134228 
+  805          693.35063    174.50326   0.00124224 
+  771          654.54538    174.3784    0.00129702 
+  658          624.72261    174.25383   0.00151976 
+  658          608.6399     174.12954   0.00151976 
+  580          595.56876    174.00555   0.00172414 
+  530          583.95636    173.88184   0.00188679 
+  530          586.37513    173.75842   0.00188679 
+  498          610.61845    173.63528   0.00200803 
+  494          648.45296    173.51243   0.00202429 
+  506          676.16946    173.38987   0.00197628 
+  562          673.07109    173.26758   0.00177936 
+  605          651.99345    173.14558   0.00165289 
+  609          638.53047    173.02386   0.00164204 
+  555          638.08557    172.90242   0.0018018 
+  575          632.60344    172.78125   0.00173913 
+  535          602.22176    172.66037   0.00186916 
+  531          549.0857     172.53977   0.00188324 
+  482          492.95735    172.41944   0.00207469 
+  414          448.0827     172.29938   0.00241546 
+  366          413.32355    172.17961   0.00273224 
+  323          380.02867    172.0601    0.00309598 
+  300          345.2796     171.94087   0.00333333 
+  261          313.31741    171.82192   0.00383142 
+  231          287.44854    171.70323   0.004329  
+  226          267.79567    171.58482   0.00442478 
+  233          253.17741    171.46667   0.00429185 
+  213          242.42043    171.34879   0.00469484 
+  180          234.78385    171.23119   0.00555556 
+  221          230.16806    171.11385   0.00452489 
+  205          229.37096    170.99677   0.00487805 
+  224          233.43594    170.87996   0.00446429 
+  209          236.70091    170.76342   0.00478469 
+  217          228.04767    170.64714   0.00460829 
+  216          218.45259    170.53113   0.00462963 
+  206          214.51774    170.41537   0.00485437 
+  201          214.98864    170.29988   0.00497512 
+  197          213.35011    170.18465   0.00507614 
+  187          207.22155    170.06968   0.00534759 
+  212          202.61636    169.95497   0.00471698 
+  161          200.27226    169.84052   0.00621118 
+  153          199.36656    169.72632   0.00653595 
+  155          199.46573    169.61238   0.00645161 
+  187          200.50407    169.4987    0.00534759 
+  210          202.36734    169.38527   0.0047619 
+  183          204.40164    169.2721    0.00546448 
+  190          205.36043    169.15918   0.00526316 
+  195          204.7597     169.04651   0.00512821 
+  187          203.55532    168.9341    0.00534759 
+  206          202.83603    168.82194   0.00485437 
+  199          202.82135    168.71002   0.00502513 
+  201          203.51594    168.59836   0.00497512 
+  204          205.57325    168.48694   0.00490196 
+  187          208.037      168.37578   0.00534759 
+  181          206.7121     168.26486   0.00552486 
+  184          205.06037    168.15418   0.00543478 
+  200          205.3264     168.04376   0.005     
+  188          206.09825    167.93357   0.00531915 
+  190          205.24404    167.82364   0.00526316 
+  198          202.45546    167.71394   0.00505051 
+  206          201.23888    167.60449   0.00485437 
+  175          202.26948    167.49528   0.00571429 
+  165          202.24565    167.38631   0.00606061 
+  183          198.29444    167.27758   0.00546448 
+  209          195.30878    167.16909   0.00478469 
+  168          195.81775    167.06084   0.00595238 
+  197          200.52212    166.95283   0.00507614 
+  207          207.6031     166.84505   0.00483092 
+  191          209.77122    166.73751   0.0052356 
+  178          206.63422    166.63021   0.00561798 
+  176          204.49357    166.52314   0.00568182 
+  202          201.99944    166.41631   0.0049505 
+  190          203.34021    166.30971   0.00526316 
+  188          206.33363    166.20334   0.00531915 
+  205          212.63121    166.09721   0.00487805 
+  218          217.5293     165.99131   0.00458716 
+  222          208.54709    165.88563   0.0045045 
+  215          198.8076     165.78019   0.00465116 
+  184          195.70868    165.67498   0.00543478 
+  199          197.89991    165.56999   0.00502513 
+  187          199.19055    165.46524   0.00534759 
+  182          195.21605    165.36071   0.00549451 
+  175          192.54158    165.2564    0.00571429 
+  191          193.11148    165.15232   0.0052356 
+  197          196.93116    165.04847   0.00507614 
+  172          205.31233    164.94484   0.00581395 
+  230          222.09199    164.84144   0.00434783 
+  233          253.19685    164.73825   0.00429185 
+  299          301.44392    164.63529   0.00334448 
+  397          357.50592    164.53255   0.00251889 
+  418          341.11985    164.43003   0.00239234 
+  393          301.40257    164.32774   0.00254453 
+  311          279.41968    164.22566   0.00321543 
+  294          280.35107    164.12379   0.00340136 
+  302          288.8284     164.02215   0.00331126 
+  309          263.28233    163.92073   0.00323625 
+  294          236.21154    163.81952   0.00340136 
+  246          217.37006    163.71852   0.00406504 
+  193          208.76263    163.61774   0.00518135 
+  220          207.29938    163.51718   0.00454545 
+  180          204.21043    163.41683   0.00555556 
+  155          198.7372     163.31669   0.00645161 
+  196          194.1292     163.21677   0.00510204 
+  190          191.9771     163.11705   0.00526316 
+  158          192.29709    163.01755   0.00632911 
+  178          191.29489    162.91826   0.00561798 
+  177          190.09944    162.81918   0.00564972 
+  193          190.38334    162.72031   0.00518135 
+  176          192.8943     162.62164   0.00568182 
+  166          193.65031    162.52319   0.0060241 
+  192          190.82004    162.42494   0.00520833 
+  176          189.00851    162.32689   0.00568182 
+  192          188.93017    162.22906   0.00520833 
+  180          189.94461    162.13142   0.00555556 
+  172          189.25134    162.034     0.00581395 
+  142          187.63216    161.93677   0.00704225 
+  176          186.75963    161.83975   0.00568182 
+  177          186.56383    161.74293   0.00564972 
+  190          186.63879    161.64632   0.00526316 
+  179          187.33425    161.5499    0.00558659 
+  199          188.59113    161.45369   0.00502513 
+  173          190.35067    161.35767   0.00578035 
+  177          192.13921    161.26186   0.00564972 
+  183          193.33073    161.16624   0.00546448 
+  173          194.09921    161.07082   0.00578035 
+  174          195.5279     160.9756    0.00574713 
+  184          198.64634    160.88058   0.00543478 
+  208          202.79534    160.78575   0.00480769 
+  191          203.92605    160.69111   0.0052356 
+  173          203.65293    160.59668   0.00578035 
+  181          205.62017    160.50243   0.00552486 
+  190          209.81863    160.40838   0.00526316 
+  174          214.04724    160.31453   0.00574713 
+  183          214.61812    160.22086   0.00546448 
+  197          212.73662    160.12739   0.00507614 
+  197          211.28299    160.03411   0.00507614 
+  172          211.05647    159.94102   0.00581395 
+  203          211.45093    159.84812   0.00492611 
+  201          211.55626    159.75541   0.00497512 
+  240          211.37657    159.66289   0.00416667 
+  199          211.6194     159.57055   0.00502513 
+  196          212.77156    159.47841   0.00510204 
+  172          214.95568    159.38645   0.00581395 
+  215          218.17344    159.29468   0.00465116 
+  199          222.44581    159.20309   0.00502513 
+  215          227.87124    159.11169   0.00465116 
+  236          234.65384    159.02047   0.00423729 
+  242          243.16784    158.92944   0.00413223 
+  215          254.12938    158.83859   0.00465116 
+  267          268.98993    158.74792   0.00374532 
+  289          290.38888    158.65744   0.00346021 
+  245          320.62292    158.56714   0.00408163 
+  328          349.61118    158.47702   0.00304878 
+  348          365.31614    158.38708   0.00287356 
+  367          388.49835    158.29732   0.0027248 
+  346          429.24933    158.20774   0.00289017 
+  403          490.11714    158.11833   0.00248139 
+  403          571.81691    158.02911   0.00248139 
+  469          683.34739    157.94006   0.0021322 
+  635          863.6965     157.8512    0.0015748 
+  895          1181.13976   157.7625    0.00111732 
+  1541         1816.34663   157.67399   0.00064893 
+  2746         3280.15253   157.58565   0.00036417 
+  4822         6447.12809   157.49748   0.00020738 
+  6966         9542.68774   157.40949   0.00014355 
+  6813         6865.78346   157.32167   0.00014678 
+  4202         3979.53927   157.23403   0.00023798 
+  2843         3222.98202   157.14656   0.00035174 
+  3109         4167.60071   157.05926   0.00032165 
+  3795         5311.82777   156.97213   0.0002635 
+  3453         3667.88469   156.88518   0.0002896 
+  2074         1980.72927   156.79839   0.00048216 
+  1051         1179.60626   156.71178   0.00095147 
+  709          817.02717    156.62533   0.00141044 
+  465          626.48156    156.53905   0.00215054 
+  413          511.09371    156.45295   0.00242131 
+  349          435.12651    156.36701   0.00286533 
+  345          382.24371    156.28123   0.00289855 
+  317          343.87552    156.19563   0.00315457 
+  247          315.15728    156.11019   0.00404858 
+  253          293.15055    156.02491   0.00395257 
+  260          275.99025    155.9398    0.00384615 
+  230          262.42625    155.85486   0.00434783 
+  216          251.61027    155.77008   0.00462963 
+  236          243.05314    155.68546   0.00423729 
+  214          236.59603    155.60101   0.0046729 
+  209          232.36594    155.51672   0.00478469 
+  253          231.00272    155.43259   0.00395257 
+  234          234.34942    155.34863   0.0042735 
+  247          246.25322    155.26482   0.00404858 
+  228          269.60651    155.18118   0.00438596 
+  191          283.80013    155.09769   0.0052356 
+  213          263.46839    155.01437   0.00469484 
+  217          243.68047    154.9312    0.00460829 
+  205          240.25257    154.8482    0.00487805 
+  248          252.70198    154.76535   0.00403226 
+  213          272.33574    154.68266   0.00469484 
+  266          291.09614    154.60012   0.0037594 
+  234          325.89155    154.51774   0.0042735 
+  255          333.51601    154.43552   0.00392157 
+  260          286.97549    154.35346   0.00384615 
+  227          251.39009    154.27155   0.00440529 
+  218          242.77793    154.18979   0.00458716 
+  223          254.17369    154.10819   0.0044843 
+  235          256.60781    154.02674   0.00425532 
+  201          230.25317    153.94545   0.00497512 
+  207          206.25482    153.86431   0.00483092 
+  175          192.53664    153.78332   0.00571429 
+  180          184.92402    153.70248   0.00555556 
+  148          180.28912    153.62179   0.00675676 
+  178          177.13879    153.54126   0.00561798 
+  177          174.82479    153.46087   0.00564972 
+  169          173.03076    153.38064   0.00591716 
+  155          171.58529    153.30055   0.00645161 
+  147          170.38647    153.22062   0.00680272 
+  151          169.37024    153.14083   0.00662252 
+  166          168.49377    153.06119   0.0060241 
+  169          167.72969    152.98169   0.00591716 
+  160          167.05733    152.90235   0.00625   
+  175          166.46292    152.82315   0.00571429 
+  162          165.93504    152.7441    0.00617284 
+  152          165.47043    152.66519   0.00657895 
+  162          165.05916    152.58643   0.00617284 
+  157          164.7033     152.50781   0.00636943 
+  178          164.40019    152.42934   0.00561798 
+  163          164.15493    152.35101   0.00613497 
+  137          163.97705    152.27283   0.00729927 
+  156          163.88514    152.19479   0.00641026 
+  161          163.91531    152.11689   0.00621118 
+  162          164.15066    152.03913   0.00617284 
+  156          164.73142    151.96152   0.00641026 
+  145          165.7101     151.88404   0.00689655 
+  154          166.39324    151.80671   0.00649351 
+  152          166.2883     151.72952   0.00657895 
+  172          166.17266    151.65247   0.00581395 
+  149          166.35544    151.57555   0.00671141 
+  145          166.77986    151.49878   0.00689655 
+  158          167.25435    151.42215   0.00632911 
+  151          167.57968    151.34565   0.00662252 
+  148          168.19099    151.26929   0.00675676 
+  169          169.336      151.19307   0.00591716 
+  141          170.97343    151.11699   0.0070922 
+  158          173.19206    151.04104   0.00632911 
+  161          176.62441    150.96523   0.00621118 
+  173          183.02429    150.88955   0.00578035 
+  200          196.00947    150.81401   0.005     
+  267          221.03782    150.73861   0.00374532 
+  248          254.29051    150.66334   0.00403226 
+  213          254.37512    150.5882    0.00469484 
+  208          224.3735     150.5132    0.00480769 
+  193          206.16407    150.43833   0.00518135 
+  205          204.97385    150.36359   0.00487805 
+  203          215.80934    150.28898   0.00492611 
+  180          218.13833    150.21451   0.00555556 
+  184          202.71733    150.14017   0.00543478 
+  171          191.16693    150.06596   0.00584795 
+  177          187.28607    149.99188   0.00564972 
+  172          188.63832    149.91794   0.00581395 
+  163          196.12316    149.84412   0.00613497 
+  180          201.84921    149.77043   0.00555556 
+  189          193.57131    149.69687   0.00529101 
+  208          184.43741    149.62344   0.00480769 
+  189          180.59458    149.55014   0.00529101 
+  170          181.81926    149.47697   0.00588235 
+  172          184.9762     149.40392   0.00581395 
+  178          182.02088    149.331     0.00561798 
+  172          177.21272    149.25821   0.00581395 
+  171          175.80972    149.18555   0.00584795 
+  182          178.05261    149.11301   0.00549451 
+  167          183.20931    149.04059   0.00598802 
+  217          187.18325    148.96831   0.00460829 
+  227          190.2736     148.89615   0.00440529 
+  257          200.14845    148.82411   0.00389105 
+  282          221.48364    148.75219   0.0035461 
+  266          248.82485    148.68041   0.0037594 
+  249          257.37503    148.60874   0.00401606 
+  268          239.72239    148.5372    0.00373134 
+  223          226.76537    148.46578   0.0044843 
+  303          232.2788     148.39448   0.00330033 
+  327          255.69346    148.32331   0.0030581 
+  307          285.85171    148.25225   0.00325733 
+  305          297.96392    148.18132   0.00327869 
+  275          296.02001    148.11051   0.00363636 
+  271          295.43939    148.03982   0.00369004 
+  280          292.81475    147.96925   0.00357143 
+  361          316.16387    147.8988    0.00277008 
+  402          383.33876    147.82847   0.00248756 
+  486          523.12692    147.75826   0.00205761 
+  661          759.11982    147.68816   0.00151286 
+  791          827.96899    147.61819   0.00126422 
+  768          598.81327    147.54834   0.00130208 
+  527          440.43995    147.4786    0.00189753 
+  438          406.63939    147.40898   0.00228311 
+  431          469.88491    147.33947   0.00232019 
+  479          535.66812    147.27009   0.00208768 
+  446          436.92972    147.20082   0.00224215 
+  361          324.52711    147.13166   0.00277008 
+  266          265.39844    147.06263   0.0037594 
+  208          234.59344    146.9937    0.00480769 
+  210          218.79012    146.9249    0.0047619 
+  186          212.53945    146.8562    0.00537634 
+  206          214.34937    146.78763   0.00485437 
+  215          226.0895     146.71916   0.00465116 
+  246          256.48296    146.65081   0.00406504 
+  318          325.9234     146.58257   0.00314465 
+  388          404.71292    146.51445   0.00257732 
+  357          357.21687    146.44644   0.00280112 
+  300          294.46436    146.37854   0.00333333 
+  318          290.36782    146.31076   0.00314465 
+  349          345.59443    146.24308   0.00286533 
+  359          444.26219    146.17552   0.00278552 
+  366          446.63026    146.10807   0.00273224 
+  315          344.72372    146.04073   0.0031746 
+  251          275.69931    145.97349   0.00398406 
+  221          253.89701    145.90637   0.00452489 
+  214          263.89794    145.83936   0.0046729 
+  203          272.34717    145.77246   0.00492611 
+  201          243.9338     145.70567   0.00497512 
+  184          210.68683    145.63899   0.00543478 
+  157          190.86587    145.57242   0.00636943 
+  153          180.76937    145.50595   0.00653595 
+  150          175.98632    145.43959   0.00666667 
+  200          174.14654    145.37334   0.005     
+  193          172.55405    145.3072    0.00518135 
+  162          170.13377    145.24117   0.00617284 
+  159          168.8057     145.17524   0.00628931 
+  178          168.96461    145.10942   0.00561798 
+  171          170.44257    145.0437    0.00584795 
+  166          172.91635    144.97809   0.0060241 
+  153          175.8023     144.91259   0.00653595 
+  172          180.58714    144.84719   0.00581395 
+  164          189.34648    144.7819    0.00609756 
+  198          205.36799    144.71671   0.00505051 
+  271          236.31582    144.65162   0.00369004 
+  327          296.6788     144.58664   0.0030581 
+  362          395.34565    144.52177   0.00276243 
+  400          455.02883    144.457     0.0025    
+  421          382.28325    144.39233   0.0023753 
+  394          302.85315    144.32776   0.00253807 
+  346          273.21774    144.2633    0.00289017 
+  308          287.25832    144.19894   0.00324675 
+  307          320.23743    144.13468   0.00325733 
+  325          300.70733    144.07052   0.00307692 
+  254          245.14136    144.00647   0.00393701 
+  205          207.15147    143.94251   0.00487805 
+  207          187.48119    143.87866   0.00483092 
+  161          176.37743    143.81491   0.00621118 
+  166          169.79554    143.75126   0.0060241 
+  169          165.56675    143.6877    0.00591716 
+  181          162.72483    143.62425   0.00552486 
+  172          160.78794    143.5609    0.00581395 
+  164          159.49229    143.49765   0.00609756 
+  139          159.06992    143.4345    0.00719424 
+  160          158.70596    143.37144   0.00625   
+  169          158.88387    143.30849   0.00591716 
+  161          159.90424    143.24563   0.00621118 
+  171          161.94609    143.18287   0.00584795 
+  199          163.42067    143.12021   0.00502513 
+  166          162.81728    143.05765   0.0060241 
+  190          162.64607    142.99518   0.00526316 
+  183          163.92974    142.93281   0.00546448 
+  192          166.48429    142.87054   0.00520833 
+  204          169.35085    142.80837   0.00490196 
+  189          170.50584    142.74629   0.00529101 
+  197          170.54698    142.6843    0.00507614 
+  179          171.58684    142.62242   0.00558659 
+  194          172.00423    142.56063   0.00515464 
+  199          169.13263    142.49893   0.00502513 
+  215          166.28026    142.43733   0.00465116 
+  221          164.62385    142.37582   0.00452489 
+  249          164.07718    142.31441   0.00401606 
+  265          164.41148    142.25309   0.00377358 
+  262          163.96005    142.19187   0.00381679 
+  278          163.53322    142.13074   0.00359712 
+  255          165.54302    142.0697    0.00392157 
+  279          168.98787    142.00876   0.00358423 
+  278          168.56322    141.94791   0.00359712 
+  263          166.49914    141.88715   0.00380228 
+  249          167.23601    141.82649   0.00401606 
+  295          171.65687    141.76592   0.00338983 
+  278          182.28328    141.70544   0.00359712 
+  253          200.54608    141.64505   0.00395257 
+  219          216.84939    141.58476   0.00456621 
+  201          207.62696    141.52455   0.00497512 
+  205          188.34996    141.46444   0.00487805 
+  195          178.24142    141.40442   0.00512821 
+  185          177.95212    141.34449   0.00540541 
+  206          185.17098    141.28465   0.00485437 
+  203          189.45304    141.2249    0.00492611 
+  208          182.61853    141.16524   0.00480769 
+  175          175.81111    141.10567   0.00571429 
+  192          170.69929    141.04618   0.00520833 
+  169          168.48525    140.98679   0.00591716 
+  179          166.9259     140.92749   0.00558659 
+  157          164.99665    140.86828   0.00636943 
+  173          165.21001    140.80916   0.00578035 
+  154          166.81498    140.75012   0.00649351 
+  181          170.19201    140.69117   0.00552486 
+  172          178.22369    140.63231   0.00581395 
+  201          191.5478     140.57354   0.00497512 
+  189          202.2502     140.51486   0.00529101 
+  191          192.9261     140.45626   0.0052356 
+  202          179.11477    140.39776   0.0049505 
+  206          172.78081    140.33933   0.00485437 
+  211          173.49403    140.281     0.00473934 
+  216          179.11247    140.22275   0.00462963 
+  201          180.65285    140.16459   0.00497512 
+  175          173.2866     140.10652   0.00571429 
+  186          166.88202    140.04853   0.00537634 
+  198          163.75424    139.99062   0.00505051 
+  171          162.69135    139.93281   0.00584795 
+  209          162.82012    139.87508   0.00478469 
+  180          163.87677    139.81743   0.00555556 
+  208          166.0316     139.75987   0.00480769 
+  190          169.73897    139.70239   0.00526316 
+  214          174.53463    139.645     0.0046729 
+  203          176.37954    139.58769   0.00492611 
+  200          175.62006    139.53047   0.005     
+  219          176.3812     139.47333   0.00456621 
+  223          179.30034    139.41627   0.0044843 
+  229          184.24891    139.3593    0.00436681 
+  257          190.38446    139.30241   0.00389105 
+  212          195.80337    139.24561   0.00471698 
+  241          202.24936    139.18889   0.00414938 
+  282          211.78174    139.13225   0.0035461 
+  308          225.32102    139.07569   0.00324675 
+  297          244.30577    139.01922   0.003367  
+  345          271.18128    138.96283   0.00289855 
+  372          310.93021    138.90652   0.00268817 
+  403          368.70898    138.8503    0.00248139 
+  498          441.15484    138.79415   0.00200803 
+  574          509.94491    138.73809   0.00174216 
+  674          566.70097    138.68211   0.00148368 
+  722          605.0099     138.62621   0.00138504 
+  708          623.55874    138.57039   0.00141243 
+  645          613.41644    138.51465   0.00155039 
+  608          576.57629    138.45899   0.00164474 
+  527          537.81004    138.40342   0.00189753 
+  499          505.56261    138.34792   0.00200401 
+  530          472.34336    138.2925    0.00188679 
+  456          436.9734     138.23717   0.00219298 
+  406          391.32123    138.18191   0.00246305 
+  375          339.96691    138.12674   0.00266667 
+  313          297.18572    138.07164   0.00319489 
+  262          263.86432    138.01662   0.00381679 
+  233          238.00461    137.96169   0.00429185 
+  211          219.34364    137.90683   0.00473934 
+  199          205.90606    137.85205   0.00502513 
+  215          195.96763    137.79735   0.00465116 
+  186          188.41368    137.74272   0.00537634 
+  156          182.54936    137.68818   0.00641026 
+  197          177.92694    137.63372   0.00507614 
+  162          174.25149    137.57933   0.00617284 
+  180          171.32625    137.52502   0.00555556 
+  178          169.02261    137.47079   0.00561798 
+  176          167.26528    137.41663   0.00568182 
+  169          166.0143     137.36256   0.00591716 
+  169          165.2178     137.30856   0.00591716 
+  167          164.9083     137.25464   0.00598802 
+  167          165.35541    137.20079   0.00598802 
+  169          166.94301    137.14702   0.00591716 
+  162          170.01413    137.09333   0.00617284 
+  180          173.28526    137.03972   0.00555556 
+  179          173.99863    136.98618   0.00558659 
+  187          175.15316    136.93272   0.00534759 
+  166          178.10956    136.87933   0.0060241 
+  189          177.78354    136.82602   0.00529101 
+  187          174.95961    136.77279   0.00534759 
+  226          173.38314    136.71963   0.00442478 
+  203          172.29614    136.66655   0.00492611 
+  169          172.93582    136.61354   0.00591716 
+  192          175.05603    136.56061   0.00520833 
+  202          175.91792    136.50775   0.0049505 
+  178          176.85526    136.45497   0.00561798 
+  198          180.14992    136.40226   0.00505051 
+  188          186.14602    136.34963   0.00531915 
+  222          195.22057    136.29707   0.0045045 
+  210          208.18122    136.24459   0.0047619 
+  218          226.82526    136.19218   0.00458716 
+  231          250.20866    136.13984   0.004329  
+  283          268.06628    136.08758   0.00353357 
+  250          267.6798     136.03539   0.004     
+  278          257.7305     135.98328   0.00359712 
+  227          256.47233    135.93124   0.00440529 
+  217          270.68687    135.87928   0.00460829 
+  248          281.17828    135.82738   0.00403226 
+  222          265.61459    135.77556   0.0045045 
+  198          241.73242    135.72382   0.00505051 
+  228          222.57066    135.67214   0.00438596 
+  204          213.39921    135.62054   0.00490196 
+  212          213.57225    135.56901   0.00471698 
+  182          211.35628    135.51756   0.00549451 
+  170          199.85619    135.46618   0.00588235 
+  178          190.26503    135.41487   0.00561798 
+  175          184.80496    135.36363   0.00571429 
+  182          181.39389    135.31246   0.00549451 
+  179          177.79459    135.26137   0.00558659 
+  163          174.79695    135.21035   0.00613497 
+  196          173.42693    135.1594    0.00510204 
+  190          173.30182    135.10852   0.00526316 
+  192          174.08405    135.05771   0.00520833 
+  214          175.70554    135.00697   0.0046729 
+  209          178.22257    134.95631   0.00478469 
+  253          183.72979    134.90572   0.00395257 
+  221          195.96706    134.85519   0.00452489 
+  236          221.24538    134.80474   0.00423729 
+  251          266.10726    134.75436   0.00398406 
+  294          324.76288    134.70405   0.00340136 
+  325          329.25377    134.65381   0.00307692 
+  320          267.64172    134.60364   0.003125  
+  282          229.16404    134.55355   0.0035461 
+  233          221.39883    134.50352   0.00429185 
+  235          235.52095    134.45356   0.00425532 
+  238          262.22971    134.40367   0.00420168 
+  266          265.171      134.35386   0.0037594 
+  254          243.01317    134.30411   0.00393701 
+  216          239.89183    134.25443   0.00462963 
+  213          243.6446     134.20482   0.00469484 
+  239          225.88491    134.15528   0.0041841 
+  210          204.54152    134.10581   0.0047619 
+  194          194.05864    134.05641   0.00515464 
+  224          193.44911    134.00708   0.00446429 
+  183          200.37639    133.95782   0.00546448 
+  194          206.53463    133.90863   0.00515464 
+  189          200.32349    133.8595    0.00529101 
+  209          192.54334    133.81045   0.00478469 
+  233          191.9734     133.76146   0.00429185 
+  220          201.22665    133.71254   0.00454545 
+  286          224.01889    133.66369   0.0034965 
+  294          247.32518    133.61491   0.00340136 
+  274          231.2663     133.5662    0.00364964 
+  194          207.23659    133.51756   0.00515464 
+  227          196.83795    133.46898   0.00440529 
+  196          197.36096    133.42047   0.00510204 
+  230          207.23742    133.37203   0.00434783 
+  235          219.09928    133.32366   0.00425532 
+  208          212.15708    133.27536   0.00480769 
+  232          200.9956     133.22712   0.00431034 
+  211          196.92754    133.17895   0.00473934 
+  204          197.90624    133.13085   0.00490196 
+  199          200.19874    133.08282   0.00502513 
+  206          201.11571    133.03485   0.00485437 
+  206          202.67817    132.98695   0.00485437 
+  217          205.83382    132.93912   0.00460829 
+  229          209.8057     132.89135   0.00436681 
+  224          213.96824    132.84366   0.00446429 
+  216          218.53604    132.79602   0.00462963 
+  222          222.85753    132.74846   0.0045045 
+  217          227.99979    132.70096   0.00460829 
+  236          234.54956    132.65353   0.00423729 
+  240          242.18362    132.60617   0.00416667 
+  224          250.58198    132.55887   0.00446429 
+  229          260.32497    132.51164   0.00436681 
+  256          271.88446    132.46448   0.00390625 
+  291          285.66564    132.41738   0.00343643 
+  279          302.36242    132.37034   0.00358423 
+  314          323.05031    132.32338   0.00318471 
+  371          347.38134    132.27648   0.00269542 
+  404          372.47486    132.22965   0.00247525 
+  441          401.35152    132.18288   0.00226757 
+  514          438.66352    132.13618   0.00194553 
+  485          486.98933    132.08954   0.00206186 
+  567          549.83332    132.04297   0.00176367 
+  512          632.12365    131.99646   0.00195312 
+  607          740.38153    131.95002   0.00164745 
+  726          888.56682    131.90365   0.00137741 
+  868          1101.40887   131.85734   0.00115207 
+  1155         1423.32222   131.8111    0.0008658 
+  1765         1943.84379   131.76492   0.00056657 
+  2968         2878.33294   131.71881   0.00033693 
+  5375         4811.48193   131.67276   0.00018605 
+  10059        9058.46446   131.62678   0.00009941 
+  15681        16501.88207  131.58086   0.00006377 
+  18827        18706.2602   131.53501   0.00005312 
+  14310        11640.64343  131.48922   0.00006988 
+  8342         6759.43598   131.4435    0.00011988 
+  5748         5137.16544   131.39784   0.00017397 
+  6186         5853.70998   131.35225   0.00016166 
+  8158         8760.52828   131.30672   0.00012258 
+  9404         10386.60564  131.26125   0.00010634 
+  7549         6813.35866   131.21586   0.00013247 
+  4426         3726.13005   131.17052   0.00022594 
+  2208         2220.86754   131.12525   0.0004529 
+  1298         1509.41398   131.08004   0.00077042 
+  921          1128.63616   131.0349    0.00108578 
+  683          898.58713    130.98982   0.00146413 
+  595          747.61711    130.94481   0.00168067 
+  498          639.04227    130.89986   0.00200803 
+  448          554.52656    130.85498   0.00223214 
+  380          488.4969     130.81015   0.00263158 
+  402          438.02474    130.7654    0.00248756 
+  317          399.76991    130.7207    0.00315457 
+  293          370.13218    130.67607   0.00341297 
+  288          344.9224     130.63151   0.00347222 
+  279          321.37658    130.58701   0.00358423 
+  285          300.16117    130.54257   0.00350877 
+  259          282.17932    130.49819   0.003861  
+  262          267.25288    130.45388   0.00381679 
+  247          254.86717    130.40963   0.00404858 
+  221          244.50892    130.36545   0.00452489 
+  207          235.78222    130.32133   0.00483092 
+  242          228.40293    130.27727   0.00413223 
+  182          222.10906    130.23328   0.00549451 
+  216          216.8517     130.18935   0.00462963 
+  197          211.96881    130.14548   0.00507614 
+  187          207.47082    130.10167   0.00534759 
+  210          203.37908    130.05793   0.0047619 
+  179          199.8574     130.01425   0.00558659 
+  200          197.01523    129.97064   0.005     
+  205          194.87624    129.92709   0.00487805 
+  176          193.50326    129.8836    0.00568182 
+  201          192.63731    129.84017   0.00497512 
+  193          192.41029    129.79681   0.00518135 
+  202          192.96562    129.75351   0.0049505 
+  222          194.6648     129.71027   0.0045045 
+  215          198.11061    129.6671    0.00465116 
+  245          203.59552    129.62398   0.00408163 
+  248          208.32534    129.58093   0.00403226 
+  274          206.56154    129.53795   0.00364964 
+  305          203.07674    129.49502   0.00327869 
+  299          201.47584    129.45216   0.00334448 
+  264          202.04764    129.40936   0.00378788 
+  247          204.63655    129.36663   0.00404858 
+  217          206.99074    129.32395   0.00460829 
+  218          204.62289    129.28134   0.00458716 
+  258          198.64681    129.23879   0.00387597 
+  274          192.99068    129.19631   0.00364964 
+  262          188.93542    129.15388   0.00381679 
+  249          186.75671    129.11152   0.00401606 
+  219          185.82763    129.06922   0.00456621 
+  199          185.29995    129.02698   0.00502513 
+  211          185.12177    128.98481   0.00473934 
+  228          186.03853    128.94269   0.00438596 
+  211          188.82408    128.90064   0.00473934 
+  174          193.59392    128.85865   0.00574713 
+  198          199.22733    128.81672   0.00505051 
+  249          203.45133    128.77486   0.00401606 
+  274          205.04373    128.73306   0.00364964 
+  258          206.12197    128.69132   0.00387597 
+  309          208.5554     128.64964   0.00323625 
+  301          207.28186    128.60802   0.00332226 
+  342          202.74815    128.56646   0.00292398 
+  315          200.20312    128.52497   0.0031746 
+  308          198.90939    128.48354   0.00324675 
+  299          198.49566    128.44217   0.00334448 
+  262          199.57975    128.40086   0.00381679 
+  263          196.06721    128.35962   0.00380228 
+  273          185.40073    128.31843   0.003663  
+  261          176.52142    128.27731   0.00383142 
+  247          171.44146    128.23625   0.00404858 
+  231          168.94713    128.19525   0.004329  
+  214          168.25871    128.15431   0.0046729 
+  208          167.64869    128.11343   0.00480769 
+  198          164.9412     128.07262   0.00505051 
+  177          162.79638    128.03187   0.00564972 
+  192          163.11617    127.99118   0.00520833 
+  190          166.64423    127.95055   0.00526316 
+  187          174.68722    127.90998   0.00534759 
+  177          186.28991    127.86947   0.00564972 
+  164          190.55672    127.82903   0.00609756 
+  172          187.55721    127.78864   0.00581395 
+  180          187.69993    127.74832   0.00555556 
+  165          183.41659    127.70806   0.00606061 
+  146          176.30792    127.66786   0.00684932 
+  183          174.63771    127.62772   0.00546448 
+  156          175.34696    127.58765   0.00641026 
+  159          172.53908    127.54763   0.00628931 
+  172          170.96312    127.50768   0.00581395 
+  172          170.09087    127.46779   0.00581395 
+  171          166.7424     127.42795   0.00584795 
+  185          165.57616    127.38818   0.00540541 
+  169          167.40644    127.34848   0.00591716 
+  144          166.62778    127.30883   0.00694444 
+  176          162.69161    127.26924   0.00568182 
+  163          160.39934    127.22972   0.00613497 
+  150          160.50257    127.19025   0.00666667 
+  164          162.72027    127.15085   0.00609756 
+  156          166.90409    127.11151   0.00641026 
+  151          171.4993     127.07223   0.00662252 
+  172          174.31237    127.03301   0.00581395 
+  181          177.4367     126.99386   0.00552486 
+  177          182.5324     126.95476   0.00564972 
+  175          189.69696    126.91573   0.00571429 
+  206          199.6465     126.87675   0.00485437 
+  200          215.85385    126.83784   0.005     
+  229          234.55875    126.79899   0.00436681 
+  218          233.82428    126.7602    0.00458716 
+  205          221.46735    126.72147   0.00487805 
+  228          216.38367    126.6828    0.00438596 
+  195          221.18294    126.64419   0.00512821 
+  250          235.05534    126.60565   0.004     
+  269          254.4057     126.56716   0.00371747 
+  231          266.97963    126.52874   0.004329  
+  254          273.20404    126.49038   0.00393701 
+  235          289.01138    126.45208   0.00425532 
+  290          323.51863    126.41384   0.00344828 
+  355          384.997      126.37566   0.0028169 
+  488          494.73075    126.33754   0.00204918 
+  762          710.66147    126.29948   0.00131234 
+  1209         1178.33009   126.26149   0.00082713 
+  1807         2080.15118   126.22355   0.0005534 
+  2108         2756.66767   126.18568   0.00047438 
+  1917         1992.45628   126.14787   0.00052165 
+  1215         1190.96307   126.11011   0.00082305 
+  810          839.711      126.07242   0.00123457 
+  779          791.30827    126.03479   0.0012837 
+  911          1010.39019   125.99723   0.00109769 
+  1135         1449.48609   125.95972   0.00088106 
+  1146         1422.35004   125.92227   0.0008726 
+  843          911.76864    125.88489   0.00118624 
+  546          586.60976    125.84756   0.0018315 
+  381          436.73337    125.8103    0.00262467 
+  297          352.26043    125.7731    0.003367  
+  286          293.49571    125.73596   0.0034965 
+  246          255.81708    125.69888   0.00406504 
+  210          232.48484    125.66186   0.0047619 
+  194          219.49904    125.6249    0.00515464 
+  201          214.01       125.58801   0.00497512 
+  198          208.729      125.55117   0.00505051 
+  198          196.67427    125.5144    0.00505051 
+  166          184.6733     125.47769   0.0060241 
+  157          175.99106    125.44103   0.00636943 
+  173          169.84156    125.40444   0.00578035 
+  139          165.40674    125.36791   0.00719424 
+  162          162.11854    125.33144   0.00617284 
+  150          159.69484    125.29504   0.00666667 
+  164          158.11755    125.25869   0.00609756 
+  160          157.60213    125.22241   0.00625   
+  168          158.85341    125.18618   0.00595238 
+  159          161.39476    125.15002   0.00628931 
+  152          162.91888    125.11392   0.00657895 
+  167          160.3963     125.07788   0.00598802 
+  133          157.57541    125.0419    0.0075188 
+  155          156.48265    125.00598   0.00645161 
+  149          156.92911    124.97013   0.00671141 
+  158          158.73236    124.93433   0.00632911 
+  156          161.83296    124.8986    0.00641026 
+  166          164.34132    124.86292   0.0060241 
+  157          166.57104    124.82731   0.00636943 
+  161          171.40822    124.79176   0.00621118 
+  197          180.89856    124.75627   0.00507614 
+  206          198.58463    124.72084   0.00485437 
+  266          233.82329    124.68548   0.0037594 
+  327          307.30823    124.65017   0.0030581 
+  436          441.65595    124.61493   0.00229358 
+  562          544.07809    124.57975   0.00177936 
+  636          440.45508    124.54463   0.00157233 
+  561          315.70999    124.50957   0.00178253 
+  440          256.31269    124.47457   0.00227273 
+  314          245.15231    124.43963   0.00318471 
+  314          273.77501    124.40476   0.00318471 
+  404          335.72222    124.36994   0.00247525 
+  382          349.43132    124.33519   0.0026178 
+  374          275.088      124.3005    0.0026738 
+  343          215.24526    124.26587   0.00291545 
+  242          184.74554    124.2313    0.00413223 
+  220          170.1489     124.19679   0.00454545 
+  191          162.65352    124.16235   0.0052356 
+  171          157.73601    124.12796   0.00584795 
+  192          154.45384    124.09364   0.00520833 
+  181          153.08673    124.05938   0.00552486 
+  176          154.31959    124.02518   0.00568182 
+  184          158.70804    123.99104   0.00543478 
+  168          163.42284    123.95697   0.00595238 
+  162          160.90788    123.92295   0.00617284 
+  188          155.26203    123.889     0.00531915 
+  174          152.40308    123.85511   0.00574713 
+  188          152.70036    123.82128   0.00531915 
+  184          156.02043    123.78751   0.00543478 
+  199          163.47036    123.75381   0.00502513 
+  195          172.48677    123.72016   0.00512821 
+  153          171.88425    123.68658   0.00653595 
+  179          162.63927    123.65306   0.00558659 
+  174          156.15367    123.6196    0.00574713 
+  168          154.71185    123.5862    0.00595238 
+  199          157.77752    123.55287   0.00502513 
+  192          165.81248    123.5196    0.00520833 
+  174          174.50748    123.48638   0.00574713 
+  175          170.69886    123.45323   0.00571429 
+  183          159.98452    123.42015   0.00546448 
+  168          153.09475    123.38712   0.00595238 
+  159          150.60677    123.35416   0.00628931 
+  161          151.44524    123.32126   0.00621118 
+  147          154.71895    123.28842   0.00680272 
+  183          156.47216    123.25564   0.00546448 
+  190          153.03532    123.22292   0.00526316 
+  150          149.25118    123.19027   0.00666667 
+  154          147.89805    123.15768   0.00649351 
+  186          148.26612    123.12515   0.00537634 
+  133          148.16605    123.09268   0.0075188 
+  126          147.18603    123.06028   0.00793651 
+  190          146.18246    123.02793   0.00526316 
+  157          145.60007    122.99565   0.00636943 
+  158          145.83496    122.96343   0.00632911 
+  157          146.86235    122.93128   0.00636943 
+  174          148.31499    122.89919   0.00574713 
+  173          149.24557    122.86715   0.00578035 
+  171          149.82493    122.83518   0.00584795 
+  152          150.67172    122.80328   0.00657895 
+  166          151.85118    122.77143   0.0060241 
+  175          153.53104    122.73965   0.00571429 
+  173          156.06943    122.70793   0.00578035 
+  159          159.79288    122.67627   0.00628931 
+  174          163.87956    122.64468   0.00574713 
+  158          165.65732    122.61315   0.00632911 
+  197          166.20869    122.58168   0.00507614 
+  194          167.82773    122.55027   0.00515464 
+  203          171.00642    122.51893   0.00492611 
+  203          176.07697    122.48764   0.00492611 
+  208          183.74333    122.45643   0.00480769 
+  249          194.48735    122.42527   0.00401606 
+  258          206.94402    122.39417   0.00387597 
+  263          215.5194     122.36314   0.00380228 
+  244          218.22408    122.33218   0.00409836 
+  270          223.92964    122.30127   0.0037037 
+  259          236.25468    122.27043   0.003861  
+  261          256.43795    122.23965   0.00383142 
+  297          286.82417    122.20893   0.003367  
+  322          328.04359    122.17828   0.00310559 
+  363          371.05103    122.14769   0.00275482 
+  377          420.40311    122.11716   0.00265252 
+  399          502.88045    122.08669   0.00250627 
+  621          648.40461    122.05629   0.00161031 
+  924          922.1542     122.02595   0.00108225 
+  1724         1491.85882   121.99567   0.00058005 
+  3082         2678.39388   121.96546   0.00032446 
+  4542         4434.93403   121.93531   0.00022017 
+  4165         4413.24196   121.90522   0.0002401 
+  2717         2717.51544   121.8752    0.00036805 
+  1696         1652.87807   121.84524   0.00058962 
+  1252         1254.61849   121.81534   0.00079872 
+  1314         1279.39181   121.78551   0.00076104 
+  1839         1722.61761   121.75574   0.00054377 
+  2367         2495.99938   121.72603   0.00042248 
+  2144         2380.39184   121.69639   0.00046642 
+  1335         1472.52491   121.66681   0.00074906 
+  829          887.0258     121.63729   0.00120627 
+  543          606.44315    121.60784   0.00184162 
+  423          463.95235    121.57845   0.00236407 
+  339          378.2777     121.54912   0.00294985 
+  280          325.58314    121.51986   0.00357143 
+  268          290.2545     121.49066   0.00373134 
+  228          260.48266    121.46152   0.00438596 
+  217          237.45336    121.43245   0.00460829 
+  171          220.98898    121.40344   0.00584795 
+  201          208.48112    121.3745    0.00497512 
+  144          199.23576    121.34562   0.00694444 
+  203          193.50386    121.3168    0.00492611 
+  184          189.20938    121.28805   0.00543478 
+  178          183.87309    121.25936   0.00561798 
+  156          179.10512    121.23073   0.00641026 
+  177          174.33028    121.20217   0.00564972 
+  186          170.84999    121.17367   0.00537634 
+  171          167.76858    121.14524   0.00584795 
+  171          165.69628    121.11687   0.00584795 
+  170          165.18       121.08857   0.00588235 
+  178          165.89       121.06032   0.00561798 
+  166          166.60719    121.03215   0.0060241 
+  160          166.50881    121.00403   0.00625   
+  157          165.46383    120.97599   0.00636943 
+  161          163.75201    120.948     0.00621118 
+  145          161.29456    120.92008   0.00689655 
+  161          158.08403    120.89222   0.00621118 
+  127          155.46338    120.86443   0.00787402 
+  181          153.71853    120.83671   0.00552486 
+  158          152.37791    120.80904   0.00632911 
+  148          151.15036    120.78144   0.00675676 
+  160          150.06879    120.75391   0.00625   
+  169          148.94745    120.72644   0.00591716 
+  159          147.62441    120.69903   0.00628931 
+  177          147.0491     120.67169   0.00564972 
+  154          147.96347    120.64442   0.00649351 
+  144          150.25725    120.61721   0.00694444 
+  163          151.63604    120.59006   0.00613497 
+  134          151.40269    120.56298   0.00746269 
+  148          152.51317    120.53596   0.00675676 
+  156          154.90587    120.50901   0.00641026 
+  184          156.21558    120.48212   0.00543478 
+  150          155.57226    120.4553    0.00666667 
+  162          154.29152    120.42854   0.00617284 
+  127          153.35914    120.40185   0.00787402 
+  135          153.10639    120.37522   0.00740741 
+  155          155.21319    120.34866   0.00645161 
+  170          158.44049    120.32216   0.00588235 
+  169          158.0488     120.29573   0.00591716 
+  159          154.4504     120.26936   0.00628931 
+  172          151.11186    120.24306   0.00581395 
+  148          149.11131    120.21682   0.00675676 
+  141          148.30499    120.19065   0.0070922 
+  144          148.38154    120.16454   0.00694444 
+  148          148.84034    120.1385    0.00675676 
+  161          148.16412    120.11252   0.00621118 
+  150          146.54685    120.08661   0.00666667 
+  164          145.63719    120.06077   0.00609756 
+  149          145.54858    120.03499   0.00671141 
+  167          145.70144    120.00927   0.00598802 
+  149          145.65771    119.98362   0.00671141 
+  168          145.45372    119.95804   0.00595238 
+  147          145.62349    119.93252   0.00680272 
+  142          146.91264    119.90707   0.00704225 
+  176          149.87652    119.88168   0.00568182 
+  173          153.1685     119.85636   0.00578035 
+  151          152.5788     119.83111   0.00662252 
+  155          149.45687    119.80592   0.00645161 
+  152          147.39634    119.78079   0.00657895 
+  156          146.90501    119.75573   0.00641026 
+  141          147.90644    119.73074   0.0070922 
+  166          150.52701    119.70582   0.0060241 
+  179          154.69226    119.68096   0.00558659 
+  168          159.00577    119.65616   0.00595238 
+  156          163.65612    119.63143   0.00641026 
+  173          169.02975    119.60677   0.00578035 
+  200          176.6185     119.58218   0.005     
+  202          191.5252     119.55765   0.0049505 
+  238          206.8869     119.53318   0.00420168 
+  238          202.64561    119.50878   0.00420168 
+  192          187.75396    119.48445   0.00520833 
+  198          178.68451    119.46019   0.00505051 
+  210          176.77371    119.43599   0.0047619 
+  208          178.76594    119.41186   0.00480769 
+  219          184.35992    119.38779   0.00456621 
+  205          193.22418    119.36379   0.00487805 
+  195          196.80414    119.33986   0.00512821 
+  196          195.72677    119.31599   0.00510204 
+  210          201.33786    119.29219   0.0047619 
+  188          216.04579    119.26846   0.00531915 
+  192          224.79951    119.24479   0.00520833 
+  220          215.01967    119.22119   0.00454545 
+  236          204.50076    119.19766   0.00423729 
+  235          202.3592     119.17419   0.00425532 
+  219          208.99114    119.15079   0.00456621 
+  234          225.26157    119.12746   0.0042735 
+  226          251.33299    119.1042    0.00442478 
+  278          272.95844    119.081     0.00359712 
+  251          272.42499    119.05786   0.00398406 
+  273          269.81524    119.0348    0.003663  
+  277          279.78112    119.0118    0.00361011 
+  310          305.96537    118.98887   0.00322581 
+  353          346.14249    118.96601   0.00283286 
+  361          367.96594    118.94321   0.00277008 
+  307          373.01815    118.92048   0.00325733 
+  341          389.52023    118.89782   0.00293255 
+  362          427.2662     118.87522   0.00276243 
+  447          494.89916    118.85269   0.00223714 
+  511          603.25171    118.83023   0.00195695 
+  723          779.01755    118.80784   0.00138313 
+  1080         1075.89635   118.78551   0.00092593 
+  1772         1643.55574   118.76325   0.00056433 
+  3105         2843.12881   118.74106   0.00032206 
+  4822         4986.85622   118.71894   0.00020738 
+  5387         6243.06168   118.69688   0.00018563 
+  3959         4379.80178   118.67489   0.00025259 
+  2521         2558.75519   118.65297   0.00039667 
+  1601         1697.64649   118.63112   0.00062461 
+  1426         1447.24101   118.60934   0.00070126 
+  1674         1653.53045   118.58762   0.00059737 
+  2281         2400.7792    118.56597   0.0004384 
+  2800         3348.49511   118.54439   0.00035714 
+  2435         2856.04268   118.52287   0.00041068 
+  1535         1718.86615   118.50142   0.00065147 
+  906          1043.36109   118.48005   0.00110375 
+  628          713.66463    118.45873   0.00159236 
+  467          545.56697    118.43749   0.00214133 
+  372          448.91554    118.41632   0.00268817 
+  305          386.91521    118.39521   0.00327869 
+  288          343.85965    118.37417   0.00347222 
+  271          312.86961    118.3532    0.00369004 
+  300          291.14376    118.3323    0.00333333 
+  293          277.15477    118.31147   0.00341297 
+  284          268.40994    118.2907    0.00352113 
+  265          259.46852    118.27      0.00377358 
+  279          251.04844    118.24937   0.00358423 
+  240          245.09732    118.22881   0.00416667 
+  253          239.93273    118.20832   0.00395257 
+  256          233.39046    118.1879    0.00390625 
+  264          227.26516    118.16754   0.00378788 
+  275          225.80432    118.14725   0.00363636 
+  242          229.39556    118.12704   0.00413223 
+  243          234.7748     118.10689   0.00411523 
+  215          231.03909    118.08681   0.00465116 
+  234          216.77544    118.06679   0.0042735 
+  195          203.41701    118.04685   0.00512821 
+  195          193.22427    118.02697   0.00512821 
+  233          186.72554    118.00717   0.00429185 
+  209          184.42866    117.98743   0.00478469 
+  202          186.23177    117.96776   0.0049505 
+  249          188.0794     117.94816   0.00401606 
+  223          184.38082    117.92863   0.0044843 
+  229          180.6592     117.90917   0.00436681 
+  210          182.37366    117.88978   0.0047619 
+  230          190.59582    117.87045   0.00434783 
+  231          203.23259    117.8512    0.004329  
+  269          218.52454    117.83201   0.00371747 
+  236          222.39095    117.8129    0.00423729 
+  225          205.40601    117.79385   0.00444444 
+  242          189.55889    117.77487   0.00413223 
+  228          183.63103    117.75596   0.00438596 
+  228          187.03068    117.73712   0.00438596 
+  209          198.85063    117.71835   0.00478469 
+  245          217.57203    117.69965   0.00408163 
+  237          234.13603    117.68102   0.00421941 
+  251          230.55784    117.66246   0.00398406 
+  239          220.33303    117.64397   0.0041841 
+  292          218.7917     117.62554   0.00342466 
+  294          225.04272    117.60719   0.00340136 
+  296          235.33216    117.5889    0.00337838 
+  259          247.31125    117.57069   0.003861  
+  289          252.32496    117.55255   0.00346021 
+  297          240.03692    117.53447   0.003367  
+  280          224.94014    117.51647   0.00357143 
+  237          215.40865    117.49853   0.00421941 
+  241          205.99444    117.48066   0.00414938 
+  230          199.15269    117.46287   0.00434783 
+  210          196.17208    117.44514   0.0047619 
+  213          194.54551    117.42749   0.00469484 
+  229          188.23496    117.4099    0.00436681 
+  194          178.89688    117.39238   0.00515464 
+  186          173.48842    117.37494   0.00537634 
+  193          170.86126    117.35756   0.00518135 
+  145          170.8736     117.34025   0.00689655 
+  145          175.40099    117.32302   0.00689655 
+  174          176.71356    117.30585   0.00574713 
+  171          166.43565    117.28875   0.00584795 
+  140          154.98509    117.27173   0.00714286 
+  143          148.82691    117.25477   0.00699301 
+  148          147.11823    117.23789   0.00675676 
+  167          149.19917    117.22107   0.00598802 
+  155          155.06895    117.20433   0.00645161 
+  173          161.9389     117.18765   0.00578035 
+  164          162.92255    117.17105   0.00609756 
+  142          160.10064    117.15452   0.00704225 
+  151          163.18873    117.13805   0.00662252 
+  161          176.27731    117.12166   0.00621118 
+  157          196.89035    117.10534   0.00636943 
+  173          203.35856    117.08909   0.00578035 
+  149          185.05773    117.07291   0.00671141 
+  165          165.7734     117.0568    0.00606061 
+  143          153.86943    117.04076   0.00699301 
+  132          148.82623    117.02479   0.00757576 
+  148          149.68585    117.00889   0.00675676 
+  135          156.21092    116.99306   0.00740741 
+  142          164.57514    116.97731   0.00704225 
+  163          161.93035    116.96162   0.00613497 
+  173          150.10278    116.94601   0.00578035 
+  115          140.61089    116.93046   0.00869565 
+  139          135.04184    116.91499   0.00719424 
+  139          131.93252    116.89959   0.00719424 
+  109          130.22291    116.88426   0.00917431 
+  128          129.38384    116.869     0.0078125 
+  143          129.23505    116.85381   0.00699301 
+  144          129.74076    116.83869   0.00694444 
+  137          131.08028    116.82364   0.00729927 
+  140          133.96678    116.80867   0.00714286 
+  117          138.26969    116.79376   0.00854701 
+  140          139.7023     116.77893   0.00714286 
+  105          135.75452    116.76417   0.00952381 
+  134          131.62816    116.74948   0.00746269 
+  143          129.40995    116.73486   0.00699301 
+  122          128.69796    116.72031   0.00819672 
+  153          128.96632    116.70583   0.00653595 
+  131          130.10836    116.69143   0.00763359 
+  133          131.82626    116.67709   0.0075188 
+  150          131.69981    116.66283   0.00666667 
+  133          129.62428    116.64864   0.0075188 
+  132          128.24004    116.63452   0.00757576 
+  146          127.85743    116.62047   0.00684932 
+  141          127.20474    116.6065    0.0070922 
+  135          125.98574    116.59259   0.00740741 
+  121          124.95754    116.57876   0.00826446 
+  128          124.36068    116.565     0.0078125 
+  130          124.12788    116.55131   0.00769231 
+  122          124.19401    116.53769   0.00819672 
+  134          124.5401     116.52414   0.00746269 
+  146          124.96493    116.51067   0.00684932 
+  134          124.98187    116.49727   0.00746269 
+  124          124.81482    116.48394   0.00806452 
+  110          124.9212     116.47068   0.00909091 
+  126          125.39811    116.45749   0.00793651 
+  136          126.21449    116.44437   0.00735294 
+  127          127.2058     116.43133   0.00787402 
+  145          128.17483    116.41836   0.00689655 
+  145          129.55026    116.40546   0.00689655 
+  137          132.19947    116.39263   0.00729927 
+  157          137.09826    116.37988   0.00636943 
+  140          145.26619    116.3672    0.00714286 
+  134          154.45844    116.35458   0.00746269 
+  139          155.72573    116.34205   0.00719424 
+  152          151.39941    116.32958   0.00657895 
+  141          150.13109    116.31718   0.0070922 
+  161          151.63003    116.30486   0.00621118 
+  137          151.41574    116.29261   0.00729927 
+  155          148.71533    116.28043   0.00645161 
+  143          148.72012    116.26833   0.00699301 
+  132          150.26347    116.2563    0.00757576 
+  171          148.22918    116.24434   0.00584795 
+  149          145.23025    116.23245   0.00671141 
+  117          145.27024    116.22063   0.00854701 
+  143          147.59468    116.20889   0.00699301 
+  143          149.71049    116.19722   0.00699301 
+  145          151.84615    116.18562   0.00689655 
+  154          154.15574    116.17409   0.00649351 
+  132          152.87681    116.16264   0.00757576 
+  156          151.46501    116.15126   0.00641026 
+  128          154.17755    116.13995   0.0078125 
+  158          158.43384    116.12871   0.00632911 
+  149          157.27846    116.11755   0.00671141 
+  149          153.97769    116.10646   0.00671141 
+  133          153.94845    116.09544   0.0075188 
+  156          156.35863    116.0845    0.00641026 
+  165          159.10669    116.07362   0.00606061 
+  152          164.6433     116.06282   0.00657895 
+  190          176.56535    116.0521    0.00526316 
+  212          197.55885    116.04144   0.00471698 
+  216          232.35924    116.03086   0.00462963 
+  279          294.60275    116.02035   0.00358423 
+  298          377.08331    116.00992   0.0033557 
+  324          374.48809    115.99956   0.00308642 
+  304          291.82858    115.98927   0.00328947 
+  279          234.12613    115.97905   0.00358423 
+  254          211.00058    115.96891   0.00393701 
+  249          212.36069    115.95883   0.00401606 
+  232          236.20935    115.94884   0.00431034 
+  251          283.78013    115.93891   0.00398406 
+  261          331.52122    115.92906   0.00383142 
+  248          314.30389    115.91928   0.00403226 
+  230          255.26638    115.90958   0.00434783 
+  248          216.92354    115.89994   0.00403226 
+  196          203.16996    115.89038   0.00510204 
+  234          207.54053    115.8809    0.0042735 
+  247          226.54471    115.87148   0.00404858 
+  268          249.37406    115.86214   0.00373134 
+  271          258.86723    115.85288   0.00369004 
+  233          264.65052    115.84368   0.00429185 
+  299          296.0478     115.83456   0.00334448 
+  368          375.48808    115.82552   0.00271739 
+  433          463.11643    115.81654   0.00230947 
+  431          424.4235     115.80764   0.00232019 
+  368          333.88987    115.79882   0.00271739 
+  302          284.08638    115.79006   0.00331126 
+  304          268.25456    115.78138   0.00328947 
+  256          284.79758    115.77277   0.00390625 
+  306          344.4294     115.76424   0.00326797 
+  360          451.91075    115.75578   0.00277778 
+  354          514.10519    115.74739   0.00282486 
+  357          426.24533    115.73908   0.00280112 
+  259          311.07048    115.73084   0.003861  
+  212          243.06199    115.72268   0.00471698 
+  196          212.15488    115.71458   0.00510204 
+  211          204.78672    115.70656   0.00473934 
+  165          216.74713    115.69862   0.00606061 
+  191          245.37385    115.69075   0.0052356 
+  195          255.30634    115.68295   0.00512821 
+  190          219.66318    115.67522   0.00526316 
+  200          184.22985    115.66757   0.005     
+  167          163.33179    115.65999   0.00598802 
+  148          152.10071    115.65249   0.00675676 
+  180          146.11194    115.64506   0.00555556 
+  162          142.62727    115.6377    0.00617284 
+  162          139.89049    115.63042   0.00617284 
+  165          137.8714     115.62321   0.00606061 
+  156          136.88808    115.61608   0.00641026 
+  151          136.92383    115.60902   0.00662252 
+  147          137.99292    115.60203   0.00680272 
+  166          140.30295    115.59511   0.0060241 
+  141          143.67967    115.58827   0.0070922 
+  171          146.55541    115.58151   0.00584795 
+  158          149.11212    115.57481   0.00632911 
+  159          154.02057    115.5682    0.00628931 
+  166          162.33375    115.56165   0.0060241 
+  164          173.7198     115.55518   0.00609756 
+  159          186.03312    115.54878   0.00628931 
+  186          188.33084    115.54246   0.00537634 
+  151          183.94452    115.53621   0.00662252 
+  160          181.93721    115.53003   0.00625   
+  163          179.7388     115.52393   0.00613497 
+  162          175.14761    115.5179    0.00617284 
+  142          170.7247     115.51195   0.00704225 
+  158          169.12598    115.50607   0.00632911 
+  175          170.67811    115.50027   0.00571429 
+  160          170.18044    115.49453   0.00625   
+  171          166.9375     115.48888   0.00584795 
+  146          166.6621     115.48329   0.00684932 
+  156          168.39528    115.47778   0.00641026 
+  152          166.75879    115.47235   0.00657895 
+  178          161.63282    115.46699   0.00561798 
+  163          157.90102    115.4617    0.00613497 
+  129          156.96704    115.45648   0.00775194 
+  145          159.84816    115.45135   0.00689655 
+  190          168.77971    115.44628   0.00526316 
+  227          188.69295    115.44129   0.00440529 
+  285          229.69352    115.43637   0.00350877 
+  346          300.60462    115.43153   0.00289017 
+  425          353.15775    115.42676   0.00235294 
+  384          303.50631    115.42207   0.00260417 
+  311          240.34072    115.41745   0.00321543 
+  271          207.26336    115.4129    0.00369004 
+  240          192.21458    115.40843   0.00416667 
+  243          189.87247    115.40403   0.00411523 
+  304          202.71192    115.39971   0.00328947 
+  388          236.9735     115.39546   0.00257732 
+  372          283.82748    115.39128   0.00268817 
+  380          292.21098    115.38718   0.00263158 
+  285          270.56087    115.38315   0.00350877 
+  221          238.90578    115.3792    0.00452489 
+  210          210.88735    115.37532   0.0047619 
+  195          195.51402    115.37152   0.00512821 
+  212          190.4596     115.36779   0.00471698 
+  221          196.90585    115.36413   0.00452489 
+  223          217.38283    115.36055   0.0044843 
+  220          241.09901    115.35704   0.00454545 
+  194          241.35049    115.35361   0.00515464 
+  212          220.00123    115.35025   0.00471698 
+  176          198.21763    115.34697   0.00568182 
+  193          186.51412    115.34376   0.00518135 
+  176          181.88406    115.34062   0.00568182 
+  182          180.59516    115.33756   0.00549451 
+  168          183.43227    115.33457   0.00595238 
+  164          188.91471    115.33166   0.00609756 
+  167          186.68605    115.32882   0.00598802 
+  172          176.52641    115.32606   0.00581395 
+  137          169.74694    115.32337   0.00729927 
+  152          169.79507    115.32075   0.00657895 
+  163          177.14866    115.31821   0.00613497 
+  165          192.43077    115.31575   0.00606061 
+  154          211.4038     115.31335   0.00649351 
+  132          212.5112     115.31103   0.00757576 
+  148          191.11163    115.30879   0.00675676 
+  134          171.2271     115.30662   0.00746269 
+  148          159.72547    115.30453   0.00675676 
+  151          153.66233    115.30251   0.00662252 
+  153          151.52315    115.30056   0.00653595 
+  151          154.34651    115.29869   0.00662252 
+  132          162.07634    115.29689   0.00757576 
+  122          167.10188    115.29517   0.00819672 
+  128          159.33271    115.29352   0.0078125 
+  130          147.7253     115.29194   0.00769231 
+  125          139.84229    115.29044   0.008     
+  124          135.04187    115.28902   0.00806452 
+  117          131.64699    115.28767   0.00854701 
+  130          129.24263    115.28639   0.00769231 
+  128          127.68314    115.28519   0.0078125 
+  133          126.72161    115.28406   0.0075188 
+  121          126.17352    115.28301   0.00826446 
+  131          125.92074    115.28203   0.00763359 
+  127          125.88737    115.28112   0.00787402 
+  125          125.83957    115.28029   0.008     
+  121          126.06211    115.27953   0.00826446 
+  133          126.44117    115.27885   0.0075188 
+  147          127.16443    115.27824   0.00680272 
+  118          128.33864    115.27771   0.00847458 
+  125          129.48783    115.27725   0.008     
+  135          130.20637    115.27687   0.00740741 
+  149          131.35128    115.27656   0.00671141 
+  121          133.46387    115.27632   0.00826446 
+  149          134.78435    115.27616   0.00671141 
+  129          133.67669    115.27607   0.00775194 
+  157          132.74386    115.27606   0.00636943 
+  158          133.66884    115.27612   0.00632911 
+  154          136.77274    115.27626   0.00649351 
+  167          141.73737    115.27647   0.00598802 
+  134          145.95531    115.27675   0.00746269 
+  132          145.25659    115.27711   0.00757576 
+  140          142.58561    115.27755   0.00714286 
+  150          140.68744    115.27805   0.00666667 
+  183          140.28711    115.27863   0.00546448 
+  164          141.97788    115.27929   0.00609756 
+  166          145.81281    115.28002   0.0060241 
+  154          153.25819    115.28083   0.00649351 
+  172          164.79039    115.28171   0.00581395 
+  192          178.48677    115.28266   0.00520833 
+  191          194.5576     115.28369   0.0052356 
+  174          202.99502    115.28479   0.00574713 
+  161          190.38793    115.28597   0.00621118 
+  161          173.14755    115.28722   0.00621118 
+  164          162.84257    115.28854   0.00609756 
+  192          159.43676    115.28994   0.00520833 
+  130          161.56382    115.29141   0.00769231 
+  167          168.00408    115.29296   0.00598802 
+  155          178.67986    115.29458   0.00645161 
+  180          191.87046    115.29628   0.00555556 
+  207          197.26226    115.29805   0.00483092 
+  194          192.89581    115.29989   0.00515464 
+  176          187.63163    115.30181   0.00568182 
+  181          184.82591    115.30381   0.00552486 
+  167          185.13599    115.30587   0.00598802 
+  174          188.58213    115.30801   0.00574713 
+  144          194.25409    115.31023   0.00694444 
+  167          200.26896    115.31252   0.00598802 
+  184          203.96367    115.31488   0.00543478 
+  198          202.0019     115.31732   0.00505051 
+  204          196.17443    115.31983   0.00490196 
+  158          191.97162    115.32242   0.00632911 
+  191          192.16843    115.32508   0.0052356 
+  182          196.85189    115.32781   0.00549451 
+  171          201.47041    115.33062   0.00584795 
+  173          200.79314    115.3335    0.00578035 
+  183          198.95827    115.33646   0.00546448 
+  185          197.88873    115.33949   0.00540541 
+  194          194.01968    115.3426    0.00515464 
+  174          190.91194    115.34577   0.00574713 
+  199          193.07644    115.34903   0.00502513 
+  198          201.06325    115.35235   0.00505051 
+  191          212.76923    115.35575   0.0052356 
+  192          221.87945    115.35923   0.00520833 
+  178          222.68096    115.36278   0.00561798 
+  178          220.25112    115.3664    0.00561798 
+  163          218.19234    115.3701    0.00613497 
+  189          217.33174    115.37387   0.00529101 
+  190          225.99157    115.37771   0.00526316 
+  247          254.09807    115.38163   0.00404858 
+  269          313.95725    115.38562   0.00371747 
+  368          400.01639    115.38969   0.00271739 
+  386          413.37072    115.39383   0.00259067 
+  306          334.80851    115.39804   0.00326797 
+  217          269.94034    115.40233   0.00460829 
+  190          232.64227    115.40669   0.00526316 
+  162          212.37447    115.41113   0.00617284 
+  191          205.29112    115.41563   0.0052356 
+  200          212.59529    115.42022   0.005     
+  235          238.85352    115.42487   0.00425532 
+  214          272.53532    115.4296    0.0046729 
+  252          258.48838    115.43441   0.00396825 
+  193          215.04933    115.43929   0.00518135 
+  168          184.84826    115.44424   0.00595238 
+  153          167.57773    115.44926   0.00653595 
+  150          157.44149    115.45436   0.00666667 
+  134          151.18126    115.45953   0.00746269 
+  131          147.20021    115.46478   0.00763359 
+  124          144.46272    115.4701    0.00806452 
+  149          141.98906    115.47549   0.00671141 
+  145          139.63285    115.48096   0.00689655 
+  138          137.78611    115.4865    0.00724638 
+  140          136.68126    115.49211   0.00714286 
+  139          136.62483    115.4978    0.00719424 
+  141          138.07185    115.50356   0.0070922 
+  154          141.36816    115.50939   0.00649351 
+  141          144.94729    115.5153    0.0070922 
+  132          144.33501    115.52128   0.00757576 
+  140          140.39081    115.52734   0.00714286 
+  130          136.93741    115.53346   0.00769231 
+  141          134.47348    115.53967   0.0070922 
+  144          132.65565    115.54594   0.00694444 
+  132          131.54761    115.55229   0.00757576 
+  169          131.44901    115.55871   0.00591716 
+  138          132.48236    115.5652    0.00724638 
+  152          133.59111    115.57177   0.00657895 
+  130          132.7426     115.57841   0.00769231 
+  109          131.04399    115.58513   0.00917431 
+  147          130.03814    115.59191   0.00680272 
+  137          129.43617    115.59877   0.00729927 
+  120          129.0107     115.60571   0.00833333 
+  110          129.44539    115.61271   0.00909091 
+  144          131.30291    115.61979   0.00694444 
+  133          134.07361    115.62695   0.0075188 
+  123          134.79139    115.63417   0.00813008 
+  129          132.36499    115.64147   0.00775194 
+  118          129.45791    115.64884   0.00847458 
+  119          127.60157    115.65629   0.00840336 
+  100          126.65567    115.66381   0.01      
+  121          126.29064    115.6714    0.00826446 
+  131          126.61513    115.67906   0.00763359 
+  125          127.76952    115.6868    0.008     
+  130          129.38085    115.69461   0.00769231 
+  126          129.87301    115.70249   0.00793651 
+  145          128.79905    115.71045   0.00689655 
+  127          127.39364    115.71848   0.00787402 
+  106          126.31336    115.72658   0.00943396 
+  123          125.63449    115.73475   0.00813008 
+  135          125.34902    115.743     0.00740741 
+  138          125.47736    115.75132   0.00724638 
+  121          125.85083    115.75971   0.00826446 
+  123          125.78377    115.76817   0.00813008 
+  122          125.17354    115.77671   0.00819672 
+  137          124.66234    115.78532   0.00729927 
+  138          124.39684    115.794     0.00724638 
+  127          124.30503    115.80276   0.00787402 
+  136          124.39079    115.81158   0.00735294 
+  135          124.7445     115.82048   0.00740741 
+  122          125.47493    115.82945   0.00819672 
+  132          126.5081     115.8385    0.00757576 
+  135          127.1969     115.84762   0.00740741 
+  130          127.26787    115.8568    0.00769231 
+  134          127.49118    115.86607   0.00746269 
+  120          128.20986    115.8754    0.00833333 
+  141          129.44432    115.88481   0.0070922 
+  123          131.09836    115.89428   0.00813008 
+  118          132.96805    115.90384   0.00847458 
+  142          135.09913    115.91346   0.00704225 
+  149          137.60239    115.92315   0.00671141 
+  152          140.58792    115.93292   0.00657895 
+  126          144.56495    115.94276   0.00793651 
+  137          150.99857    115.95267   0.00729927 
+  166          162.3634     115.96265   0.0060241 
+  165          182.65215    115.97271   0.00606061 
+  229          214.70406    115.98284   0.00436681 
+  206          240.84149    115.99304   0.00485437 
+  201          223.51342    116.00331   0.00497512 
+  205          190.18848    116.01365   0.00487805 
+  172          168.71019    116.02407   0.00581395 
+  174          158.12636    116.03455   0.00574713 
+  165          154.47072    116.04511   0.00606061 
+  181          156.18335    116.05574   0.00552486 
+  172          163.99145    116.06644   0.00581395 
+  175          179.2213     116.07722   0.00571429 
+  205          194.85587    116.08806   0.00487805 
+  199          191.90494    116.09898   0.00502513 
+  189          182.09406    116.10997   0.00529101 
+  167          180.13732    116.12103   0.00598802 
+  155          178.84878    116.13216   0.00645161 
+  172          171.68524    116.14336   0.00581395 
+  164          164.69626    116.15464   0.00609756 
+  169          160.17503    116.16598   0.00591716 
+  180          155.54753    116.1774    0.00555556 
+  165          152.03544    116.18889   0.00606061 
+  161          151.5253     116.20045   0.00621118 
+  152          154.53903    116.21208   0.00657895 
+  139          160.62324    116.22378   0.00719424 
+  152          165.71485    116.23556   0.00657895 
+  144          165.64339    116.2474    0.00694444 
+  155          165.03159    116.25932   0.00645161 
+  153          168.05155    116.2713    0.00653595 
+  144          174.26827    116.28336   0.00694444 
+  164          179.95807    116.29549   0.00609756 
+  154          177.70666    116.30769   0.00649351 
+  192          172.18889    116.31996   0.00520833 
+  175          169.83379    116.3323    0.00571429 
+  164          169.64229    116.34472   0.00609756 
+  186          173.93239    116.3572    0.00537634 
+  229          188.74362    116.36976   0.00436681 
+  250          221.8001     116.38238   0.004     
+  277          271.45868    116.39508   0.00361011 
+  309          286.01959    116.40784   0.00323625 
+  237          242.3293     116.42068   0.00421941 
+  227          201.37758    116.43359   0.00440529 
+  200          179.82297    116.44657   0.005     
+  174          170.93376    116.45962   0.00574713 
+  190          170.20448    116.47274   0.00526316 
+  205          175.62258    116.48593   0.00487805 
+  196          187.28324    116.49919   0.00510204 
+  192          206.8787     116.51252   0.00520833 
+  213          214.58661    116.52592   0.00469484 
+  191          190.75243    116.53939   0.0052356 
+  166          165.56826    116.55293   0.0060241 
+  170          151.47834    116.56654   0.00588235 
+  170          145.1809     116.58023   0.00588235 
+  129          143.14033    116.59398   0.00775194 
+  160          142.57821    116.6078    0.00625   
+  154          141.68113    116.62169   0.00649351 
+  118          140.60565    116.63566   0.00847458 
+  145          139.05063    116.64969   0.00689655 
+  146          137.54883    116.66379   0.00684932 
+  147          137.67599    116.67796   0.00680272 
+  127          139.86468    116.69221   0.00787402 
+  142          143.55697    116.70652   0.00704225 
+  149          146.72152    116.7209    0.00671141 
+  125          146.74752    116.73535   0.008     
+  142          145.77968    116.74987   0.00704225 
+  160          147.56792    116.76446   0.00625   
+  146          154.13736    116.77912   0.00684932 
+  144          167.15108    116.79385   0.00694444 
+  142          186.22462    116.80865   0.00704225 
+  173          203.38957    116.82352   0.00578035 
+  137          211.15347    116.83846   0.00729927 
+  158          204.35592    116.85347   0.00632911 
+  127          184.79478    116.86855   0.00787402 
+  139          166.52426    116.88369   0.00719424 
+  129          155.59322    116.89891   0.00775194 
+  147          151.40116    116.91419   0.00680272 
+  157          152.84072    116.92955   0.00636943 
+  130          159.20217    116.94497   0.00769231 
+  165          167.18306    116.96046   0.00606061 
+  135          171.3089     116.97602   0.00740741 
+  122          168.95788    116.99165   0.00819672 
+  145          159.20198    117.00735   0.00689655 
+  99           148.38624    117.02312   0.01010101 
+  131          140.88679    117.03896   0.00763359 
+  144          136.43131    117.05486   0.00694444 
+  124          133.93577    117.07084   0.00806452 
+  131          132.63231    117.08688   0.00763359 
+  141          132.14555    117.10299   0.0070922 
+  130          132.11594    117.11917   0.00769231 
+  129          132.06029    117.13542   0.00775194 
+  129          131.86213    117.15174   0.00775194 
+  123          131.82297    117.16813   0.00813008 
+  127          132.16833    117.18458   0.00787402 
+  126          132.93368    117.20111   0.00793651 
+  127          134.1558     117.2177    0.00787402 
+  122          136.04563    117.23436   0.00819672 
+  142          139.13637    117.25108   0.00704225 
+  120          143.8402     117.26788   0.00833333 
+  164          148.62804    117.28474   0.00609756 
+  131          150.36172    117.30168   0.00763359 
+  137          150.00826    117.31868   0.00729927 
+  125          150.4737     117.33575   0.008     
+  141          150.48005    117.35288   0.0070922 
+  135          148.6355     117.37009   0.00740741 
+  147          147.80704    117.38736   0.00680272 
+  153          149.89202    117.4047    0.00653595 
+  138          155.90476    117.42211   0.00724638 
+  140          167.36013    117.43958   0.00714286 
+  155          186.63593    117.45712   0.00645161 
+  182          218.64567    117.47473   0.00549451 
+  187          260.92449    117.49241   0.00534759 
+  194          271.23197    117.51016   0.00515464 
+  180          238.74572    117.52797   0.00555556 
+  183          211.33348    117.54585   0.00546448 
+  196          195.74819    117.5638    0.00510204 
+  161          181.98073    117.58182   0.00621118 
+  168          171.25792    117.5999    0.00595238 
+  147          167.92325    117.61805   0.00680272 
+  158          173.69256    117.63627   0.00632911 
+  151          189.3781     117.65455   0.00662252 
+  187          204.42491    117.6729    0.00534759 
+  152          195.80695    117.69132   0.00657895 
+  163          178.26541    117.7098    0.00613497 
+  158          167.51607    117.72836   0.00632911 
+  159          159.63102    117.74697   0.00628931 
+  157          151.63694    117.76566   0.00636943 
+  148          145.45574    117.78441   0.00675676 
+  150          141.64275    117.80323   0.00666667 
+  126          139.44682    117.82212   0.00793651 
+  149          138.16652    117.84107   0.00671141 
+  143          137.35136    117.86009   0.00699301 
+  143          136.77714    117.87917   0.00699301 
+  122          136.36487    117.89833   0.00819672 
+  138          136.06096    117.91754   0.00724638 
+  145          135.96821    117.93683   0.00689655 
+  138          136.22925    117.95618   0.00724638 
+  153          136.8695     117.9756    0.00653595 
+  143          137.87327    117.99508   0.00699301 
+  154          139.23609    118.01463   0.00649351 
+  180          141.00792    118.03425   0.00555556 
+  150          143.36246    118.05393   0.00666667 
+  158          146.60275    118.07368   0.00632911 
+  163          150.71364    118.09349   0.00613497 
+  156          154.23782    118.11337   0.00641026 
+  129          156.26737    118.13331   0.00775194 
+  138          158.88574    118.15332   0.00724638 
+  171          163.16543    118.1734    0.00584795 
+  136          168.47223    118.19354   0.00735294 
+  163          174.82766    118.21375   0.00613497 
+  161          183.68806    118.23402   0.00621118 
+  178          196.68607    118.25436   0.00561798 
+  199          215.97427    118.27477   0.00502513 
+  193          244.85437    118.29524   0.00518135 
+  301          289.51435    118.31577   0.00332226 
+  358          366.17271    118.33637   0.0027933 
+  562          510.71814    118.35704   0.00177936 
+  798          778.66061    118.37777   0.00125313 
+  1052         1151.90623   118.39856   0.00095057 
+  1046         1232.80958   118.41942   0.00095602 
+  737          890.1101     118.44035   0.00135685 
+  514          587.36755    118.46134   0.00194553 
+  398          423.91702    118.4824    0.00251256 
+  314          348.41992    118.50352   0.00318471 
+  313          323.65763    118.5247    0.00319489 
+  358          338.93062    118.54595   0.0027933 
+  411          405.57254    118.56726   0.00243309 
+  512          546.74802    118.58864   0.00195312 
+  617          717.73252    118.61009   0.00162075 
+  567          685.33936    118.63159   0.00176367 
+  410          495.3556     118.65317   0.00243902 
+  311          357.31156    118.6748    0.00321543 
+  254          283.78989    118.69651   0.00393701 
+  228          242.15201    118.71827   0.00438596 
+  212          214.71929    118.7401    0.00471698 
+  187          196.24054    118.76199   0.00534759 
+  161          182.68089    118.78395   0.00621118 
+  188          173.37111    118.80597   0.00531915 
+  152          167.27579    118.82806   0.00657895 
+  151          162.36196    118.85021   0.00662252 
+  166          159.25191    118.87242   0.0060241 
+  149          158.63909    118.8947    0.00671141 
+  139          158.49641    118.91704   0.00719424 
+  117          155.48144    118.93944   0.00854701 
+  132          150.89258    118.96191   0.00757576 
+  131          146.73974    118.98445   0.00763359 
+  134          142.85573    119.00704   0.00746269 
+  139          139.79649    119.0297    0.00719424 
+  124          137.73508    119.05242   0.00806452 
+  118          136.42453    119.07521   0.00847458 
+  133          135.72166    119.09806   0.0075188 
+  129          135.50467    119.12097   0.00775194 
+  152          135.38064    119.14394   0.00657895 
+  130          134.9675     119.16698   0.00769231 
+  135          134.65503    119.19008   0.00740741 
+  133          134.83122    119.21325   0.0075188 
+  151          135.53252    119.23647   0.00662252 
+  127          136.51297    119.25976   0.00787402 
+  110          137.48184    119.28312   0.00909091 
+  153          138.34618    119.30653   0.00653595 
+  145          139.13516    119.33001   0.00689655 
+  144          139.41542    119.35355   0.00694444 
+  109          139.14113    119.37716   0.00917431 
+  148          139.07433    119.40082   0.00675676 
+  147          139.72423    119.42455   0.00680272 
+  144          141.39724    119.44834   0.00694444 
+  133          144.46282    119.47219   0.0075188 
+  160          149.50032    119.49611   0.00625   
+  174          157.65266    119.52009   0.00574713 
+  175          170.87398    119.54413   0.00571429 
+  201          192.29413    119.56823   0.00497512 
+  216          222.53118    119.59239   0.00462963 
+  209          241.36098    119.61662   0.00478469 
+  189          229.46669    119.64091   0.00529101 
+  208          206.92939    119.66526   0.00480769 
+  195          186.68918    119.68967   0.00512821 
+  186          171.10855    119.71414   0.00537634 
+  183          162.19838    119.73867   0.00546448 
+  158          159.44515    119.76327   0.00632911 
+  151          162.04985    119.78793   0.00662252 
+  184          170.50485    119.81265   0.00543478 
+  170          184.88031    119.83743   0.00588235 
+  201          195.0587     119.86227   0.00497512 
+  215          191.58554    119.88717   0.00465116 
+  187          185.23378    119.91214   0.00534759 
+  211          183.62695    119.93716   0.00473934 
+  209          187.4698     119.96225   0.00478469 
+  209          189.43284    119.9874    0.00478469 
+  233          179.33047    120.01261   0.00429185 
+  202          165.04027    120.03788   0.0049505 
+  185          154.87311    120.06321   0.00540541 
+  204          149.29767    120.0886    0.00490196 
+  189          146.96556    120.11405   0.00529101 
+  191          146.79723    120.13957   0.0052356 
+  203          148.73658    120.16514   0.00492611 
+  221          153.63829    120.19078   0.00452489 
+  229          161.65587    120.21647   0.00436681 
+  218          169.18366    120.24223   0.00458716 
+  231          171.54383    120.26804   0.004329  
+  217          172.43482    120.29392   0.00460829 
+  197          174.64966    120.31985   0.00507614 
+  174          174.15232    120.34585   0.00574713 
+  171          166.85669    120.37191   0.00584795 
+  158          158.94603    120.39802   0.00632911 
+  191          155.06432    120.4242    0.0052356 
+  172          155.22519    120.45044   0.00581395 
+  165          156.59255    120.47673   0.00606061 
+  177          155.48188    120.50309   0.00564972 
+  163          153.76505    120.52951   0.00613497 
+  153          154.0846     120.55598   0.00653595 
+  161          155.78839    120.58252   0.00621118 
+  143          156.45229    120.60911   0.00699301 
+  154          153.54006    120.63577   0.00649351 
+  142          149.7964     120.66248   0.00704225 
+  169          147.99014    120.68926   0.00591716 
+  138          148.2668     120.71609   0.00724638 
+  122          149.35845    120.74298   0.00819672 
+  169          149.23703    120.76993   0.00591716 
+  163          148.29866    120.79694   0.00613497 
+  152          148.04925    120.82401   0.00657895 
+  147          148.78768    120.85114   0.00680272 
+  133          150.39642    120.87833   0.0075188 
+  152          152.83094    120.90558   0.00657895 
+  160          156.17112    120.93288   0.00625   
+  160          160.63719    120.96025   0.00625   
+  180          166.55037    120.98767   0.00555556 
+  172          174.01531    121.01515   0.00581395 
+  169          182.24067    121.04269   0.00591716 
+  182          191.12688    121.07029   0.00549451 
+  197          203.03423    121.09795   0.00507614 
+  223          220.47673    121.12566   0.0044843 
+  264          246.34274    121.15344   0.00378788 
+  320          285.70481    121.18127   0.003125  
+  381          348.45443    121.20916   0.00262467 
+  568          454.09697    121.23711   0.00176056 
+  771          638.04544    121.26512   0.00129702 
+  1218         959.65126    121.29318   0.00082102 
+  1674         1435.91628   121.3213    0.00059737 
+  1801         1663.63942   121.34948   0.00055525 
+  1373         1278.42098   121.37772   0.00072833 
+  928          837.8234     121.40602   0.00107759 
+  638          579.89397    121.43437   0.0015674 
+  512          452.89944    121.46279   0.00195312 
+  440          399.71906    121.49126   0.00227273 
+  408          395.17176    121.51978   0.00245098 
+  501          439.76366    121.54837   0.00199601 
+  642          552.41422    121.57701   0.00155763 
+  831          756.41783    121.60571   0.00120337 
+  938          934.32147    121.63447   0.0010661 
+  785          807.89737    121.66328   0.00127389 
+  625          560.11833    121.69215   0.0016    
+  437          394.54999    121.72108   0.00228833 
+  330          304.18562    121.75007   0.0030303 
+  233          255.05139    121.77911   0.00429185 
+  219          226.23831    121.80821   0.00456621 
+  202          207.23125    121.83736   0.0049505 
+  162          192.78659    121.86658   0.00617284 
+  203          181.72981    121.89585   0.00492611 
+  190          173.6554     121.92517   0.00526316 
+  195          167.72006    121.95456   0.00512821 
+  189          163.23681    121.98399   0.00529101 
+  170          159.83595    122.01349   0.00588235 
+  158          157.41128    122.04304   0.00632911 
+  173          156.04732    122.07265   0.00578035 
+  166          155.91826    122.10232   0.0060241 
+  149          156.98514    122.13204   0.00671141 
+  178          158.95614    122.16182   0.00561798 
+  154          162.0867     122.19165   0.00649351 
+  169          164.77763    122.22154   0.00591716 
+  151          162.97217    122.25149   0.00662252 
+  143          158.41628    122.28149   0.00699301 
+  170          155.09821    122.31155   0.00588235 
+  147          153.61466    122.34166   0.00680272 
+  173          152.69792    122.37183   0.00578035 
+  149          151.61736    122.40206   0.00671141 
+  165          151.32727    122.43234   0.00606061 
+  158          152.58474    122.46267   0.00632911 
+  167          155.70945    122.49307   0.00598802 
+  143          160.46477    122.52351   0.00699301 
+  160          165.28112    122.55402   0.00625   
+  142          170.38244    122.58458   0.00704225 
+  144          180.2765     122.61519   0.00694444 
+  169          200.42016    122.64586   0.00591716 
+  194          234.73203    122.67658   0.00515464 
+  239          269.46947    122.70736   0.0041841 
+  252          261.83462    122.7382    0.00396825 
+  213          224.37189    122.76908   0.00469484 
+  234          196.46044    122.80003   0.0042735 
+  176          183.56392    122.83103   0.00568182 
+  163          181.8982     122.86208   0.00613497 
+  190          188.95599    122.89319   0.00526316 
+  188          203.10879    122.92435   0.00531915 
+  207          215.31694    122.95557   0.00483092 
+  211          218.71702    122.98684   0.00473934 
+  206          224.31738    123.01817   0.00485437 
+  214          224.89434    123.04955   0.0046729 
+  174          206.51428    123.08099   0.00574713 
+  222          186.86316    123.11248   0.0045045 
+  187          174.2291     123.14402   0.00534759 
+  156          166.84926    123.17562   0.00641026 
+  184          164.20805    123.20728   0.00543478 
+  171          165.79123    123.23898   0.00584795 
+  168          169.18422    123.27074   0.00595238 
+  177          167.25198    123.30256   0.00564972 
+  174          160.08877    123.33443   0.00574713 
+  177          153.93932    123.36635   0.00564972 
+  166          150.85991    123.39833   0.0060241 
+  153          150.449      123.43036   0.00653595 
+  140          151.63823    123.46244   0.00714286 
+  169          153.09836    123.49458   0.00591716 
+  163          154.67002    123.52677   0.00613497 
+  133          156.5944     123.55902   0.0075188 
+  181          157.15812    123.59132   0.00552486 
+  153          156.59123    123.62367   0.00653595 
+  171          157.01106    123.65607   0.00584795 
+  147          156.40314    123.68853   0.00680272 
+  151          152.8202     123.72104   0.00662252 
+  161          148.95242    123.75361   0.00621118 
+  159          146.71136    123.78623   0.00628931 
+  185          146.13533    123.8189    0.00540541 
+  170          146.69625    123.85162   0.00588235 
+  153          147.94744    123.8844    0.00653595 
+  170          149.34436    123.91723   0.00588235 
+  164          149.93245    123.95011   0.00609756 
+  180          150.51289    123.98305   0.00555556 
+  146          151.68776    124.01604   0.00684932 
+  165          152.03543    124.04908   0.00606061 
+  146          151.41489    124.08217   0.00684932 
+  149          150.98726    124.11532   0.00671141 
+  156          150.43572    124.14852   0.00641026 
+  161          149.61165    124.18177   0.00621118 
+  154          149.12883    124.21507   0.00649351 
+  176          149.25041    124.24843   0.00568182 
+  176          149.94332    124.28184   0.00568182 
+  171          151.11941    124.3153    0.00584795 
+  187          152.73878    124.34881   0.00534759 
+  179          154.814      124.38238   0.00558659 
+  179          157.39732    124.41599   0.00558659 
+  181          160.52548    124.44966   0.00552486 
+  177          164.08181    124.48338   0.00564972 
+  166          167.68197    124.51716   0.0060241 
+  194          171.68722    124.55098   0.00515464 
+  180          176.69315    124.58486   0.00555556 
+  219          183.14028    124.61879   0.00456621 
+  226          191.40643    124.65277   0.00442478 
+  265          202.32357    124.6868    0.00377358 
+  210          217.04289    124.72088   0.0047619 
+  292          237.8364     124.75502   0.00342466 
+  398          268.74375    124.7892    0.00251256 
+  409          315.42788    124.82344   0.00244499 
+  540          377.43624    124.85773   0.00185185 
+  590          428.29521    124.89207   0.00169492 
+  679          461.96573    124.92646   0.00147275 
+  822          530.29281    124.96091   0.00121655 
+  973          681.39013    124.9954    0.00102775 
+  1334         979.55734    125.02995   0.00074963 
+  1833         1515.18217   125.06454   0.00054555 
+  2354         2216.26969   125.09919   0.00042481 
+  2402         2359.83993   125.13389   0.00041632 
+  1879         1736.26295   125.16864   0.0005322 
+  1312         1158.09299   125.20344   0.0007622 
+  967          836.14346    125.23829   0.00103413 
+  810          672.63472    125.27319   0.00123457 
+  704          595.23423    125.30814   0.00142045 
+  730          592.248      125.34315   0.00136986 
+  773          662.41211    125.3782    0.00129366 
+  1003         795.33973    125.4133    0.00099701 
+  1221         1020.88566   125.44846   0.000819  
+  1399         1313.60656   125.48366   0.0007148 
+  1307         1296.6889    125.51892   0.00076511 
+  1028         942.16945    125.55423   0.00097276 
+  744          641.42339    125.58958   0.00134409 
+  515          466.67886    125.62499   0.00194175 
+  377          372.65788    125.66045   0.00265252 
+  306          323.95068    125.69595   0.00326797 
+  290          302.49199    125.73151   0.00344828 
+  319          295.72094    125.76712   0.0031348 
+  261          281.09238    125.80277   0.00383142 
+  249          253.77845    125.83848   0.00401606 
+  254          231.41546    125.87424   0.00393701 
+  228          218.3885     125.91005   0.00438596 
+  255          212.84782    125.9459    0.00392157 
+  217          213.42825    125.98181   0.00460829 
+  222          218.85066    126.01777   0.0045045 
+  171          223.42985    126.05377   0.00584795 
+  216          218.37243    126.08983   0.00462963 
+  199          208.05848    126.12593   0.00502513 
+  186          200.59214    126.16209   0.00537634 
+  184          195.41254    126.19829   0.00543478 
+  152          189.89885    126.23455   0.00657895 
+  168          185.16799    126.27085   0.00595238 
+  182          182.34374    126.3072    0.00549451 
+  170          181.46206    126.34361   0.00588235 
+  190          182.83692    126.38006   0.00526316 
+  167          186.81958    126.41656   0.00598802 
+  170          191.25632    126.45311   0.00588235 
+  153          191.46403    126.48971   0.00653595 
+  178          187.69164    126.52636   0.00561798 
+  135          183.45891    126.56305   0.00740741 
+  171          180.99835    126.5998    0.00584795 
+  184          180.38274    126.6366    0.00543478 
+  150          180.88866    126.67344   0.00666667 
+  184          179.84204    126.71033   0.00543478 
+  175          177.70607    126.74728   0.00571429 
+  208          177.76388    126.78427   0.00480769 
+  236          180.78666    126.82131   0.00423729 
+  238          185.44278    126.8584    0.00420168 
+  245          187.53021    126.89553   0.00408163 
+  194          182.62535    126.93272   0.00515464 
+  196          174.52262    126.96995   0.00510204 
+  190          168.61157    127.00724   0.00526316 
+  178          166.20648    127.04457   0.00561798 
+  154          166.24837    127.08195   0.00649351 
+  151          166.53843    127.11938   0.00662252 
+  189          166.58371    127.15686   0.00529101 
+  173          167.77957    127.19438   0.00578035 
+  201          170.57068    127.23196   0.00497512 
+  207          174.70226    127.26958   0.00483092 
+  207          179.05465    127.30725   0.00483092 
+  181          181.44829    127.34497   0.00552486 
+  186          180.35744    127.38274   0.00537634 
+  175          174.3473     127.42055   0.00571429 
+  163          166.85036    127.45841   0.00613497 
+  135          161.54556    127.49633   0.00740741 
+  153          158.74698    127.53428   0.00653595 
+  163          157.6869     127.57229   0.00613497 
+  156          157.67471    127.61035   0.00641026 
+  157          158.35207    127.64845   0.00636943 
+  138          159.74364    127.6866    0.00724638 
+  177          162.17787    127.7248    0.00564972 
+  175          165.93113    127.76305   0.00571429 
+  164          170.14163    127.80134   0.00609756 
+  158          172.62362    127.83969   0.00632911 
+  189          172.32754    127.87808   0.00529101 
+  173          168.94401    127.91652   0.00578035 
+  165          165.17471    127.955     0.00606061 
+  197          164.06212    127.99354   0.00507614 
+  188          166.57738    128.03212   0.00531915 
+  215          172.90996    128.07075   0.00465116 
+  205          181.16514    128.10942   0.00487805 
+  259          184.40037    128.14815   0.003861  
+  225          178.97074    128.18692   0.00444444 
+  185          171.36614    128.22574   0.00540541 
+  184          166.49727    128.2646    0.00543478 
+  209          164.2497     128.30352   0.00478469 
+  175          162.43518    128.34248   0.00571429 
+  206          160.79815    128.38149   0.00485437 
+  192          160.86559    128.42054   0.00520833 
+  182          163.47098    128.45965   0.00549451 
+  201          169.05129    128.4988    0.00497512 
+  224          177.28334    128.53799   0.00446429 
+  220          184.50703    128.57724   0.00454545 
+  218          185.75466    128.61653   0.00458716 
+  239          183.50508    128.65587   0.0041841 
+  210          180.2301     128.69526   0.0047619 
+  175          174.58275    128.73469   0.00571429 
+  193          168.95224    128.77417   0.00518135 
+  180          165.57573    128.8137    0.00555556 
+  172          164.41855    128.85327   0.00581395 
+  184          164.86777    128.89289   0.00543478 
+  200          166.95654    128.93256   0.005     
+  167          170.63854    128.97228   0.00598802 
+  164          174.73385    129.01204   0.00609756 
+  227          177.92276    129.05185   0.00440529 
+  190          180.5717     129.0917    0.00526316 
+  215          183.72381    129.13161   0.00465116 
+  213          186.70365    129.17156   0.00469484 
+  215          190.30773    129.21155   0.00465116 
+  213          196.66958    129.2516    0.00469484 
+  190          206.71159    129.29169   0.00526316 
+  227          221.09534    129.33182   0.00440529 
+  250          240.0859     129.37201   0.004     
+  267          262.61199    129.41224   0.00374532 
+  297          293.22345    129.45252   0.003367  
+  358          345.26227    129.49284   0.0027933 
+  524          440.24988    129.53321   0.0019084 
+  703          614.04424    129.57363   0.00142248 
+  1040         903.08071    129.61409   0.00096154 
+  1317         1208.25076   129.6546    0.0007593 
+  1252         1164.19981   129.69516   0.00079872 
+  1062         844.96541    129.73576   0.00094162 
+  723          589.91121    129.77641   0.00138313 
+  562          447.29445    129.81711   0.00177936 
+  411          376.68992    129.85785   0.00243309 
+  351          348.15232    129.89864   0.002849  
+  325          351.85343    129.93948   0.00307692 
+  400          388.2868     129.98036   0.0025    
+  485          452.96402    130.02129   0.00206186 
+  623          543.28025    130.06226   0.00160514 
+  733          675.77766    130.10328   0.00136426 
+  745          741.5272     130.14435   0.00134228 
+  677          611.0446     130.18547   0.0014771 
+  537          443.7531     130.22663   0.0018622 
+  389          335.31897    130.26783   0.00257069 
+  292          274.73939    130.30909   0.00342466 
+  233          241.90536    130.35039   0.00429185 
+  217          225.50905    130.39173   0.00460829 
+  223          220.57138    130.43313   0.0044843 
+  231          222.0794     130.47456   0.004329  
+  221          217.25706    130.51605   0.00452489 
+  210          201.67576    130.55758   0.0047619 
+  216          186.701      130.59916   0.00462963 
+  199          176.57947    130.64078   0.00502513 
+  170          170.27528    130.68245   0.00588235 
+  165          166.20758    130.72417   0.00606061 
+  166          163.10736    130.76593   0.0060241 
+  175          160.1803     130.80774   0.00571429 
+  159          157.29905    130.8496    0.00628931 
+  152          154.82554    130.8915    0.00657895 
+  153          152.95782    130.93345   0.00653595 
+  153          151.63327    130.97544   0.00653595 
+  164          150.69697    131.01748   0.00609756 
+  142          150.01343    131.05957   0.00704225 
+  158          149.62043    131.1017    0.00632911 
+  148          149.67649    131.14388   0.00675676 
+  118          150.27055    131.1861    0.00847458 
+  148          151.35657    131.22838   0.00675676 
+  131          152.52736    131.27069   0.00763359 
+  149          152.80932    131.31306   0.00671141 
+  127          151.92891    131.35547   0.00787402 
+  178          150.91218    131.39792   0.00561798 
+  145          150.30288    131.44043   0.00689655 
+  172          150.37953    131.48297   0.00581395 
+  173          151.51809    131.52557   0.00578035 
+  160          153.78562    131.56821   0.00625   
+  146          156.72153    131.6109    0.00684932 
+  142          158.0472     131.65363   0.00704225 
+  158          156.20231    131.69641   0.00632911 
+  161          153.57123    131.73924   0.00621118 
+  140          151.81835    131.78211   0.00714286 
+  130          150.6005     131.82503   0.00769231 
+  140          149.67805    131.86799   0.00714286 
+  154          149.34064    131.911     0.00649351 
+  135          149.7281     131.95406   0.00740741 
+  150          151.12697    131.99716   0.00666667 
+  165          153.96913    132.04031   0.00606061 
+  155          158.69322    132.08351   0.00645161 
+  163          165.51671    132.12675   0.00613497 
+  179          173.41857    132.17004   0.00558659 
+  153          179.41266    132.21338   0.00653595 
+  166          178.25162    132.25676   0.0060241 
+  155          170.61652    132.30018   0.00645161 
+  151          163.21498    132.34366   0.00662252 
+  145          158.88302    132.38718   0.00689655 
+  184          157.60926    132.43074   0.00543478 
+  195          159.10676    132.47436   0.00512821 
+  179          162.69111    132.51802   0.00558659 
+  199          165.27222    132.56172   0.00502513 
+  182          164.35683    132.60547   0.00549451 
+  140          163.57301    132.64927   0.00714286 
+  155          165.50449    132.69312   0.00645161 
+  152          168.62079    132.73701   0.00657895 
+  148          169.11843    132.78095   0.00675676 
+  175          166.31574    132.82493   0.00571429 
+  134          162.3188     132.86896   0.00746269 
+  147          159.08417    132.91304   0.00680272 
+  168          157.29323    132.95716   0.00595238 
+  141          156.80755    133.00133   0.0070922 
+  135          157.04451    133.04555   0.00740741 
+  144          156.17664    133.08982   0.00694444 
+  144          153.4715     133.13413   0.00694444 
+  140          150.95916    133.17848   0.00714286 
+  141          149.72365    133.22289   0.0070922 
+  135          149.74657    133.26734   0.00740741 
+  147          150.71983    133.31183   0.00680272 
+  149          151.98878    133.35638   0.00671141 
+  179          153.2057     133.40097   0.00558659 
+  146          155.14885    133.4456    0.00684932 
+  137          158.61515    133.49029   0.00729927 
+  179          163.76417    133.53502   0.00558659 
+  158          168.82001    133.5798    0.00632911 
+  157          170.10805    133.62462   0.00636943 
+  143          167.54299    133.66949   0.00699301 
+  166          162.63653    133.71441   0.0060241 
+  130          156.76199    133.75938   0.00769231 
+  129          152.07504    133.80439   0.00775194 
+  156          149.15215    133.84945   0.00641026 
+  166          147.65191    133.89455   0.0060241 
+  138          147.24113    133.93971   0.00724638 
+  137          147.78913    133.98491   0.00729927 
+  148          149.36058    134.03016   0.00675676 
+  146          151.96494    134.07545   0.00684932 
+  126          154.76686    134.12079   0.00793651 
+  137          155.95516    134.16618   0.00729927 
+  136          155.36727    134.21162   0.00735294 
+  144          153.76488    134.2571    0.00694444 
+  167          151.86185    134.30263   0.00598802 
+  136          150.83454    134.34821   0.00735294 
+  128          150.97991    134.39384   0.0078125 
+  124          151.86946    134.43951   0.00806452 
+  149          152.39897    134.48523   0.00671141 
+  145          151.99377    134.531     0.00689655 
+  136          151.68767    134.57682   0.00735294 
+  163          151.93941    134.62268   0.00613497 
+  151          152.67313    134.66859   0.00662252 
+  141          154.06101    134.71455   0.0070922 
+  151          155.83947    134.76056   0.00662252 
+  155          158.16032    134.80661   0.00645161 
+  133          160.29736    134.85272   0.0075188 
+  153          159.54839    134.89887   0.00653595 
+  130          156.29286    134.94507   0.00769231 
+  148          153.32403    134.99131   0.00675676 
+  126          151.26877    135.03761   0.00793651 
+  138          149.60306    135.08395   0.00724638 
+  129          148.48628    135.13034   0.00775194 
+  133          148.01807    135.17678   0.0075188 
+  137          148.01376    135.22326   0.00729927 
+  132          148.3585     135.2698    0.00757576 
+  142          149.1756     135.31638   0.00704225 
+  124          150.3541     135.36301   0.00806452 
+  144          151.76593    135.40969   0.00694444 
+  138          152.15923    135.45642   0.00724638 
+  153          151.41474    135.5032    0.00653595 
+  150          151.15333    135.55002   0.00666667 
+  143          152.04793    135.5969    0.00699301 
+  143          153.0943     135.64382   0.00699301 
+  144          152.80868    135.69079   0.00694444 
+  126          151.4144     135.73781   0.00793651 
+  132          149.79818    135.78488   0.00757576 
+  136          148.48075    135.832     0.00735294 
+  134          147.93577    135.87917   0.00746269 
+  143          148.10061    135.92638   0.00699301 
+  144          148.90056    135.97365   0.00694444 
+  156          150.30488    136.02096   0.00641026 
+  141          152.23524    136.06832   0.0070922 
+  152          154.43176    136.11574   0.00657895 
+  140          156.61572    136.1632    0.00714286 
+  155          158.27615    136.21071   0.00645161 
+  138          159.24972    136.25827   0.00724638 
+  152          160.1432     136.30588   0.00657895 
+  145          160.5777     136.35354   0.00689655 
+  147          159.0626     136.40125   0.00680272 
+  153          156.25609    136.44901   0.00653595 
+  123          153.78283    136.49682   0.00813008 
+  129          152.21485    136.54467   0.00775194 
+  161          151.58275    136.59258   0.00621118 
+  132          151.74737    136.64054   0.00757576 
+  144          152.45038    136.68855   0.00694444 
+  137          153.41544    136.73661   0.00729927 
+  156          154.51941    136.78472   0.00641026 
+  155          156.0943     136.83287   0.00645161 
+  129          158.55819    136.88108   0.00775194 
+  145          160.69091    136.92934   0.00689655 
+  150          159.97543    136.97765   0.00666667 
+  131          156.86276    137.02601   0.00763359 
+  153          153.77744    137.07442   0.00653595 
+  146          151.65132    137.12289   0.00684932 
+  132          150.42449    137.1714    0.00757576 
+  145          149.83203    137.21996   0.00689655 
+  116          149.63673    137.26858   0.00862069 
+  136          149.67188    137.31724   0.00735294 
+  146          149.88399    137.36596   0.00684932 
+  138          150.34425    137.41473   0.00724638 
+  142          151.08146    137.46355   0.00704225 
+  146          151.80412    137.51242   0.00684932 
+  147          151.80774    137.56134   0.00680272 
+  132          150.98937    137.61031   0.00757576 
+  130          150.20907    137.65933   0.00769231 
+  145          149.77226    137.70841   0.00689655 
+  139          149.46083    137.75754   0.00719424 
+  136          149.37305    137.80672   0.00735294 
+  148          149.65816    137.85595   0.00675676 
+  135          150.35169    137.90523   0.00740741 
+  120          151.55081    137.95457   0.00833333 
+  150          153.47417    138.00396   0.00666667 
+  142          156.36168    138.0534    0.00704225 
+  138          160.0193     138.10289   0.00724638 
+  157          162.86487    138.15244   0.00636943 
+  133          162.72578    138.20204   0.0075188 
+  141          160.48391    138.25169   0.0070922 
+  146          158.6527     138.30139   0.00684932 
+  153          158.18986    138.35115   0.00653595 
+  196          159.17643    138.40095   0.00510204 
+  181          161.46411    138.45082   0.00552486 
+  187          164.02507    138.50073   0.00534759 
+  184          165.72333    138.5507    0.00543478 
+  202          167.71559    138.60072   0.0049505 
+  180          171.88463    138.6508    0.00555556 
+  157          176.84136    138.70093   0.00636943 
+  168          178.21415    138.75111   0.00595238 
+  162          174.81157    138.80135   0.00617284 
+  157          169.86678    138.85164   0.00636943 
+  158          165.84687    138.90198   0.00632911 
+  166          163.4275     138.95238   0.0060241 
+  167          162.32267    139.00283   0.00598802 
+  174          162.36104    139.05334   0.00574713 
+  171          163.31912    139.1039    0.00584795 
+  185          164.51101    139.15452   0.00540541 
+  190          165.65509    139.20519   0.00526316 
+  178          167.35701    139.25591   0.00561798 
+  187          169.41081    139.30669   0.00534759 
+  202          170.31128    139.35753   0.0049505 
+  165          168.8526     139.40842   0.00606061 
+  162          166.69262    139.45936   0.00617284 
+  191          165.51368    139.51036   0.0052356 
+  174          165.79836    139.56142   0.00574713 
+  163          167.4632     139.61253   0.00613497 
+  172          170.48086    139.6637    0.00581395 
+  197          174.3935     139.71492   0.00507614 
+  141          177.03205    139.7662    0.0070922 
+  176          176.53641    139.81753   0.00568182 
+  173          174.83021    139.86892   0.00578035 
+  173          173.95756    139.92037   0.00578035 
+  163          174.03998    139.97187   0.00613497 
+  160          174.96013    140.02343   0.00625   
+  165          177.03999    140.07505   0.00606061 
+  180          180.62514    140.12672   0.00555556 
+  187          185.99312    140.17845   0.00534759 
+  164          192.99479    140.23024   0.00609756 
+  198          200.02183    140.28208   0.00505051 
+  249          205.16314    140.33399   0.00401606 
+  205          209.38012    140.38595   0.00487805 
+  193          213.81013    140.43796   0.00518135 
+  212          219.06153    140.49004   0.00471698 
+  244          226.90903    140.54217   0.00409836 
+  267          238.90263    140.59436   0.00374532 
+  267          256.29267    140.64661   0.00374532 
+  307          281.07585    140.69891   0.00325733 
+  365          317.02281    140.75128   0.00273973 
+  421          371.3745     140.8037    0.0023753 
+  588          458.13541    140.85618   0.00170068 
+  875          603.36543    140.90872   0.00114286 
+  1252         849.1944     140.96132   0.00079872 
+  1829         1233.11306   141.01398   0.00054675 
+  2411         1632.53358   141.0667    0.00041477 
+  2438         1620.11417   141.11948   0.00041017 
+  1873         1220.1183    141.17231   0.0005339 
+  1360         854.75852    141.22521   0.00073529 
+  976          629.57095    141.27817   0.00102459 
+  694          503.81       141.33118   0.00144092 
+  631          436.39621    141.38426   0.00158479 
+  536          404.31169    141.43739   0.00186567 
+  522          398.29629    141.49059   0.00191571 
+  547          418.8082     141.54385   0.00182815 
+  641          475.55957    141.59717   0.00156006 
+  766          587.63682    141.65054   0.00130548 
+  1114         771.17043    141.70398   0.00089767 
+  1263         956.25016    141.75749   0.00079177 
+  1281         927.60518    141.81105   0.00078064 
+  1080         717.16922    141.86467   0.00092593 
+  755          531.91063    141.91836   0.0013245 
+  617          416.88879    141.9721    0.00162075 
+  491          350.71359    142.02591   0.00203666 
+  396          312.55778    142.07978   0.00252525 
+  317          290.05212    142.13372   0.00315457 
+  320          276.62294    142.18771   0.003125  
+  265          268.63514    142.24177   0.00377358 
+  275          263.61294    142.29589   0.00363636 
+  279          259.27453    142.35008   0.00358423 
+  246          253.89012    142.40432   0.00406504 
+  238          247.11729    142.45863   0.00420168 
+  243          239.52357    142.51301   0.00411523 
+  204          231.99267    142.56744   0.00490196 
+  249          225.36158    142.62195   0.00401606 
+  246          220.08038    142.67651   0.00406504 
+  212          215.33709    142.73114   0.00471698 
+  237          210.55255    142.78583   0.00421941 
+  218          206.64746    142.84059   0.00458716 
+  208          204.2333     142.89541   0.00480769 
+  190          203.12476    142.9503    0.00526316 
+  199          202.80318    143.00526   0.00502513 
+  198          202.6499     143.06027   0.00505051 
+  181          202.10592    143.11536   0.00552486 
+  218          200.91721    143.17051   0.00458716 
+  173          199.30681    143.22572   0.00578035 
+  194          197.77622    143.281     0.00515464 
+  196          196.856      143.33635   0.00510204 
+  174          196.86447    143.39176   0.00574713 
+  178          197.5182     143.44724   0.00561798 
+  161          198.38778    143.50278   0.00621118 
+  175          199.66003    143.5584    0.00571429 
+  205          201.20719    143.61408   0.00487805 
+  181          202.21273    143.66983   0.00552486 
+  208          201.79524    143.72564   0.00480769 
+  162          199.64984    143.78152   0.00617284 
+  170          196.18604    143.83747   0.00588235 
+  184          192.17666    143.89349   0.00543478 
+  191          188.39938    143.94958   0.0052356 
+  182          185.36644    144.00573   0.00549451 
+  217          183.27255    144.06196   0.00460829 
+  202          182.18125    144.11825   0.0049505 
+  209          182.09433    144.17461   0.00478469 
+  176          182.95876    144.23104   0.00568182 
+  213          184.65939    144.28754   0.00469484 
+  203          186.97559    144.34411   0.00492611 
+  257          189.57403    144.40075   0.00389105 
+  247          192.12215    144.45746   0.00404858 
+  277          194.48455    144.51424   0.00361011 
+  296          196.73577    144.57109   0.00337838 
+  324          198.97896    144.62801   0.00308642 
+  377          201.47359    144.685     0.00265252 
+  443          204.75649    144.74207   0.00225734 
+  456          208.38322    144.7992    0.00219298 
+  392          209.72548    144.85641   0.00255102 
+  353          207.34763    144.91368   0.00283286 
+  284          203.69226    144.97103   0.00352113 
+  297          201.64809    145.02846   0.003367  
+  256          201.84695    145.08595   0.00390625 
+  266          203.44165    145.14352   0.0037594 
+  248          205.14247    145.20116   0.00403226 
+  263          205.81543    145.25887   0.00380228 
+  248          204.97911    145.31666   0.00403226 
+  280          202.92023    145.37452   0.00357143 
+  302          200.36507    145.43245   0.00331126 
+  310          198.15488    145.49046   0.00322581 
+  320          196.74324    145.54854   0.003125  
+  314          195.33307    145.6067    0.00318471 
+  266          192.65023    145.66493   0.0037594 
+  248          189.06811    145.72324   0.00403226 
+  247          185.97983    145.78162   0.00404858 
+  215          184.151      145.84007   0.00465116 
+  203          183.49951    145.89861   0.00492611 
+  200          183.46625    145.95721   0.005     
+  213          183.34129    146.0159    0.00469484 
+  197          182.44712    146.07466   0.00507614 
+  182          180.41859    146.1335    0.00549451 
+  188          177.73113    146.19241   0.00531915 
+  201          175.28846    146.2514    0.00497512 
+  212          173.70473    146.31047   0.00471698 
+  203          173.34684    146.36962   0.00492611 
+  203          174.44158    146.42884   0.00492611 
+  196          176.66641    146.48814   0.00510204 
+  160          178.06637    146.54752   0.00625   
+  193          176.16139    146.60698   0.00518135 
+  167          172.00904    146.66652   0.00598802 
+  164          168.20656    146.72614   0.00609756 
+  199          165.65278    146.78584   0.00502513 
+  177          164.18281    146.84561   0.00564972 
+  157          163.36398    146.90547   0.00636943 
+  179          162.8889     146.9654    0.00558659 
+  168          162.72428    147.02542   0.00595238 
+  201          162.76142    147.08552   0.00497512 
+  161          162.95376    147.1457    0.00621118 
+  173          163.57935    147.20595   0.00578035 
+  173          164.87151    147.26629   0.00578035 
+  155          166.49094    147.32672   0.00645161 
+  145          167.19163    147.38722   0.00689655 
+  153          166.31686    147.44781   0.00653595 
+  156          164.99839    147.50848   0.00641026 
+  175          164.23319    147.56923   0.00571429 
+  155          164.22753    147.63006   0.00645161 
+  151          164.9492     147.69098   0.00662252 
+  141          166.40576    147.75198   0.0070922 
+  160          168.69281    147.81307   0.00625   
+  163          171.9799     147.87424   0.00613497 
+  188          176.58656    147.9355    0.00531915 
+  183          183.2949     147.99683   0.00546448 
+  164          193.76102    148.05826   0.00609756 
+  191          210.75567    148.11977   0.0052356 
+  227          237.07523    148.18136   0.00440529 
+  236          267.98418    148.24305   0.00423729 
+  220          277.65254    148.30481   0.00454545 
+  230          254.55002    148.36667   0.00434783 
+  223          226.83479    148.42861   0.0044843 
+  186          209.05047    148.49063   0.00537634 
+  150          200.52595    148.55275   0.00666667 
+  171          198.86113    148.61495   0.00584795 
+  188          203.1285     148.67724   0.00531915 
+  189          214.121      148.73962   0.00529101 
+  223          234.05749    148.80209   0.0044843 
+  208          264.87158    148.86464   0.00480769 
+  232          301.31622    148.92729   0.00431034 
+  275          320.31063    148.99002   0.00363636 
+  256          309.66942    149.05285   0.00390625 
+  294          290.74579    149.11576   0.00340136 
+  248          266.41616    149.17877   0.00403226 
+  247          237.06918    149.24186   0.00404858 
+  210          214.18076    149.30505   0.0047619 
+  210          200.04975    149.36833   0.0047619 
+  178          192.33221    149.43169   0.00561798 
+  180          189.11507    149.49516   0.00555556 
+  177          189.63499    149.55871   0.00564972 
+  166          194.13101    149.62235   0.0060241 
+  189          203.47991    149.68609   0.00529101 
+  183          217.91241    149.74993   0.00546448 
+  189          232.8661     149.81385   0.00529101 
+  187          234.98268    149.87787   0.00534759 
+  203          220.90006    149.94198   0.00492611 
+  205          204.61066    150.00619   0.00487805 
+  217          193.12026    150.07049   0.00460829 
+  181          185.67696    150.13489   0.00552486 
+  187          180.21163    150.19938   0.00534759 
+  171          175.96374    150.26397   0.00584795 
+  187          172.88046    150.32866   0.00534759 
+  159          170.7975     150.39344   0.00628931 
+  155          169.50252    150.45832   0.00645161 
+  165          168.81881    150.52329   0.00606061 
+  140          168.57332    150.58837   0.00714286 
+  155          168.54397    150.65354   0.00645161 
+  130          168.52254    150.7188    0.00769231 
+  163          168.41114    150.78417   0.00613497 
+  147          168.18785    150.84964   0.00680272 
+  150          167.99902    150.9152    0.00666667 
+  165          168.0595     150.98087   0.00606061 
+  148          168.2727     151.04663   0.00675676 
+  174          168.41107    151.1125    0.00574713 
+  157          168.65319    151.17846   0.00636943 
+  153          169.34982    151.24453   0.00653595 
+  141          170.55772    151.3107    0.0070922 
+  147          171.45786    151.37696   0.00680272 
+  132          170.9026     151.44334   0.00757576 
+  153          169.29068    151.50981   0.00653595 
+  139          167.80051    151.57639   0.00719424 
+  141          166.81095    151.64306   0.0070922 
+  130          166.01054    151.70985   0.00769231 
+  149          165.18233    151.77673   0.00671141 
+  157          164.54231    151.84372   0.00636943 
+  138          164.30626    151.91082   0.00724638 
+  170          164.53364    151.97802   0.00588235 
+  167          165.21913    152.04532   0.00598802 
+  155          166.33042    152.11274   0.00645161 
+  131          167.84171    152.18025   0.00763359 
+  136          169.58777    152.24788   0.00735294 
+  136          170.79556    152.31561   0.00735294 
+  135          170.37698    152.38344   0.00740741 
+  140          168.55176    152.45139   0.00714286 
+  157          166.60076    152.51944   0.00636943 
+  151          165.17476    152.5876    0.00662252 
+  145          164.19266    152.65587   0.00689655 
+  167          163.45324    152.72425   0.00598802 
+  166          162.9319     152.79274   0.0060241 
+  150          162.58457    152.86134   0.00666667 
+  170          162.36437    152.93004   0.00588235 
+  164          162.32282    152.99886   0.00609756 
+  166          162.49441    153.06779   0.0060241 
+  142          162.85983    153.13683   0.00704225 
+  158          163.34058    153.20599   0.00632911 
+  175          163.7469     153.27525   0.00571429 
+  148          163.81311    153.34463   0.00675676 
+  147          163.50304    153.41412   0.00680272 
+  146          163.13139    153.48373   0.00684932 
+  162          162.95159    153.55344   0.00617284 
+  159          163.0262     153.62328   0.00628931 
+  154          163.33258    153.69322   0.00649351 
+  147          163.76949    153.76328   0.00680272 
+  139          164.14284    153.83346   0.00719424 
+  151          164.36984    153.90375   0.00662252 
+  157          164.57567    153.97416   0.00636943 
+  157          164.87081    154.04469   0.00636943 
+  163          165.28971    154.11533   0.00613497 
+  156          165.83968    154.18609   0.00641026 
+  152          166.51171    154.25697   0.00657895 
+  162          167.29573    154.32797   0.00617284 
+  151          168.1416     154.39909   0.00662252 
+  154          168.89932    154.47032   0.00649351 
+  165          169.51736    154.54168   0.00606061 
+  163          170.18002    154.61315   0.00613497 
+  161          171.12701    154.68475   0.00621118 
+  179          172.56555    154.75646   0.00558659 
+  173          174.68411    154.8283    0.00578035 
+  162          177.68461    154.90026   0.00617284 
+  166          181.63116    154.97234   0.0060241 
+  203          185.69771    155.04455   0.00492611 
+  172          187.7683     155.11687   0.00581395 
+  165          186.78115    155.18933   0.00606061 
+  171          184.48565    155.2619    0.00584795 
+  165          182.6166     155.3346    0.00606061 
+  177          181.65821    155.40742   0.00564972 
+  175          181.61828    155.48037   0.00571429 
+  168          182.52819    155.55345   0.00595238 
+  152          184.4291     155.62665   0.00657895 
+  157          186.87395    155.69998   0.00636943 
+  185          188.87905    155.77344   0.00540541 
+  186          190.35352    155.84702   0.00537634 
+  168          192.03343    155.92073   0.00595238 
+  171          194.2358     155.99457   0.00584795 
+  199          197.41554    156.06854   0.00502513 
+  202          201.81321    156.14264   0.0049505 
+  171          206.94572    156.21687   0.00584795 
+  167          212.36793    156.29123   0.00598802 
+  178          216.51588    156.36572   0.00561798 
+  187          215.8597     156.44034   0.00534759 
+  218          211.48993    156.51509   0.00458716 
+  187          208.88425    156.58998   0.00534759 
+  187          210.59239    156.66499   0.00534759 
+  182          217.25577    156.74015   0.00549451 
+  221          229.76157    156.81543   0.00452489 
+  252          250.48651    156.89085   0.00396825 
+  259          283.08773    156.9664    0.003861  
+  283          323.83349    157.04209   0.00353357 
+  328          343.21117    157.11792   0.00304878 
+  260          317.59467    157.19388   0.00384615 
+  243          278.19141    157.26998   0.00411523 
+  238          250.12447    157.34621   0.00420168 
+  195          234.29299    157.42258   0.00512821 
+  213          225.2127     157.49909   0.00469484 
+  207          218.33047    157.57574   0.00483092 
+  190          213.45055    157.65253   0.00526316 
+  210          211.1792     157.72946   0.0047619 
+  195          210.67764    157.80653   0.00512821 
+  218          211.9507     157.88374   0.00458716 
+  233          216.67282    157.96109   0.00429185 
+  210          226.83035    158.03858   0.0047619 
+  211          243.68148    158.11621   0.00473934 
+  266          262.28854    158.19399   0.0037594 
+  238          264.9346     158.27191   0.00420168 
+  227          248.40147    158.34997   0.00440529 
+  235          230.7864     158.42818   0.00425532 
+  215          219.04854    158.50653   0.00465116 
+  216          210.85113    158.58503   0.00462963 
+  177          203.79906    158.66367   0.00564972 
+  171          198.05639    158.74246   0.00584795 
+  180          194.15811    158.8214    0.00555556 
+  174          191.5552     158.90048   0.00574713 
+  211          189.41112    158.97971   0.00473934 
+  176          187.51336    159.05909   0.00568182 
+  159          185.91124    159.13862   0.00628931 
+  198          184.52242    159.2183    0.00505051 
+  190          183.50397    159.29813   0.00526316 
+  153          183.16081    159.37811   0.00653595 
+  186          183.5833     159.45824   0.00537634 
+  174          184.57758    159.53852   0.00574713 
+  181          185.6502     159.61896   0.00552486 
+  170          186.12592    159.69954   0.00588235 
+  182          185.59316    159.78028   0.00549451 
+  180          184.19783    159.86118   0.00555556 
+  191          182.89174    159.94222   0.0052356 
+  163          181.78092    160.02343   0.00613497 
+  140          180.58062    160.10479   0.00714286 
+  157          179.48891    160.1863    0.00636943 
+  186          178.77316    160.26797   0.00537634 
+  144          178.29422    160.3498    0.00694444 
+  178          177.94085    160.43179   0.00561798 
+  177          177.88168    160.51393   0.00564972 
+  174          178.25418    160.59624   0.00574713 
+  171          178.95453    160.6787    0.00584795 
+  150          179.52202    160.76133   0.00666667 
+  152          179.48125    160.84411   0.00657895 
+  160          179.04184    160.92705   0.00625   
+  159          178.72387    161.01016   0.00628931 
+  159          178.89499    161.09343   0.00628931 
+  152          179.50729    161.17686   0.00657895 
+  197          180.3614     161.26046   0.00507614 
+  166          181.26086    161.34422   0.0060241 
+  170          182.06014    161.42814   0.00588235 
+  154          182.29849    161.51223   0.00649351 
+  175          181.77654    161.59649   0.00571429 
+  158          181.05417    161.68091   0.00632911 
+  149          180.65333    161.7655    0.00671141 
+  167          180.71278    161.85026   0.00598802 
+  194          181.13932    161.93518   0.00515464 
+  191          181.69404    162.02027   0.0052356 
+  160          182.1895     162.10554   0.00625   
+  173          182.74012    162.19097   0.00578035 
+  185          183.55488    162.27658   0.00540541 
+  183          184.75316    162.36235   0.00546448 
+  161          186.43182    162.4483    0.00621118 
+  180          188.73203    162.53442   0.00555556 
+  155          191.83248    162.62071   0.00645161 
+  177          195.81514    162.70718   0.00564972 
+  173          200.38034    162.79382   0.00578035 
+  174          204.61932    162.88063   0.00574713 
+  167          207.1888     162.96763   0.00598802 
+  189          208.08624    163.05479   0.00529101 
+  192          209.05298    163.14214   0.00520833 
+  189          210.86607    163.22966   0.00529101 
+  178          212.42418    163.31736   0.00561798 
+  199          212.52284    163.40524   0.00502513 
+  205          211.67194    163.4933    0.00487805 
+  197          210.96641    163.58153   0.00507614 
+  188          211.00445    163.66995   0.00531915 
+  200          212.04587    163.75855   0.005     
+  200          214.23682    163.84734   0.005     
+  195          217.61597    163.9363    0.00512821 
+  217          222.13324    164.02545   0.00460829 
+  209          227.56737    164.11478   0.00478469 
+  208          233.24871    164.2043    0.00480769 
+  215          237.96738    164.294     0.00465116 
+  215          241.10002    164.38388   0.00465116 
+  216          243.41223    164.47396   0.00462963 
+  207          245.72723    164.56422   0.00483092 
+  254          248.06282    164.65467   0.00393701 
+  252          250.1217     164.74531   0.00396825 
+  275          252.24179    164.83613   0.00363636 
+  249          255.34397    164.92715   0.00401606 
+  284          260.99699    165.01836   0.00352113 
+  318          271.26509    165.10975   0.00314465 
+  350          287.2458     165.20134   0.00285714 
+  367          305.05616    165.29313   0.0027248 
+  343          312.38073    165.3851    0.00291545 
+  367          304.49995    165.47727   0.0027248 
+  304          292.80508    165.56963   0.00328947 
+  340          284.65237    165.66219   0.00294118 
+  295          280.25773    165.75495   0.00338983 
+  284          278.21765    165.8479    0.00352113 
+  310          277.8318     165.94105   0.00322581 
+  316          279.05859    166.0344    0.00316456 
+  283          281.84889    166.12794   0.00353357 
+  312          285.99811    166.22169   0.00320513 
+  318          291.26056    166.31563   0.00314465 
+  314          297.81092    166.40978   0.00318471 
+  338          306.56316    166.50413   0.00295858 
+  359          318.65461    166.59868   0.00278552 
+  349          334.02151    166.69343   0.00286533 
+  414          348.65036    166.78839   0.00241546 
+  348          357.50436    166.88355   0.00287356 
+  385          364.32732    166.97891   0.0025974 
+  393          375.47784    167.07448   0.00254453 
+  428          393.26252    167.17026   0.00233645 
+  446          418.08035    167.26625   0.00224215 
+  481          450.28902    167.36244   0.002079  
+  517          491.58342    167.45884   0.00193424 
+  572          545.32808    167.55545   0.00174825 
+  666          613.05827    167.65228   0.0015015 
+  742          692.11351    167.74931   0.00134771 
+  967          788.04223    167.84655   0.00103413 
+  1068         922.28879    167.94401   0.00093633 
+  1351         1124.10247   168.04168   0.00074019 
+  1847         1437.83487   168.13956   0.00054142 
+  2572         1938.88353   168.23766   0.0003888 
+  3766         2738.79217   168.33597   0.00026553 
+  5245         3919.30828   168.4345    0.00019066 
+  6497         5188.75849   168.53325   0.00015392 
+  6313         5503.44862   168.63221   0.0001584 
+  5066         4493.82637   168.73139   0.00019739 
+  3862         3211.52517   168.8308    0.00025893 
+  2961         2270.82161   168.93042   0.00033772 
+  2240         1679.27315   169.03026   0.00044643 
+  1807         1322.99899   169.13032   0.0005534 
+  1451         1110.69375   169.23061   0.00068918 
+  1246         985.39305    169.33111   0.00080257 
+  1217         921.08486    169.43185   0.00082169 
+  1146         911.81586    169.5328    0.0008726 
+  1288         962.80391    169.63398   0.0007764 
+  1427         1093.27344   169.73539   0.00070077 
+  1822         1342.2118    169.83703   0.00054885 
+  2243         1765.09973   169.93889   0.00044583 
+  2780         2374.49975   170.04098   0.00035971 
+  3124         2914.61545   170.1433    0.0003201 
+  3213         2837.64006   170.24585   0.00031124 
+  2581         2215.21877   170.34863   0.00038745 
+  1986         1590.97198   170.45164   0.00050352 
+  1516         1156.41441   170.55488   0.00065963 
+  1109         880.47128    170.65836   0.00090171 
+  896          706.17181    170.76207   0.00111607 
+  718          593.00404    170.86602   0.00139276 
+  633          516.21742    170.9702    0.00157978 
+  519          461.01637    171.07462   0.00192678 
+  488          418.56208    171.17927   0.00204918 
+  405          384.16675    171.28416   0.00246914 
+  368          356.26051    171.3893    0.00271739 
+  379          334.16005    171.49467   0.00263852 
+  349          316.97762    171.60028   0.00286533 
+  326          303.8197     171.70613   0.00306748 
+  294          294.00051    171.81223   0.00340136 
+  289          286.84184    171.91857   0.00346021 
+  244          281.17749    172.02515   0.00409836 
+  277          275.49701    172.13197   0.00361011 
+  268          269.44848    172.23905   0.00373134 
+  261          263.88366    172.34636   0.00383142 
+  263          259.58015    172.45393   0.00380228 
+  260          256.68612    172.56174   0.00384615 
+  274          254.50909    172.66981   0.00364964 
+  288          251.96637    172.77812   0.00347222 
+  255          248.32713    172.88668   0.00392157 
+  272          243.62976    172.99549   0.00367647 
+  255          238.78447    173.10456   0.00392157 
+  227          234.75506    173.21388   0.00440529 
+  225          231.86765    173.32345   0.00444444 
+  238          229.93222    173.43328   0.00420168 
+  221          228.87873    173.54336   0.00452489 
+  233          228.86778    173.6537    0.00429185 
+  243          229.72488    173.7643    0.00411523 
+  238          230.86741    173.87515   0.00420168 
+  223          232.10193    173.98627   0.0044843 
+  216          234.03822    174.09764   0.00462963 
+  227          237.98283    174.20927   0.00440529 
+  234          245.36219    174.32117   0.0042735 
+  238          257.05039    174.43333   0.00420168 
+  241          272.19745    174.54575   0.00414938 
+  299          283.5585     174.65844   0.00334448 
+  227          279.23321    174.77139   0.00440529 
+  260          262.14815    174.88461   0.00384615 
+  290          244.94798    174.9981    0.00344828 
+  233          232.63428    175.11185   0.00429185 
+  212          224.72651    175.22588   0.00471698 
+  221          219.91755    175.34017   0.00452489 
+  227          217.40623    175.45473   0.00440529 
+  196          216.81775    175.56957   0.00510204 
+  213          217.99955    175.68467   0.00469484 
+  207          220.94508    175.80006   0.00483092 
+  201          225.92631    175.91571   0.00497512 
+  210          233.76553    176.03164   0.0047619 
+  210          245.81187    176.14785   0.0047619 
+  214          263.94071    176.26433   0.0046729 
+#--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--#
+
+# start Validation Reply Form
+_vrf_PLAT741_NEW1minmill_phase_0 # for all atoms in 0_pyrite
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+# start Validation Reply Form
+_vrf_PLAT741_NEW1minmill_phase_1 # for all atoms in 1_quartz
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT741_NEW1minmill_phase_3 # for all atoms in 3_pyrrhotite
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT741_NEW1minmill_phase_4 # for all atoms in 4_rutile
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT741_NEW1minmill_phase_2 # for all atoms in 2_albite
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT155_NEW1minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT141_NEW1minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT142_NEW1minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT143_NEW1minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT144_NEW1minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT145_NEW1minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT146_NEW1minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT151_NEW1minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+# end Validation Reply Form

--- a/data/hamish/fixed/vb5042sup6.cif
+++ b/data/hamish/fixed/vb5042sup6.cif
@@ -1,0 +1,6669 @@
+
+data_NEW2minmill_publ
+_audit_creation_method  "created in GSAS-II"
+_audit_creation_date  2021-08-04T18:30
+_audit_author_name  "McDougall, Hamish"
+_audit_update_record
+   "2021-08-04T18:30  Initial software-generated CIF"
+_pd_block_id  2021-08-04T18:30|NEW2minmill|McDougallHamish|Overall
+# GSAS-II edited template follows Publication_Template
+#=============================================================================
+# this information describes the project, paper etc. for the CIF             #
+# Acta Cryst. Section C papers and editorial correspondence is generated     #
+# from the information in this section                                       #
+#                                                                            #
+#   (from)   CIF submission form for Rietveld refinements (Acta Cryst. C)    #
+#                                                 Version 14 December 1998   #
+#=============================================================================
+# 1. SUBMISSION DETAILS
+
+_publ_contact_author_name            "Suzanne Neville; Vanessa Peterson; Christophe Didier"   # Name of author for correspondence
+_publ_contact_author_address             # Address of author for correspondence
+; ?
+;
+_publ_contact_author_email           "s.neville@unsw.edu.au; vanessa.peterson@ansto.gov.au; drchristophedidier@gmail.com"
+_publ_contact_author_fax             ?
+_publ_contact_author_phone           ?
+
+_publ_contact_letter
+; ?
+;
+   
+_publ_requested_journal              ?
+_publ_requested_coeditor_name        ?
+_publ_requested_category             ?   # Acta C: one of CI/CM/CO/FI/FM/FO
+
+#==============================================================================
+
+# 2. PROCESSING SUMMARY (IUCr Office Use Only)
+
+_journal_data_validation_number      ?
+
+_journal_date_recd_electronic        ?
+_journal_date_to_coeditor            ?
+_journal_date_from_coeditor          ?
+_journal_date_accepted               ?
+_journal_date_printers_first         ?
+_journal_date_printers_final         ?
+_journal_date_proofs_out             ?
+_journal_date_proofs_in              ?
+_journal_coeditor_name               ?
+_journal_coeditor_code               ?
+_journal_coeditor_notes
+; ?
+;
+_journal_techeditor_code             ?
+_journal_techeditor_notes
+; ?
+;
+_journal_coden_ASTM                  ?
+_journal_name_full                   ?
+_journal_year                        ?
+_journal_volume                      ?
+_journal_issue                       ?
+_journal_page_first                  ?
+_journal_page_last                   ?
+_journal_paper_category              ?
+_journal_suppl_publ_number           ?
+_journal_suppl_publ_pages            ?
+
+#==============================================================================
+
+# 3. TITLE AND AUTHOR LIST
+
+_publ_section_title
+; ?
+;
+_publ_section_title_footnote
+; ?
+;         
+ 
+# The loop structure below should contain the names and addresses of all 
+# authors, in the required order of publication. Repeat as necessary.
+
+loop_
+	_publ_author_name
+        _publ_author_footnote
+	_publ_author_address
+ ?                                   #<--'Last name, first name' 
+; ?
+;
+; ?
+;
+
+#==============================================================================
+
+# 4. TEXT
+
+_publ_section_synopsis
+;  ?
+;
+_publ_section_abstract                         
+; ?
+;          
+_publ_section_comment                          
+; ?
+;
+_publ_section_exptl_prep      # Details of the preparation of the sample(s)
+                              # should be given here. 
+; ?
+;
+_publ_section_exptl_refinement                  
+; ?
+;
+_publ_section_references
+; ?
+;
+_publ_section_figure_captions
+; ?
+;
+_publ_section_acknowledgements
+; ?
+;
+
+#=============================================================================
+# 5. OVERALL REFINEMENT & COMPUTING DETAILS
+
+_refine_special_details
+; ?
+;
+_pd_proc_ls_special_details
+; ?
+;
+
+# The following items are used to identify the programs used.
+_computing_molecular_graphics     ?
+_computing_publication_material   ?
+
+_refine_ls_weighting_scheme       ?        
+_refine_ls_weighting_details      ?
+_refine_ls_hydrogen_treatment     ?        
+_refine_ls_extinction_method      ?        
+_refine_ls_extinction_coef        ?         
+_refine_ls_number_constraints     ?        
+
+_refine_ls_restrained_S_all       ?        
+_refine_ls_restrained_S_obs       ?
+
+#==============================================================================
+# 6. SAMPLE PREPARATION DATA
+
+# (In the unusual case where multiple samples are used in a single
+#  Rietveld study, this information should be moved into the phase
+#  blocks)
+
+# The following three fields describe the preparation of the material.
+# The cooling rate is in K/min.  The pressure at which the sample was  
+# prepared is in kPa.  The temperature of preparation is in K.
+               
+_pd_prep_cool_rate                N/A        
+_pd_prep_pressure                 101.3        
+_pd_prep_temperature              298        
+
+_pd_char_colour                   ?       # use ICDD colour descriptions
+
+data_NEW2minmill_overall
+_pd_proc_info_datetime  2021-08-04T18:30
+_pd_calc_method  "Rietveld Refinement"
+_computing_structure_refinement
+   "GSAS-II (Toby & Von Dreele, J. Appl. Cryst. 46, 544-549, 2013)"
+_refine_ls_number_parameters  31
+_refine_ls_goodness_of_fit_all  2.540
+_refine_ls_shift/su_max  1.0720
+
+# OVERALL WEIGHTED R-FACTOR
+_refine_ls_wR_factor_obs  0.10293
+_refine_ls_matrix_type  full
+# POINTERS TO PHASE AND HISTOGRAM BLOCKS
+loop_   _pd_phase_block_id
+  2021-08-04T18:30|NEW2minmill|phase_0|McDougallHamish
+  2021-08-04T18:30|NEW2minmill|phase_2|McDougallHamish
+  2021-08-04T18:30|NEW2minmill|phase_4|McDougallHamish
+  2021-08-04T18:30|NEW2minmill|phase_1|McDougallHamish
+  2021-08-04T18:30|NEW2minmill|phase_3|McDougallHamish
+_pd_block_diffractogram_id
+;
+2021-08-04T18:30|NEW2minmill|McDougallHamish|PANalytical,Co-EmpyreanII_hist_0
+;
+
+data_NEW2minmill_phase_0
+# Information for phase 0
+_pd_block_id  2021-08-04T18:30|NEW2minmill|phase_0|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for FeS2 follows
+_pd_phase_name  FeS2
+_cell_length_a  5.419509(28)
+_cell_length_b  5.419509(28)
+_cell_length_c  5.419509(28)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  90
+_cell_volume  159.1768(25)
+_exptl_crystal_density_diffrn  5.0060
+_symmetry_cell_setting  cubic
+_symmetry_space_group_name_H-M  "P a -3"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  z,x,y
+     3  y,z,x
+     4  1/2+x,y,1/2-z
+     5  1/2-z,1/2+x,y
+     6  y,1/2-z,1/2+x
+     7  -z,1/2+x,1/2-y
+     8  1/2-y,-z,1/2+x
+     9  1/2+y,1/2-z,-x
+    10  -x,1/2+y,1/2-z
+    11  1/2-z,-x,1/2+y
+    12  1/2+x,1/2-y,-z
+    13  -x,-y,-z
+    14  -z,-x,-y
+    15  -y,-z,-x
+    16  1/2-x,-y,1/2+z
+    17  1/2+z,1/2-x,-y
+    18  -y,1/2+z,1/2-x
+    19  z,1/2-x,1/2+y
+    20  1/2+y,z,1/2-x
+    21  1/2-y,1/2+z,x
+    22  x,1/2-y,1/2+z
+    23  1/2+z,x,1/2-y
+    24  1/2-x,1/2+y,z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Fe1    Fe   0.00000     0.00000     0.00000     1.000      Uiso 0.0063(4)  4   
+S2     S    0.38541(12) 0.38541     0.38541     1.000      Uiso 0.0053(4)  8   
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Fe   4      11.7695    7.3573     3.5222     2.3045     4.7611     0.3072     15.3535    76.8805    1.0369     0.945
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S    8      6.9053     5.2034     1.4379     1.5863     1.4679     22.2151    0.2536     56.172     0.8669     0.2847
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Fe S2"
+_chemical_formula_weight  119.97
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Fe1    S2     2.26586(18)   1_555    4_455 yes
+  Fe1    S2     2.26586(18)   1_555    5_545 yes
+  Fe1    S2     2.26586(18)   1_555    6_554 yes
+  Fe1    S2     2.26586(18)   1_555    7_545 yes
+  Fe1    S2     2.26586(18)   1_555    8_554 yes
+  Fe1    S2     2.2659(6)    1_555    9_455 yes
+  S2     Fe1    2.26586(18)   1_555    4_555 yes
+  S2     Fe1    2.26586(18)   1_555    5_555 yes
+  S2     Fe1    2.2659(6)    1_555    6_555 yes
+  S2     S2     2.1513(8)    1_555   13_666 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.2643(21), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW2minmill_phase_2
+# Information for phase 2
+_pd_block_id  2021-08-04T18:30|NEW2minmill|phase_2|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for NaAlSi3O8 follows
+_pd_phase_name  NaAlSi3O8
+_cell_length_a  8.137
+_cell_length_b  12.785
+_cell_length_c  7.1583
+_cell_angle_alpha  94.26
+_cell_angle_beta   116.6
+_cell_angle_gamma  87.71
+_cell_volume  664.008
+_exptl_crystal_density_diffrn  2.6230
+_symmetry_cell_setting  triclinic
+_symmetry_space_group_name_H-M  "C -1"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -x,-y,-z
+     3  1/2+x,1/2+y,z
+     4  1/2-x,1/2-y,-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Al1    Al3+ 0.00887     0.16846     0.20805     1.000      Uani 0.007      4   
+Si1    Si4+ 0.00375     0.82051     0.23737     1.000      Uani 0.006      4   
+Si2    Si4+ 0.69162     0.11021     0.31466     1.000      Uani 0.006      4   
+Si3    Si4+ 0.68129     0.88190     0.36076     1.000      Uani 0.006      4   
+Na1    Na1+ 0.26799     0.98865     0.14650     1.000      Uani 0.031      4   
+O1     O2-  0.00490     0.13103     0.96660     1.000      Uani 0.012      4   
+O2     O2-  0.59176     0.99756     0.28040     1.000      Uani 0.008      4   
+O3     O2-  0.81230     0.10966     0.19010     1.000      Uani 0.014      4   
+O4     O2-  0.82000     0.85101     0.25870     1.000      Uani 0.018      4   
+O5     O2-  0.01288     0.30238     0.27060     1.000      Uani 0.011      4   
+O6     O2-  0.02329     0.69368     0.22910     1.000      Uani 0.011      4   
+O7     O2-  0.20780     0.10896     0.38900     1.000      Uani 0.011      4   
+O8     O2-  0.18400     0.86817     0.43620     1.000      Uani 0.012      4   
+
+loop_
+   _atom_site_aniso_label
+   _atom_site_aniso_U_11
+   _atom_site_aniso_U_22
+   _atom_site_aniso_U_33
+   _atom_site_aniso_U_12
+   _atom_site_aniso_U_13
+   _atom_site_aniso_U_23
+Al1    0.0074      0.0068      0.0061      -0.0009     0.0031      0.0004      
+Si1    0.0068      0.0065      0.0055      0.0011      0.0030      0.0008      
+Si2    0.0061      0.0055      0.0073      -0.0002     0.0025      0.0004      
+Si3    0.0060      0.0055      0.0074      0.0006      0.0028      0.0009      
+Na1    0.0136      0.0471      0.0315      -0.0050     0.0084      -0.0219     
+O1     0.0164      0.0122      0.0074      -0.0002     0.0067      0.0014      
+O2     0.0074      0.0056      0.0119      0.0003      0.0033      0.0020      
+O3     0.0117      0.0130      0.0162      -0.0040     0.0093      -0.0017     
+O4     0.0134      0.0179      0.0216      0.0046      0.0129      0.0020      
+O5     0.0103      0.0076      0.0150      -0.0020     0.0052      -0.0009     
+O6     0.0101      0.0071      0.0145      0.0022      0.0034      0.0012      
+O7     0.0120      0.0129      0.0080      0.0024      0.0013      0.0015      
+O8     0.0140      0.0140      0.0084      -0.0026     -0.0002     -0.0006     
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Al   4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Na   4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  O    32     ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si   12     ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Al Na O8 Si3"
+_chemical_formula_weight  262.22
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Al1    O1     1.74519      1_555    1_554 yes
+  Al1    O3     1.7429       1_555    1_455 yes
+  Al1    O5     1.73509      1_555    1_555 yes
+  Al1    O7     1.74556      1_555    1_555 yes
+  Si1    O1     1.59985      1_555    2_566 yes
+  Si1    O4     1.59997      1_555    1_455 yes
+  Si1    O6     1.62225      1_555    1_555 yes
+  Si1    O8     1.61907      1_555    1_555 yes
+  Si2    O2     1.63011      1_555    1_545 yes
+  Si2    O3     1.59435      1_555    1_555 yes
+  Si2    O6     1.61836      1_555    3_545 yes
+  Si2    O8     1.6168       1_555    2_666 yes
+  Si3    O2     1.64718      1_555    1_555 yes
+  Si3    O4     1.61975      1_555    1_555 yes
+  Si3    O5     1.59682      1_555    3_555 yes
+  Si3    O7     1.60203      1_555    2_666 yes
+  Na1    O1     2.66887      1_555    1_564 yes
+  Na1    O1     2.53079      1_555    2_566 yes
+  Na1    O2     2.3704       1_555    1_555 yes
+  Na1    O3     2.45321      1_555    2_665 yes
+  Na1    O7     2.43384      1_555    1_565 yes
+  O1     Al1    1.74519      1_555    1_556 yes
+  O1     Si1    1.59985      1_555    2_566 yes
+  O1     Na1    2.66887      1_555    1_546 yes
+  O1     Na1    2.53079      1_555    2_566 yes
+  O2     Si2    1.63011      1_555    1_565 yes
+  O2     Si3    1.64718      1_555    1_555 yes
+  O2     Na1    2.3704       1_555    1_555 yes
+  O3     Al1    1.7429       1_555    1_655 yes
+  O3     Si2    1.59435      1_555    1_555 yes
+  O3     Na1    2.45321      1_555    2_665 yes
+  O4     Si1    1.59997      1_555    1_655 yes
+  O4     Si3    1.61975      1_555    1_555 yes
+  O5     Al1    1.73509      1_555    1_555 yes
+  O5     Si3    1.59682      1_555    3_445 yes
+  O6     Si1    1.62225      1_555    1_555 yes
+  O6     Si2    1.61836      1_555    3_455 yes
+  O7     Al1    1.74556      1_555    1_555 yes
+  O7     Si3    1.60203      1_555    2_666 yes
+  O7     Na1    2.43384      1_555    1_545 yes
+  O8     Si1    1.61907      1_555    1_555 yes
+  O8     Si2    1.6168       1_555    2_666 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Al1    O3     102.836       1_554  1_555    1_455 yes
+  O1     Al1    O5     116.047       1_554  1_555    1_555 yes
+  O3     Al1    O5     112.215       1_455  1_555    1_555 yes
+  O1     Al1    O7     104.004       1_554  1_555    1_555 yes
+  O3     Al1    O7     111.151       1_455  1_555    1_555 yes
+  O5     Al1    O7     110.14        1_555  1_555    1_555 yes
+  O1     Si1    O4     109.433       2_566  1_555    1_455 yes
+  O1     Si1    O6     112.47        2_566  1_555    1_555 yes
+  O4     Si1    O6     108.187       1_455  1_555    1_555 yes
+  O1     Si1    O8     107.176       2_566  1_555    1_555 yes
+  O4     Si1    O8     111.446       1_455  1_555    1_555 yes
+  O6     Si1    O8     108.16        1_555  1_555    1_555 yes
+  O2     Si2    O3     111.144       1_545  1_555    1_555 yes
+  O2     Si2    O6     104.24        1_545  1_555    3_545 yes
+  O3     Si2    O6     112.114       1_555  1_555    3_545 yes
+  O2     Si2    O8     106.97        1_545  1_555    2_666 yes
+  O3     Si2    O8     111.591       1_555  1_555    2_666 yes
+  O6     Si2    O8     110.422       3_545  1_555    2_666 yes
+  O2     Si3    O4     107.269       1_555  1_555    1_555 yes
+  O2     Si3    O5     105.914       1_555  1_555    3_555 yes
+  O4     Si3    O5     110.224       1_555  1_555    3_555 yes
+  O2     Si3    O7     108.565       1_555  1_555    2_666 yes
+  O4     Si3    O7     110.208       1_555  1_555    2_666 yes
+  O5     Si3    O7     114.328       3_555  1_555    2_666 yes
+  Al1    O1     Si1    141.397       1_556  1_555    2_566 yes
+  Si2    O2     Si3    130.019       1_565  1_555    1_555 yes
+  Si2    O2     Na1    120.351       1_565  1_555    1_555 yes
+  Si3    O2     Na1    108.811       1_555  1_555    1_555 yes
+  Al1    O3     Si2    139.461       1_655  1_555    1_555 yes
+  Si1    O4     Si3    161.151       1_655  1_555    1_555 yes
+  Al1    O5     Si3    129.689       1_555  1_555    3_445 yes
+  Si1    O6     Si2    135.676       1_555  1_555    3_455 yes
+  Al1    O7     Si3    133.943       1_555  1_555    2_666 yes
+  Si1    O8     Si2    151.747       1_555  1_555    2_666 yes
+_pd_proc_ls_pref_orient_corr  none
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.171(12), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW2minmill_phase_4
+# Information for phase 4
+_pd_block_id  2021-08-04T18:30|NEW2minmill|phase_4|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Pyrrhotite 4M follows
+_pd_phase_name  "Pyrrhotite 4M"
+_cell_length_a  11.927(18)
+_cell_length_b  6.8693(28)
+_cell_length_c  12.820(21)
+_cell_angle_alpha  90
+_cell_angle_beta   117.20(4)
+_cell_angle_gamma  90
+_cell_volume  934.14(31)
+_exptl_crystal_density_diffrn  4.6034
+_symmetry_cell_setting  monoclinic
+_symmetry_space_group_name_H-M  "C 2/c"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -x,y,1/2-z
+     3  -x,-y,-z
+     4  x,-y,1/2+z
+     5  1/2+x,1/2+y,z
+     6  1/2-x,1/2+y,1/2-z
+     7  1/2-x,1/2-y,-z
+     8  1/2+x,1/2-y,1/2+z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+S1     S    0.01800     0.38330     0.11960     1.000      Uiso 0.010      8   
+S2     S    0.02910     0.11420     0.63900     1.000      Uiso 0.010      8   
+Fe3    Fe   0.10860     0.10250     0.49980     1.000      Uiso 0.010      8   
+S4     S    0.23410     0.13550     0.38260     1.000      Uiso 0.010      8   
+Fe5    Fe   0.24180     0.36600     0.24680     1.000      Uiso 0.010      8   
+S6     S    0.26790     0.13400     0.12360     1.000      Uiso 0.010      8   
+Fe7    Fe   0.38720     0.15000     0.01260     1.000      Uiso 0.010      8   
+Fe8    Fe   0.00000     0.14720     0.25000     1.000      Uiso 0.010      4   
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Fe   28     11.7695    7.3573     3.5222     2.3045     4.7611     0.3072     15.3535    76.8805    1.0369     0.945
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S    32     6.9053     5.2034     1.4379     1.5863     1.4679     22.2151    0.2536     56.172     0.8669     0.2847
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Fe7 S8"
+_chemical_formula_weight  647.41
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  S1     Fe3    2.49607      1_555    2_555 yes
+  S1     Fe5    2.41207      1_555    1_555 yes
+  S1     Fe7    2.39063      1_555    5_455 yes
+  S1     Fe7    2.44033      1_555    7_555 yes
+  S1     Fe8    2.40819      1_555    1_555 yes
+  S2     Fe3    2.3743       1_555    1_555 yes
+  S2     Fe3    2.32539      1_555    3_556 yes
+  S2     Fe5    2.44341      1_555    7_556 yes
+  S2     Fe7    2.36776      1_555    8_456 yes
+  S2     Fe8    2.41276      1_555    3_556 yes
+  Fe3    S1     2.49607      1_555    2_555 yes
+  Fe3    S2     2.3743       1_555    1_555 yes
+  Fe3    S2     2.32539      1_555    3_556 yes
+  Fe3    S6     2.45171      1_555    4_556 yes
+  S4     Fe5    2.38595      1_555    1_555 yes
+  Fe5    S1     2.41207      1_555    1_555 yes
+  Fe5    S2     2.44341      1_555    7_556 yes
+  Fe5    S4     2.38595      1_555    1_555 yes
+  Fe5    S6     2.3624       1_555    1_555 yes
+  S6     Fe3    2.45171      1_555    4_555 yes
+  S6     Fe5    2.3624       1_555    1_555 yes
+  S6     Fe7    2.43165      1_555    1_555 yes
+  S6     Fe7    2.39145      1_555    7_555 yes
+  Fe7    S1     2.39063      1_555    5_545 yes
+  Fe7    S1     2.44033      1_555    7_555 yes
+  Fe7    S2     2.36776      1_555    8_555 yes
+  Fe7    S6     2.43165      1_555    1_555 yes
+  Fe7    S6     2.39145      1_555    7_555 yes
+  Fe8    S1     2.40819      1_555    1_555 yes
+  Fe8    S1     2.40819      1_555    2_555 yes
+  Fe8    S2     2.41276      1_555    3_556 yes
+  Fe8    S2     2.41276      1_555    4_555 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.049(4), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW2minmill_phase_1
+# Information for phase 1
+_pd_block_id  2021-08-04T18:30|NEW2minmill|phase_1|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for SiO2 follows
+_pd_phase_name  SiO2
+_cell_length_a  4.9149(4)
+_cell_length_b  4.9149(4)
+_cell_length_c  5.4057(3)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  120
+_cell_volume  113.084(8)
+_exptl_crystal_density_diffrn  2.6468
+_symmetry_cell_setting  trigonal
+_symmetry_space_group_name_H-M  "P 32 2 1"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -y,x-y,2/3+z
+     3  y-x,-x,1/3+z
+     4  y,x,-z
+     5  -x,y-x,2/3-z
+     6  x-y,-y,1/3-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Si1    Si4+ 0.47000     0.00000     0.66670     1.000      Uani 0.006      3   
+O1     O2-  0.41460     0.26780     0.78543     1.000      Uani 0.011      6   
+
+loop_
+   _atom_site_aniso_label
+   _atom_site_aniso_U_11
+   _atom_site_aniso_U_22
+   _atom_site_aniso_U_33
+   _atom_site_aniso_U_12
+   _atom_site_aniso_U_13
+   _atom_site_aniso_U_23
+Si1    0.0073      0.0059      0.0053      0.0029      0.0003      0.0006      
+O1     0.0120      0.0105      0.0118      0.0065      -0.0029     -0.0040     
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  O    6      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si   3      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  3
+_chemical_formula_sum  "O2 Si"
+_chemical_formula_weight  60.08
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Si1    O1     1.60525      1_555    1_555 yes
+  Si1    O1     1.61159      1_555    2_654 yes
+  Si1    O1     1.61134      1_555    5_656 yes
+  Si1    O1     1.60539      1_555    6_556 yes
+  O1     Si1    1.60525      1_555    1_555 yes
+  O1     Si1    1.61159      1_555    3_665 yes
+  O1     Si1    1.61134      1_555    5_666 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Si1    O1     110.256       1_555  1_555    2_654 yes
+  O1     Si1    O1     108.745       1_555  1_555    5_656 yes
+  O1     Si1    O1     109.685       2_654  1_555    5_656 yes
+  O1     Si1    O1     109.161       1_555  1_555    6_556 yes
+  O1     Si1    O1     108.725       2_654  1_555    6_556 yes
+  O1     Si1    O1     110.262       5_656  1_555    6_556 yes
+  Si1    O1     Si1    143.832       1_555  1_555    3_665 yes
+  Si1    O1     Si1    143.836       1_555  1_555    5_666 yes
+  Si1    O1     Si1    0.009         3_665  1_555    5_666 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.220(12), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW2minmill_phase_3
+# Information for phase 3
+_pd_block_id  2021-08-04T18:30|NEW2minmill|phase_3|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for TiO2 follows
+_pd_phase_name  TiO2
+_cell_length_a  4.5979(16)
+_cell_length_b  4.5979(16)
+_cell_length_c  2.9608(14)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  90
+_cell_volume  62.59(3)
+_exptl_crystal_density_diffrn  4.2393
+_symmetry_cell_setting  tetragonal
+_symmetry_space_group_name_H-M  "P 42/m n m"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  1/2-y,1/2+x,1/2+z
+     3  -x,-y,z
+     4  1/2+y,1/2-x,1/2+z
+     5  1/2-x,1/2+y,1/2+z
+     6  -y,-x,z
+     7  1/2+x,1/2-y,1/2+z
+     8  y,x,z
+     9  -x,-y,-z
+    10  1/2+y,1/2-x,1/2-z
+    11  x,y,-z
+    12  1/2-y,1/2+x,1/2-z
+    13  1/2+x,1/2-y,1/2-z
+    14  y,x,-z
+    15  1/2-x,1/2+y,1/2-z
+    16  -y,-x,-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Ti1    Ti4+ 0.00000     0.00000     0.00000     1.000      Uani 0.006      2   
+O1     O2-  0.30493     0.30493     0.00000     1.000      Uani 0.006      4   
+
+loop_
+   _atom_site_aniso_label
+   _atom_site_aniso_U_11
+   _atom_site_aniso_U_22
+   _atom_site_aniso_U_33
+   _atom_site_aniso_U_12
+   _atom_site_aniso_U_13
+   _atom_site_aniso_U_23
+Ti1    0.0070      0.0070      0.0047      -0.0002     0.0000      0.0000      
+O1     0.0060      0.0060      0.0045      -0.0019     0.0000      0.0000      
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  O    4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Ti   2      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  2
+_chemical_formula_sum  "O2 Ti"
+_chemical_formula_weight  79.9
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Ti1    O1     1.98276      1_555    1_555 yes
+  Ti1    O1     1.94948      1_555    2_544 yes
+  Ti1    O1     1.94948      1_555    2_545 yes
+  Ti1    O1     1.98276      1_555    3_555 yes
+  Ti1    O1     1.94948      1_555    4_454 yes
+  Ti1    O1     1.94948      1_555    4_455 yes
+  O1     Ti1    1.98276      1_555    1_555 yes
+  O1     Ti1    1.94948      1_555    2_554 yes
+  O1     Ti1    1.94948      1_555    2_555 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Ti1    O1     90            1_555  1_555    2_544 yes
+  O1     Ti1    O1     90            1_555  1_555    2_545 yes
+  O1     Ti1    O1     98.82         2_544  1_555    2_545 yes
+  O1     Ti1    O1     180           1_555  1_555    3_555 yes
+  O1     Ti1    O1     90            2_544  1_555    3_555 yes
+  O1     Ti1    O1     90            2_545  1_555    3_555 yes
+  O1     Ti1    O1     90            1_555  1_555    4_454 yes
+  O1     Ti1    O1     81.18         2_544  1_555    4_454 yes
+  O1     Ti1    O1     180           2_545  1_555    4_454 yes
+  O1     Ti1    O1     90            3_555  1_555    4_454 yes
+  O1     Ti1    O1     90            1_555  1_555    4_455 yes
+  O1     Ti1    O1     180           2_544  1_555    4_455 yes
+  O1     Ti1    O1     81.18         2_545  1_555    4_455 yes
+  O1     Ti1    O1     90            3_555  1_555    4_455 yes
+  O1     Ti1    O1     98.82         4_454  1_555    4_455 yes
+  Ti1    O1     Ti1    130.59        1_555  1_555    2_554 yes
+  Ti1    O1     Ti1    130.59        1_555  1_555    2_555 yes
+  Ti1    O1     Ti1    98.82         2_554  1_555    2_555 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.13(4), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW2minmill_pwd_0
+_pd_proc_ls_profile_function
+;
+Finger-Cox-Jephcoat function parameters U, V, W, X, Y, SH/L:
+  peak variance(Gauss) = Utan(Th)^2^+Vtan(Th)+W:
+  peak HW(Lorentz) = X/cos(Th)+Ytan(Th); SH/L = S/L+H/L
+  U, V, W in (centideg)^2^, X & Y in centideg
+    0.000, 0.000, 1.089, 0.882, 1.689, 0.058, 
+;
+# Information for histogram 0: PWDR BAT3_2min_milla_30mm_MonicaHamish_Ruoming_step size 0_2_min_mill_a.xrdml Scan 1
+_pd_block_id
+;
+2021-08-04T18:30|NEW2minmill|McDougallHamish|PANalytical,Co-EmpyreanII_hist_0
+;
+# GSAS-II edited template follows Instrument_Template
+#==============================================================================
+# 9. INSTRUMENT CHARACTERIZATION
+
+_exptl_special_details
+; ?
+;
+
+# if regions of the data are excluded, the reason(s) are supplied here:
+_pd_proc_info_excluded_regions
+; ?
+;
+
+# The following item is used to identify the equipment used to record 
+# the powder pattern when the diffractogram was measured at a laboratory 
+# other than the authors' home institution, e.g. when neutron or synchrotron
+# radiation is used.
+
+_pd_instr_location
+; ?
+;
+_pd_calibration_special_details           # description of the method used
+                                          # to calibrate the instrument
+; ?
+;
+
+_diffrn_source                    Co-Ka       
+_diffrn_source_target             Co
+_diffrn_source_type               Graded_Flat
+_diffrn_measurement_device_type   Panalytical_Reflection_Transmission       
+_diffrn_detector                  PIXcel1D      
+_diffrn_detector_type             Empyrean_II       # make or model of detector
+
+_pd_meas_scan_method              ?       # options are 'step', 'cont',
+                                          # 'tof', 'fixed' or
+                                          # 'disp' (= dispersive)
+_pd_meas_special_details
+;  ?
+;
+
+# The following two items identify the program(s) used (if appropriate).
+_computing_data_collection        ?        
+_computing_data_reduction         ?                   
+
+# Describe any processing performed on the data, prior to refinement.
+# For example: a manual Lp correction or a precomputed absorption correction
+_pd_proc_info_data_reduction      ?
+
+# The following item is used for angular dispersive measurements only.
+
+_diffrn_radiation_monochromator   ?        
+
+# The following items are used to define the size of the instrument.
+# Not all distances are appropriate for all instrument types.
+
+_pd_instr_dist_src/mono           ?
+_pd_instr_dist_mono/spec          ?
+_pd_instr_dist_src/spec           ?
+_pd_instr_dist_spec/anal          ?
+_pd_instr_dist_anal/detc          ?
+_pd_instr_dist_spec/detc          ?
+
+# 10. Specimen size and mounting information
+
+# The next three fields give the specimen dimensions in mm.  The equatorial 
+# plane contains the incident and diffracted beam.
+
+_pd_spec_size_axial               ?       # perpendicular to 
+                                          # equatorial plane
+
+_pd_spec_size_equat               ?       # parallel to 
+                                          # scattering vector 
+                                          # in transmission
+
+_pd_spec_size_thick               ?       # parallel to 
+                                          # scattering vector 
+                                          # in reflection
+
+_pd_spec_mounting                         # This field should be
+                                          # used to give details of the 
+                                          # container.
+; ?
+;
+
+_pd_spec_mount_mode               ?       # options are 'reflection' 
+                                          # or 'transmission'
+    
+_pd_spec_shape                    ?       # options are 'cylinder' 
+                                          # 'flat_sheet' or 'irregular'
+
+
+loop_
+     _atom_type_symbol
+     _atom_type_scat_dispersion_real
+     _atom_type_scat_dispersion_imag
+     _atom_type_scat_dispersion_source
+  Al        0.255   0.328   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Fe       -3.332   0.490   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Na        0.167   0.167   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  O         0.063   0.044   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S         0.371   0.733   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si        0.298   0.438   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Ti       -0.063   2.321   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+_diffrn_radiation_type  K\a~1,2~
+loop_
+   _diffrn_radiation_wavelength
+   _diffrn_radiation_wavelength_wt
+   _diffrn_radiation_wavelength_id
+  1.78892         1.0             1     
+  1.79278         0.5000          2     
+
+# PHASE TABLE
+loop_
+   _pd_phase_id
+   _pd_phase_block_id
+   _pd_phase_mass_%
+  0  2021-08-04T18:30|NEW2minmill|phase_0|McDougallHamish  0.776(3)
+  2  2021-08-04T18:30|NEW2minmill|phase_2|McDougallHamish  0.1086(26)
+  4  2021-08-04T18:30|NEW2minmill|phase_4|McDougallHamish  0.0440(14)
+  1  2021-08-04T18:30|NEW2minmill|phase_1|McDougallHamish  0.0646(10)
+  3  2021-08-04T18:30|NEW2minmill|phase_3|McDougallHamish  0.0064(7)
+loop_
+   _gsas_proc_phase_R_F_factor
+   _gsas_proc_phase_R_Fsqd_factor
+   _gsas_proc_phase_id
+   _gsas_proc_phase_block_id
+    0.03669  0.08611  0  2021-08-04T18:30|NEW2minmill|phase_0|McDougallHamish
+    0.08136  0.18791  2  2021-08-04T18:30|NEW2minmill|phase_2|McDougallHamish
+    0.06571  0.11431  4  2021-08-04T18:30|NEW2minmill|phase_4|McDougallHamish
+    0.07936  0.21331  1  2021-08-04T18:30|NEW2minmill|phase_1|McDougallHamish
+    0.06162  0.12220  3  2021-08-04T18:30|NEW2minmill|phase_3|McDougallHamish
+_pd_proc_ls_prof_R_factor     0.07717
+_pd_proc_ls_prof_wR_factor    0.10293
+_gsas_proc_ls_prof_R_B_factor   0.09857
+_gsas_proc_ls_prof_wR_B_factor  0.12507
+_pd_proc_ls_prof_wR_expected  0.04068
+_diffrn_radiation_probe  x-ray
+_diffrn_radiation_polarisn_ratio  0.7000
+_pd_proc_ls_background_function
+;
+Background function: "chebyschev-1" function with 7 terms:
+    441.7(15), -516.8(24), 391.3(23), -201.4(20), 106.7(19), 
+    -34.6(14), 13.8(13), 
+;
+_diffrn_ambient_temperature  300
+_diffrn_ambient_pressure  100
+
+# STRUCTURE FACTOR TABLE
+loop_
+   _pd_refln_phase_id
+   _refln_index_h
+   _refln_index_k
+   _refln_index_l
+   _refln_F_squared_meas
+   _refln_F_squared_calc
+   _refln_phase_calc
+   _refln_d_spacing
+   _gsas_i100_meas
+  0  1    1    1    965.4302   845.6058   0.0     3.12895  25.38  
+  0  2    0    0    6862.9192  6423.2830  -0.0    2.70975  100.00 
+  0  2    1    0    3761.3126  3393.7780  0.0     2.42368  86.57  
+  0  2    1    1    1782.5766  1744.8952  -180.0  2.21251  67.62  
+  0  2    2    0    3082.3406  3376.4171  -0.0    1.91609  43.15  
+  0  2    2    1    40.6730    42.0768    -0.0    1.80650  1.01   
+  0  3    1    1    4825.2164  5347.8502  -0.0    1.63404  97.64  
+  0  2    2    2    2236.6680  2390.6180  0.0     1.56448  13.88  
+  0  3    0    2    3162.9932  3201.5825  -0.0    1.50310  27.34  
+  0  3    1    2    575.8989   596.5668   0.0     1.44842  9.33   
+  0  3    2    1    1675.8909  1736.0355  180.0   1.44842  27.16  
+  0  4    0    0    430.3698   407.5986   -180.0  1.35488  1.57   
+  0  3    2    2    40.4160    46.8285    -0.0    1.31442  0.57   
+  0  4    1    0    101.6887   117.8228   -0.0    1.31442  0.71   
+  0  4    1    1    63.4246    64.4449    180.0   1.27739  0.86   
+  0  3    3    1    591.6096   592.2572   -0.0    1.24332  7.82   
+  0  4    0    2    979.9400   889.6544   0.0     1.21184  6.35   
+  0  4    2    0    979.9400   889.6544   0.0     1.21184  6.35   
+  0  4    1    2    1.7306     1.7712     -0.0    1.18263  0.02   
+  0  4    2    1    1394.6990  1427.4381  -180.0  1.18263  17.85  
+  0  3    3    2    752.7469   729.9380   0.0     1.15544  9.58   
+  0  4    2    2    1126.4083  1051.7125  0.0     1.10625  14.46  
+  0  4    3    0    133.7114   148.3047   -0.0    1.08390  0.87   
+  0  4    1    3    77.3070    81.6638    -180.0  1.06285  1.03   
+  0  4    3    1    26.5656    28.0628    0.0     1.06285  0.35   
+  0  3    3    3    1847.9613  1618.5630  -0.0    1.04298  8.46   
+  0  5    1    1    3937.7804  3448.9606  -0.0    1.04298  54.11  
+  1  1    0    0    265.5469   242.5017   180.0   4.25639  0.68   
+  1  1    0    1    717.0683   634.4313   120.0   3.34415  1.12   
+  1  1    0    -1   1705.8547  1509.2673  -120.0  3.34415  2.67   
+  1  1    1    0    401.2670   343.7722   -155.6  2.45743  0.33   
+  1  1    0    -2   96.6524    86.1421    -60.0   2.28168  0.07   
+  1  1    0    2    335.3049   298.8427   -120.0  2.28168  0.23   
+  1  1    1    1    100.4215   96.0360    82.9    2.23711  0.13   
+  1  2    0    0    326.7152   308.9287   0.0     2.12820  0.20   
+  1  2    0    -1   68.6499    77.2019    60.0    1.98026  0.04   
+  1  2    0    1    164.4591   184.9464   -60.0   1.98026  0.09   
+  1  1    1    2    585.8090   602.7489   9.8     1.81825  0.51   
+  1  0    0    3    73.9176    94.4702    0.0     1.80189  0.01   
+  1  2    0    2    113.5032   82.0653    60.0    1.67207  0.04   
+  1  2    0    -2   503.6147   364.1246   120.0   1.67207  0.18   
+  1  1    0    -3   195.1883   203.8210   180.0   1.65932  0.07   
+  1  1    0    3    2.4727     2.5820     0.0     1.65932  0.00   
+  1  2    1    0    16.7661    14.6336    -38.9   1.60877  0.01   
+  1  2    1    -1   326.3551   356.2509   95.9    1.54193  0.20   
+  1  2    1    1    280.9515   306.6880   -109.6  1.54193  0.18   
+  1  1    1    3    144.6091   142.5492   117.5   1.45312  0.08   
+  1  3    0    0    83.7612    76.3346    180.0   1.41880  0.02   
+  1  2    1    -2   324.7861   413.7275   -123.3  1.38241  0.17   
+  1  2    1    2    100.8308   128.4429   143.4   1.38241  0.05   
+  1  2    0    -3   186.8663   292.6402   -0.0    1.37518  0.05   
+  1  2    0    3    657.8352   1030.1967  0.0     1.37518  0.17   
+  1  3    0    -1   564.6776   815.6481   -120.0  1.37232  0.15   
+  1  3    0    1    0.7013     1.0131     -60.0   1.37232  0.00   
+  1  1    0    -4   129.7332   120.2777   -120.0  1.28805  0.03   
+  1  1    0    4    427.5343   396.3738   120.0   1.28805  0.10   
+  1  3    0    -2   222.5709   208.2536   120.0   1.25624  0.05   
+  1  3    0    2    507.4733   474.8292   -120.0  1.25624  0.12   
+  1  2    2    0    311.7651   370.9709   -16.5   1.22872  0.07   
+  1  2    1    -3   66.9574    70.9898    179.1   1.20006  0.03   
+  1  2    1    3    284.2047   301.3205   -134.8  1.20006  0.13   
+  1  2    2    1    92.4183    105.5589   88.6    1.19815  0.04   
+  1  1    1    4    333.3075   334.1040   -14.4   1.18417  0.15   
+  1  3    1    0    357.9161   361.4386   121.4   1.18051  0.16   
+  1  3    1    -1   200.7100   189.8528   -18.5   1.15333  0.09   
+  1  3    1    1    67.0181    63.3928    16.4    1.15333  0.03   
+  1  2    0    -4   1.1393     1.4721     -120.0  1.14084  0.00   
+  1  2    0    4    54.6853    70.6614    120.0   1.14084  0.01   
+  1  2    2    2    3.3441     3.3484     -9.8    1.11856  0.00   
+  1  3    0    3    74.8372    62.7056    -180.0  1.11472  0.02   
+  1  3    0    -3   7.9750     6.6822     -0.0    1.11472  0.00   
+  1  3    1    -2   232.3302   304.2534   -8.9    1.08182  0.10   
+  1  3    1    2    94.9244    124.3104   59.1    1.08182  0.04   
+  1  4    0    0    139.6793   168.1434   0.0     1.06410  0.03   
+  1  1    0    -5   378.8904   346.2031   120.0   1.04786  0.09   
+  1  1    0    5    142.1607   129.8963   -120.0  1.04786  0.03   
+  1  4    0    -1   36.4646    31.3968    60.0    1.04406  0.01   
+  1  4    0    1    336.3343   289.5912   120.0   1.04406  0.08   
+  1  2    1    4    148.5739   240.8323   -129.5  1.03477  0.07   
+  1  2    1    -4   6.7001     10.8606    51.2    1.03477  0.00   
+  2  0    0    1    1843.9762  685.7541   180.0   6.38786  0.09   
+  2  0    2    0    1008.1778  396.3962   180.0   6.37466  0.02   
+  2  1    1    0    552.1706   238.2363   -0.0    6.33955  0.01   
+  2  1    -1   0    634.6479   287.4879   -0.0    6.29869  0.01   
+  2  1    1    -1   1023.8206  406.2352   180.0   5.91009  0.02   
+  2  1    -1   -1   741.8423   415.6378   -180.0  5.58552  0.02   
+  2  0    2    -1   10.2388    16.5792    0.0     4.66174  0.00   
+  2  0    2    1    1.0273     1.8371     180.0   4.37623  0.00   
+  2  2    0    -1   19775.7552 21037.4763 -0.0    4.02732  0.16   
+  2  1    -1   1    5454.4244  3767.3897  -0.0    3.85265  0.06   
+  2  1    1    1    12021.5287 10390.3834 0.0     3.77565  0.16   
+  2  1    3    0    9321.4927  5886.9121  180.0   3.68167  0.07   
+  2  1    3    -1   6949.8120  4505.3267  0.0     3.66562  0.05   
+  2  1    -3   0    13988.5097 11675.3013 180.0   3.65766  0.09   
+  2  2    0    0    1.3528     2.5781     0.0     3.63776  0.00   
+  2  1    1    -2   5818.5735  4328.5159  0.0     3.50520  0.06   
+  2  2    2    -1   2553.2400  1650.0035  180.0   3.48122  0.01   
+  2  1    -3   -1   78.0944    12.1276    0.0     3.43616  0.00   
+  2  1    -1   -2   5427.6234  5251.4578  0.0     3.37264  0.06   
+  2  2    -2   -1   346.0304   364.8637   0.0     3.33313  0.00   
+  2  2    0    -2   22175.2387 26655.4799 -180.0  3.21484  0.15   
+  2  0    0    2    38980.4499 37071.8044 -180.0  3.19393  0.48   
+  2  0    4    0    26154.0059 25362.8195 180.0   3.18733  0.13   
+  2  2    2    0    16086.8365 13873.6743 180.0   3.16977  0.09   
+  2  2    -2   0    16483.6303 14946.6082 -180.0  3.14934  0.08   
+  2  1    -3   1    11765.3692 11175.2497 -180.0  2.96418  0.06   
+  2  2    2    -2   6634.1920  7187.5067  0.0     2.95504  0.03   
+  2  0    2    -2   5799.8786  5310.5610  0.0     2.93060  0.04   
+  2  0    4    -1   8151.7504  8585.7945  0.0     2.92677  0.03   
+  2  1    3    1    6236.6840  6897.0276  180.0   2.86133  0.04   
+  2  1    3    -2   1685.1360  1923.0466  -0.0    2.83885  0.01   
+  2  2    -2   -2   166.9524   183.4547   -0.0    2.79276  0.00   
+  2  0    2    2    180.4216   191.6414   0.0     2.78600  0.00   
+  2  0    4    1    353.8645   387.5360   -0.0    2.78271  0.00   
+  2  2    0    1    109.8515   109.5836   -0.0    2.68712  0.00   
+  2  3    1    -1   399.3014   431.0071   -180.0  2.66293  0.00   
+  2  1    -3   -2   6719.0914  6171.6319  -0.0    2.63839  0.04   
+  2  3    -1   -1   41.5985    33.5476    -180.0  2.62530  0.00   
+  2  2    4    -1   15867.5191 12550.4891 -180.0  2.55995  0.05   
+  2  3    1    -2   2433.3634  1812.0722  180.0   2.53704  0.01   
+  2  1    -1   2    1205.2696  667.2869   180.0   2.51139  0.01   
+  2  2    -2   1    2105.5635  1686.7859  -180.0  2.49495  0.01   
+  2  3    -1   -2   546.7046   451.5613   180.0   2.48043  0.00   
+  2  1    1    2    129.2951   110.2849   180.0   2.46610  0.00   
+  2  2    2    1    1594.5516  1367.0046  -180.0  2.45771  0.01   
+  2  2    -4   -1   11502.9103 10453.7459 -180.0  2.44277  0.03   
+  2  1    5    -1   4610.7195  4093.1663  -0.0    2.42941  0.01   
+  2  1    5    0    58.0510    64.0884    180.0   2.41202  0.00   
+  2  2    4    0    3644.1525  3944.1458  -0.0    2.40628  0.01   
+  2  1    -5   0    2134.4420  2230.8323  180.0   2.40074  0.01   
+  2  2    -4   0    2406.7775  2079.3222  -0.0    2.38844  0.01   
+  2  3    1    0    1882.7766  1565.2946  -0.0    2.38575  0.01   
+  2  3    -1   0    2343.8334  2090.0863  -0.0    2.37918  0.01   
+  2  2    0    -3   9.0569     7.3701     180.0   2.35133  0.00   
+  2  2    4    -2   3.0729     2.9331     0.0     2.34729  0.00   
+  2  1    1    -3   119.0629   110.8373   -0.0    2.33656  0.00   
+  2  0    4    -2   1309.8432  884.3144   -180.0  2.33087  0.00   
+  2  3    3    -1   19581.6420 9809.7794  180.0   2.31766  0.05   
+  2  1    -5   -1   2134.6567  1044.9800  0.0     2.31526  0.01   
+  2  1    -1   -3   2483.3500  2291.2470  -0.0    2.27750  0.01   
+  2  2    2    -3   178.5831   155.6865   -0.0    2.26146  0.00   
+  2  3    3    -2   19.6905    15.9172    0.0     2.25070  0.00   
+  2  3    -3   -1   3210.8535  2703.2457  -180.0  2.24518  0.01   
+  2  1    -3   2    840.2647   824.7896   -0.0    2.22556  0.00   
+  2  0    4    2    1853.5992  2085.0250  0.0     2.18812  0.01   
+  2  2    -4   -2   1272.5245  1431.8638  0.0     2.18799  0.00   
+  2  1    -5   1    3531.0165  4194.8986  180.0   2.18493  0.01   
+  2  2    -2   -3   1836.0978  1851.4932  0.0     2.15451  0.01   
+  2  1    5    -2   346.9346   312.7232   -180.0  2.15169  0.00   
+  2  3    1    -3   213.0550   204.6119   0.0     2.13824  0.00   
+  2  3    -3   -2   507.9092   512.1941   180.0   2.13724  0.00   
+  2  1    3    2    180.5985   174.4523   -180.0  2.13433  0.00   
+  2  0    0    3    485.7774   454.6548   -0.0    2.12929  0.00   
+  2  0    6    0    11395.4534 11042.6256 -0.0    2.12489  0.02   
+  2  1    3    -3   640.6103   674.2906   -180.0  2.11876  0.00   
+  2  1    5    1    4452.1473  4734.7647  180.0   2.11595  0.01   
+  2  3    3    0    1418.2327  1496.6439  -180.0  2.11318  0.00   
+  2  3    -3   0    109.5363   182.7827   -180.0  2.09956  0.00   
+  2  3    -1   -3   1307.9496  2416.5634  0.0     2.08973  0.00   
+  2  2    -4   1    7090.4797  8370.0925  180.0   2.07604  0.02   
+  2  0    2    -3   272.5174   286.8930   -180.0  2.05903  0.00   
+  2  0    6    -1   74.4241    83.9001    -0.0    2.05549  0.00   
+  2  2    4    1    1591.3879  2723.1302  180.0   2.03350  0.00   
+  2  4    0    -2   1234.0923  1673.8545  -0.0    2.01366  0.00   
+  2  1    -5   -2   786.1593   976.2191   -0.0    2.00557  0.00   
+  2  4    0    -1   3034.9590  3207.5402  -0.0    2.00025  0.01   
+  2  2    0    2    894.6601   914.6787   0.0     1.99827  0.00   
+  2  1    -3   -3   1824.8773  2006.9284  -0.0    1.99351  0.01   
+  2  0    2    3    1161.9305  1320.4879  0.0     1.98235  0.01   
+  2  0    6    1    4371.7988  4760.1395  0.0     1.97919  0.01   
+  2  3    -1   1    1527.2335  1778.1424  0.0     1.97162  0.00   
+  2  3    3    -3   589.4513   747.2487   -180.0  1.97003  0.00   
+  2  3    1    1    1135.4423  1049.8991  0.0     1.96352  0.00   
+  2  2    4    -3   228.5724   210.6125   -180.0  1.96339  0.00   
+  2  4    2    -2   1107.7087  1505.1300  0.0     1.94723  0.00   
+  2  2    -2   2    4246.7102  4434.5615  -0.0    1.92633  0.01   
+  2  4    2    -1   187.0874   195.3738   0.0     1.92397  0.00   
+  2  2    6    -1   23.6656    25.7092    -0.0    1.91781  0.00   
+  2  4    -2   -2   14873.2834 14612.2943 -0.0    1.89414  0.02   
+  2  4    -2   -1   85.0387    83.9894    180.0   1.89341  0.00   
+  2  3    5    -1   3189.5434  3253.1319  -180.0  1.88804  0.01   
+  2  2    2    2    11037.3030 11147.4650 -0.0    1.88782  0.03   
+  2  3    -3   -3   207.0590   242.1347   -0.0    1.86184  0.00   
+  2  3    5    -2   137.7655   151.7748   -180.0  1.86122  0.00   
+  2  4    0    -3   11478.0149 17227.6438 -180.0  1.84958  0.02   
+  2  2    -6   -1   652.8691   630.1904   -180.0  1.84310  0.00   
+  2  1    -5   2    35.0321    32.7906    -180.0  1.84286  0.00   
+  2  2    6    0    7959.0460  5973.8074  -0.0    1.84084  0.01   
+  2  2    6    -2   3844.7046  2234.4122  -180.0  1.83281  0.01   
+  2  1    -1   3    3674.0681  2403.8627  -180.0  1.82957  0.01   
+  2  2    -6   0    15315.5614 11170.3478 0.0     1.82883  0.02   
+  2  2    -4   -3   459.3325   351.5785   -0.0    1.82817  0.00   
+  2  0    4    -3   7430.2213  6600.1943  180.0   1.82454  0.02   
+  2  3    -5   -1   574.4002   547.0575   -180.0  1.82305  0.00   
+  2  0    6    -2   9834.3714  9376.7847  -180.0  1.82300  0.02   
+  2  4    0    0    16517.7909 16544.7345 -0.0    1.81888  0.03   
+  2  3    -3   1    1332.7013  1388.1619  -0.0    1.81269  0.00   
+  2  4    2    -3   1634.6228  1698.2109  -0.0    1.80678  0.00   
+  2  1    1    3    11028.9435 13204.6231 -180.0  1.80269  0.04   
+  2  3    3    1    433.2348   659.8672   -0.0    1.79396  0.00   
+  2  1    5    -3   26.2176    36.9138    180.0   1.79152  0.00   
+  2  1    7    -1   288.1544   370.2527   -180.0  1.78554  0.00   
+  2  2    0    -4   23499.8976 29304.7955 0.0     1.78457  0.07   
+  2  1    7    0    1666.1380  1186.7943  -0.0    1.76994  0.00   
+  2  3    5    0    543.7071   192.4714   -180.0  1.76391  0.00   
+  2  1    -7   0    5424.2417  1861.7091  0.0     1.76369  0.01   
+  2  1    5    2    5651.3574  1478.1411  -180.0  1.75728  0.01   
+  2  3    -5   -2   974.4470   292.8600   -180.0  1.75539  0.00   
+  2  2    2    -4   11657.1452 5374.4235  180.0   1.75260  0.03   
+  2  4    2    0    6996.6533  3240.2714  180.0   1.75255  0.01   
+  2  3    -5   0    1.2789     0.6787     -180.0  1.75073  0.00   
+  2  4    -2   -3   2343.4548  1498.9920  -180.0  1.74735  0.00   
+  2  4    -2   0    2212.8680  1478.3757  -180.0  1.74562  0.00   
+  2  4    4    -2   12135.7203 11156.5991 -180.0  1.74061  0.02   
+  2  3    1    -4   15.3201    11.6942    0.0     1.73791  0.00   
+  2  1    1    -4   1332.8395  931.5858   180.0   1.73044  0.00   
+  2  0    4    3    1734.0608  1649.4123  180.0   1.72108  0.00   
+  2  1    -7   -1   570.5367   544.5769   -0.0    1.72100  0.00   
+  2  2    -4   2    5287.4467  5111.9528  -180.0  1.72066  0.01   
+  2  0    6    2    4111.6571  4043.0244  180.0   1.71979  0.01   
+  2  2    -6   -2   5826.5371  5843.5104  180.0   1.71808  0.01   
+  2  1    -3   3    3869.5625  3889.7621  0.0     1.71755  0.01   
+  2  4    4    -1   3492.9789  3425.3612  -0.0    1.71605  0.00   
+  2  3    -1   -4   39.7616    26.3196    -0.0    1.70384  0.00   
+  2  3    5    -3   2522.9689  1781.5059  180.0   1.70048  0.00   
+  2  1    -1   -4   1640.1655  1087.2281  180.0   1.69839  0.01   
+  2  2    -2   -4   7119.0520  6607.2640  -0.0    1.68632  0.02   
+  2  2    -6   1    126.3669   111.8094   180.0   1.68403  0.00   
+  2  1    -7   1    1371.6243  1037.6002  0.0     1.67991  0.00   
+  2  1    7    -2   4279.8269  3014.1863  0.0     1.67337  0.01   
+  2  4    -4   -1   4399.4008  3113.5342  -0.0    1.67328  0.01   
+  2  1    -5   -3   363.7236   322.6770   -180.0  1.66739  0.00   
+  2  2    4    2    7687.5180  6980.1241  -180.0  1.66673  0.02   
+  2  4    -4   -2   3292.2727  2996.9232  -180.0  1.66656  0.00   
+  2  1    3    3    607.7874   605.4945   0.0     1.65314  0.00   
+  2  3    3    -4   491.2200   474.5918   180.0   1.65084  0.00   
+  2  2    6    1    15.6879    15.0623    180.0   1.64996  0.00   
+  2  4    4    -3   86.7576    81.5092    0.0     1.64497  0.00   
+  2  1    3    -4   1323.2953  1267.0308  -180.0  1.64299  0.00   
+  2  2    6    -3   385.3158   438.3802   0.0     1.63845  0.00   
+  2  1    7    1    862.6274   959.6711   0.0     1.63566  0.00   
+  2  5    1    -2   52.6144    62.3555    -180.0  1.62122  0.00   
+  2  2    4    -4   7.5658     6.6299     0.0     1.60885  0.00   
+  2  3    -1   2    268.2717   237.1891   -180.0  1.60779  0.00   
+  2  4    0    -4   28.8653    25.5451    0.0     1.60742  0.00   
+  2  5    -1   -2   122.5931   104.4782   -0.0    1.60481  0.00   
+  2  3    1    2    5.2627     3.3755     -180.0  1.59704  0.00   
+  2  0    0    4    2689.1823  1719.5025  -0.0    1.59697  0.01   
+  2  0    8    0    6784.0094  4104.7411  -0.0    1.59366  0.01   
+  2  3    -5   -3   7779.2131  7048.0684  -180.0  1.58673  0.01   
+  2  4    2    -4   5949.2017  5767.4424  -180.0  1.58523  0.01   
+  2  4    4    0    82.5773    80.5872    180.0   1.58489  0.00   
+  2  3    -5   1    3624.9969  3541.7994  0.0     1.57987  0.00   
+  2  1    -7   -2   123.9238   106.0592   180.0   1.57566  0.00   
+  2  4    -4   0    1116.1011  972.7791   180.0   1.57467  0.00   
+  2  4    0    1    1528.2845  1313.3627  0.0     1.57405  0.00   
+  2  0    2    -4   7882.8944  6835.8768  -180.0  1.57267  0.02   
+  2  5    1    -1   2086.3543  1838.8969  0.0     1.57223  0.00   
+  2  5    1    -3   4.7392     4.5305     0.0     1.57056  0.00   
+  2  0    8    -1   5072.2793  5105.5113  -180.0  1.56971  0.01   
+  2  3    -3   -4   206.3108   222.0271   -180.0  1.56739  0.00   
+  2  1    -3   -4   1107.9153  1168.3240  -180.0  1.56437  0.00   
+  2  5    -1   -1   3437.2388  3532.8589  -0.0    1.56314  0.00   
+  2  3    5    1    6106.3110  6630.5027  -0.0    1.55930  0.01   
+  2  2    0    3    1618.5273  1763.6711  -180.0  1.55911  0.00   
+  2  4    -4   -3   611.1001   668.2938   0.0     1.55805  0.00   
+  2  0    6    -3   51.0501    50.4752    180.0   1.55391  0.00   
+  2  5    -1   -3   3416.6073  3177.9812  180.0   1.54983  0.00   
+  2  5    3    -2   1815.6385  1684.3120  0.0     1.53962  0.00   
+  2  3    7    -1   366.5052   255.3064   -0.0    1.53554  0.00   
+  2  4    -2   -4   6897.0448  4566.3850  180.0   1.53333  0.01   
+  2  4    -2   1    555.3251   360.2122   -0.0    1.53138  0.00   
+  2  2    -2   3    5213.1945  3884.5431  0.0     1.52972  0.01   
+  2  1    -5   3    156.0408   114.2358   180.0   1.52775  0.00   
+  2  0    2    4    2635.1878  1999.2534  180.0   1.52655  0.01   
+  2  3    7    -2   1865.6482  1417.6951  180.0   1.52649  0.00   
+  2  4    2    1    74.8020    55.0425    -0.0    1.52494  0.00   
+  2  0    8    1    76.7777    53.4117    0.0     1.52385  0.00   
+  2  3    -3   2    1062.2291  713.5252   0.0     1.52351  0.00   
+  2  2    -6   -3   1471.4320  972.3599   180.0   1.52111  0.00   
+  2  1    -7   2    2828.4764  2092.8268  180.0   1.51406  0.00   
+  2  2    -4   -4   4183.2175  3475.0688  -180.0  1.51008  0.01   
+  2  2    8    -1   8880.1272  8932.7653  0.0     1.50687  0.01   
+  2  5    3    -3   11303.6354 11216.4371 -0.0    1.50125  0.01   
+  2  2    2    3    251.9261   261.4234   0.0     1.49966  0.00   
+  2  5    -3   -2   1246.0409  1283.3165  0.0     1.49852  0.00   
+  2  4    6    -2   1584.7864  1643.4734  -180.0  1.49804  0.00   
+  2  3    3    2    2649.9514  2828.3266  0.0     1.49651  0.00   
+  2  5    3    -1   1432.5529  1375.8687  180.0   1.49230  0.00   
+  2  1    7    -3   998.3490   963.7100   -0.0    1.49138  0.00   
+  2  3    5    -4   1003.3271  976.7543   0.0     1.48741  0.00   
+  2  3    -7   -1   4.4772     4.1505     -180.0  1.48641  0.00   
+  2  2    -6   2    2299.1588  2225.9899  -180.0  1.48209  0.00   
+  2  1    5    -4   547.7520   569.2303   -0.0    1.48061  0.00   
+  2  4    4    -4   1018.2803  936.8644   -0.0    1.47752  0.00   
+  2  4    6    -1   2690.0761  2425.3077  -0.0    1.47727  0.00   
+  2  2    8    -2   2619.6394  2036.6290  -0.0    1.46947  0.00   
+  2  5    -3   -1   2918.2114  2250.7625  180.0   1.46932  0.00   
+  2  0    4    -4   2243.9846  1799.2981  0.0     1.46530  0.00   
+  2  2    8    0    20520.2755 17372.8918 180.0   1.46378  0.02   
+  2  0    8    -2   3141.6761  2670.5014  0.0     1.46338  0.00   
+  2  3    7    0    1576.7859  1344.4772  -0.0    1.46164  0.00   
+  2  0    6    3    10269.0333 9727.2084  -180.0  1.45874  0.02   
+  2  2    -8   -1   303.3630   277.6153   0.0     1.45806  0.00   
+  2  2    -8   0    15975.5259 14971.6548 -180.0  1.45572  0.02   
+  2  1    5    3    87.5285    84.4701    0.0     1.45352  0.00   
+  2  3    -7   0    1805.1801  1874.7884  -0.0    1.45113  0.00   
+  2  5    -3   -3   3883.1925  3973.0050  -0.0    1.44873  0.00   
+  2  1    7    2    343.6355   339.6716   180.0   1.44736  0.00   
+  2  5    1    0    476.3633   468.7582   0.0     1.44694  0.00   
+  2  5    -1   0    282.9247   282.6566   0.0     1.44450  0.00   
+  2  3    -7   -2   410.3996   407.5222   -180.0  1.44435  0.00   
+  2  5    1    -4   378.8477   376.0669   -0.0    1.44434  0.00   
+  2  4    6    -3   5099.8858  4799.2632  180.0   1.44037  0.00   
+  2  3    7    -3   2321.3084  2066.9126  0.0     1.43858  0.00   
+  2  4    -6   -1   16301.5415 13974.0377 -0.0    1.43651  0.02   
+  2  1    -1   4    2141.1874  1747.7612  -0.0    1.43156  0.00   
+  2  2    6    2    16361.2346 14127.5120 -180.0  1.43067  0.03   
+  2  4    -6   -2   12390.8602 11494.7453 -180.0  1.42772  0.01   
+  2  3    1    -5   57.2510    54.5453    0.0     1.42498  0.00   
+  2  2    -4   3    9777.3889  9304.7725  -0.0    1.42492  0.01   
+  2  5    -1   -4   6660.8853  6191.0063  0.0     1.42367  0.01   
+  2  2    0    -5   568.4136   530.6717   -0.0    1.41970  0.00   
+  2  2    6    -4   4426.3625  4109.1661  -0.0    1.41942  0.01   
+  2  4    -4   1    2250.0101  2328.2327  -180.0  1.41643  0.00   
+  2  1    1    4    9636.7169  9765.5200  -0.0    1.41417  0.02   
+  2  2    2    -5   147.7943   102.1798   180.0   1.40774  0.00   
+  2  4    4    1    5517.5791  4251.1055  -180.0  1.40628  0.01   
+  2  1    9    -1   539.3824   313.3806   180.0   1.40427  0.00   
+  2  3    -1   -5   894.9104   559.2035   180.0   1.40173  0.00   
+  2  5    5    -2   177.0959   121.8591   180.0   1.39689  0.00   
+  2  4    -4   -4   481.8542   333.7965   -180.0  1.39638  0.00   
+  2  5    3    -4   11909.7857 10290.7248 -180.0  1.39407  0.01   
+  2  0    4    4    740.1695   603.2489   180.0   1.39300  0.00   
+  2  1    9    0    7525.7609  6061.3448  -180.0  1.39244  0.01   
+  2  0    8    2    930.2593   841.8614   -0.0    1.39135  0.00   
+  2  1    -7   -3   9.2506     8.6161     0.0     1.39082  0.00   
+  2  2    -8   -2   449.4119   389.1003   0.0     1.38958  0.00   
+  2  1    -9   0    5341.2445  5032.6219  -180.0  1.38852  0.00   
+  2  3    -5   -4   728.7941   712.8918   180.0   1.38828  0.00   
+  2  1    -5   -4   10.8938    12.2841    -0.0    1.38705  0.00   
+  2  4    6    0    6103.3672  6881.9956  0.0     1.38694  0.01   
+  2  2    -8   1    2132.0206  2583.5813  -0.0    1.38353  0.00   
+  2  3    -5   2    93.1746    107.7060   180.0   1.38139  0.00   
+  2  1    -3   4    9188.6018  11498.8556 180.0   1.38001  0.02   
+  2  3    3    -5   473.1903   601.2645   -0.0    1.37984  0.00   
+  2  5    3    0    1621.8316  2064.1961  180.0   1.37983  0.00   
+  2  2    4    3    5702.1855  7682.9819  -0.0    1.37735  0.01   
+  2  4    -6   0    2111.8483  2929.6322  0.0     1.37669  0.00   
+  2  5    -3   0    1290.4546  1846.9850  -180.0  1.37349  0.00   
+  2  4    0    -5   6922.6049  9852.1453  -0.0    1.37263  0.01   
+  2  5    5    -3   745.6649   1000.1841  -0.0    1.37203  0.00   
+  2  1    1    -5   63.2063    51.8333    180.0   1.36876  0.00   
+  2  2    8    -3   1373.3731  897.0709   0.0     1.36740  0.00   
+  2  2    -2   -5   1347.0783  890.9937   -180.0  1.36475  0.00   
+  2  1    -9   -1   3430.7986  2521.2414  180.0   1.36346  0.00   
+  2  4    2    -5   14136.0228 11335.5971 180.0   1.36264  0.02   
+  2  2    8    1    4224.4211  3611.9875  -180.0  1.35827  0.00   
+  2  5    5    -1   1053.4940  870.4892   -180.0  1.35737  0.00   
+  2  4    -6   -3   4373.8772  4126.3352  180.0   1.35385  0.00   
+  2  3    -7   1    623.9461   576.4772   0.0     1.35312  0.00   
+  2  1    9    -2   14529.6867 16147.0686 0.0     1.35152  0.01   
+  2  6    0    -2   14997.2011 16981.3924 180.0   1.35133  0.01   
+  2  1    -9   1    3338.9795  3741.5161  -0.0    1.35032  0.00   
+  2  1    -1   -5   9658.3435  10683.9602 -0.0    1.34891  0.02   
+  2  3    5    2    193.3569   209.3398   0.0     1.34817  0.00   
+  2  5    -5   -2   519.9820   568.7530   180.0   1.34647  0.00   
+  2  4    0    2    16506.9049 20266.7951 180.0   1.34356  0.02   
+  2  6    0    -3   384.4535   424.9852   0.0     1.34244  0.00   
+  2  3    -7   -3   916.9365   987.1236   180.0   1.34218  0.00   
+  2  5    -3   -4   18.6513    19.4544    -0.0    1.34037  0.00   
+  2  3    7    1    789.3033   545.2034   0.0     1.33504  0.00   
+  2  1    3    4    434.9781   303.9072   180.0   1.33473  0.00   
+  2  2    4    -5   2431.2064  2138.1647  -0.0    1.33359  0.00   
+  2  6    2    -2   7505.5497  7470.5514  0.0     1.33146  0.01   
+  2  3    -1   3    526.8931   551.6386   -0.0    1.32984  0.00   
+  2  5    -5   -1   2805.5805  3077.6343  -180.0  1.32879  0.00   
+  2  1    -7   3    750.3996   845.5145   -180.0  1.32789  0.00   
+  2  1    3    -5   11455.8474 12956.3684 180.0   1.32785  0.02   
+  2  4    6    -4   1038.3410  1219.1637  0.0     1.32754  0.00   
+  2  6    2    -3   5.1330     6.0091     -0.0    1.32656  0.00   
+  2  4    -2   -5   2829.8514  3146.4347  0.0     1.32203  0.00   
+  2  1    9    1    962.6676   1105.1306  -0.0    1.32057  0.00   
+  2  4    -2   2    1903.7006  2255.4357  0.0     1.32028  0.00   
+  2  3    1    3    2701.0331  3237.6008  0.0     1.32015  0.00   
+  2  2    -6   -4   93.1285    114.0134   0.0     1.31919  0.00   
+  2  3    -3   -5   1781.3581  2179.7868  180.0   1.31918  0.00   
+  2  0    6    -4   3034.6570  3685.3963  0.0     1.31717  0.00   
+  2  0    8    -3   3807.8551  4546.6333  -0.0    1.31636  0.00   
+  2  6    -2   -2   305.1190   330.6363   180.0   1.31265  0.00   
+  2  4    2    2    581.4175   505.4413   0.0     1.30914  0.00   
+  2  5    -5   -3   7043.6306  6208.9517  0.0     1.30653  0.01   
+  2  3    7    -4   15.4270    11.5530    -180.0  1.30602  0.00   
+  2  6    0    -1   1083.7063  635.2341   -0.0    1.30261  0.00   
+  2  6    -2   -3   7866.4996  4797.6968  0.0     1.30107  0.01   
+  2  1    7    -4   1374.0467  816.7390   180.0   1.30069  0.00   
+  2  4    4    -5   1380.2343  839.8412   -180.0  1.29576  0.00   
+  2  5    -1   1    941.8947   560.8179   -180.0  1.29287  0.00   
+  2  5    5    -4   162.7033   102.0732   -0.0    1.29210  0.00   
+  2  5    1    1    322.4145   213.0414   180.0   1.29128  0.00   
+  2  5    1    -5   1474.6531  1297.0866  -180.0  1.28850  0.00   
+  2  1    -9   -2   7676.5272  7594.2794  0.0     1.28440  0.01   
+  2  3    -3   3    3759.0297  3821.2749  180.0   1.28422  0.00   
+  2  2    -6   3    90.3300    97.9036    -0.0    1.28363  0.00   
+  2  3    5    -5   2851.3777  3037.5557  -0.0    1.28334  0.00   
+  2  6    2    -1   2480.1691  2446.8719  180.0   1.28151  0.00   
+  2  4    8    -2   15882.5509 16043.2073 -0.0    1.27998  0.01   
+  2  6    0    -4   4746.4607  4642.8182  0.0     1.27913  0.00   
+  2  1    -5   4    0.2808     0.2762     -0.0    1.27885  0.00   
+  2  0    0    5    1509.1878  1504.7953  0.0     1.27757  0.00   
+  2  2    -8   -3   1065.0823  969.8153   0.0     1.27578  0.00   
+  2  1    -3   -5   1809.7494  1649.0848  -180.0  1.27554  0.00   
+  2  0    10   0    6255.9573  5612.4673  -0.0    1.27493  0.01   
+  2  3    9    -1   703.6411   567.6734   180.0   1.27318  0.00   
+  2  3    9    -2   276.1022   209.3409   0.0     1.27118  0.00   
+  2  6    -2   -1   789.9871   604.9530   -180.0  1.27102  0.00   
+  2  5    -1   -5   3998.9177  3287.3648  -0.0    1.27057  0.00   
+  2  4    -6   1    2534.9507  2157.0193  180.0   1.27033  0.00   
+  2  2    0    4    5123.8636  5970.9564  -0.0    1.26862  0.01   
+  2  6    2    -4   2220.1810  2642.8907  -180.0  1.26852  0.00   
+  2  0    2    -5   3265.9525  4140.6925  180.0   1.26818  0.01   
+  2  2    -8   2    12072.1896 15669.9235 0.0     1.26800  0.01   
+  2  5    5    0    1176.9376  1539.1640  -0.0    1.26791  0.00   
+  2  0    10   -1   619.1467   722.1628   -180.0  1.26570  0.00   
+  2  4    8    -1   121.3910   116.1733   180.0   1.26381  0.00   
+  2  2    -4   -5   34.1349    34.2839    180.0   1.26302  0.00   
+  2  1    -9   2    406.0799   407.6104   0.0     1.26267  0.00   
+  2  6    4    -2   4272.9767  4060.9393  -0.0    1.26012  0.00   
+  2  1    7    3    1533.2638  1423.0605  -180.0  1.25993  0.00   
+  2  5    -5   0    1362.9484  1251.7915  -0.0    1.25974  0.00   
+  2  4    6    1    37.8273    35.4122    180.0   1.25938  0.00   
+  2  6    4    -3   6004.6300  5742.7030  -180.0  1.25904  0.00   
+  2  3    3    3    35.1147    34.1056    0.0     1.25855  0.00   
+  2  2    -2   4    2820.1382  2630.4316  180.0   1.25569  0.00   
+  2  5    3    -5   8490.4824  7849.9862  180.0   1.25548  0.01   
+  2  1    9    -3   500.4729   446.4585   -180.0  1.25310  0.00   
+  2  4    -4   2    3197.3930  2913.1494  0.0     1.24747  0.00   
+  2  4    8    -3   1611.8176  1591.0184  -180.0  1.24643  0.00   
+  2  5    -3   1    161.7634   154.1169   -180.0  1.24419  0.00   
+  2  4    -6   -4   4595.3782  4649.8078  0.0     1.24074  0.00   
+  2  1    5    -5   20.4717    20.8490    -0.0    1.24058  0.00   
+  2  6    -2   -4   113.8169   116.0421   -0.0    1.24022  0.00   
+  2  5    3    1    850.8972   865.0651   -180.0  1.23993  0.00   
+  2  0    6    4    4350.4515  4402.8269  -0.0    1.23960  0.01   
+  2  0    8    3    2539.8859  2523.8232  0.0     1.23892  0.00   
+  2  5    7    -2   47.3270    48.4702    -180.0  1.23815  0.00   
+  2  0    2    5    5.9269     6.1649     -0.0    1.23770  0.00   
+  2  3    -9   -1   1959.5731  1878.7146  -180.0  1.23697  0.00   
+  2  0    10   1    78.3571    69.0195    180.0   1.23540  0.00   
+  2  2    8    -4   0.7217     0.6712     -0.0    1.23509  0.00   
+  2  2    2    4    268.2740   202.3679   180.0   1.23305  0.00   
+  2  2    10   -1   828.4506   674.5837   -0.0    1.23266  0.00   
+  2  2    6    3    619.0189   591.5126   -0.0    1.23202  0.00   
+  2  4    -8   -1   1542.8697  1660.8265  180.0   1.22975  0.00   
+  2  4    4    2    6256.1503  7216.8110  -0.0    1.22886  0.01   
+  2  6    -4   -2   6378.6685  7429.0559  0.0     1.22874  0.00   
+  2  4    -4   -5   5099.9827  5935.8119  180.0   1.22833  0.01   
+  2  3    9    0    192.1309   207.1256   180.0   1.22722  0.00   
+  2  2    8    2    16694.6090 16367.8700 -0.0    1.22501  0.02   
+  2  3    -7   2    4.5360     4.4310     -180.0  1.22493  0.00   
+  2  5    7    -3   816.8430   701.3947   180.0   1.22357  0.00   
+  2  5    -5   -4   559.0196   527.2945   -180.0  1.22255  0.00   
+  2  2    6    -5   96.8221    93.3157    -0.0    1.22244  0.00   
+  2  3    9    -3   3837.4036  3989.5508  -0.0    1.22187  0.00   
+  2  4    -8   -2   14892.0157 15576.6760 0.0     1.22139  0.01   
+  2  1    5    4    2822.2926  2923.6151  -180.0  1.22003  0.00   
+  2  3    -9   0    63.5259    63.1939    -0.0    1.21922  0.00   
+  2  6    -4   -3   2.1064     1.6171     -180.0  1.21643  0.00   
+  2  6    4    -1   12.3782    10.2523    180.0   1.21473  0.00   
+  2  2    10   -2   3858.7846  3195.8904  -180.0  1.21471  0.00   
+  2  3    -7   -4   10.9976    9.5153     0.0     1.21279  0.00   
+  2  6    0    0    15108.2221 13100.2263 0.0     1.21259  0.01   
+  2  1    9    2    2017.8924  1749.7864  0.0     1.21259  0.00   
+  2  0    4    -5   59.2781    51.4047    -180.0  1.21258  0.00   
+  2  1    -7   -4   776.4372   673.8718   0.0     1.21254  0.00   
+  2  6    4    -4   222.1781   199.9465   0.0     1.21185  0.00   
+  2  0    10   -2   2669.4120  2393.1814  180.0   1.21068  0.00   
+  2  3    -9   -2   2.6770     2.4088     0.0     1.20966  0.00   
+  2  5    7    -1   1004.0305  919.5910   -0.0    1.20764  0.00   
+  2  5    -3   -5   1819.2091  1669.4106  -180.0  1.20756  0.00   
+  2  2    10   0    13.5604    11.8619    180.0   1.20601  0.00   
+  2  3    -5   -5   5758.4500  5223.5291  -0.0    1.20426  0.01   
+  2  4    8    0    2350.1538  2036.1638  -180.0  1.20314  0.00   
+  2  2    -10  0    1200.2991  1234.3417  180.0   1.20037  0.00   
+  2  2    -10  -1   1746.2988  1881.5821  0.0     1.19900  0.00   
+  2  2    -4   4    0.0038     0.0043     180.0   1.19841  0.00   
+  2  3    -5   3    4579.1833  5149.8089  -180.0  1.19827  0.00   
+  2  6    -4   -1   3471.2701  4013.4094  180.0   1.19705  0.00   
+  2  4    -8   0    1740.5693  1701.7086  -180.0  1.19422  0.00   
+  2  4    6    -5   5762.9090  5356.2972  -0.0    1.19366  0.01   
+  2  6    2    0    7991.9484  6359.8747  -180.0  1.19287  0.01   
+  2  3    1    -6   223.1199   172.0799   180.0   1.19278  0.00   
+  2  3    7    2    288.2946   210.6961   180.0   1.19262  0.00   
+  2  6    -2   0    2566.6814  1825.4606  -180.0  1.18959  0.00   
+  2  5    -7   -2   328.4722   235.2689   -180.0  1.18926  0.00   
+  2  5    5    -5   646.6713   652.0282   -0.0    1.18202  0.00   
+  2  6    0    -5   1883.5331  1859.8386  -0.0    1.18139  0.00   
+  2  5    -7   -1   1136.6432  1170.6276  -0.0    1.17956  0.00   
+  2  3    -1   -6   9439.6303  10651.6340 0.0     1.17652  0.01   
+  2  1    -9   -3   3002.0186  3479.3329  -0.0    1.17569  0.00   
+  2  4    0    -6   600.1953   694.8770   -180.0  1.17567  0.00   
+  2  6    2    -5   599.4071   690.4314   180.0   1.17553  0.00   
+  2  4    8    -4   4535.9469  5262.2410  180.0   1.17365  0.00   
+  2  1    -1   5    38.5355    44.3347    0.0     1.17349  0.00   
+  2  2    0    -6   3026.0804  3262.2227  -180.0  1.17258  0.01   
+  2  4    2    -6   722.7864   785.7923   0.0     1.17185  0.00   
+  2  4    -8   -3   466.3518   512.5086   -0.0    1.17167  0.00   
+  2  1    -5   -5   4893.3993  5414.4867  -180.0  1.17131  0.01   
+  2  3    3    -6   3291.1545  3178.6335  180.0   1.16840  0.00   
+  2  5    7    -4   6181.0861  5932.4007  0.0     1.16833  0.00   
+  2  2    2    -6   464.9924   444.4424   0.0     1.16828  0.00   
+  2  0    8    -4   6492.5768  6734.2463  -180.0  1.16544  0.01   
+  2  3    5    3    7837.3822  9033.3981  -180.0  1.16397  0.01   
+  2  6    -4   -4   1186.5544  1331.0105  -180.0  1.16381  0.00   
+  2  3    7    -5   1062.6968  1180.8749  180.0   1.16377  0.00   
+  2  3    -9   1    27.6779    24.5109    -0.0    1.16177  0.00   
+  2  1    1    5    2272.6272  1984.2370  0.0     1.16142  0.00   
+  2  2    -10  1    468.7988   408.7012   -180.0  1.16134  0.00   
+  2  0    4    5    4436.4687  3674.6390  -180.0  1.16082  0.01   
+  2  6    6    -3   741.7378   572.9928   0.0     1.16041  0.00   
+  2  5    -5   1    10.6604    8.2052     180.0   1.16017  0.00   
+  2  7    1    -3   417.1045   326.8856   180.0   1.15995  0.00   
+  2  2    4    4    424.8499   334.7388   180.0   1.15990  0.00   
+  2  0    10   2    2501.5691  1953.1670  -180.0  1.15916  0.00   
+  2  5    -7   -3   17.9682    13.9221    0.0     1.15905  0.00   
+  2  6    6    -2   1378.9679  1062.5954  180.0   1.15883  0.00   
+  2  2    -10  -2   1081.3257  927.1428   -180.0  1.15763  0.00   
+  2  2    10   -3   528.4451   456.9863   180.0   1.15752  0.00   
+  2  1    -7   4    8901.9560  7894.1741  -0.0    1.15699  0.01   
+  2  1    11   -1   181.4985   172.4013   -0.0    1.15488  0.00   
+  2  5    5    1    15.6363    14.5872    180.0   1.15443  0.00   
+  2  4    0    3    418.1234   372.8509   -0.0    1.15214  0.00   
+  2  7    -1   -3   211.1866   190.7937   -0.0    1.15103  0.00   
+  2  1    -9   3    432.3401   390.2848   -180.0  1.15086  0.00   
+  2  7    1    -2   513.2056   417.6649   180.0   1.14957  0.00   
+  2  6    -2   -5   3.5402     3.3422     180.0   1.14818  0.00   
+  2  2    -8   -4   1376.2944  1241.1393  -0.0    1.14713  0.00   
+  2  3    9    1    950.7162   840.9132   -180.0  1.14703  0.00   
+  2  1    -3   5    151.8280   131.0137   -0.0    1.14691  0.00   
+  2  4    -6   2    1088.3403  884.2580   -180.0  1.14653  0.00   
+  2  1    11   0    724.2876   673.8595   0.0     1.14593  0.00   
+  2  3    -9   -3   6191.9247  6842.7549  -0.0    1.14539  0.01   
+  2  1    -11  0    51.9631    56.5171    180.0   1.14326  0.00   
+  2  7    -1   -2   234.3334   258.5173   180.0   1.14319  0.00   
+  2  2    10   1    1816.0652  2221.3310  -180.0  1.14260  0.00   
+  2  2    -6   -5   6759.0852  8280.7099  -0.0    1.14253  0.01   
+  2  5    -1   2    0.2080     0.2523     -180.0  1.14237  0.00   
+  2  4    -2   -6   131.5406   159.9954   -0.0    1.14109  0.00   
+  2  5    7    0    1287.5413  1584.2307  0.0     1.14103  0.00   
+  2  3    9    -4   3181.0682  3452.1120  -180.0  1.13977  0.00   
+  2  4    -2   3    653.3735   675.3480   180.0   1.13965  0.00   
+  2  2    -8   3    951.3010   940.5804   180.0   1.13923  0.00   
+  2  5    1    2    142.1834   151.0052   180.0   1.13897  0.00   
+  2  2    -2   -6   397.0419   457.5743   180.0   1.13875  0.00   
+  2  5    1    -6   86.7901    92.8501    180.0   1.13644  0.00   
+  2  6    4    0    8621.3437  9886.1889  -180.0  1.13618  0.01   
+  2  1    9    -4   5247.9166  6387.1239  180.0   1.13575  0.00   
+  2  7    1    -4   88.5127    104.3489   0.0     1.13318  0.00   
+  2  5    -7   0    470.8872   561.3250   0.0     1.13270  0.00   
+  2  6    4    -5   2988.5689  3560.8356  -0.0    1.13225  0.00   
+  2  7    3    -3   1611.2767  1752.7599  180.0   1.13164  0.00   
+  2  1    7    -5   1759.3579  1876.4532  -0.0    1.13113  0.00   
+  2  4    4    -6   60.8384    74.0198    180.0   1.13073  0.00   
+  2  6    -4   0    6755.3548  8996.3605  -180.0  1.13052  0.01   
+  2  1    1    -6   9.2859     12.7255    180.0   1.13041  0.00   
+  2  4    2    3    21.7976    26.9687    0.0     1.12798  0.00   
+  2  1    11   -2   3282.4613  4054.5939  -180.0  1.12721  0.00   
+  2  2    4    -6   506.6028   617.9103   -180.0  1.12706  0.00   
+  2  1    -11  -1   65.9581    80.5660    180.0   1.12692  0.00   
+  2  0    6    -5   665.2204   825.3110   -0.0    1.12677  0.00   
+  2  0    10   -3   22.6508    25.1309    180.0   1.12560  0.00   
+  2  6    6    -4   1056.8877  1116.6065  -0.0    1.12535  0.00   
+  2  4    -8   1    1416.7681  1428.0735  -0.0    1.12500  0.00   
+  2  4    6    2    488.4370   491.6513   180.0   1.12497  0.00   
+  2  3    -3   -6   2639.0709  2679.1058  0.0     1.12421  0.00   
+  2  1    -11  1    528.4984   520.4388   180.0   1.12385  0.00   
+  2  3    -1   4    61.2739    62.3074    180.0   1.12290  0.00   
+  2  7    -1   -4   330.6752   340.7362   180.0   1.12266  0.00   
+  2  6    -6   -2   5.6882     5.8815     -0.0    1.12259  0.00   
+  2  5    -1   -6   3363.4938  3679.1020  -180.0  1.12188  0.00   
+  2  6    6    -1   22.4003    18.5196    -180.0  1.12105  0.00   
+  2  7    3    -2   427.6700   466.2613   -180.0  1.11981  0.00   
+  2  5    -5   -5   2861.4588  3254.1700  180.0   1.11710  0.00   
+  2  1    -1   -6   1419.4048  1573.1101  -180.0  1.11699  0.00   
+  2  4    -6   -5   12.9909    12.1624    -180.0  1.11621  0.00   
+  2  5    3    -6   4204.8458  3572.8767  0.0     1.11574  0.00   
+  2  3    1    4    671.4688   557.2568   180.0   1.11489  0.00   
+  2  4    8    1    3646.7294  3030.2470  -0.0    1.11486  0.00   
+  2  1    3    5    265.4056   208.8946   -180.0  1.11404  0.00   
+  2  2    -6   4    2381.5148  1626.0861  -0.0    1.11278  0.00   
+  2  6    -6   -3   12143.1838 9170.8262  180.0   1.11104  0.01   
+  2  5    -3   2    30.2197    23.9804    -180.0  1.11049  0.00   
+  2  3    5    -6   94.1108    75.3696    -0.0    1.11017  0.00   
+  2  1    3    -6   4376.7179  3749.4968  0.0     1.10915  0.01   
+  2  7    3    -4   987.2078   851.8273   -0.0    1.10885  0.00   
+  2  7    -3   -3   9.3055     8.0510     -0.0    1.10731  0.00   
+  2  7    1    -1   612.2508   540.2195   -180.0  1.10485  0.00   
+  2  6    0    1    3141.9409  2851.2916  180.0   1.10441  0.00   
+  2  1    11   1    381.7599   353.4958   0.0     1.10278  0.00   
+  2  7    -3   -2   8.0967     7.6618     -0.0    1.10240  0.00   
+  2  4    10   -2   318.9308   293.9448   -180.0  1.10139  0.00   
+  2  7    -1   -1   613.5236   560.8360   -180.0  1.10125  0.00   
+  2  5    3    2    101.5473   92.4856    -180.0  1.10119  0.00   
+  2  2    8    -5   4189.6011  3728.5603  180.0   1.10077  0.00   
+  2  6    -6   -1   6.8871     6.2337     0.0     1.10033  0.00   
+  2  5    -7   -4   144.2314   136.6182   0.0     1.09716  0.00   
+  2  3    -3   4    150.6037   143.6453   -0.0    1.09706  0.00   
+  2  1    7    4    56.7978    57.0295    -0.0    1.09661  0.00   
+  2  0    8    4    2875.0229  2959.2417  180.0   1.09406  0.00   
+  2  4    -8   -4   3565.3341  3685.4545  -180.0  1.09399  0.00   
+  2  4    -4   3    2120.0416  2186.7268  180.0   1.09385  0.00   
+  2  3    -7   3    1759.8358  1814.2931  0.0     1.09384  0.00   
+  2  1    9    3    299.3080   308.2223   180.0   1.09383  0.00   
+  2  2    -10  2    4.3520     3.3265     -0.0    1.09247  0.00   
+  2  2    8    3    483.8681   379.8198   0.0     1.09126  0.00   
+  2  5    9    -2   2351.5655  1582.6840  -0.0    1.09021  0.00   
+  2  4    10   -1   2.5041     1.7369     -180.0  1.08903  0.00   
+  2  6    -2   1    2.1966     1.5406     -180.0  1.08894  0.00   
+  2  1    -5   5    8011.6208  5646.2565  0.0     1.08884  0.01   
+  2  6    2    1    358.6465   245.3481   -0.0    1.08745  0.00   
+  2  2    -10  -3   899.8027   617.4947   180.0   1.08733  0.00   
+  2  5    7    -5   126.2835   91.0318    -180.0  1.08704  0.00   
+  2  6    -4   -5   466.0175   422.0173   180.0   1.08477  0.00   
+  2  3    -7   -5   2726.4398  3180.2930  0.0     1.08232  0.00   
+  2  5    9    -3   30.4607    37.0056    -180.0  1.08217  0.00   
+  2  4    10   -3   390.4136   496.5346   180.0   1.08176  0.00   
+  2  4    8    -5   367.3143   416.8216   0.0     1.08002  0.00   
+  2  7    -3   -4   419.2551   475.9937   -180.0  1.08002  0.00   
+  2  3    11   -2   985.1286   1209.7235  180.0   1.07973  0.00   
+  2  3    -9   2    892.2257   1162.0253  -0.0    1.07952  0.00   
+  2  1    -11  -2   377.0205   505.5742   -0.0    1.07909  0.00   
+  2  3    11   -1   1890.7155  2531.9784  -180.0  1.07901  0.00   
+  2  4    -4   -6   61.9086    79.4879    0.0     1.07725  0.00   
+  2  7    3    -1   318.5904   517.9063   0.0     1.07642  0.00   
+  2  7    1    -5   15.0558    25.2106    -0.0    1.07626  0.00   
+  2  5    -3   -6   804.4223   1371.1187  180.0   1.07586  0.00   
+  2  2    10   -4   1669.3471  2842.5457  0.0     1.07584  0.00   
+  2  2    -4   -6   112.1364   186.5753   0.0     1.07568  0.00   
+  2  3    3    4    362.8170   560.4316   180.0   1.07511  0.00   
+  2  1    -11  2    360.1701   558.2780   -180.0  1.07370  0.00   
+  2  7    5    -3   620.6600   928.6481   180.0   1.07351  0.00   
+  2  4    4    3    549.1710   818.8776   180.0   1.07348  0.00   
+  2  1    -3   -6   98.2039    135.6225   180.0   1.07233  0.00   
+  2  6    0    -6   2.8435     4.1780     -180.0  1.07161  0.00   
+  2  1    11   -3   393.8452   540.3856   180.0   1.07008  0.00   
+  2  6    2    -6   80.7781    107.8329   0.0     1.06912  0.00   
+  2  6    -6   -4   475.8559   552.9788   0.0     1.06862  0.00   
+  2  5    9    -1   800.5536   1026.4794  0.0     1.06732  0.00   
+  2  2    6    4    3313.3656  4143.5979  0.0     1.06716  0.01   
+  2  7    -3   -1   155.3972   173.9010   0.0     1.06652  0.00   
+  2  2    0    5    1650.3373  1937.9253  0.0     1.06580  0.00   
+  2  0    6    5    296.1133   358.8678   0.0     1.06561  0.00   
+  2  7    -1   -5   2684.2655  3288.8085  0.0     1.06535  0.00   
+  2  5    5    -6   375.9320   447.2840   -180.0  1.06509  0.00   
+  2  0    0    6    45.1420    53.4823    180.0   1.06464  0.00   
+  2  0    10   3    2761.8336  3276.3246  0.0     1.06463  0.00   
+  2  4    6    -6   29.4393    31.3322    -180.0  1.06282  0.00   
+  2  6    6    -5   410.2379   434.3157   -0.0    1.06260  0.00   
+  2  0    12   0    106.3979   112.6819   180.0   1.06244  0.00   
+  2  4    -10  -1   1054.9776  1132.6677  180.0   1.06171  0.00   
+  2  7    5    -2   4175.8964  4496.3914  -180.0  1.06153  0.00   
+  2  0    2    -6   681.2577   748.1993   0.0     1.06104  0.00   
+  2  5    -7   1    916.4291   969.1237   180.0   1.06052  0.00   
+  2  1    -9   -4   1637.1616  1706.8793  -180.0  1.06015  0.00   
+  2  2    -2   5    3087.3664  3313.4198  -180.0  1.05994  0.01   
+  2  3    -9   -4   12.6963    13.6703    -180.0  1.05993  0.00   
+  2  2    6    -6   247.6101   288.6216   -180.0  1.05938  0.00   
+  2  0    12   -1   1067.4219  1340.4500  -0.0    1.05892  0.00   
+  2  1    -7   -5   6.2929     7.5059     -180.0  1.05860  0.00   
+  2  1    5    -6   39.9127    47.4061    -180.0  1.05858  0.00   
+  2  2    10   2    1253.2663  1237.1699  -0.0    1.05797  0.00   
+  2  3    7    3    12.7311    12.9031    -180.0  1.05758  0.00   
+  2  7    3    -5   2083.0579  2239.1302  -180.0  1.05718  0.00   
+  2  6    6    0    433.2552   461.7745   -0.0    1.05659  0.00   
+  2  7    5    -4   2222.7751  2051.4003  0.0     1.05581  0.00   
+  2  4    -10  -2   3205.0577  3145.7849  0.0     1.05450  0.00   
+  2  5    7    1    38.1821    37.2884    180.0   1.05440  0.00   
+  2  6    8    -3   9795.7243  8866.7538  -0.0    1.05196  0.01   
+  2  3    -11  -1   287.3913   261.5320   -0.0    1.05193  0.00   
+  2  5    -5   2    5342.5696  5387.0808  -180.0  1.05131  0.01   
+  2  3    9    2    862.9496   862.2832   -0.0    1.05108  0.00   
+  2  3    11   -3   697.3870   673.7850   180.0   1.05082  0.00   
+  2  6    -6   0    518.5984   488.9045   -0.0    1.04978  0.00   
+  2  6    8    -2   353.4278   331.3808   0.0     1.04899  0.00   
+  2  3    11   0    439.2946   407.0557   -0.0    1.04881  0.00   
+  2  3    -5   -6   1341.4814  1235.7557  -180.0  1.04872  0.00   
+  2  4    10   0    66.9200    61.4161    -0.0    1.04771  0.00   
+  2  5    -9   -2   2409.4682  2208.3085  -0.0    1.04729  0.00   
+  2  5    9    -4   242.5564   228.7958   -180.0  1.04516  0.00   
+  2  6    -2   -6   1398.0926  1293.5044  -0.0    1.04487  0.00   
+  2  6    -4   1    3420.0068  3160.5795  -0.0    1.04485  0.00   
+  2  3    -5   4    2719.3288  2301.6767  -0.0    1.04377  0.00   
+  2  3    9    -5   2140.8719  1817.7670  180.0   1.04328  0.00   
+  2  1    5    5    1861.6781  1623.2967  -0.0    1.04294  0.00   
+  2  3    -11  0    1594.5279  1387.3612  0.0     1.04270  0.00   
+  2  2    2    5    303.9364   264.3036   0.0     1.04269  0.00   
+  2  5    -9   -1   73.5561    62.5557    0.0     1.04240  0.00   
+  2  6    4    1    1214.6882  1021.8291  -0.0    1.04223  0.00   
+  2  4    -10  0    610.2630   554.7785   -0.0    1.04034  0.00   
+  2  2    12   -1   4174.3018  3828.0670  -180.0  1.03971  0.00   
+  2  0    2    6    1599.4597  1492.8101  0.0     1.03949  0.00   
+  2  7    -5   -3   3745.5270  3517.5593  180.0   1.03943  0.00   
+  2  5    5    2    3980.1369  4324.4718  -180.0  1.03825  0.01   
+  2  4    -8   2    271.1930   298.1823   -0.0    1.03802  0.00   
+  2  6    4    -6   1136.6951  1251.2761  -180.0  1.03798  0.00   
+  2  0    12   1    294.6931   335.8693   -0.0    1.03750  0.00   
+  2  7    -5   -2   1230.9087  1492.9651  -180.0  1.03709  0.00   
+  2  7    1    0    952.8698   1264.8986  -0.0    1.03656  0.00   
+  2  1    -9   4    1.8565     2.8086     180.0   1.03594  0.00   
+  2  1    11   2    1095.5154  1702.3367  180.0   1.03580  0.00   
+  2  7    -1   0    1158.3636  1823.6465  -0.0    1.03529  0.00   
+  2  4    10   -4   5.7160     9.1218     0.0     1.03486  0.00   
+  2  3    -11  -2   814.0545   1522.0493  -180.0  1.03326  0.00   
+  3  1    1    0    1334.1960  1271.9616  -0.0    3.25118  0.03   
+  3  1    0    1    573.8927   492.3083   -0.0    2.48932  0.01   
+  3  2    0    0    293.4264   149.3026   -0.0    2.29893  0.00   
+  3  1    1    1    331.6865   374.9555   180.0   2.18908  0.01   
+  3  2    1    0    137.0637   152.7665   0.0     2.05623  0.00   
+  3  2    1    1    960.7703   880.2245   -0.0    1.68889  0.02   
+  3  2    2    0    956.8227   1142.9561  -0.0    1.62559  0.01   
+  3  0    0    2    1397.0015  1418.4370  -0.0    1.48040  0.00   
+  3  3    1    0    375.2406   356.7420   -0.0    1.45397  0.00   
+  3  2    2    1    29.8338    28.2349    180.0   1.42495  0.00   
+  3  3    0    1    1273.6201  1055.2044  -0.0    1.36108  0.01   
+  3  1    1    2    510.6420   541.7155   -0.0    1.34730  0.00   
+  3  3    1    1    47.0334    32.7482    0.0     1.30510  0.00   
+  3  3    2    0    16.6550    15.0214    180.0   1.27522  0.00   
+  3  2    0    2    151.0387   145.3475   -0.0    1.24466  0.00   
+  3  2    1    2    44.9276    42.1752    0.0     1.20142  0.00   
+  3  3    2    1    142.6309   154.4876   -0.0    1.17121  0.00   
+  3  4    0    0    513.4055   422.1172   -0.0    1.14947  0.00   
+  3  4    1    0    94.2206    78.6710    180.0   1.11515  0.00   
+  3  2    2    2    588.8972   562.7287   -0.0    1.09454  0.00   
+  3  3    3    0    557.2875   592.2106   -0.0    1.08373  0.00   
+  3  4    1    1    319.7452   271.7076   -0.0    1.04358  0.00   
+  3  3    1    2    189.2126   220.8531   -0.0    1.03733  0.00   
+  4  1    1    0    8901.7804  5230.9801  0.0     5.76584  0.01   
+  4  1    1    -1   2315.8541  1404.6704  0.0     5.75322  0.00   
+  4  0    0    2    11353.3689 6634.3195  0.0     5.70106  0.00   
+  4  2    0    0    1177.2941  777.5840   180.0   5.30365  0.00   
+  4  2    0    -2   15375.6028 11505.0663 0.0     5.26468  0.01   
+  4  1    1    1    5400.3099  5911.9602  -180.0  4.69678  0.00   
+  4  1    1    -2   415.8960   470.8719   -180.0  4.67639  0.00   
+  4  1    1    2    1479.7888  1807.6343  -180.0  3.62818  0.00   
+  4  1    1    -3   5874.3556  6211.2421  180.0   3.61251  0.00   
+  4  0    2    0    8582.1911  1738.6637  180.0   3.43465  0.00   
+  4  3    1    -1   2419.7228  1015.4506  -0.0    3.40613  0.00   
+  4  3    1    -2   6152.3886  3188.3766  180.0   3.39833  0.00   
+  4  0    2    1    4386.8050  5008.4817  -0.0    3.28869  0.00   
+  4  2    0    2    10310.5845 11585.3666 -0.0    3.21816  0.00   
+  4  2    0    -4   5047.4572  4995.9553  180.0   3.19207  0.00   
+  4  3    1    0    2378.7213  2137.7205  0.0     3.14376  0.00   
+  4  3    1    -3   2907.8642  2675.3550  180.0   3.12546  0.00   
+  4  4    0    -2   89183.5889 80910.5503 180.0   2.98152  0.01   
+  4  2    2    -1   86031.3825 75056.7102 -0.0    2.97625  0.02   
+  4  0    2    2    811.7833   793.0397   0.0     2.94199  0.00   
+  4  2    2    0    1049.8273  1809.9835  0.0     2.88292  0.00   
+  4  2    2    -2   354.5790   529.5161   -0.0    2.87661  0.00   
+  4  1    1    3    2084.3808  2484.3500  -0.0    2.86316  0.00   
+  4  1    1    -4   5034.4975  5797.7013  -0.0    2.85237  0.00   
+  4  0    0    4    8969.0157  10329.0263 -0.0    2.85053  0.00   
+  4  3    1    1    3533.1388  3753.2275  -180.0  2.75709  0.00   
+  4  3    1    -4   2801.6188  3262.1954  -0.0    2.73656  0.00   
+  4  4    0    0    75454.7838 71041.9911 0.0     2.65183  0.01   
+  4  2    2    1    147196.8728 133022.1773 0.0     2.64322  0.03   
+  4  2    2    -3   74514.0922 66277.1922 -180.0  2.63352  0.01   
+  4  4    0    -4   158893.4581 140508.8148 180.0   2.63234  0.01   
+  4  0    2    3    18236.6407 14181.7572 180.0   2.54828  0.00   
+  4  3    1    2    10014.4897 9772.1059  -180.0  2.37485  0.00   
+  4  3    1    -5   6204.5627  5858.2101  -0.0    2.35649  0.00   
+  4  2    2    2    161.6583   143.8182   -180.0  2.34839  0.00   
+  4  2    2    -4   1012.3875  881.4346   180.0   2.33820  0.00   
+  4  1    1    4    3638.5725  2963.5205  -0.0    2.33515  0.00   
+  4  1    1    -5   461.4799   299.5633   -0.0    2.32762  0.00   
+  4  4    2    -2   1693.9113  1408.0652  -0.0    2.25154  0.00   
+  4  5    1    -2   2468.8533  2123.3090  180.0   2.24419  0.00   
+  4  5    1    -3   601.5468   539.1542   180.0   2.24047  0.00   
+  4  1    3    0    57.2455    52.5027    0.0     2.23821  0.00   
+  4  1    3    -1   4533.0633  4186.2462  -0.0    2.23747  0.00   
+  4  4    2    -1   899.5071   918.5298   0.0     2.21174  0.00   
+  4  4    2    -3   12043.4937 13298.4938 -0.0    2.20604  0.00   
+  4  0    2    4    824.5510   966.9500   180.0   2.19350  0.00   
+  4  5    1    -1   10015.9840 11520.4080 -0.0    2.16535  0.00   
+  4  1    3    1    1007.7397  1032.3941  -0.0    2.15732  0.00   
+  4  1    3    -2   11109.3106 10975.5516 0.0     2.15533  0.00   
+  4  5    1    -4   718.0625   709.7605   -180.0  2.15536  0.00   
+  4  2    0    4    1698.6268  1630.7411  0.0     2.13639  0.00   
+  4  2    0    -6   7105.4566  7201.1177  0.0     2.12363  0.00   
+  4  4    2    0    491.4653   728.5144   -180.0  2.09901  0.00   
+  4  4    2    -4   366.4721   548.6325   -180.0  2.08931  0.00   
+  4  4    0    2    272101.4556 285741.4893 180.0   2.06969  0.01   
+  4  2    2    3    283593.4331 292787.7239 0.0     2.06326  0.03   
+  4  2    2    -5   261055.1180 297019.9126 0.0     2.05405  0.03   
+  4  4    0    -6   259643.2256 302016.1855 -180.0  2.05120  0.01   
+  4  3    1    3    906.9078   1081.1190  -180.0  2.04788  0.00   
+  4  3    1    -6   100.2043   154.6340   -0.0    2.03274  0.00   
+  4  5    1    0    487.7035   771.0005   180.0   2.02700  0.00   
+  4  1    3    2    9532.4932  14027.7789 -0.0    2.01823  0.00   
+  4  1    3    -3   877.5958   1239.3116  -0.0    2.01552  0.00   
+  4  5    1    -5   10294.4162 14151.2165 -0.0    2.01339  0.00   
+  4  3    3    -1   6270.5844  7028.4965  -0.0    1.97746  0.00   
+  4  3    3    -2   168.2668   188.2835   0.0     1.97593  0.00   
+  4  1    1    5    4704.0115  4612.1293  180.0   1.96050  0.00   
+  4  6    0    -2   988.5318   970.6743   180.0   1.96113  0.00   
+  4  1    1    -6   1454.7640  1560.3950  -0.0    1.95505  0.00   
+  4  6    0    -4   16159.2833 17257.5959 -180.0  1.95518  0.00   
+  4  4    2    1    16682.5780 20965.9734 -0.0    1.94293  0.00   
+  4  4    2    -5   65.1600    70.9153    180.0   1.93141  0.00   
+  4  3    3    0    9089.5197  9843.5896  180.0   1.92195  0.00   
+  4  3    3    -3   2526.4448  2771.1302  -0.0    1.91774  0.00   
+  4  0    0    6    1602.4146  1705.1365  -0.0    1.90035  0.00   
+  4  0    2    5    85.5763    90.1372    -180.0  1.89981  0.00   
+  4  5    1    1    2408.6767  2501.1033  -180.0  1.86056  0.00   
+  4  1    3    3    2945.3718  3425.4494  0.0     1.85210  0.00   
+  4  1    3    -4   422.3063   509.1035   -180.0  1.84917  0.00   
+  4  5    1    -6   2641.8126  2896.6648  -180.0  1.84586  0.00   
+  4  3    3    1    3691.9521  3298.1879  -0.0    1.82244  0.00   
+  4  3    3    -4   15622.5130 15083.2702 -180.0  1.81647  0.00   
+  4  2    2    4    2020.2816  2004.7601  180.0   1.81409  0.00   
+  4  2    2    -6   106.1499   110.8462   -0.0    1.80626  0.00   
+  4  3    1    4    1090.1152  1170.9069  -0.0    1.78183  0.00   
+  4  4    2    2    734.4924   570.0027   -0.0    1.77271  0.00   
+  4  3    1    -7   1145.4003  720.6469   -180.0  1.76963  0.00   
+  4  6    0    0    60810.7365 33117.2582 180.0   1.76788  0.00   
+  4  4    2    -6   3809.2767  1198.1600  -0.0    1.76106  0.00   
+  4  6    0    -6   5.6554     2.0510     0.0     1.75489  0.00   
+  4  6    2    -3   419846.4104 370038.4229 -180.0  1.72037  0.03   
+  4  0    4    0    389637.2899 349197.4003 -180.0  1.71733  0.01   
+  4  6    2    -2   572.2204   389.6517   -0.0    1.70307  0.00   
+  4  6    2    -4   2259.8535  1559.8102  180.0   1.69917  0.00   
+  4  0    4    1    4743.8186  3261.1281  -0.0    1.69817  0.00   
+  4  3    3    2    5243.3467  3601.8680  -0.0    1.69798  0.00   
+  4  3    3    -5   13582.3751 10536.8117 0.0     1.69123  0.00   
+  4  5    1    2    3266.2867  2567.1386  -180.0  1.69091  0.00   
+  4  1    1    6    877.6322   741.7350   -0.0    1.68468  0.00   
+  4  1    3    4    54.6404    44.9703    -0.0    1.68329  0.00   
+  4  1    1    -7   16038.6048 12420.3292 -180.0  1.68059  0.00   
+  4  1    3    -5   6063.4900  4681.6764  0.0     1.68046  0.00   
+  4  5    1    -7   368.1094   265.7581   -180.0  1.67673  0.00   
+  4  0    2    6    1077.5844  1003.5888  0.0     1.66280  0.00   
+  4  2    4    -1   2937.4525  2846.0747  180.0   1.65025  0.00   
+  4  6    2    -1   893.1706   865.8969   -180.0  1.65056  0.00   
+  4  7    1    -3   36.6213    35.4867    180.0   1.65033  0.00   
+  4  5    3    -2   347.8877   336.9162   -180.0  1.64825  0.00   
+  4  7    1    -4   575.6921   557.5403   -0.0    1.64826  0.00   
+  4  5    3    -3   1278.2257  1233.5025  -180.0  1.64677  0.00   
+  4  0    4    2    634.2501   612.1127   -180.0  1.64434  0.00   
+  4  6    2    -5   520.7166   505.2539   -180.0  1.64348  0.00   
+  4  2    4    0    700.9425   754.1348   -0.0    1.63381  0.00   
+  4  2    4    -2   4148.0449  4465.8494  180.0   1.63266  0.00   
+  4  7    1    -2   3283.4949  3571.4802  180.0   1.61877  0.00   
+  4  5    3    -1   927.4004   967.1505   0.0     1.61624  0.00   
+  4  7    1    -5   942.5880   916.8984   -0.0    1.61292  0.00   
+  4  5    3    -4   4032.7979  3836.8577  -180.0  1.61207  0.00   
+  4  4    0    4    71771.0133 64364.2002 180.0   1.60908  0.00   
+  4  4    2    3    31.1188    27.4398    180.0   1.60765  0.00   
+  4  2    2    5    43884.8411 37127.6016 -180.0  1.60496  0.00   
+  4  2    2    -7   94794.3405 66511.2896 0.0     1.59845  0.01   
+  4  4    2    -7   3860.7317  2580.8493  -0.0    1.59679  0.00   
+  4  4    0    -8   56267.4239 36927.3328 0.0     1.59604  0.00   
+  4  2    4    1    2223.6817  1926.4611  0.0     1.58623  0.00   
+  4  2    4    -3   2005.5685  1878.0675  0.0     1.58413  0.00   
+  4  2    0    6    32451.0384 28885.1715 -0.0    1.57490  0.00   
+  4  6    2    0    345.5868   317.4281   -0.0    1.57188  0.00   
+  4  2    0    -8   4913.3916  4971.2983  -180.0  1.56773  0.00   
+  4  3    1    5    1717.5987  1737.9254  180.0   1.56773  0.00   
+  4  3    3    3    473.6775   485.0009   0.0     1.56559  0.00   
+  4  0    4    3    2848.1001  2917.1059  -0.0    1.56499  0.00   
+  4  6    2    -6   1216.3660  1247.1099  -180.0  1.56273  0.00   
+  4  3    3    -6   1445.6006  1492.8885  -180.0  1.55880  0.00   
+  4  3    1    -8   1809.7244  1857.3102  0.0     1.55790  0.00   
+  4  7    1    -1   1976.6180  2042.4001  -0.0    1.55896  0.00   
+  4  5    3    0    3764.2581  3764.8648  180.0   1.55620  0.00   
+  4  7    1    -6   4128.4910  3784.2912  -180.0  1.55028  0.00   
+  4  5    3    -5   1534.7364  1407.6591  0.0     1.55002  0.00   
+  4  5    1    3    1120.2479  786.8987   0.0     1.53211  0.00   
+  4  1    3    5    10.1177    7.3898     -180.0  1.52550  0.00   
+  4  1    3    -6   1669.5493  1155.7827  0.0     1.52293  0.00   
+  4  5    1    -8   7.8343     5.3759     0.0     1.51922  0.00   
+  4  2    4    2    5831.1410  4259.2701  180.0   1.51510  0.00   
+  4  2    4    -4   3172.0352  2489.5300  -0.0    1.51235  0.00   
+  4  6    0    2    9313.4141  8929.2480  -180.0  1.50509  0.00   
+  4  6    0    -8   4563.8228  4381.9848  -180.0  1.49176  0.00   
+  4  8    0    -4   21170.0301 20096.2166 0.0     1.49076  0.00   
+  4  4    4    -2   21979.6561 20517.7233 -0.0    1.48812  0.00   
+  4  7    1    0    550.4952   522.1602   0.0     1.47975  0.00   
+  4  6    2    1    554.0119   505.4373   180.0   1.47800  0.00   
+  4  5    3    1    1663.1476  1470.7859  180.0   1.47697  0.00   
+  4  4    4    -1   207.2902   180.6208   180.0   1.47646  0.00   
+  4  1    1    7    10982.3968 9073.7519  -0.0    1.47458  0.00   
+  4  4    4    -3   2010.5814  1670.1267  180.0   1.47476  0.00   
+  4  1    1    -8   9496.5506  7391.2827  0.0     1.47142  0.00   
+  4  0    2    7    3191.6584  2499.6018  180.0   1.47175  0.00   
+  4  0    4    4    756.0358   585.1247   180.0   1.47100  0.00   
+  4  5    3    -6   0.2318     0.1795     -180.0  1.46958  0.00   
+  4  7    1    -7   299.0160   231.8398   -180.0  1.46938  0.00   
+  4  6    2    -7   1373.4839  1079.4025  180.0   1.46787  0.00   
+  4  4    2    4    338.2100   309.0628   -180.0  1.45711  0.00   
+  4  4    2    -8   307.7954   302.4845   -180.0  1.44740  0.00   
+  4  8    0    -2   53427.9027 52301.5540 0.0     1.44545  0.00   
+  4  4    4    0    42921.7105 40431.8829 -180.0  1.44146  0.00   
+  4  8    0    -6   43706.7771 39499.2643 -180.0  1.43911  0.00   
+  4  4    4    -4   60928.1627 54152.0299 0.0     1.43831  0.00   
+  4  3    3    4    5353.0591  4620.7657  -180.0  1.43665  0.00   
+  4  2    2    6    0.9690     0.8056     -180.0  1.43158  0.00   
+  4  3    3    -7   1716.8497  1448.7970  0.0     1.43023  0.00   
+  4  2    4    3    3187.6185  2700.7215  180.0   1.42973  0.00   
+  4  2    2    -8   1989.0658  1819.8832  -0.0    1.42619  0.00   
+  4  2    4    -5   1840.3395  1673.3904  180.0   1.42665  0.00   
+  4  0    0    8    289630.4012 266539.2379 -0.0    1.42526  0.01   
+  4  3    1    6    1178.9703  937.8761   180.0   1.39460  0.00   
+  4  5    1    4    846.0027   766.4026   0.0     1.38990  0.00   
+  4  7    1    1    56.0186    50.2105    -180.0  1.39036  0.00   
+  4  3    1    -9   682.7487   707.0497   -0.0    1.38661  0.00   
+  4  4    4    1    3668.2072  3625.7059  -0.0    1.38781  0.00   
+  4  5    3    2    445.8577   442.9769   -180.0  1.38770  0.00   
+  4  1    3    6    2862.5623  3149.1806  0.0     1.38425  0.00   
+  4  4    4    -5   1091.0110  1224.9425  0.0     1.38359  0.00   
+  4  1    3    -7   421.1838   485.7509   -180.0  1.38198  0.00   
+  4  5    3    -7   898.8470   1075.5006  180.0   1.37983  0.00   
+  4  7    1    -8   190.8088   231.2862   0.0     1.37932  0.00   
+  4  5    1    -9   2565.7551  3159.9602  -0.0    1.37851  0.00   
+  4  6    2    2    207.5878   255.5312   -180.0  1.37854  0.00   
+  4  0    4    5    323.2811   361.2702   -180.0  1.37183  0.00   
+  4  6    2    -8   3.5837     2.8619     0.0     1.36828  0.00   
+  4  8    2    -4   979.5381   738.9032   180.0   1.36751  0.00   
+  4  7    3    -3   4402.7365  3199.1281  -180.0  1.36501  0.00   
+  4  7    3    -4   614.0930   462.5993   -180.0  1.36383  0.00   
+  4  1    5    0    5492.0879  4377.5663  -180.0  1.36248  0.00   
+  4  1    5    -1   71.7019    57.4866    -0.0    1.36231  0.00   
+  4  8    2    -3   2287.8677  1922.5602  180.0   1.35910  0.00   
+  4  8    2    -5   16188.3504 14150.5569 180.0   1.35646  0.00   
+  4  7    3    -2   6700.4195  6974.2207  0.0     1.34698  0.00   
+  4  1    5    1    7073.1475  7447.5757  0.0     1.34359  0.00   
+  4  7    3    -5   2271.3569  2391.3241  180.0   1.34361  0.00   
+  4  1    5    -2   2666.5087  2805.7617  180.0   1.34311  0.00   
+  4  2    4    4    244.1891   204.8439   -180.0  1.33849  0.00   
+  4  2    4    -6   5315.8777  4277.5018  180.0   1.33534  0.00   
+  4  8    2    -2   209.6330   192.2543   0.0     1.33228  0.00   
+  4  8    2    -6   106.7389   116.6868   0.0     1.32731  0.00   
+  4  8    0    0    115156.4622 126661.5899 0.0     1.32591  0.00   
+  4  4    2    5    11589.4105 12808.5293 0.0     1.32400  0.00   
+  4  4    4    2    103063.5033 113941.9059 0.0     1.32161  0.00   
+  4  0    2    8    328.3465   368.2075   180.0   1.31642  0.00   
+  4  4    4    -6   107083.9061 120729.4823 0.0     1.31676  0.00   
+  4  3    3    5    1099.7247  1245.5389  -0.0    1.31715  0.00   
+  4  4    2    -9   5012.1830  5522.7067  180.0   1.31550  0.00   
+  4  8    0    -8   124620.7451 139112.4286 -0.0    1.31617  0.00   
+  4  3    3    -8   7374.0095  7098.7737  180.0   1.31130  0.00   
+  4  7    3    -1   1044.0315  1032.5927  180.0   1.31193  0.00   
+  4  1    1    8    173.2706   157.0013   180.0   1.30987  0.00   
+  4  1    1    -9   871.1902   714.9877   180.0   1.30735  0.00   
+  4  1    5    2    2098.0356  1741.0921  180.0   1.30791  0.00   
+  4  1    5    -3   8976.8069  7332.3806  -0.0    1.30718  0.00   
+  4  7    3    -6   9393.1460  7542.3359  -0.0    1.30675  0.00   
+  4  6    4    -3   3842.5896  2359.2813  -0.0    1.29949  0.00   
+  4  9    1    -4   1370.0050  840.7626   0.0     1.29967  0.00   
+  4  9    1    -5   411.5297   256.7371   0.0     1.29837  0.00   
+  4  7    1    2    6354.8197  3971.2947  -180.0  1.29827  0.00   
+  4  3    5    -1   986.2570   623.9480   0.0     1.29662  0.00   
+  4  3    5    -2   3456.8585  2195.2006  -0.0    1.29619  0.00   
+  4  5    3    3    525.9553   335.5374   180.0   1.29581  0.00   
+  4  6    4    -2   37.7622    25.6459    0.0     1.29198  0.00   
+  4  4    0    6    24495.8393 18445.1890 180.0   1.29041  0.00   
+  4  6    4    -4   9397.8591  7147.8738  -0.0    1.29028  0.00   
+  4  8    2    -1   11605.2924 8919.4141  180.0   1.29014  0.00   
+  4  5    3    -8   4023.8939  3485.2815  180.0   1.28798  0.00   
+  4  7    1    -9   150.4702   133.1816   180.0   1.28729  0.00   
+  4  2    2    7    18436.8806 16121.3989 -0.0    1.28772  0.00   
+  4  2    2    -9   20348.2776 19749.4871 0.0     1.28323  0.00   
+  4  8    2    -7   442.7558   429.3576   -180.0  1.28339  0.00   
+  4  9    1    -3   5801.1991  5505.8053  180.0   1.28437  0.00   
+  4  4    0    -10  21281.4361 20626.8832 -180.0  1.28142  0.00   
+  4  3    5    0    743.9925   723.0322   -0.0    1.28059  0.00   
+  4  9    1    -6   191.8088   186.4033   -0.0    1.28061  0.00   
+  4  6    2    3    0.3914     0.3803     180.0   1.28034  0.00   
+  4  3    5    -3   6264.3295  6057.1432  -0.0    1.27934  0.00   
+  4  0    4    6    137.1936   118.7790   180.0   1.27414  0.00   
+  4  6    2    -9   522.1614   464.9998   180.0   1.27048  0.00   
+  4  6    4    -1   464.9381   482.3156   -180.0  1.26861  0.00   
+  4  6    4    -5   544.6456   582.1506   -180.0  1.26538  0.00   
+  4  5    1    5    4323.3349  4608.9316  180.0   1.26524  0.00   
+  4  6    0    4    6781.5899  7257.1579  180.0   1.26546  0.00   
+  4  7    3    0    792.1173   802.9980   180.0   1.26367  0.00   
+  4  1    3    7    8566.8731  8422.3689  -0.0    1.26045  0.00   
+  4  1    5    3    37.0440    35.3555    180.0   1.25929  0.00   
+  4  1    3    -8   3285.5328  3096.4805  180.0   1.25847  0.00   
+  4  1    5    -4   3305.2546  3109.1160  180.0   1.25836  0.00   
+  4  7    3    -7   2629.3510  2422.5128  180.0   1.25719  0.00   
+  4  5    1    -10  7701.4415  7040.6080  -180.0  1.25533  0.00   
+  4  6    0    -10  130.0901   117.7995   180.0   1.25436  0.00   
+  4  3    1    7    1818.2242  1611.9052  -0.0    1.25310  0.00   
+  4  9    1    -2   400.6261   361.7381   0.0     1.25413  0.00   
+  4  3    5    1    10017.1110 8364.6882  0.0     1.24984  0.00   
+  4  4    4    3    19.5158    16.4610    0.0     1.24881  0.00   
+  4  9    1    -7   10158.8601 8727.7224  -180.0  1.24831  0.00   
+  4  3    5    -4   1249.7928  1094.9028  -0.0    1.24791  0.00   
+  4  3    1    -10  3199.8515  2986.1989  180.0   1.24653  0.00   
+  4  2    4    5    1291.1252  1152.6107  0.0     1.24755  0.00   
+  4  2    4    -7   828.1319   791.7891   0.0     1.24448  0.00   
+  4  4    4    -7   6817.9210  6546.9764  -0.0    1.24370  0.00   
+  4  2    0    8    28.5082    27.6681    -0.0    1.24151  0.00   
+  4  2    0    -10  2141.4729  2004.2607  180.0   1.23699  0.00   
+  4  8    2    0    784.1793   732.5347   180.0   1.23694  0.00   
+  4  6    4    0    15016.5044 14164.7168 -0.0    1.23182  0.00   
+  4  8    2    -8   599.2056   627.3611   180.0   1.22902  0.00   
+  4  6    4    -6   126.0499   129.7550   -180.0  1.22740  0.00   
+  4  9    1    -1   3093.1624  2737.0310  -0.0    1.21201  0.00   
+  4  3    3    6    945.7147   849.4249   0.0     1.20939  0.00   
+  4  4    2    6    457.4657   411.6959   -0.0    1.20797  0.00   
+  4  7    1    3    81.5159    73.2966    180.0   1.20853  0.00   
+  4  3    5    2    4172.4957  3752.2007  0.0     1.20744  0.00   
+  4  5    3    4    8461.7501  7534.7350  -180.0  1.20632  0.00   
+  4  7    3    1    3065.2228  2738.1132  180.0   1.20663  0.00   
+  4  3    5    -5   55.0455    48.9057    180.0   1.20500  0.00   
+  4  3    3    -9   1052.0110  945.1661   -0.0    1.20417  0.00   
+  4  9    1    -8   2600.7183  2320.3991  0.0     1.20467  0.00   
+  4  1    5    4    4288.7581  3946.6484  180.0   1.20212  0.00   
+  4  4    2    -10  168.9483   165.4794   -0.0    1.20059  0.00   
+  4  1    5    -5   686.9334   658.1130   0.0     1.20109  0.00   
+  4  7    3    -8   5.3040     5.4369     0.0     1.19939  0.00   
+  4  5    3    -9   288.9057   300.8548   180.0   1.19886  0.00   
+  4  7    1    -10  7804.4340  8291.7393  -180.0  1.19807  0.00   
+  4  0    2    9    341.0630   269.4602   -0.0    1.18862  0.00   
+  4  5    5    -2   3921.1970  3033.1047  -0.0    1.18916  0.00   
+  4  5    5    -3   0.1281     0.1013     -0.0    1.18860  0.00   
+  4  6    2    4    316.1101   267.9123   180.0   1.18743  0.00   
+  4  10   0    -4   7908.7935  6791.4438  0.0     1.18724  0.00   
+  4  10   0    -6   11645.4891 11083.9325 0.0     1.18504  0.00   
+  4  6    4    1    1388.7900  1321.5609  0.0     1.18505  0.00   
+  4  0    4    7    288.3496   286.3109   180.0   1.18182  0.00   
+  4  6    4    -7   1752.8757  1787.8415  0.0     1.17981  0.00   
+  4  6    2    -10  2.1270     2.2339     -0.0    1.17825  0.00   
+  4  1    1    9    115.4029   122.6215   -0.0    1.17757  0.00   
+  4  8    0    2    29628.1664 31208.9425 180.0   1.17807  0.00   
+  4  5    5    -1   6815.5795  7333.2479  -180.0  1.17697  0.00   
+  4  1    1    -10  691.5487   762.8322   180.0   1.17552  0.00   
+  4  8    2    1    5431.9286  5829.5691  -180.0  1.17708  0.00   
+  4  5    5    -4   5046.5579  5571.4326  -0.0    1.17536  0.00   
+  4  4    4    4    30603.4596 33801.2648 0.0     1.17420  0.00   
+  4  4    4    -8   28967.0942 28612.5301 -180.0  1.16910  0.00   
+  4  8    2    -9   8559.4840  8411.0748  180.0   1.16856  0.00   
+  4  8    0    -10  39027.0032 38238.0217 0.0     1.16784  0.00   
+  4  2    2    8    102.3545   100.3650   0.0     1.16757  0.00   
+  4  2    2    -10  559.6885   559.3630   -0.0    1.16381  0.00   
+  4  2    4    6    16187.5767 13793.8077 180.0   1.16072  0.00   
+  4  9    1    0    199.0621   175.9750   180.0   1.16162  0.00   
+  4  2    4    -8   2824.2114  2418.4289  0.0     1.15783  0.00   
+  4  3    5    3    3553.5113  3138.9165  0.0     1.15697  0.00   
+  4  5    1    6    57.0628    50.4393    0.0     1.15695  0.00   
+  4  3    5    -6   56.1601    51.9835    -0.0    1.15422  0.00   
+  4  9    1    -9   612.8339   565.3148   180.0   1.15332  0.00   
+  4  1    3    8    3008.7507  2761.9705  0.0     1.15288  0.00   
+  4  5    5    0    7249.3341  6677.8488  -0.0    1.15317  0.00   
+  4  1    3    -9   1.4814     1.3309     -0.0    1.15116  0.00   
+  4  5    5    -5   9562.4964  8524.5720  -180.0  1.15064  0.00   
+  4  5    1    -11  1672.5476  1512.6930  0.0     1.14836  0.00   
+  4  9    3    -4   440.7034   426.9046   0.0     1.14591  0.00   
+  4  0    6    0    2512.6088  2617.0231  -0.0    1.14488  0.00   
+  4  9    3    -5   62.6914    64.8810    -0.0    1.14502  0.00   
+  4  7    3    2    4718.3733  4899.9757  -0.0    1.14495  0.00   
+  4  0    0    10   372.6139   423.7872   -0.0    1.14021  0.00   
+  4  1    5    5    4404.1931  5052.6414  -0.0    1.14051  0.00   
+  4  10   0    -2   13883.0153 15977.0108 0.0     1.14083  0.00   
+  4  1    5    -6   4816.4067  5316.8792  180.0   1.13943  0.00   
+  4  0    6    1    1501.4347  1652.6802  180.0   1.13916  0.00   
+  4  7    3    -9   4265.2313  4662.3484  180.0   1.13739  0.00   
+  4  3    1    8    60.5148    68.5290    180.0   1.13600  0.00   
+  4  10   0    -8   1234.0975  1446.9812  0.0     1.13500  0.00   
+  4  9    3    -3   1226.1904  1425.8009  -180.0  1.13538  0.00   
+  4  9    3    -6   1601.7970  1854.9560  -0.0    1.13278  0.00   
+  4  3    1    -11  26.0510    30.9463    0.0     1.13052  0.00   
+  4  6    4    2    2466.0310  2828.6870  0.0     1.13190  0.00   
+  4  6    4    -8   1857.5445  2098.6789  -0.0    1.12620  0.00   
+  4  10   2    -5   5436.2243  6260.3145  0.0     1.12662  0.00   
+  4  8    4    -4   3779.2891  4163.4508  -180.0  1.12577  0.00   
+  4  2    6    -1   3482.1034  3576.1516  180.0   1.12435  0.00   
+  4  7    1    4    4830.6288  4923.6613  -0.0    1.12407  0.00   
+  4  0    6    2    1365.2966  1380.1016  -180.0  1.12247  0.00   
+  4  5    3    5    1957.1560  1969.9637  -180.0  1.12210  0.00   
+  4  10   2    -4   8.9927     9.0506     180.0   1.12210  0.00   
+  4  8    4    -3   3401.0442  3322.0045  -180.0  1.12107  0.00   
+  4  10   2    -6   172.8767   172.4285   180.0   1.12024  0.00   
+  4  5    5    1    707.4841   712.3459   0.0     1.11980  0.00   
+  4  8    4    -5   1023.6725  1031.7594  180.0   1.11958  0.00   
+  4  2    6    0    5287.4183  5323.9761  180.0   1.11911  0.00   
+  4  2    6    -2   984.9688   994.6994   180.0   1.11874  0.00   
+  4  5    5    -6   2608.4208  2507.7650  0.0     1.11656  0.00   
+  4  5    3    -10  1858.7907  1595.3866  -0.0    1.11517  0.00   
+  4  7    1    -11  2546.0356  2080.5242  180.0   1.11435  0.00   
+  4  3    3    7    9207.9764  7162.2968  0.0     1.11361  0.00   
+  4  9    3    -2   2473.7398  2019.0786  0.0     1.11433  0.00   
+  4  8    2    2    147.6833   120.6468   0.0     1.11435  0.00   
+  4  9    3    -7   2148.9615  1750.0554  -180.0  1.11024  0.00   
+  4  3    3    -10  310.0217   264.2393   -0.0    1.10899  0.00   
+  4  4    2    7    10566.5860 9262.0651  0.0     1.10733  0.00   
+  4  8    2    -10  40.6464    36.4788    0.0     1.10568  0.00   
+  4  10   2    -3   39907.6176 35134.6049 -180.0  1.10704  0.00   
+  4  9    1    1    4275.0763  3804.5571  -180.0  1.10646  0.00   
+  4  8    4    -2   32753.1084 29367.7986 -180.0  1.10587  0.00   
+  4  2    6    1    30154.8437 27657.2710 -180.0  1.10346  0.00   
+  4  10   2    -7   38105.7908 34945.5796 0.0     1.10347  0.00   
+  4  8    4    -6   32764.0487 30145.0352 0.0     1.10302  0.00   
+  4  2    6    -3   32468.4049 29932.7872 0.0     1.10275  0.00   
+  4  4    2    -11  2378.4464  2171.7260  -0.0    1.10093  0.00   
+  4  3    5    4    76.3996    70.5308    0.0     1.10191  0.00   
+  4  6    2    5    143295.7929 132118.4929 -180.0  1.10176  0.01   
+  4  4    4    5    2949.3019  2698.2919  180.0   1.10112  0.00   
+  4  3    5    -7   3235.7019  2940.6878  0.0     1.09901  0.00   
+  4  9    1    -10  302.9170   279.5570   0.0     1.09771  0.00   
+  4  0    4    8    141171.4401 133943.8055 -180.0  1.09675  0.01   
+  4  4    4    -9   140.1937   134.0820   0.0     1.09622  0.00   
+  4  0    6    3    3561.1558  3405.7446  -0.0    1.09623  0.00   
+  4  6    2    -11  169050.6587 149682.1479 -180.0  1.09337  0.01   
+  4  9    3    -1   1163.5215  1114.3484  0.0     1.08447  0.00   
+  4  0    2    10   120.0551   133.7299   0.0     1.08214  0.00   
+  4  10   2    -2   817.0129   879.0255   -0.0    1.08267  0.00   
+  4  7    3    3    5336.3436  5994.9982  180.0   1.08198  0.00   
+  4  8    4    -1   5.7194     6.5236     0.0     1.08141  0.00   
+  4  2    4    7    122.0853   143.6472   180.0   1.07999  0.00   
+  4  9    3    -8   13.8018    16.9908    180.0   1.07920  0.00   
+  4  5    5    2    4349.0567  5313.7515  0.0     1.07936  0.00   
+  4  2    6    2    383.4858   479.5437   0.0     1.07866  0.00   
+  4  2    4    -9   1001.4871  1303.4737  -180.0  1.07733  0.00   
+  4  1    5    6    5903.8848  7502.3719  180.0   1.07773  0.00   
+  4  2    6    -4   2480.6502  3161.5489  -0.0    1.07767  0.00   
+  4  10   2    -8   236.6520   301.4058   0.0     1.07768  0.00   
+  4  8    4    -7   685.1252   885.6925   -0.0    1.07743  0.00   
+  4  1    5    -7   8101.0029  11199.6750 0.0     1.07666  0.00   
+  4  5    5    -7   11.3717    16.4800    0.0     1.07564  0.00   
+  4  6    4    3    1048.5957  1519.6083  -180.0  1.07562  0.00   
+  4  7    3    -10  8612.0953  12260.3533 0.0     1.07445  0.00   
+  4  6    0    6    625.8370   878.8977   180.0   1.07272  0.00   
+  4  6    4    -9   617.0028   817.6472   -180.0  1.06975  0.00   
+  4  1    1    10   2020.0582  2598.9786  -180.0  1.06913  0.00   
+  4  11   1    -5   117.0977   156.8616   180.0   1.07020  0.00   
+  4  11   1    -6   4.3628     5.6711     -180.0  1.06931  0.00   
+  4  4    6    -2   1975.7405  2494.2659  -180.0  1.06880  0.00   
+  4  1    1    -11  34.4641    42.2046    0.0     1.06744  0.00   
+  4  7    5    -3   1065.2954  1332.0657  -180.0  1.06857  0.00   
+  4  4    0    8    18978.0990 23529.7854 -0.0    1.06820  0.00   
+  4  7    5    -4   136.3562   168.7354   180.0   1.06801  0.00   
+  4  2    2    9    20763.0563 24380.3803 -0.0    1.06635  0.00   
+  4  6    0    -12  2554.1421  2929.7469  -180.0  1.06402  0.00   
+  4  4    6    -1   1.7626     2.0438     -0.0    1.06445  0.00   
+  4  2    2    -11  18916.8430 21004.2825 -180.0  1.06316  0.00   
+  4  4    6    -3   2486.6507  2831.4970  180.0   1.06381  0.00   
+  4  4    0    -12  26000.5422 28258.1165 -180.0  1.06181  0.00   
+  4  5    1    7    2948.6836  3263.4211  0.0     1.06306  0.00   
+  4  0    6    4    1536.1092  1675.3512  0.0     1.06240  0.00   
+  4  11   1    -4   4701.9103  5109.6716  0.0     1.06176  0.00   
+  4  1    3    9    1462.3517  1610.8804  0.0     1.05959  0.00   
+  4  10   0    0    755.0686   818.6871   0.0     1.06073  0.00   
+  4  7    5    -2   1.5029     1.6444     -0.0    1.05986  0.00   
+  4  11   1    -7   59.5744    66.0173    -180.0  1.05916  0.00   
+  4  1    3    -10  2217.1023  2357.5321  0.0     1.05810  0.00   
+  4  7    5    -5   3633.3939  3887.5199  -180.0  1.05821  0.00   
+  4  5    1    -12  2148.1893  2093.0629  -180.0  1.05561  0.00   
+  4  10   0    -10  5001.8794  4647.5795  0.0     1.05294  0.00   
+  4  4    6    0    1670.3477  1594.2503  0.0     1.05111  0.00   
+  4  8    2    3    23814.1835 22550.5447 180.0   1.05162  0.00   
+  4  10   2    -1   60768.8328 57925.1992 0.0     1.05081  0.00   
+  4  4    6    -4   1240.6329  1172.5845  0.0     1.04988  0.00   
+  4  8    4    0    65941.0658 62159.8536 -180.0  1.04950  0.00   
+  4  9    1    2    140.5690   132.4732   -0.0    1.04947  0.00   
+  4  9    3    0    2543.3858  2356.5625  0.0     1.04792  0.00   
+  4  2    6    3    60346.0865 55953.1978 -180.0  1.04653  0.00   
+  4  7    1    5    1102.7280  1023.5807  0.0     1.04623  0.00   
+  4  2    6    -5   60844.8669 56260.1373 -180.0  1.04532  0.00   
+  4  3    5    5    3960.8946  3649.5277  -0.0    1.04514  0.00   
+  4  10   2    -9   73767.5668 67209.1538 0.0     1.04473  0.00   
+  4  8    4    -8   74328.3223 67545.8582 -180.0  1.04465  0.00   
+  4  5    3    6    1549.0514  1400.2751  -180.0  1.04449  0.00   
+  4  8    2    -11  5.5092     4.8524     0.0     1.04312  0.00   
+  4  11   1    -3   30.1242    27.3651    180.0   1.04464  0.00   
+  4  3    5    -8   435.1391   382.4968   -0.0    1.04221  0.00   
+  4  7    5    -1   5296.6754  4658.2850  -180.0  1.04253  0.00   
+  4  9    3    -9   559.1026   492.8769   -180.0  1.04182  0.00   
+  4  9    1    -11  5388.1953  4934.4777  180.0   1.04066  0.00   
+  4  11   1    -8   5788.4441  5328.4278  0.0     1.04053  0.00   
+  4  7    5    -6   21.7941    20.5779    180.0   1.03992  0.00   
+  4  5    3    -11  154.9534   166.7382   -0.0    1.03815  0.00   
+  4  7    1    -12  487.4535   563.7093   -180.0  1.03735  0.00   
+  4  3    1    9    893.5204   983.6862   -180.0  1.03788  0.00   
+_reflns_number_total  1184
+_reflns_d_resolution_low    6.388
+_reflns_d_resolution_high   1.033
+
+# POWDER DATA TABLE
+_pd_meas_2theta_range_min  10.01313
+_pd_meas_2theta_range_max  119.99238
+_pd_meas_2theta_range_inc  0.02626
+_pd_proc_2theta_range_min  9.98829
+_pd_proc_2theta_range_max  119.96754
+_pd_proc_2theta_range_inc  0.02626
+_pd_proc_number_of_points  4189
+
+loop_
+   _pd_meas_intensity_total
+   _pd_calc_intensity_total
+   _pd_proc_intensity_bkg_calc
+   _pd_proc_ls_weight
+  2703         0            0           0         
+  2678         0            0           0         
+  2659         0            0           0         
+  2758         0            0           0         
+  2748         0            0           0         
+  2641         0            0           0         
+  2689         0            0           0         
+  2578         0            0           0         
+  2670         0            0           0         
+  2692         0            0           0         
+  2616         0            0           0         
+  2558         0            0           0         
+  2644         0            0           0         
+  2644         0            0           0         
+  2656         0            0           0         
+  2709         0            0           0         
+  2677         0            0           0         
+  2614         0            0           0         
+  2500         0            0           0         
+  2625         0            0           0         
+  2618         0            0           0         
+  2558         0            0           0         
+  2609         0            0           0         
+  2630         0            0           0         
+  2577         0            0           0         
+  2660         0            0           0         
+  2521         0            0           0         
+  2533         0            0           0         
+  2591         0            0           0         
+  2539         0            0           0         
+  2563         0            0           0         
+  2462         0            0           0         
+  2552         0            0           0         
+  2614         0            0           0         
+  2441         0            0           0         
+  2494         0            0           0         
+  2462         0            0           0         
+  2503         0            0           0         
+  2546         0            0           0         
+  2478         0            0           0         
+  2449         0            0           0         
+  2462         0            0           0         
+  2498         0            0           0         
+  2391         0            0           0         
+  2400         0            0           0         
+  2430         0            0           0         
+  2445         0            0           0         
+  2350         0            0           0         
+  2429         0            0           0         
+  2382         0            0           0         
+  2327         0            0           0         
+  2476         0            0           0         
+  2374         0            0           0         
+  2393         0            0           0         
+  2393         0            0           0         
+  2320         0            0           0         
+  2400         0            0           0         
+  2377         0            0           0         
+  2281         0            0           0         
+  2312         0            0           0         
+  2414         0            0           0         
+  2357         0            0           0         
+  2365         0            0           0         
+  2276         0            0           0         
+  2361         0            0           0         
+  2276         0            0           0         
+  2328         0            0           0         
+  2372         0            0           0         
+  2252         0            0           0         
+  2194         0            0           0         
+  2339         0            0           0         
+  2264         0            0           0         
+  2225         0            0           0         
+  2164         0            0           0         
+  2288         0            0           0         
+  2258         0            0           0         
+  2341         0            0           0         
+  2290         0            0           0         
+  2253         0            0           0         
+  2154         0            0           0         
+  2249         0            0           0         
+  2239         0            0           0         
+  2214         0            0           0         
+  2222         0            0           0         
+  2236         0            0           0         
+  2179         0            0           0         
+  2106         0            0           0         
+  2181         0            0           0         
+  2173         0            0           0         
+  2153         0            0           0         
+  2164         0            0           0         
+  2071         0            0           0         
+  2114         0            0           0         
+  2179         0            0           0         
+  2113         0            0           0         
+  2142         0            0           0         
+  2067         0            0           0         
+  2247         0            0           0         
+  2147         0            0           0         
+  2190         0            0           0         
+  2130         0            0           0         
+  2144         0            0           0         
+  2092         0            0           0         
+  2121         0            0           0         
+  2007         0            0           0         
+  2081         0            0           0         
+  2099         0            0           0         
+  2057         0            0           0         
+  2034         0            0           0         
+  2022         0            0           0         
+  2002         0            0           0         
+  2056         0            0           0         
+  2079         0            0           0         
+  2072         0            0           0         
+  2025         0            0           0         
+  2094         0            0           0         
+  2030         0            0           0         
+  2034         0            0           0         
+  2054         0            0           0         
+  2061         0            0           0         
+  1988         0            0           0         
+  2009         0            0           0         
+  1954         0            0           0         
+  2032         0            0           0         
+  2027         0            0           0         
+  2012         0            0           0         
+  1953         0            0           0         
+  1962         0            0           0         
+  1955         0            0           0         
+  1969         0            0           0         
+  1989         0            0           0         
+  1944         0            0           0         
+  1907         0            0           0         
+  1874         0            0           0         
+  1949         0            0           0         
+  1893         0            0           0         
+  1947         0            0           0         
+  1967         0            0           0         
+  1959         0            0           0         
+  1915         0            0           0         
+  1884         0            0           0         
+  1960         0            0           0         
+  1896         0            0           0         
+  1908         0            0           0         
+  1966         0            0           0         
+  1887         0            0           0         
+  1851         0            0           0         
+  1801         0            0           0         
+  1879         0            0           0         
+  1928         0            0           0         
+  1831         0            0           0         
+  1854         0            0           0         
+  1783         0            0           0         
+  1779         0            0           0         
+  1837         0            0           0         
+  1923         0            0           0         
+  1907         0            0           0         
+  1753         0            0           0         
+  1828         0            0           0         
+  1814         0            0           0         
+  1798         0            0           0         
+  1744         0            0           0         
+  1870         0            0           0         
+  1792         0            0           0         
+  1810         0            0           0         
+  1860         0            0           0         
+  1780         0            0           0         
+  1751         0            0           0         
+  1818         0            0           0         
+  1804         0            0           0         
+  1789         0            0           0         
+  1814         0            0           0         
+  1767         0            0           0         
+  1817         0            0           0         
+  1804         0            0           0         
+  1736         0            0           0         
+  1727         0            0           0         
+  1746         0            0           0         
+  1675         0            0           0         
+  1723         1706.50316   1706.10301  0.000580383 
+  1770         1703.04545   1702.63351  0.000564972 
+  1708         1699.59524   1699.17087  0.00058548 
+  1737         1696.15257   1695.71509  0.000575705 
+  1705         1692.71748   1692.26615  0.00058651 
+  1690         1689.29001   1688.82405  0.000591716 
+  1746         1685.87024   1685.38876  0.000572738 
+  1716         1682.45822   1681.96029  0.000582751 
+  1714         1679.05403   1678.53862  0.000583431 
+  1739         1675.65775   1675.12373  0.000575043 
+  1724         1672.26948   1671.71562  0.000580046 
+  1651         1668.88943   1668.31428  0.000605694 
+  1691         1665.51752   1664.91969  0.000591366 
+  1725         1662.15401   1661.53184  0.00057971 
+  1714         1658.7991    1658.15072  0.000583431 
+  1669         1655.45288   1654.77633  0.000599161 
+  1614         1652.11564   1651.40864  0.000619579 
+  1647         1648.78763   1648.04765  0.000607165 
+  1630         1645.46916   1644.69335  0.000613497 
+  1612         1642.16057   1641.34573  0.000620347 
+  1725         1638.86228   1638.00477  0.00057971 
+  1642         1635.57492   1634.67046  0.000609013 
+  1720         1632.29882   1631.3428   0.000581395 
+  1705         1629.03482   1628.02177  0.00058651 
+  1628         1625.78421   1624.70736  0.000614251 
+  1681         1622.54715   1621.39956  0.000594884 
+  1646         1619.32554   1618.09836  0.000607533 
+  1552         1616.1206    1614.80374  0.00064433 
+  1640         1612.93452   1611.51571  0.000609756 
+  1644         1609.76983   1608.23424  0.000608273 
+  1637         1606.62985   1604.95932  0.000610874 
+  1660         1603.51891   1601.69095  0.00060241 
+  1640         1600.44288   1598.42911  0.000609756 
+  1653         1597.40989   1595.17379  0.000604961 
+  1582         1594.43157   1591.92498  0.000632111 
+  1630         1591.52536   1588.68268  0.000613497 
+  1592         1588.71908   1585.44686  0.000628141 
+  1665         1586.06195   1582.21752  0.000600601 
+  1578         1583.65488   1578.99465  0.000633714 
+  1539         1581.71245   1575.77824  0.000649773 
+  1543         1580.5722    1572.56827  0.000648088 
+  1698         1580.08924   1569.36474  0.000588928 
+  1662         1580.23641   1566.16763  0.000601685 
+  1629         1582.10842   1562.97694  0.000613874 
+  1652         1584.46685   1559.79265  0.000605327 
+  1632         1588.09374   1556.61475  0.000612745 
+  1608         1593.91392   1553.44323  0.000621891 
+  1630         1600.59962   1550.27809  0.000613497 
+  1648         1611.59563   1547.1193   0.000606796 
+  1721         1625.0089    1543.96687  0.000581058 
+  1679         1645.0231    1540.82077  0.000595593 
+  1737         1666.72471   1537.681    0.000575705 
+  1736         1674.70458   1534.54755  0.000576037 
+  1763         1653.22819   1531.4204   0.000567215 
+  1651         1617.60708   1528.29956  0.000605694 
+  1621         1588.62724   1525.18499  0.000616903 
+  1599         1572.07052   1522.07671  0.000625391 
+  1568         1561.23626   1518.97468  0.000637755 
+  1607         1551.19168   1515.87891  0.000622278 
+  1533         1543.63984   1512.78939  0.000652316 
+  1551         1538.69818   1509.70609  0.000644745 
+  1538         1532.25046   1506.62902  0.000650195 
+  1510         1522.75567   1503.55816  0.000662252 
+  1532         1513.33585   1500.49351  0.000652742 
+  1497         1506.14275   1497.43504  0.000668003 
+  1513         1500.87292   1494.38275  0.000660939 
+  1528         1496.56215   1491.33663  0.00065445 
+  1503         1492.71407   1488.29668  0.000665336 
+  1505         1489.11997   1485.26287  0.000664452 
+  1551         1485.68473   1482.2352   0.000644745 
+  1501         1482.35785   1479.21366  0.000666223 
+  1499         1479.10956   1476.19823  0.000667111 
+  1504         1475.92114   1473.18892  0.000664894 
+  1475         1472.78021   1470.1857   0.000677966 
+  1489         1469.67835   1467.18857  0.000671592 
+  1472         1466.60968   1464.19751  0.000679348 
+  1482         1463.57002   1461.21252  0.000674764 
+  1400         1460.55644   1458.23358  0.000714286 
+  1499         1457.56693   1455.2607   0.000667111 
+  1463         1454.60018   1452.29384  0.000683527 
+  1484         1451.65551   1449.33301  0.000673854 
+  1503         1448.7328    1446.3782   0.000665336 
+  1412         1445.83248   1443.42939  0.000708215 
+  1429         1442.95563   1440.48657  0.00069979 
+  1407         1440.10413   1437.54974  0.000710732 
+  1518         1437.28096   1434.61888  0.000658762 
+  1418         1434.49079   1431.69399  0.000705219 
+  1412         1431.74122   1428.77505  0.000708215 
+  1426         1429.04575   1425.86205  0.000701262 
+  1465         1426.43216   1422.95499  0.000682594 
+  1390         1423.96016   1420.05385  0.000719424 
+  1407         1421.71943   1417.15862  0.000710732 
+  1453         1419.64642   1414.26929  0.000688231 
+  1464         1417.68871   1411.38586  0.00068306 
+  1330         1416.26954   1408.50831  0.00075188 
+  1433         1415.04149   1405.63663  0.000697837 
+  1400         1413.93933   1402.77082  0.000714286 
+  1449         1413.76492   1399.91085  0.000690131 
+  1523         1413.68092   1397.05673  0.000656599 
+  1464         1415.00088   1394.20844  0.00068306 
+  1361         1416.92112   1391.36598  0.000734754 
+  1446         1419.57875   1388.52932  0.000691563 
+  1444         1417.90276   1385.69847  0.000692521 
+  1390         1410.24905   1382.87341  0.000719424 
+  1442         1401.26841   1380.05414  0.000693481 
+  1461         1394.50312   1377.24063  0.000684463 
+  1405         1390.75422   1374.43289  0.000711744 
+  1400         1388.87261   1371.6309   0.000714286 
+  1386         1388.20089   1368.83465  0.000721501 
+  1317         1388.48861   1366.04414  0.000759301 
+  1400         1389.53646   1363.25935  0.000714286 
+  1477         1391.0256    1360.48027  0.000677048 
+  1413         1392.65013   1357.7069   0.000707714 
+  1361         1394.43602   1354.93922  0.000734754 
+  1366         1396.79943   1352.17722  0.000732064 
+  1406         1400.12717   1349.4209   0.000711238 
+  1435         1404.0748    1346.67024  0.000696864 
+  1387         1407.16035   1343.92524  0.000720981 
+  1410         1407.41974   1341.18588  0.00070922 
+  1425         1403.84843   1338.45215  0.000701754 
+  1336         1397.13323   1335.72405  0.000748503 
+  1366         1389.10053   1333.00157  0.000732064 
+  1379         1381.55652   1330.28469  0.000725163 
+  1317         1375.43035   1327.5734   0.000759301 
+  1423         1370.49744   1324.86771  0.000702741 
+  1402         1365.64887   1322.16759  0.000713267 
+  1400         1359.76471   1319.47303  0.000714286 
+  1355         1352.61087   1316.78404  0.000738007 
+  1309         1344.84366   1314.10059  0.000763942 
+  1347         1337.35952   1311.42267  0.00074239 
+  1306         1330.79132   1308.75029  0.000765697 
+  1388         1325.306     1306.08343  0.000720461 
+  1286         1320.6807    1303.42207  0.000777605 
+  1356         1317.09619   1300.76621  0.000737463 
+  1326         1314.40639   1298.11585  0.000754148 
+  1324         1312.05093   1295.47096  0.000755287 
+  1307         1310.96946   1292.83155  0.000765111 
+  1306         1310.23786   1290.19759  0.000765697 
+  1356         1311.08656   1287.56909  0.000737463 
+  1309         1312.68527   1284.94603  0.000763942 
+  1330         1314.62425   1282.3284   0.00075188 
+  1346         1311.06182   1279.7162   0.000742942 
+  1285         1301.61659   1277.10941  0.00077821 
+  1252         1291.11471   1274.50803  0.000798722 
+  1288         1282.76593   1271.91204  0.000776398 
+  1229         1277.1645    1269.32143  0.00081367 
+  1320         1272.99852   1266.7362   0.000757576 
+  1328         1269.48504   1264.15634  0.000753012 
+  1290         1266.29703   1261.58184  0.000775194 
+  1332         1263.29751   1259.01268  0.000750751 
+  1233         1260.42012   1256.44886  0.00081103 
+  1293         1257.62854   1253.89037  0.000773395 
+  1203         1254.90143   1251.3372   0.000831255 
+  1248         1252.22564   1248.78934  0.000801282 
+  1251         1249.59288   1246.24679  0.000799361 
+  1249         1246.99795   1243.70952  0.000800641 
+  1215         1244.43769   1241.17754  0.000823045 
+  1209         1241.91049   1238.65083  0.00082713 
+  1263         1239.41601   1236.12938  0.000791766 
+  1247         1236.95496   1233.61319  0.000801925 
+  1263         1234.52919   1231.10225  0.000791766 
+  1237         1232.14172   1228.59654  0.000808407 
+  1225         1229.79699   1226.09606  0.000816327 
+  1292         1227.50117   1223.6008   0.000773994 
+  1204         1225.26271   1221.11074  0.000830565 
+  1252         1223.09298   1218.62589  0.000798722 
+  1236         1221.0073    1216.14623  0.000809061 
+  1186         1219.02601   1213.67174  0.00084317 
+  1227         1217.17558   1211.20243  0.000814996 
+  1158         1215.48877   1208.73828  0.000863558 
+  1167         1214.00288   1206.27929  0.000856898 
+  1186         1212.75853   1203.82544  0.00084317 
+  1262         1211.80697   1201.37673  0.000792393 
+  1181         1211.22651   1198.93314  0.00084674 
+  1141         1211.11709   1196.49467  0.000876424 
+  1147         1211.54085   1194.06131  0.00087184 
+  1204         1212.39312   1191.63305  0.000830565 
+  1201         1213.38014   1189.20988  0.000832639 
+  1152         1214.20244   1186.79179  0.000868056 
+  1248         1214.89525   1184.37878  0.000801282 
+  1227         1215.76149   1181.97082  0.000814996 
+  1091         1216.84767   1179.56793  0.00091659 
+  1258         1217.39137   1177.17007  0.000794913 
+  1114         1215.99197   1174.77726  0.000897666 
+  1165         1211.73951   1172.38947  0.000858369 
+  1228         1205.02439   1170.0067   0.000814332 
+  1171         1197.12377   1167.62894  0.000853971 
+  1190         1189.29992   1165.25618  0.000840336 
+  1175         1182.256     1162.88841  0.000851064 
+  1178         1176.16242   1160.52562  0.000848896 
+  1115         1170.92404   1158.16781  0.000896861 
+  1126         1166.36015   1155.81497  0.000888099 
+  1047         1162.31819   1153.46708  0.00095511 
+  1157         1158.65575   1151.12414  0.000864304 
+  1113         1155.27827   1148.78614  0.000898473 
+  1153         1152.11981   1146.45307  0.000867303 
+  1134         1149.13482   1144.12491  0.000881834 
+  1087         1146.26351   1141.80168  0.000919963 
+  1136         1143.49146   1139.48334  0.000880282 
+  1132         1140.80505   1137.1699   0.000883392 
+  1148         1138.17616   1134.86135  0.00087108 
+  1078         1135.5998    1132.55767  0.000927644 
+  1074         1133.06713   1130.25886  0.000931099 
+  1101         1130.57127   1127.96491  0.000908265 
+  1092         1128.10679   1125.67582  0.000915751 
+  1160         1125.66939   1123.39156  0.000862069 
+  1126         1123.25559   1121.11214  0.000888099 
+  1091         1120.86256   1118.83755  0.00091659 
+  1113         1118.48811   1116.56777  0.000898473 
+  1072         1116.13019   1114.3028   0.000932836 
+  1128         1113.7873    1112.04263  0.000886525 
+  1163         1111.45818   1109.78725  0.000859845 
+  1140         1109.14166   1107.53665  0.000877193 
+  1080         1106.83687   1105.29082  0.000925926 
+  1062         1104.54302   1103.04976  0.00094162 
+  1091         1102.25945   1100.81346  0.00091659 
+  1134         1099.98559   1098.5819   0.000881834 
+  1071         1097.72098   1096.35509  0.000933707 
+  1121         1095.46519   1094.133    0.000892061 
+  1050         1093.21787   1091.91564  0.000952381 
+  1091         1090.97872   1089.70298  0.00091659 
+  1126         1088.74748   1087.49504  0.000888099 
+  1083         1086.52394   1085.29179  0.000923361 
+  1112         1084.30791   1083.09323  0.000899281 
+  1071         1082.10331   1080.89935  0.000933707 
+  1099         1079.90188   1078.71014  0.000909918 
+  1058         1077.70961   1076.52559  0.00094518 
+  1040         1075.52236   1074.3457   0.000961538 
+  1044         1073.34209   1072.17045  0.000957854 
+  1067         1071.17155   1069.99984  0.000937207 
+  1045         1069.00517   1067.83386  0.000956938 
+  1037         1066.85417   1065.6725   0.00096432 
+  1059         1064.70175   1063.51575  0.000944287 
+  1037         1062.55634   1061.36361  0.00096432 
+  1074         1060.42154   1059.21606  0.000931099 
+  1046         1058.29041   1057.0731   0.000956023 
+  1044         1056.16672   1054.93472  0.000957854 
+  1026         1054.05033   1052.80091  0.000974659 
+  1005         1051.94158   1050.67166  0.000995025 
+  1012         1049.84081   1048.54697  0.000988142 
+  1059         1047.74804   1046.42682  0.000944287 
+  1064         1045.66373   1044.31121  0.00093985 
+  1073         1043.58827   1042.20012  0.000931966 
+  1048         1041.52207   1040.09356  0.000954198 
+  1030         1039.4657    1037.99151  0.000970874 
+  1006         1037.4198    1035.89397  0.000994036 
+  1033         1035.38533   1033.80092  0.000968054 
+  1049         1033.3628    1031.71236  0.000953289 
+  1071         1031.3535    1029.62829  0.000933707 
+  993          1029.35889   1027.54868  0.001007049 
+  1003         1027.38036   1025.47353  0.000997009 
+  1007         1025.4205    1023.40285  0.000993049 
+  1019         1023.48119   1021.3366   0.000981354 
+  1012         1021.56508   1019.2748   0.000988142 
+  972          1019.67667   1017.21743  0.001028807 
+  968          1017.82049   1015.16448  0.001033058 
+  1010         1016.00255   1013.11595  0.000990099 
+  996          1014.23106   1011.07182  0.001004016 
+  973          1012.51652   1009.0321   0.001027749 
+  985          1010.87296   1006.99676  0.001015228 
+  994          1009.31914   1004.9658   0.001006036 
+  1015         1007.88051   1002.93922  0.000985222 
+  1006         1006.59178   1000.91701  0.000994036 
+  958          1005.49963   998.89916   0.001043841 
+  1012         1004.66576   996.88565   0.000988142 
+  1009         1004.16677   994.87649   0.00099108 
+  950          1004.08344   992.87166   0.001052632 
+  912          1004.46807   990.87116   0.001096491 
+  1040         1005.28671   988.87498   0.000961538 
+  955          1006.3946    986.8831    0.00104712 
+  973          1007.64822   984.89554   0.001027749 
+  924          1009.03671   982.91226   0.001082251 
+  951          1010.52618   980.93327   0.001051525 
+  968          1011.68143   978.95856   0.001033058 
+  1017         1011.55738   976.98813   0.000983284 
+  1018         1009.31526   975.02195   0.000982318 
+  963          1004.96726   973.06003   0.001038422 
+  992          999.22996    971.10236   0.001008065 
+  917          993.06138    969.14893   0.001090513 
+  915          987.16147    967.19972   0.001092896 
+  922          981.83364    965.25475   0.001084599 
+  965          977.10979    963.31399   0.001036269 
+  966          972.79617    961.37743   0.001035197 
+  982          968.89141    959.44508   0.00101833 
+  908          965.37915    957.51692   0.001101322 
+  949          962.2246     955.59295   0.001053741 
+  901          959.37442    953.67315   0.001109878 
+  939          956.74127    951.75752   0.001064963 
+  980          954.2612     949.84605   0.001020408 
+  913          951.89549    947.93874   0.00109529 
+  920          949.61812    946.03557   0.001086957 
+  940          947.40941    944.13655   0.00106383 
+  943          945.25619    942.24165   0.001060445 
+  855          943.14821    940.35088   0.001169591 
+  905          941.07775    938.46422   0.001104972 
+  940          939.03883    936.58167   0.00106383 
+  903          937.02677    934.70321   0.00110742 
+  940          935.0379     932.82886   0.00106383 
+  944          933.06929    930.95858   0.001059322 
+  968          931.11854    929.09239   0.001033058 
+  919          929.18377    927.23026   0.001088139 
+  838          927.26368    925.3722    0.001193317 
+  893          925.35641    923.51819   0.001119821 
+  920          923.4612     921.66822   0.001086957 
+  894          921.57731    919.8223    0.001118568 
+  875          919.70372    917.98041   0.001142857 
+  903          917.83997    916.14254   0.00110742 
+  889          915.98558    914.30869   0.001124859 
+  941          914.14012    912.47884   0.001062699 
+  888          912.30326    910.653     0.001126126 
+  944          910.47473    908.83116   0.001059322 
+  909          908.65431    907.0133    0.00110011 
+  899          906.84211    905.19942   0.001112347 
+  878          905.03748    903.38951   0.001138952 
+  827          903.2406     901.58356   0.00120919 
+  905          901.45158    899.78158   0.001104972 
+  902          899.67015    897.98354   0.001108647 
+  884          897.89648    896.18944   0.001131222 
+  938          896.13066    894.39928   0.001066098 
+  913          894.3728     892.61304   0.00109529 
+  867          892.62305    890.83073   0.001153403 
+  880          890.88163    889.05233   0.001136364 
+  863          889.14879    887.27783   0.001158749 
+  871          887.42483    885.50723   0.001148106 
+  869          885.71014    883.74052   0.001150748 
+  848          884.01075    881.97769   0.001179245 
+  864          882.31609    880.21874   0.001157407 
+  888          880.63241    878.46366   0.001126126 
+  856          878.96016    876.71244   0.001168224 
+  877          877.29925    874.96507   0.001140251 
+  863          875.65495    873.22155   0.001158749 
+  796          874.03308    871.48187   0.001256281 
+  855          872.42295    869.74601   0.001169591 
+  855          870.83164    868.01399   0.001169591 
+  850          869.26545    866.28578   0.001176471 
+  830          867.72426    864.56138   0.001204819 
+  843          866.20578    862.84079   0.00118624 
+  820          864.70525    861.12399   0.001219512 
+  835          863.20929    859.41097   0.001197605 
+  837          861.74078    857.70174   0.001194743 
+  887          860.31279    855.99629   0.001127396 
+  833          858.94068    854.2946    0.00120048 
+  841          857.63539    852.59667   0.001189061 
+  804          856.40473    850.90249   0.001243781 
+  805          855.26243    849.21206   0.001242236 
+  843          854.22869    847.52537   0.00118624 
+  836          853.33163    845.84241   0.001196172 
+  787          852.61077    844.16317   0.001270648 
+  825          852.12244    842.48765   0.001212121 
+  806          851.94939    840.81584   0.001240695 
+  790          852.21884    839.14774   0.001265823 
+  823          853.13629    837.48333   0.001215067 
+  843          855.06177    835.8226    0.00118624 
+  842          858.72565    834.16556   0.001187648 
+  766          865.91609    832.5122    0.001305483 
+  905          880.61877    830.8625    0.001104972 
+  845          905.38907    829.21646   0.001183432 
+  947          935.17125    827.57408   0.001055966 
+  954          994.29535    825.93534   0.001048218 
+  1066         1054.53981   824.30024   0.000938086 
+  1132         1156.8372    822.66878   0.000883392 
+  1436         1283.70687   821.04094   0.000696379 
+  1649         1437.55232   819.41672   0.000606428 
+  1639         1456.0558    817.79611   0.000610128 
+  1401         1306.46152   816.17911   0.000713776 
+  1213         1162.86102   814.5657    0.000824402 
+  919          1005.0968    812.95589   0.001088139 
+  863          914.2557     811.34966   0.001158749 
+  797          872.99414    809.74701   0.001254705 
+  830          851.88728    808.14792   0.001204819 
+  809          839.03741    806.55241   0.001236094 
+  847          830.26527    804.96044   0.001180638 
+  779          823.79871    803.37203   0.001283697 
+  781          818.75066    801.78716   0.00128041 
+  811          814.63016    800.20583   0.001233046 
+  805          811.13281    798.62803   0.001242236 
+  802          808.07974    797.05375   0.001246883 
+  866          805.35124    795.48298   0.001154734 
+  764          802.86563    793.91573   0.001308901 
+  768          800.56845    792.35197   0.001302083 
+  849          798.41881    790.79172   0.001177856 
+  832          796.38865    789.23495   0.001201923 
+  830          794.45646    787.68166   0.001204819 
+  773          792.60665    786.13185   0.001293661 
+  830          790.82754    784.5855    0.001204819 
+  807          789.12742    783.04262   0.001239157 
+  804          787.46644    781.50319   0.001243781 
+  765          785.85697    779.96722   0.00130719 
+  786          784.30467    778.43468   0.001272265 
+  734          782.79133    776.90558   0.001362398 
+  727          781.32525    775.3799    0.001375516 
+  737          779.90758    773.85765   0.001356852 
+  735          778.5409     772.33881   0.001360544 
+  767          777.27263    770.82339   0.001303781 
+  768          776.02214    769.31136   0.001302083 
+  794          774.84054    767.80273   0.001259446 
+  740          773.77266    766.29748   0.001351351 
+  771          772.76517    764.79562   0.001297017 
+  797          771.87125    763.29714   0.001254705 
+  750          771.12345    761.80202   0.001333333 
+  757          770.54561    760.31026   0.001321004 
+  780          770.19452    758.82186   0.001282051 
+  758          770.14312    757.33681   0.001319261 
+  801          770.50679    755.85511   0.001248439 
+  775          771.43656    754.37674   0.001290323 
+  725          773.21053    752.90169   0.00137931 
+  785          776.30954    751.42997   0.001273885 
+  795          781.68409    749.96157   0.001257862 
+  830          791.41088    748.49648   0.001204819 
+  820          809.40433    747.03469   0.001219512 
+  807          838.01263    745.5762    0.001239157 
+  896          871.71685    744.121     0.001116071 
+  940          931.84558    742.66908   0.00106383 
+  1078         1012.06001   741.22044   0.000927644 
+  1178         1102.95403   739.77507   0.000848896 
+  1294         1236.27494   738.33297   0.000772798 
+  1231         1293.12742   736.89412   0.000812348 
+  1120         1222.69434   735.45853   0.000892857 
+  963          1106.46343   734.02618   0.001038422 
+  837          982.93756    732.59707   0.001194743 
+  800          875.83048    731.1712    0.00125   
+  789          817.11578    729.74855   0.001267427 
+  775          786.7002     728.32912   0.001290323 
+  737          769.26011    726.91291   0.001356852 
+  756          757.97279    725.4999    0.001322751 
+  718          749.99369    724.09009   0.001392758 
+  725          743.98873    722.68348   0.00137931 
+  769          739.24159    721.28006   0.00130039 
+  705          735.33752    719.87982   0.00141844 
+  727          732.0212     718.48276   0.001375516 
+  712          729.12839    717.08886   0.001404494 
+  699          726.54986    715.69813   0.001430615 
+  691          724.21057    714.31056   0.001447178 
+  684          722.05756    712.92613   0.001461988 
+  759          720.05292    711.54485   0.001317523 
+  750          718.16897    710.16671   0.001333333 
+  712          716.38522    708.79171   0.001404494 
+  683          714.68661    707.41982   0.001464129 
+  727          713.06206    706.05106   0.001375516 
+  715          711.50355    704.68541   0.001398601 
+  719          710.00568    703.32287   0.001390821 
+  720          708.56527    701.96343   0.001388889 
+  680          707.18116    700.60709   0.001470588 
+  731          705.85439    699.25383   0.001367989 
+  710          704.58835    697.90366   0.001408451 
+  707          703.38929    696.55657   0.001414427 
+  681          702.26739    695.21254   0.001468429 
+  670          701.23826    693.87158   0.001492537 
+  623          700.32563    692.53368   0.001605136 
+  733          699.56634    691.19883   0.001364256 
+  746          699.01947    689.86702   0.001340483 
+  693          698.78523    688.53826   0.001443001 
+  681          699.05292    687.21253   0.001468429 
+  665          700.22281    685.88983   0.001503759 
+  685          703.12339    684.57015   0.001459854 
+  693          708.93378    683.25349   0.001443001 
+  690          716.96214    681.93983   0.001449275 
+  765          729.25956    680.62918   0.00130719 
+  894          750.14382    679.32153   0.001118568 
+  872          772.14377    678.01687   0.001146789 
+  988          805.72       676.71519   0.001012146 
+  949          825.24149    675.4165    0.001053741 
+  843          809.9297     674.12078   0.00118624 
+  770          780.77459    672.82803   0.001298701 
+  721          750.81532    671.53823   0.001386963 
+  657          720.61018    670.2514    0.00152207 
+  715          702.75938    668.96751   0.001398601 
+  649          693.62995    667.68657   0.001540832 
+  684          688.741      666.40857   0.001461988 
+  666          686.00558    665.1335    0.001501502 
+  686          684.63164    663.86136   0.001457726 
+  714          684.37603    662.59213   0.00140056 
+  675          685.29409    661.32583   0.001481481 
+  714          687.74353    660.06243   0.00140056 
+  664          692.62223    658.80193   0.001506024 
+  675          701.95574    657.54433   0.001481481 
+  713          719.46206    656.28962   0.001402525 
+  731          746.65511    655.0378    0.001367989 
+  757          781.93542    653.78885   0.001321004 
+  831          845.30412    652.54278   0.001203369 
+  907          919.06621    651.29958   0.001102536 
+  1030         1019.24805   650.05924   0.000970874 
+  1324         1110.03798   648.82176   0.000755287 
+  1375         1090.35702   647.58713   0.000727273 
+  1117         1000.33199   646.35534   0.000895255 
+  945          911.62085    645.12639   0.001058201 
+  865          810.03487    643.90027   0.001156069 
+  696          740.99804    642.67698   0.001436782 
+  698          705.18153    641.45652   0.001432665 
+  647          685.97977    640.23887   0.001545595 
+  692          674.41102    639.02403   0.001445087 
+  626          666.68698    637.81199   0.001597444 
+  647          661.16718    636.60276   0.001545595 
+  633          657.04318    635.39631   0.001579779 
+  668          653.8579     634.19266   0.001497006 
+  605          651.36048    632.99178   0.001652893 
+  589          649.40774    631.79369   0.001697793 
+  617          647.91964    630.59836   0.001620746 
+  691          646.88227    629.4058    0.001447178 
+  652          646.32366    628.21599   0.001533742 
+  616          646.35543    627.02894   0.001623377 
+  630          647.22212    625.84464   0.001587302 
+  626          649.45472    624.66309   0.001597444 
+  613          654.12488    623.48426   0.001631321 
+  671          662.47926    622.30817   0.001490313 
+  682          673.83273    621.13481   0.001466276 
+  781          692.97997    619.96416   0.00128041 
+  734          720.36905    618.79623   0.001362398 
+  777          754.73173    617.63101   0.001287001 
+  943          797.22215    616.4685    0.001060445 
+  992          813.47323    615.30868   0.001008065 
+  1053         812.48374    614.15155   0.000949668 
+  1005         820.28132    612.99711   0.000995025 
+  1036         836.99634    611.84535   0.000965251 
+  1077         873.4324     610.69626   0.000928505 
+  1224         901.84268    609.54985   0.000816993 
+  1093         935.96513    608.4061    0.000914913 
+  932          929.8324     607.26501   0.001072961 
+  923          863.68871    606.12658   0.001083424 
+  721          802.75807    604.99079   0.001386963 
+  605          742.89807    603.85765   0.001652893 
+  597          692.50307    602.72714   0.001675042 
+  602          665.09843    601.59927   0.00166113 
+  593          651.29306    600.47402   0.001686341 
+  640          643.86707    599.3514    0.0015625 
+  610          639.59058    598.23138   0.001639344 
+  642          637.05402    597.11399   0.001557632 
+  580          635.30854    595.99919   0.001724138 
+  635          633.40379    594.887     0.001574803 
+  616          630.6027     593.77739   0.001623377 
+  630          626.74799    592.67038   0.001587302 
+  629          622.1328     591.56595   0.001589825 
+  575          617.21724    590.4641    0.00173913 
+  595          612.47941    589.36483   0.001680672 
+  627          608.23955    588.26812   0.001594896 
+  608          604.59293    587.17397   0.001644737 
+  647          601.49136    586.08238   0.001545595 
+  577          598.83743    584.99334   0.001733102 
+  580          596.53435    583.90685   0.001724138 
+  567          594.50264    582.8229    0.001763668 
+  610          592.68169    581.74148   0.001639344 
+  609          591.02733    580.6626    0.001642036 
+  597          589.50602    579.58624   0.001675042 
+  574          588.09524    578.5124    0.00174216 
+  562          586.78308    577.44107   0.001779359 
+  592          585.55049    576.37226   0.001689189 
+  600          584.39463    575.30595   0.001666667 
+  589          583.31516    574.24214   0.001697793 
+  570          582.30872    573.18082   0.001754386 
+  591          581.38227    572.12199   0.001692047 
+  581          580.54544    571.06564   0.00172117 
+  565          579.81437    570.01177   0.001769912 
+  604          579.21466    568.96038   0.001655629 
+  552          578.78655    567.91145   0.001811594 
+  613          578.59544    566.86499   0.001631321 
+  584          578.75125    565.82098   0.001712329 
+  608          579.45357    564.77943   0.001644737 
+  609          581.12251    563.74032   0.001642036 
+  594          584.68106    562.70366   0.001683502 
+  593          591.83726    561.66943   0.001686341 
+  644          603.32969    560.63764   0.001552795 
+  641          616.10345    559.60827   0.001560062 
+  601          640.52855    558.58132   0.001663894 
+  738          675.24556    557.55679   0.001355014 
+  777          700.57164    556.53467   0.001287001 
+  757          711.2441     555.51496   0.001321004 
+  720          682.57057    554.49765   0.001388889 
+  638          658.96643    553.48274   0.001567398 
+  623          631.90509    552.47022   0.001605136 
+  609          607.0317     551.46008   0.001642036 
+  596          597.02785    550.45233   0.001677852 
+  553          596.31621    549.44695   0.001808318 
+  617          596.89834    548.44394   0.001620746 
+  646          595.32705    547.4433    0.001547988 
+  595          586.51586    546.44502   0.001680672 
+  584          579.47232    545.4491    0.001712329 
+  597          571.63224    544.45553   0.001675042 
+  591          564.64862    543.4643    0.001692047 
+  561          560.4756     542.47542   0.001782531 
+  624          557.98493    541.48887   0.001602564 
+  605          556.34678    540.50466   0.001652893 
+  626          555.19265    539.52277   0.001597444 
+  615          554.37439    538.5432    0.001626016 
+  632          553.82441    537.56595   0.001582278 
+  629          553.4842     536.59102   0.001589825 
+  697          553.29339    535.61838   0.00143472 
+  699          553.1659     534.64806   0.001430615 
+  729          552.98536    533.68002   0.001371742 
+  685          552.74892    532.71428   0.001459854 
+  679          552.46946    531.75083   0.001472754 
+  677          552.31005    530.78966   0.001477105 
+  641          552.37971    529.83077   0.001560062 
+  624          552.77242    528.87415   0.001602564 
+  572          553.59326    527.9198    0.001748252 
+  584          554.87746    526.96771   0.001712329 
+  616          556.60642    526.01788   0.001623377 
+  600          558.69904    525.07031   0.001666667 
+  588          561.0204     524.12498   0.00170068 
+  582          563.38603    523.1819    0.001718213 
+  568          565.61345    522.24105   0.001760563 
+  608          567.73548    521.30244   0.001644737 
+  582          570.13808    520.36606   0.001718213 
+  590          573.51201    519.43191   0.001694915 
+  565          579.01095    518.49997   0.001769912 
+  606          588.6908     517.57025   0.001650165 
+  585          605.40273    516.64274   0.001709402 
+  611          627.84806    515.71744   0.001636661 
+  655          658.29828    514.79434   0.001526718 
+  683          711.80296    513.87343   0.001464129 
+  728          763.80789    512.95472   0.001373626 
+  747          804.91339    512.03819   0.001338688 
+  792          803.32814    511.12385   0.001262626 
+  799          799.47182    510.21168   0.001251564 
+  877          821.88491    509.30169   0.001140251 
+  902          877.37776    508.39386   0.001108647 
+  1071         1032.79356   507.4882    0.000933707 
+  1235         1285.73345   506.5847    0.000809717 
+  1657         1695.6685    505.68335   0.0006035 
+  2310         2370.74642   504.78415   0.0004329 
+  3803         3184.41508   503.8871    0.00026295 
+  5138         4012.43977   502.99218   0.000194628 
+  4420         3686.27995   502.09941   0.000226244 
+  3195         2948.63075   501.20876   0.000312989 
+  2793         2489.61312   500.32024   0.000358038 
+  1750         1730.38642   499.43384   0.000571429 
+  1028         1156.98293   498.54956   0.000972763 
+  763          890.24563    497.6674    0.001310616 
+  656          763.59093    496.78734   0.00152439 
+  612          692.33698    495.90938   0.001633987 
+  573          647.44894    495.03353   0.001745201 
+  625          617.43812    494.15977   0.0016    
+  573          596.43532    493.28809   0.001745201 
+  568          581.25554    492.41851   0.001760563 
+  578          570.09006    491.551     0.001730104 
+  482          561.8619     490.68558   0.002074689 
+  548          555.89041    489.82222   0.001824818 
+  524          551.67862    488.96093   0.001908397 
+  500          548.72719    488.10171   0.002     
+  544          546.41443    487.24454   0.001838235 
+  566          544.11032    486.38943   0.001766784 
+  506          541.49895    485.53636   0.001976285 
+  524          538.65725    484.68534   0.001908397 
+  519          535.83488    483.83637   0.001926782 
+  526          533.35873    482.98943   0.001901141 
+  536          531.59753    482.14452   0.001865672 
+  519          530.88632    481.30163   0.001926782 
+  553          531.55768    480.46078   0.001808318 
+  527          534.12109    479.62193   0.001897533 
+  564          539.57861    478.78511   0.00177305 
+  509          549.88588    477.95029   0.001964637 
+  534          568.17376    477.11748   0.001872659 
+  610          595.51484    476.28667   0.001639344 
+  591          623.78874    475.45786   0.001692047 
+  695          659.91322    474.63104   0.001438849 
+  827          711.85219    473.8062    0.00120919 
+  738          725.44938    472.98335   0.001355014 
+  676          693.77034    472.16248   0.00147929 
+  693          670.34716    471.34358   0.001443001 
+  672          639.44295    470.52666   0.001488095 
+  603          604.9227     469.7117    0.001658375 
+  559          585.65498    468.8987    0.001788909 
+  594          580.94852    468.08766   0.001683502 
+  563          588.05769    467.27858   0.001776199 
+  555          608.40928    466.47144   0.001801802 
+  594          648.26143    465.66624   0.001683502 
+  627          709.59019    464.86299   0.001594896 
+  689          786.98537    464.06167   0.001451379 
+  894          924.4786     463.26229   0.001118568 
+  1012         1073.04914   462.46483   0.000988142 
+  1032         1166.48486   461.6693    0.000968992 
+  907          1129.45517   460.87568   0.001102536 
+  971          1072.74049   460.08398   0.001029866 
+  918          1078.47339   459.29419   0.001089325 
+  935          1103.65575   458.50631   0.001069519 
+  1069         1199.57459   457.72033   0.000935454 
+  1398         1462.90091   456.93625   0.000715308 
+  1903         1862.50772   456.15406   0.000525486 
+  2555         2154.38207   455.37376   0.000391389 
+  2558         2183.9686    454.59534   0.00039093 
+  2350         1998.90021   453.81881   0.000425532 
+  1986         1848.68356   453.04416   0.000503525 
+  1458         1520.45671   452.27137   0.000685871 
+  1119         1202.88311   451.50046   0.000893655 
+  931          1027.96613   450.73141   0.001074114 
+  768          902.98073    449.96422   0.001302083 
+  815          861.24538    449.19889   0.001226994 
+  894          871.07794    448.43541   0.001118568 
+  951          876.78441    447.67377   0.001051525 
+  914          832.77504    446.91399   0.001094092 
+  972          784.08213    446.15604   0.001028807 
+  889          758.01863    445.39992   0.001124859 
+  884          728.0843     444.64564   0.001131222 
+  880          722.03614    443.89319   0.001136364 
+  867          757.18612    443.14256   0.001153403 
+  857          828.69571    442.39375   0.001166861 
+  865          894.71494    441.64675   0.001156069 
+  886          928.22833    440.90157   0.001128668 
+  984          956.1663     440.15819   0.00101626 
+  1109         1067.53924   439.41662   0.000901713 
+  1361         1321.12219   438.67685   0.000734754 
+  1791         1730.00241   437.93887   0.000558347 
+  2673         2478.32988   437.20268   0.000374111 
+  4375         3655.66385   436.46828   0.000228571 
+  6501         5229.7208    435.73566   0.000153822 
+  7461         5999.14327   435.00482   0.00013403 
+  5116         4568.76405   434.27576   0.000195465 
+  4259         3811.60068   433.54847   0.000234797 
+  3507         3197.19039   432.82294   0.000285144 
+  1905         1925.27207   432.09918   0.000524934 
+  1018         1193.35415   431.37718   0.000982318 
+  746          892.19419    430.65693   0.001340483 
+  678          749.2928     429.93844   0.001474926 
+  652          666.83114    429.22169   0.001533742 
+  585          613.82731    428.50669   0.001709402 
+  573          577.39789    427.79342   0.001745201 
+  552          551.09266    427.08189   0.001811594 
+  495          531.36208    426.3721    0.002020202 
+  546          516.09243    425.66403   0.001831502 
+  531          503.97322    424.95768   0.001883239 
+  523          494.15106    424.25306   0.001912046 
+  476          486.04139    423.55015   0.00210084 
+  506          479.24002    422.84895   0.001976285 
+  501          473.46143    422.14946   0.001996008 
+  467          468.48732    421.45168   0.002141328 
+  438          464.16225    420.7556    0.002283105 
+  466          460.36837    420.06121   0.002145923 
+  487          457.00967    419.36852   0.002053388 
+  458          454.01578    418.67752   0.002183406 
+  466          451.33018    417.9882    0.002145923 
+  515          448.90779    417.30056   0.001941748 
+  449          446.71233    416.6146    0.002227171 
+  461          444.71541    415.93032   0.002169197 
+  450          442.89235    415.2477    0.002222222 
+  427          441.22457    414.56675   0.00234192 
+  406          439.69711    413.88747   0.002463054 
+  430          438.29708    413.20984   0.002325581 
+  404          437.01497    412.53387   0.002475248 
+  411          435.84342    411.85955   0.00243309 
+  446          434.77692    411.18688   0.002242152 
+  420          433.8118     410.51585   0.002380952 
+  422          432.94626    409.84646   0.002369668 
+  452          432.18014    409.1787    0.002212389 
+  433          431.51499    408.51258   0.002309469 
+  412          430.95434    407.84809   0.002427184 
+  449          430.50373    407.18522   0.002227171 
+  414          430.16698    406.52398   0.002415459 
+  416          429.96284    405.86435   0.002403846 
+  426          429.89924    405.20634   0.002347418 
+  467          429.99854    404.54993   0.002141328 
+  402          430.28123    403.89514   0.002487562 
+  425          430.77693    403.24194   0.002352941 
+  398          431.52378    402.59035   0.002512563 
+  450          432.57034    401.94035   0.002222222 
+  417          433.98032    401.29194   0.002398082 
+  395          435.83697    400.64512   0.002531646 
+  473          438.25076    399.99989   0.002114165 
+  430          441.36977    399.35623   0.002325581 
+  437          445.39388    398.71416   0.00228833 
+  412          450.59515    398.07365   0.002427184 
+  417          457.34468    397.43472   0.002398082 
+  489          466.13772    396.79735   0.00204499 
+  472          477.62692    396.16155   0.002118644 
+  500          492.612      395.52731   0.002     
+  575          511.92066    394.89462   0.00173913 
+  520          536.04825    394.26348   0.001923077 
+  596          564.42822    393.6339    0.001677852 
+  573          594.67859    393.00585   0.001745201 
+  584          622.7901     392.37935   0.001712329 
+  695          644.31184    391.75439   0.001438849 
+  736          655.21104    391.13096   0.001358696 
+  774          654.19796    390.50906   0.00129199 
+  748          645.25892    389.88869   0.001336898 
+  768          635.85871    389.26984   0.001302083 
+  757          630.55767    388.65252   0.001321004 
+  817          636.06126    388.03671   0.00122399 
+  731          662.64311    387.42241   0.001367989 
+  685          684.23511    386.80962   0.001459854 
+  619          671.84281    386.19834   0.001615509 
+  611          643.58805    385.58856   0.001636661 
+  596          640.90238    384.98028   0.001677852 
+  568          631.25777    384.3735    0.001760563 
+  555          594.81969    383.7682    0.001801802 
+  515          549.40385    383.1644    0.001941748 
+  544          521.14788    382.56208   0.001838235 
+  514          499.3586     381.96125   0.001945525 
+  408          473.36888    381.36189   0.00245098 
+  505          457.55107    380.76401   0.001980198 
+  461          453.51079    380.16759   0.002169197 
+  451          460.0222     379.57265   0.002217295 
+  529          476.28275    378.97917   0.001890359 
+  584          506.20155    378.38715   0.001712329 
+  603          550.5951     377.79659   0.001658375 
+  640          592.69285    377.20749   0.0015625 
+  676          610.07911    376.61983   0.00147929 
+  627          603.33956    376.03363   0.001594896 
+  563          572.78321    375.44886   0.001776199 
+  503          532.45731    374.86554   0.001988072 
+  457          496.34493    374.28366   0.002188184 
+  405          460.91963    373.70321   0.002469136 
+  392          432.74989    373.12419   0.00255102 
+  394          416.75188    372.5466    0.002538071 
+  370          407.75133    371.97043   0.002702703 
+  389          402.14984    371.39568   0.002570694 
+  367          398.32273    370.82235   0.002724796 
+  362          395.53289    370.25044   0.002762431 
+  375          393.42057    369.67993   0.002666667 
+  372          391.80011    369.11083   0.002688172 
+  399          390.55434    368.54314   0.002506266 
+  370          389.64038    367.97685   0.002702703 
+  388          389.0045     367.41195   0.00257732 
+  385          388.64665    366.84845   0.002597403 
+  369          388.55417    366.28634   0.002710027 
+  351          388.70195    365.72562   0.002849003 
+  375          388.97595    365.16628   0.002666667 
+  370          389.29889    364.60832   0.002702703 
+  381          389.66087    364.05174   0.002624672 
+  352          390.14078    363.49654   0.002840909 
+  356          390.90246    362.94271   0.002808989 
+  383          392.16191    362.39024   0.002610966 
+  398          394.38197    361.83914   0.002512563 
+  415          398.40285    361.2894    0.002409639 
+  383          405.80219    360.74102   0.002610966 
+  401          419.08098    360.194     0.002493766 
+  449          438.52204    359.64833   0.002227171 
+  445          467.18844    359.104     0.002247191 
+  478          505.87052    358.56103   0.00209205 
+  534          529.22577    358.01939   0.001872659 
+  510          514.18461    357.47909   0.001960784 
+  507          493.12855    356.94013   0.001972387 
+  453          480.87062    356.40251   0.002207506 
+  478          458.45444    355.86621   0.00209205 
+  410          432.3949     355.33124   0.002439024 
+  393          416.66056    354.79759   0.002544529 
+  383          408.65014    354.26526   0.002610966 
+  415          405.62498    353.73425   0.002409639 
+  402          404.87115    353.20456   0.002487562 
+  442          406.33326    352.67617   0.002262443 
+  364          411.40484    352.14909   0.002747253 
+  400          406.67034    351.62332   0.0025    
+  409          397.40036    351.09885   0.002444988 
+  406          393.65411    350.57568   0.002463054 
+  383          388.36841    350.0538    0.002610966 
+  328          381.12119    349.53321   0.00304878 
+  347          376.43672    349.01392   0.002881844 
+  359          373.75071    348.49591   0.002785515 
+  348          372.08879    347.97918   0.002873563 
+  386          370.95265    347.46373   0.002590674 
+  398          370.12593    346.94956   0.002512563 
+  354          369.50864    346.43667   0.002824859 
+  379          369.04732    345.92504   0.002638522 
+  363          368.7111     345.41468   0.002754821 
+  375          368.4779     344.90559   0.002666667 
+  375          368.87628    344.39776   0.002666667 
+  370          368.84379    343.89118   0.002702703 
+  352          368.90789    343.38587   0.002840909 
+  339          369.08513    342.8818    0.002949853 
+  357          369.67259    342.37899   0.00280112 
+  381          370.21126    341.87742   0.002624672 
+  401          371.05773    341.37709   0.002493766 
+  356          372.13673    340.87801   0.002808989 
+  334          373.57993    340.38016   0.002994012 
+  378          375.66804    339.88355   0.002645503 
+  376          377.27345    339.38816   0.002659574 
+  402          378.89924    338.89401   0.002487562 
+  361          381.91327    338.40108   0.002770083 
+  387          384.40604    337.90938   0.002583979 
+  395          385.40335    337.4189    0.002531646 
+  363          385.73173    336.92963   0.002754821 
+  389          385.04973    336.44157   0.002570694 
+  388          384.63502    335.95473   0.00257732 
+  372          384.86758    335.4691    0.002688172 
+  369          384.95068    334.98467   0.002710027 
+  387          385.8111     334.50144   0.002583979 
+  371          387.60628    334.01941   0.002695418 
+  380          390.06267    333.53858   0.002631579 
+  382          393.07896    333.05894   0.002617801 
+  402          396.62386    332.58049   0.002487562 
+  383          400.65061    332.10323   0.002610966 
+  414          405.03697    331.62716   0.002415459 
+  399          409.61173    331.15226   0.002506266 
+  435          414.30268    330.67855   0.002298851 
+  422          419.23465    330.20601   0.002369668 
+  400          424.62333    329.73464   0.0025    
+  451          430.68648    329.26445   0.002217295 
+  459          437.68116    328.79542   0.002178649 
+  441          445.91944    328.32756   0.002267574 
+  447          455.71829    327.86086   0.002237136 
+  393          467.38686    327.39532   0.002544529 
+  430          481.23526    326.93093   0.002325581 
+  456          497.59179    326.4677    0.002192982 
+  453          516.84308    326.00562   0.002207506 
+  493          539.62482    325.54469   0.002028398 
+  522          567.0142     325.0849    0.001915709 
+  528          600.59774    324.62625   0.001893939 
+  547          642.59542    324.16875   0.001828154 
+  586          696.22088    323.71238   0.001706485 
+  718          766.32196    323.25714   0.001392758 
+  807          860.49756    322.80304   0.001239157 
+  985          991.3065     322.35006   0.001015228 
+  1260         1181.03371   321.89821   0.000793651 
+  1639         1473.72806   321.44748   0.000610128 
+  2202         1975.84534   320.99787   0.000454133 
+  3241         2982.21841   320.54938   0.000308547 
+  4986         5090.496     320.10201   0.000200562 
+  8373         8202.81393   319.65574   0.000119432 
+  15312        13689.19332  319.21059   0.000065308 
+  25287        20776.06237  318.76654   0.000039546 
+  26562        22667.96229  318.32359   0.000037648 
+  16314        15754.3688   317.88175   0.000061297 
+  13615        13520.66014  317.441     0.000073448 
+  13800        12864.03992  317.00135   0.000072464 
+  8215         8258.73694   316.56279   0.000121729 
+  3436         4229.15143   316.12533   0.000291036 
+  1846         2505.48342   315.68895   0.000541712 
+  1540         1752.46293   315.25365   0.000649351 
+  1186         1348.38316   314.81944   0.00084317 
+  997          1099.73281   314.3863    0.001003009 
+  957          934.67144    313.95425   0.001044932 
+  888          819.16084    313.52326   0.001126126 
+  771          735.20866    313.09335   0.001297017 
+  635          671.72545    312.66451   0.001574803 
+  636          622.45685    312.23673   0.001572327 
+  582          584.03232    311.81002   0.001718213 
+  542          553.5235     311.38436   0.001845018 
+  543          528.81025    310.95977   0.001841621 
+  521          508.95139    310.53623   0.001919386 
+  520          493.09473    310.11375   0.001923077 
+  481          480.55853    309.69231   0.002079002 
+  466          470.91028    309.27192   0.002145923 
+  443          463.9401     308.85258   0.002257336 
+  434          459.63629    308.43428   0.002304147 
+  403          457.82204    308.01702   0.00248139 
+  453          458.73607    307.6008    0.002207506 
+  436          462.79278    307.18561   0.002293578 
+  479          468.66787    306.77145   0.002087683 
+  428          477.18624    306.35833   0.002336449 
+  471          490.33842    305.94623   0.002123142 
+  471          507.50676    305.53515   0.002123142 
+  559          527.15911    305.1251    0.001788909 
+  614          549.38258    304.71607   0.001628664 
+  589          574.676      304.30805   0.001697793 
+  641          603.88962    303.90105   0.001560062 
+  654          636.22108    303.49506   0.001529052 
+  784          668.29489    303.09008   0.00127551 
+  723          697.25935    302.68611   0.001383126 
+  876          724.65629    302.28314   0.001141553 
+  809          749.39248    301.88117   0.001236094 
+  841          778.03873    301.4802    0.001189061 
+  755          798.91735    301.08023   0.001324503 
+  790          774.47457    300.68125   0.001265823 
+  762          742.43042    300.28327   0.001312336 
+  721          717.03466    299.88627   0.001386963 
+  725          673.2631     299.49026   0.00137931 
+  639          619.17089    299.09524   0.001564945 
+  631          571.20187    298.7012    0.001584786 
+  581          528.98544    298.30813   0.00172117 
+  593          492.06561    297.91604   0.001686341 
+  536          460.89776    297.52493   0.001865672 
+  476          435.5497     297.13479   0.00210084 
+  448          415.34293    296.74562   0.002232143 
+  401          399.19769    296.35742   0.002493766 
+  412          386.22463    295.97018   0.002427184 
+  357          375.7305     295.5839    0.00280112 
+  368          367.12782    295.19858   0.002717391 
+  338          359.97776    294.81422   0.00295858 
+  398          353.9571     294.43082   0.002512563 
+  357          348.82644    294.04837   0.00280112 
+  347          344.36445    293.66687   0.002881844 
+  348          340.51893    293.28631   0.002873563 
+  348          337.11226    292.9067    0.002873563 
+  325          334.12947    292.52804   0.003076923 
+  326          331.47514    292.15031   0.003067485 
+  354          329.09388    291.77353   0.002824859 
+  353          326.95832    291.39768   0.002832861 
+  312          325.03127    291.02276   0.003205128 
+  322          323.28799    290.64877   0.00310559 
+  331          321.70879    290.27572   0.003021148 
+  313          320.27119    289.90358   0.003194888 
+  320          318.97848    289.53238   0.003125  
+  315          317.812      289.16209   0.003174603 
+  337          316.77497    288.79273   0.002967359 
+  341          315.86344    288.42428   0.002932551 
+  346          315.08166    288.05675   0.002890173 
+  309          314.43965    287.69012   0.003236246 
+  327          313.95927    287.32441   0.003058104 
+  318          313.65489    286.95961   0.003144654 
+  310          313.59049    286.59571   0.003225806 
+  314          313.83711    286.23272   0.003184713 
+  369          314.52229    285.87062   0.002710027 
+  340          315.87864    285.50943   0.002941176 
+  317          318.3606     285.14913   0.003154574 
+  343          322.97316    284.78972   0.002915452 
+  360          331.90271    284.43121   0.002777778 
+  376          348.76823    284.07359   0.002659574 
+  417          372.77405    283.71685   0.002398082 
+  418          399.50396    283.361     0.002392344 
+  486          430.10154    283.00603   0.002057613 
+  432          419.71709    282.65194   0.002314815 
+  397          394.40936    282.29873   0.002518892 
+  434          387.77268    281.9464    0.002304147 
+  391          382.49629    281.59494   0.002557545 
+  367          360.71126    281.24435   0.002724796 
+  351          344.25347    280.89463   0.002849003 
+  350          335.33762    280.54577   0.002857143 
+  336          329.88862    280.19778   0.00297619 
+  329          325.85766    279.85066   0.003039514 
+  352          322.6412     279.50439   0.002840909 
+  341          320.34617    279.15899   0.002932551 
+  317          319.53587    278.81443   0.003154574 
+  350          319.88508    278.47074   0.002857143 
+  327          321.40915    278.12789   0.003058104 
+  348          322.43127    277.78589   0.002873563 
+  315          317.31921    277.44474   0.003174603 
+  279          312.47826    277.10444   0.003584229 
+  352          310.61265    276.76498   0.002840909 
+  316          307.79141    276.42636   0.003164557 
+  323          303.38733    276.08857   0.003095975 
+  360          300.39777    275.75163   0.002777778 
+  312          298.67784    275.41551   0.003205128 
+  287          297.6548     275.08023   0.003484321 
+  275          297.02923    274.74578   0.003636364 
+  310          296.69238    274.41216   0.003225806 
+  336          297.11757    274.07936   0.00297619 
+  349          297.47107    273.74739   0.00286533 
+  309          298.49523    273.41624   0.003236246 
+  353          300.51404    273.0859    0.002832861 
+  342          303.27896    272.75639   0.002923977 
+  302          306.45238    272.42769   0.003311258 
+  343          308.09078    272.0998    0.002915452 
+  338          305.85877    271.77272   0.00295858 
+  339          304.49089    271.44645   0.002949853 
+  371          304.95582    271.12099   0.002695418 
+  308          304.48347    270.79633   0.003246753 
+  317          303.67812    270.47248   0.003154574 
+  297          304.61347    270.14942   0.003367003 
+  336          307.73071    269.82717   0.00297619 
+  339          313.5527     269.5057    0.002949853 
+  331          321.72385    269.18504   0.003021148 
+  370          333.50254    268.86516   0.002702703 
+  381          346.80503    268.54608   0.002624672 
+  339          358.88383    268.22778   0.002949853 
+  362          374.52534    267.91027   0.002762431 
+  400          392.5601     267.59354   0.0025    
+  382          392.62484    267.2776    0.002617801 
+  404          375.82568    266.96243   0.002475248 
+  397          364.64227    266.64805   0.002518892 
+  371          359.36812    266.33443   0.002695418 
+  381          348.04455    266.0216    0.002624672 
+  335          335.50582    265.70953   0.002985075 
+  331          326.99329    265.39823   0.003021148 
+  339          321.63117    265.0877    0.002949853 
+  334          319.36323    264.77794   0.002994012 
+  352          319.17326    264.46894   0.002840909 
+  340          319.5263     264.1607    0.002941176 
+  300          320.72077    263.85322   0.003333333 
+  322          323.31264    263.5465    0.00310559 
+  346          327.37734    263.24054   0.002890173 
+  321          333.05229    262.93533   0.003115265 
+  370          341.06598    262.63087   0.002702703 
+  388          352.42466    262.32716   0.00257732 
+  374          371.934      262.02419   0.002673797 
+  439          410.38938    261.72198   0.002277904 
+  505          475.33274    261.4205    0.001980198 
+  580          545.27892    261.11977   0.001724138 
+  692          640.60073    260.81978   0.001445087 
+  680          621.55846    260.52053   0.001470588 
+  625          548.61476    260.22202   0.0016    
+  546          532.91024    259.92423   0.001831502 
+  619          549.74431    259.62718   0.001615509 
+  542          504.91144    259.33086   0.001845018 
+  547          468.10528    259.03527   0.001828154 
+  523          466.30817    258.74041   0.001912046 
+  516          488.46121    258.44627   0.001937984 
+  583          523.02856    258.15285   0.001715266 
+  630          568.04018    257.86015   0.001587302 
+  575          600.52894    257.56818   0.00173913 
+  624          616.09949    257.27692   0.001602564 
+  636          652.22109    256.98637   0.001572327 
+  736          715.11231    256.69654   0.001358696 
+  827          790.20982    256.40742   0.00120919 
+  1038         895.23617    256.11901   0.000963391 
+  1097         1065.26882   255.8313    0.000911577 
+  1441         1340.17615   255.5443    0.000693963 
+  2017         1814.76259   255.25801   0.000495786 
+  3200         2755.31816   254.97242   0.0003125 
+  5248         4755.97908   254.68752   0.000190549 
+  9251         8167.96268   254.40333   0.000108096 
+  16489        13867.674    254.11983   0.000060646 
+  23059        18864.39016  253.83703   0.000043367 
+  18152        15827.83202  253.55492   0.00005509 
+  11154        10643.27736  253.2735    0.000089654 
+  10891        10420.52507  252.99277   0.000091819 
+  11360        10599.35986  252.71273   0.000088028 
+  7099         6848.70818   252.43337   0.000140865 
+  3116         3524.85552   252.1547    0.000320924 
+  1732         2084.78213   251.8767    0.000577367 
+  1165         1455.10298   251.59939   0.000858369 
+  979          1120.9884    251.32276   0.00102145 
+  872          919.94757    251.0468    0.001146789 
+  744          790.56532    250.77152   0.001344086 
+  611          703.9757     250.49691   0.001636661 
+  625          637.39789    250.22297   0.0016    
+  537          578.20169    249.9497    0.001862197 
+  542          535.22202    249.6771    0.001845018 
+  448          506.26316    249.40516   0.002232143 
+  459          477.45396    249.13389   0.002178649 
+  426          444.25406    248.86328   0.002347418 
+  397          418.94297    248.59333   0.002518892 
+  417          401.49857    248.32404   0.002398082 
+  378          386.65544    248.0554    0.002645503 
+  379          373.27893    247.78743   0.002638522 
+  385          364.63132    247.5201    0.002597403 
+  389          360.23882    247.25342   0.002570694 
+  346          359.31943    246.9874    0.002890173 
+  369          358.0245     246.72202   0.002710027 
+  374          352.90794    246.45729   0.002673797 
+  381          347.92705    246.19321   0.002624672 
+  369          342.14246    245.92977   0.002710027 
+  384          338.60844    245.66697   0.002604167 
+  379          336.60354    245.40481   0.002638522 
+  368          335.77055    245.14328   0.002717391 
+  338          330.84991    244.8824    0.00295858 
+  308          322.33916    244.62214   0.003246753 
+  314          316.57738    244.36252   0.003184713 
+  324          313.18138    244.10353   0.00308642 
+  301          308.01424    243.84517   0.003322259 
+  307          301.14928    243.58744   0.003257329 
+  299          295.61351    243.33034   0.003344482 
+  278          291.27505    243.07385   0.003597122 
+  287          287.70915    242.818     0.003484321 
+  266          284.76518    242.56276   0.003759398 
+  243          282.39469    242.30814   0.004115226 
+  267          280.5584     242.05414   0.003745318 
+  259          279.20183    241.80075   0.003861004 
+  247          278.24087    241.54798   0.004048583 
+  259          277.52547    241.29582   0.003861004 
+  293          276.82081    241.04428   0.003412969 
+  258          275.8979     240.79334   0.003875969 
+  290          274.69169    240.54301   0.003448276 
+  279          272.67072    240.29328   0.003584229 
+  311          271.20853    240.04416   0.003215434 
+  268          269.69461    239.79565   0.003731343 
+  288          267.82935    239.54773   0.003472222 
+  290          266.33483    239.30042   0.003448276 
+  244          265.01768    239.0537    0.004098361 
+  282          263.92665    238.80758   0.003546099 
+  250          263.05747    238.56205   0.004     
+  254          262.42315    238.31712   0.003937008 
+  243          262.05055    238.07278   0.004115226 
+  271          261.95626    237.82902   0.003690037 
+  266          262.16648    237.58586   0.003759398 
+  266          262.64546    237.34328   0.003759398 
+  271          263.26461    237.10129   0.003690037 
+  243          263.86379    236.85988   0.004115226 
+  250          264.16078    236.61906   0.004     
+  263          265.08486    236.37881   0.003802281 
+  289          266.57072    236.13915   0.003460208 
+  262          268.14856    235.90006   0.003816794 
+  298          267.01486    235.66154   0.003355705 
+  281          264.60146    235.4236    0.003558719 
+  282          263.77966    235.18624   0.003546099 
+  312          264.38071    234.94944   0.003205128 
+  271          264.88205    234.71322   0.003690037 
+  281          266.58634    234.47756   0.003558719 
+  320          272.41219    234.24247   0.003125  
+  338          284.92879    234.00794   0.00295858 
+  362          303.02854    233.77398   0.002762431 
+  399          323.45186    233.54058   0.002506266 
+  429          331.70415    233.30774   0.002331002 
+  441          316.41398    233.07545   0.002267574 
+  391          305.50261    232.84373   0.002557545 
+  421          301.79083    232.61256   0.002375297 
+  353          296.01123    232.38195   0.002832861 
+  337          281.03935    232.15188   0.002967359 
+  295          269.27459    231.92237   0.003389831 
+  303          261.70164    231.69341   0.00330033 
+  275          257.58251    231.465     0.003636364 
+  264          255.60023    231.23714   0.003787879 
+  271          254.9991     231.00982   0.003690037 
+  265          255.65287    230.78304   0.003773585 
+  311          257.75644    230.55681   0.003215434 
+  282          260.77464    230.33111   0.003546099 
+  286          261.56937    230.10596   0.003496503 
+  313          259.57021    229.88134   0.003194888 
+  305          258.3929     229.65726   0.003278689 
+  288          258.79069    229.43372   0.003472222 
+  295          258.8873     229.21071   0.003389831 
+  284          258.15184    228.98823   0.003521127 
+  293          258.26673    228.76628   0.003412969 
+  260          259.89209    228.54486   0.003846154 
+  284          263.35263    228.32397   0.003521127 
+  273          269.57369    228.10361   0.003663004 
+  274          281.19013    227.88377   0.003649635 
+  312          305.04158    227.66445   0.003205128 
+  335          353.52149    227.44566   0.002985075 
+  386          421.28147    227.22739   0.002590674 
+  536          500.79196    227.00963   0.001865672 
+  558          512.83564    226.79239   0.001792115 
+  524          441.42385    226.57567   0.001908397 
+  407          420.31163    226.35947   0.002457002 
+  445          435.18836    226.14378   0.002247191 
+  457          414.09338    225.9286    0.002188184 
+  396          348.80269    225.71393   0.002525253 
+  296          311.53971    225.49977   0.003378378 
+  292          294.93182    225.28612   0.003424658 
+  240          280.61882    225.07297   0.004166667 
+  276          269.62548    224.86033   0.003623188 
+  277          263.30558    224.64819   0.003610108 
+  260          259.83031    224.43656   0.003846154 
+  261          257.92334    224.22543   0.003831418 
+  252          256.98883    224.01479   0.003968254 
+  247          256.7669     223.80466   0.004048583 
+  279          257.01831    223.59502   0.003584229 
+  250          257.5393     223.38588   0.004     
+  273          257.78158    223.17723   0.003663004 
+  241          258.12882    222.96907   0.004149378 
+  268          258.97447    222.76141   0.003731343 
+  273          260.20893    222.55423   0.003663004 
+  292          261.50592    222.34755   0.003424658 
+  274          263.00064    222.14135   0.003649635 
+  258          264.93686    221.93564   0.003875969 
+  268          267.3502     221.73041   0.003731343 
+  280          270.39809    221.52567   0.003571429 
+  291          274.48274    221.32141   0.003436426 
+  352          280.38322    221.11762   0.002840909 
+  304          288.36523    220.91432   0.003289474 
+  291          297.38569    220.7115    0.003436426 
+  321          304.7359     220.50915   0.003115265 
+  338          306.90206    220.30728   0.00295858 
+  335          312.59183    220.10588   0.002985075 
+  308          326.35427    219.90496   0.003246753 
+  407          351.59102    219.70451   0.002457002 
+  373          385.67067    219.50453   0.002680965 
+  449          424.32788    219.30501   0.002227171 
+  421          440.11323    219.10597   0.002375297 
+  412          407.52069    218.90739   0.002427184 
+  405          397.81035    218.70927   0.002469136 
+  404          409.91889    218.51162   0.002475248 
+  436          422.3756     218.31444   0.002293578 
+  433          410.61292    218.11771   0.002309469 
+  402          409.30541    217.92144   0.002487562 
+  383          423.46263    217.72564   0.002610966 
+  467          448.59506    217.53029   0.002141328 
+  478          483.10869    217.33539   0.00209205 
+  513          526.67554    217.14095   0.001949318 
+  609          582.80106    216.94697   0.001642036 
+  748          661.28429    216.75343   0.001336898 
+  813          773.36602    216.56035   0.001230012 
+  904          938.04597    216.36772   0.001106195 
+  1162         1194.6111    216.17554   0.000860585 
+  1665         1637.97115   215.9838    0.000600601 
+  2670         2533.31152   215.79251   0.000374532 
+  4433         4565.3321    215.60167   0.000225581 
+  8163         8391.59924   215.41127   0.000122504 
+  14358        12840.7159   215.22131   0.000069648 
+  18172        16188.25663  215.03179   0.00005503 
+  11693        10856.13443  214.84272   0.000085521 
+  7374         7793.64198   214.65408   0.000135612 
+  7940         7921.74402   214.46588   0.000125945 
+  9172         9091.93885   214.27812   0.000109027 
+  6176         6060.26904   214.09079   0.000161917 
+  2774         3116.86094   213.9039    0.00036049 
+  1433         1825.54427   213.71743   0.000697837 
+  991          1264.13139   213.5314    0.001009082 
+  766          967.16742    213.3458    0.001305483 
+  603          785.49361    213.16064   0.001658375 
+  539          665.06435    212.97589   0.001855288 
+  440          580.97643    212.79158   0.002272727 
+  431          520.15253    212.60769   0.002320186 
+  381          475.26347    212.42422   0.002624672 
+  407          442.12576    212.24118   0.002457002 
+  339          418.69682    212.05856   0.002949853 
+  389          404.81092    211.87637   0.002570694 
+  372          401.85929    211.69459   0.002688172 
+  385          408.73435    211.51323   0.002597403 
+  393          411.24592    211.33229   0.002544529 
+  400          403.06283    211.15176   0.0025    
+  418          390.76464    210.97165   0.002392344 
+  370          380.03531    210.79195   0.002702703 
+  362          374.31373    210.61267   0.002762431 
+  316          357.48609    210.4338    0.003164557 
+  296          335.1057     210.25534   0.003378378 
+  277          315.53972    210.07729   0.003610108 
+  288          302.97083    209.89964   0.003472222 
+  264          291.96244    209.72241   0.003787879 
+  269          280.18503    209.54558   0.003717472 
+  281          271.61145    209.36915   0.003558719 
+  237          265.82127    209.19313   0.004219409 
+  258          261.70009    209.01751   0.003875969 
+  224          258.62464    208.84229   0.004464286 
+  266          256.31192    208.66748   0.003759398 
+  227          254.63999    208.49306   0.004405286 
+  264          253.54952    208.31904   0.003787879 
+  256          252.98248    208.14542   0.00390625 
+  263          252.81105    207.9722    0.003802281 
+  235          252.77661    207.79937   0.004255319 
+  243          252.55009    207.62693   0.004115226 
+  255          251.9361     207.45489   0.003921569 
+  213          251.05343    207.28323   0.004694836 
+  232          250.18552    207.11197   0.004310345 
+  240          249.52122    206.9411    0.004166667 
+  233          249.16505    206.77062   0.004291845 
+  247          249.31489    206.60052   0.004048583 
+  256          250.36602    206.43081   0.00390625 
+  255          252.91853    206.26148   0.003921569 
+  294          257.28612    206.09254   0.003401361 
+  252          262.09683    205.92399   0.003968254 
+  237          264.54467    205.75581   0.004219409 
+  215          259.85686    205.58802   0.004651163 
+  275          255.17151    205.4206    0.003636364 
+  269          252.97087    205.25357   0.003717472 
+  234          248.299      205.08691   0.004273504 
+  278          241.75389    204.92063   0.003597122 
+  256          237.14229    204.75472   0.00390625 
+  235          233.81193    204.58919   0.004255319 
+  268          231.48798    204.42403   0.003731343 
+  235          230.01659    204.25925   0.004255319 
+  232          229.1705     204.09483   0.004310345 
+  226          228.86852    203.93079   0.004424779 
+  234          229.19323    203.76712   0.004273504 
+  248          230.40737    203.60381   0.004032258 
+  237          232.61286    203.44087   0.004219409 
+  226          234.64248    203.2783    0.004424779 
+  215          235.34663    203.1161    0.004651163 
+  242          236.76724    202.95426   0.004132231 
+  249          239.57068    202.79278   0.004016064 
+  223          244.14578    202.63166   0.004484305 
+  280          251.69388    202.47091   0.003571429 
+  262          267.42339    202.31051   0.003816794 
+  330          300.69611    202.15048   0.003030303 
+  344          353.84691    201.9908    0.002906977 
+  441          412.44858    201.83148   0.002267574 
+  476          434.40908    201.67252   0.00210084 
+  415          401.16338    201.51391   0.002409639 
+  419          394.30271    201.35566   0.002386635 
+  401          381.49479    201.19776   0.002493766 
+  335          370.73091    201.04021   0.002985075 
+  344          335.6928     200.88302   0.002906977 
+  315          311.43532    200.72617   0.003174603 
+  305          293.1091     200.56967   0.003278689 
+  273          277.25805    200.41353   0.003663004 
+  234          272.70617    200.25773   0.004273504 
+  268          279.34384    200.10227   0.003731343 
+  267          277.5421     199.94717   0.003745318 
+  293          265.9615     199.7924    0.003412969 
+  236          260.07082    199.63798   0.004237288 
+  290          257.14437    199.48391   0.003448276 
+  264          253.53641    199.33017   0.003787879 
+  232          243.9907     199.17678   0.004310345 
+  222          236.57484    199.02372   0.004504505 
+  206          231.47197    198.87101   0.004854369 
+  259          226.61409    198.71863   0.003861004 
+  219          223.44914    198.56659   0.00456621 
+  196          221.68826    198.41488   0.005102041 
+  222          220.74625    198.26352   0.004504505 
+  202          220.30851    198.11248   0.004950495 
+  223          220.25978    197.96178   0.004484305 
+  200          220.59088    197.81141   0.005     
+  208          221.19394    197.66137   0.004807692 
+  196          221.48593    197.51166   0.005102041 
+  219          221.56739    197.36229   0.00456621 
+  202          222.00237    197.21324   0.004950495 
+  220          222.88416    197.06452   0.004545455 
+  241          224.06692    196.91612   0.004149378 
+  216          225.51245    196.76806   0.00462963 
+  203          227.94594    196.62031   0.004926108 
+  217          232.42469    196.47289   0.004608295 
+  219          240.05181    196.3258    0.00456621 
+  224          247.39136    196.17903   0.004464286 
+  194          245.40166    196.03257   0.005154639 
+  206          241.531      195.88644   0.004854369 
+  234          241.98382    195.74063   0.004273504 
+  241          245.9163     195.59514   0.004149378 
+  213          248.08068    195.44997   0.004694836 
+  201          247.35389    195.30511   0.004975124 
+  248          248.38696    195.16057   0.004032258 
+  249          251.85214    195.01634   0.004016064 
+  269          257.56179    194.87243   0.003717472 
+  281          266.02836    194.72883   0.003558719 
+  278          279.00987    194.58555   0.003597122 
+  295          299.95859    194.44257   0.003389831 
+  279          330.72725    194.29991   0.003584229 
+  324          352.66499    194.15756   0.00308642 
+  325          352.2588     194.01552   0.003076923 
+  320          358.814      193.87378   0.003125  
+  332          381.16182    193.73236   0.003012048 
+  389          412.42358    193.59124   0.002570694 
+  385          434.35771    193.45042   0.002597403 
+  468          449.39194    193.30991   0.002136752 
+  464          465.87431    193.16971   0.002155172 
+  566          484.93696    193.02981   0.001766784 
+  530          508.13332    192.89021   0.001886792 
+  586          535.42678    192.75091   0.001706485 
+  622          563.13137    192.61191   0.001607717 
+  603          584.9358     192.47322   0.001658375 
+  672          595.69437    192.33482   0.001488095 
+  582          595.98781    192.19672   0.001718213 
+  599          592.11362    192.05892   0.001669449 
+  636          590.48613    191.92141   0.001572327 
+  609          593.00907    191.7842    0.001642036 
+  563          599.05451    191.64729   0.001776199 
+  570          611.0742     191.51067   0.001754386 
+  602          627.31369    191.37434   0.00166113 
+  573          641.64978    191.23831   0.001745201 
+  599          651.47101    191.10257   0.001669449 
+  588          654.10446    190.96712   0.00170068 
+  582          648.20109    190.83196   0.001718213 
+  542          631.79886    190.69709   0.001845018 
+  572          604.92511    190.5625    0.001748252 
+  534          570.38735    190.42821   0.001872659 
+  460          531.06801    190.2942    0.002173913 
+  454          490.11152    190.16048   0.002202643 
+  418          449.90062    190.02704   0.002392344 
+  376          412.07403    189.89389   0.002659574 
+  366          378.12722    189.76102   0.00273224 
+  328          349.09992    189.62844   0.00304878 
+  300          325.15264    189.49614   0.003333333 
+  256          305.79662    189.36412   0.00390625 
+  272          290.28793    189.23238   0.003676471 
+  295          277.91271    189.10092   0.003389831 
+  238          268.10026    188.96974   0.004201681 
+  263          260.49564    188.83884   0.003802281 
+  229          255.07041    188.70821   0.004366812 
+  223          252.34905    188.57786   0.004484305 
+  208          253.47628    188.44779   0.004807692 
+  240          257.67891    188.318     0.004166667 
+  217          254.8016     188.18848   0.004608295 
+  215          244.6692     188.05923   0.004651163 
+  234          238.04846    187.93026   0.004273504 
+  210          236.31467    187.80155   0.004761905 
+  199          236.19186    187.67312   0.005025126 
+  229          231.55387    187.54497   0.004366812 
+  201          225.79155    187.41708   0.004975124 
+  198          222.04108    187.28946   0.005050505 
+  202          219.84047    187.16211   0.004950495 
+  222          218.57288    187.03503   0.004504505 
+  192          217.95576    186.90821   0.005208333 
+  217          217.88573    186.78166   0.004608295 
+  209          218.32819    186.65538   0.004784689 
+  195          219.2425     186.52936   0.005128205 
+  191          220.4962     186.40361   0.005235602 
+  224          221.87229    186.27812   0.004464286 
+  207          223.11308    186.15289   0.004830918 
+  195          224.30088    186.02793   0.005128205 
+  207          225.89097    185.90323   0.004830918 
+  225          228.50104    185.77878   0.004444444 
+  239          231.90067    185.6546    0.0041841 
+  220          232.01295    185.53068   0.004545455 
+  210          227.71762    185.40701   0.004761905 
+  221          223.94877    185.28361   0.004524887 
+  196          222.01935    185.16046   0.005102041 
+  202          221.14921    185.03757   0.004950495 
+  213          218.8651     184.91493   0.004694836 
+  210          216.25266    184.79255   0.004761905 
+  216          215.53898    184.67042   0.00462963 
+  201          216.24767    184.54855   0.004975124 
+  200          214.65042    184.42693   0.005     
+  171          211.87595    184.30556   0.005847953 
+  218          211.49563    184.18445   0.004587156 
+  227          214.54479    184.06358   0.004405286 
+  232          220.96206    183.94297   0.004310345 
+  220          226.46759    183.8226    0.004545455 
+  230          224.85873    183.70249   0.004347826 
+  233          222.13045    183.58262   0.004291845 
+  227          219.63829    183.463     0.004405286 
+  212          219.02572    183.34363   0.004716981 
+  168          221.1738     183.2245    0.005952381 
+  226          224.16246    183.10562   0.004424779 
+  243          229.88667    182.98699   0.004115226 
+  217          227.78809    182.86859   0.004608295 
+  229          218.22762    182.75045   0.004366812 
+  212          212.66546    182.63254   0.004716981 
+  205          212.39562    182.51488   0.004878049 
+  210          214.61532    182.39746   0.004761905 
+  213          213.011      182.28028   0.004694836 
+  209          209.66352    182.16334   0.004784689 
+  184          208.67015    182.04664   0.005434783 
+  190          210.25213    181.93018   0.005263158 
+  191          214.69826    181.81396   0.005235602 
+  224          223.58948    181.69798   0.004464286 
+  249          240.06958    181.58223   0.004016064 
+  258          266.27579    181.46672   0.003875969 
+  295          309.40511    181.35145   0.003389831 
+  334          368.36721    181.23641   0.002994012 
+  347          356.92148    181.12161   0.002881844 
+  303          310.17497    181.00704   0.00330033 
+  276          284.34928    180.8927    0.003623188 
+  246          287.67095    180.7786    0.004065041 
+  284          301.41152    180.66473   0.003521127 
+  291          278.91422    180.55109   0.003436426 
+  263          249.48506    180.43768   0.003802281 
+  243          232.37925    180.3245    0.004115226 
+  236          226.70294    180.21155   0.004237288 
+  208          224.86405    180.09883   0.004807692 
+  210          219.96426    179.98634   0.004761905 
+  190          215.01764    179.87408   0.005263158 
+  192          210.97053    179.76205   0.005208333 
+  204          210.20474    179.65024   0.004901961 
+  219          210.01916    179.53865   0.00456621 
+  201          208.57751    179.4273    0.004975124 
+  205          207.72926    179.31616   0.004878049 
+  203          208.84722    179.20526   0.004926108 
+  229          210.80126    179.09457   0.004366812 
+  207          209.20811    178.98411   0.004830918 
+  210          206.81265    178.87387   0.004761905 
+  201          206.3269     178.76386   0.004975124 
+  206          207.51197    178.65406   0.004854369 
+  229          208.73814    178.54449   0.004366812 
+  208          208.04523    178.43513   0.004807692 
+  217          207.29484    178.326     0.004608295 
+  235          207.3125     178.21708   0.004255319 
+  207          207.64414    178.10838   0.004830918 
+  218          207.87864    177.99991   0.004587156 
+  194          207.91197    177.89164   0.005154639 
+  205          207.89494    177.7836    0.004878049 
+  199          208.0144     177.67577   0.005025126 
+  210          208.36632    177.56816   0.004761905 
+  164          209.0262     177.46076   0.006097561 
+  209          210.23749    177.35357   0.004784689 
+  205          212.51891    177.2466    0.004878049 
+  200          216.2239     177.13985   0.005     
+  213          219.12392    177.0333    0.004694836 
+  213          219.04196    176.92697   0.004694836 
+  200          219.55653    176.82085   0.005     
+  197          221.82937    176.71494   0.005076142 
+  197          225.10931    176.60925   0.005076142 
+  217          227.23985    176.50376   0.004608295 
+  219          227.1786     176.39848   0.00456621 
+  230          226.90633    176.29341   0.004347826 
+  190          227.12742    176.18855   0.005263158 
+  211          227.76418    176.0839    0.004739336 
+  237          228.6181     175.97945   0.004219409 
+  215          229.6228     175.87521   0.004651163 
+  226          230.91516    175.77118   0.004424779 
+  220          232.71987    175.66735   0.004545455 
+  234          235.21777    175.56373   0.004273504 
+  229          238.52845    175.46031   0.004366812 
+  238          242.75056    175.3571    0.004201681 
+  219          248.00747    175.25409   0.00456621 
+  260          254.47926    175.15128   0.003846154 
+  262          262.45831    175.04868   0.003816794 
+  245          272.446      174.94628   0.004081633 
+  286          285.3905     174.84408   0.003496503 
+  332          303.0904     174.74208   0.003012048 
+  332          328.1634     174.64028   0.003012048 
+  331          359.07482    174.53868   0.003021148 
+  391          380.97467    174.43728   0.002557545 
+  418          399.55727    174.33608   0.002392344 
+  465          431.82791    174.23508   0.002150538 
+  485          482.26386    174.13427   0.002061856 
+  492          553.45398    174.03367   0.00203252 
+  565          646.46764    173.93326   0.001769912 
+  657          782.36471    173.83304   0.00152207 
+  908          1005.44529   173.73303   0.001101322 
+  1302         1406.37772   173.63321   0.000768049 
+  2179         2241.43905   173.53358   0.000458926 
+  3966         4158.63981   173.43415   0.000252143 
+  7317         7680.63237   173.33491   0.000136668 
+  10482        11136.9385   173.23586   0.000095402 
+  8779         9299.25205   173.13701   0.000113908 
+  4869         5332.88453   173.03835   0.000205381 
+  3711         4148.93118   172.93988   0.000269469 
+  4493         5020.99053   172.84161   0.000222568 
+  5492         6261.43079   172.74352   0.000182083 
+  4412         4918.73479   172.64563   0.000226655 
+  2320         2615.69288   172.54792   0.000431034 
+  1199         1480.84121   172.45041   0.000834028 
+  820          991.1027     172.35308   0.001219512 
+  639          745.66718    172.25595   0.001564945 
+  499          600.79625    172.159     0.002004008 
+  435          506.79776    172.06223   0.002298851 
+  365          441.98787    171.96566   0.002739726 
+  345          395.28088    171.86927   0.002898551 
+  292          360.46154    171.77307   0.003424658 
+  278          333.83081    171.67706   0.003597122 
+  282          313.07753    171.58123   0.003546099 
+  294          296.69952    171.48558   0.003401361 
+  265          283.72026    171.39012   0.003773585 
+  271          273.54941    171.29484   0.003690037 
+  289          265.94982    171.19975   0.003460208 
+  238          261.12566    171.10484   0.004201681 
+  272          260.11525    171.01011   0.003676471 
+  277          265.50726    170.91557   0.003610108 
+  296          281.26545    170.8212    0.003378378 
+  314          302.68678    170.72702   0.003184713 
+  311          297.66918    170.63302   0.003215434 
+  286          273.74746    170.5392    0.003496503 
+  287          261.32736    170.44556   0.003484321 
+  249          264.56028    170.3521    0.004016064 
+  278          280.09178    170.25881   0.003597122 
+  258          294.74665    170.16571   0.003875969 
+  285          315.36706    170.07278   0.003508772 
+  326          340.10507    169.98003   0.003067485 
+  316          317.35231    169.88746   0.003164557 
+  304          276.78873    169.79507   0.003289474 
+  261          257.1499     169.70285   0.003831418 
+  242          258.69314    169.61081   0.004132231 
+  281          268.28096    169.51894   0.003558719 
+  274          255.56642    169.42725   0.003649635 
+  240          231.01716    169.33573   0.004166667 
+  231          214.51499    169.24439   0.004329004 
+  184          205.19225    169.15322   0.005434783 
+  206          199.67233    169.06223   0.004854369 
+  197          196.03665    168.97141   0.005076142 
+  171          193.40389    168.88076   0.005847953 
+  203          191.37649    168.79028   0.004926108 
+  195          189.74447    168.69998   0.005128205 
+  168          188.38846    168.60984   0.005952381 
+  188          187.23495    168.51988   0.005319149 
+  192          186.23646    168.43009   0.005208333 
+  173          185.36312    168.34046   0.005780347 
+  154          184.58823    168.25101   0.006493506 
+  185          183.89842    168.16173   0.005405405 
+  183          183.28244    168.07261   0.005464481 
+  186          182.73249    167.98367   0.005376344 
+  196          182.24291    167.89489   0.005102041 
+  182          181.81218    167.80628   0.005494505 
+  181          181.44046    167.71784   0.005524862 
+  181          181.128      167.62956   0.005524862 
+  159          180.88215    167.54145   0.006289308 
+  199          180.71461    167.45351   0.005025126 
+  173          180.64987    167.36573   0.005780347 
+  189          180.73539    167.27812   0.005291005 
+  190          181.06299    167.19067   0.005263158 
+  155          181.73669    167.10339   0.006451613 
+  161          182.49908    167.01627   0.00621118 
+  190          182.49667    166.92931   0.005263158 
+  172          181.97576    166.84252   0.005813953 
+  198          181.68297    166.75589   0.005050505 
+  174          181.79975    166.66943   0.005747126 
+  177          182.21275    166.58312   0.005649718 
+  187          182.49367    166.49698   0.005347594 
+  171          182.67039    166.411     0.005847953 
+  203          183.18625    166.32518   0.004926108 
+  193          184.25857    166.23952   0.005181347 
+  185          186.07215    166.15403   0.005405405 
+  173          189.01827    166.06869   0.005780347 
+  189          194.01014    165.98351   0.005291005 
+  187          203.21092    165.89849   0.005347594 
+  233          220.86028    165.81363   0.004291845 
+  231          250.48048    165.72893   0.004329004 
+  224          272.02776    165.64439   0.004464286 
+  193          252.97645    165.56      0.005181347 
+  191          228.49231    165.47577   0.005235602 
+  219          219.50789    165.3917    0.00456621 
+  194          224.67688    165.30778   0.005154639 
+  179          233.70725    165.22403   0.005586592 
+  200          225.21914    165.14042   0.005     
+  180          210.42327    165.05698   0.005555556 
+  160          202.97481    164.97369   0.00625   
+  190          201.59429    164.89055   0.005263158 
+  216          205.62103    164.80757   0.00462963 
+  209          213.59592    164.72474   0.004784689 
+  244          212.18861    164.64207   0.004098361 
+  253          202.31738    164.55955   0.003952569 
+  237          196.12082    164.47718   0.004219409 
+  217          194.90908    164.39496   0.004608295 
+  189          197.7523     164.3129    0.005291005 
+  197          198.4418     164.23099   0.005076142 
+  222          193.85942    164.14924   0.004504505 
+  206          190.79237    164.06763   0.004854369 
+  209          191.18669    163.98617   0.004784689 
+  184          194.83661    163.90487   0.005434783 
+  246          199.71418    163.82372   0.004065041 
+  264          202.19483    163.74271   0.003787879 
+  298          207.24456    163.66186   0.003355705 
+  324          220.90026    163.58115   0.00308642 
+  309          244.66006    163.5006    0.003236246 
+  269          265.00879    163.42019   0.003717472 
+  259          259.79102    163.33993   0.003861004 
+  255          242.52543    163.25982   0.003921569 
+  316          238.09483    163.17986   0.003164557 
+  307          251.01083    163.10005   0.003257329 
+  283          277.0605     163.02038   0.003533569 
+  302          299.20506    162.94086   0.003311258 
+  280          300.78388    162.86148   0.003571429 
+  303          300.75546    162.78226   0.00330033 
+  292          296.14214    162.70317   0.003424658 
+  293          299.30971    162.62424   0.003412969 
+  379          330.87053    162.54545   0.002638522 
+  457          400.74229    162.4668    0.002188184 
+  510          542.6182     162.3883    0.001960784 
+  580          755.04672    162.30994   0.001724138 
+  703          793.44963    162.23173   0.001422475 
+  602          577.00374    162.15366   0.00166113 
+  578          437.11308    162.07573   0.001730104 
+  470          414.62911    161.99795   0.00212766 
+  450          477.55279    161.92031   0.002222222 
+  404          529.07365    161.84281   0.002475248 
+  418          431.22647    161.76545   0.002392344 
+  326          327.70651    161.68824   0.003067485 
+  275          272.77442    161.61117   0.003636364 
+  228          245.54886    161.53424   0.004385965 
+  217          233.07131    161.45745   0.004608295 
+  245          229.92197    161.3808    0.004081633 
+  252          235.57188    161.30429   0.003968254 
+  217          254.33101    161.22792   0.004608295 
+  286          304.25274    161.15169   0.003496503 
+  376          410.00182    161.0756    0.002659574 
+  449          463.06063    160.99965   0.002227171 
+  434          363.58421    160.92384   0.002304147 
+  333          306.53861    160.84816   0.003003003 
+  355          318.39981    160.77263   0.002816901 
+  378          392.57396    160.69723   0.002645503 
+  420          472.93056    160.62197   0.002380952 
+  373          409.10364    160.54685   0.002680965 
+  307          314.27669    160.47187   0.003257329 
+  262          267.85354    160.39702   0.003816794 
+  233          259.52077    160.32231   0.004291845 
+  219          269.28146    160.24773   0.00456621 
+  225          260.49832    160.17329   0.004444444 
+  176          232.17622    160.09899   0.005681818 
+  186          209.44851    160.02482   0.005376344 
+  168          196.78964    159.95079   0.005952381 
+  150          190.42684    159.87689   0.006666667 
+  186          187.61791    159.80313   0.005376344 
+  167          186.3748     159.7295    0.005988024 
+  182          184.38147    159.65601   0.005494505 
+  201          182.5047     159.58265   0.004975124 
+  180          181.91732    159.50942   0.005555556 
+  168          182.57864    159.43633   0.005952381 
+  157          184.33791    159.36337   0.006369427 
+  169          186.62491    159.29054   0.00591716 
+  158          189.70517    159.21785   0.006329114 
+  211          195.34373    159.14528   0.004739336 
+  188          205.59601    159.07285   0.005319149 
+  201          224.73727    159.00055   0.004975124 
+  225          261.87935    158.92839   0.004444444 
+  284          329.6103     158.85635   0.003521127 
+  359          411.41872    158.78444   0.002785515 
+  318          403.95369    158.71267   0.003144654 
+  312          327.705      158.64102   0.003205128 
+  277          280.67988    158.56951   0.003610108 
+  246          274.15333    158.49812   0.004065041 
+  244          297.9103     158.42687   0.004098361 
+  244          310.08604    158.35574   0.004098361 
+  261          270.99078    158.28475   0.003831418 
+  244          229.49113    158.21388   0.004098361 
+  210          205.13416    158.14314   0.004761905 
+  183          192.02779    158.07253   0.005464481 
+  186          184.62578    158.00205   0.005376344 
+  165          180.07985    157.93169   0.006060606 
+  174          177.11765    157.86147   0.005747126 
+  165          175.14989    157.79137   0.006060606 
+  166          173.87453    157.7214    0.006024096 
+  172          173.13772    157.65155   0.005813953 
+  173          172.87644    157.58183   0.005780347 
+  180          174.12216    157.51224   0.005555556 
+  185          175.0885     157.44277   0.005405405 
+  171          177.01297    157.37343   0.005847953 
+  188          179.42252    157.30422   0.005319149 
+  175          179.99053    157.23513   0.005714286 
+  175          179.23884    157.16617   0.005714286 
+  180          178.90726    157.09733   0.005555556 
+  185          179.53723    157.02861   0.005405405 
+  187          180.0506     156.96003   0.005347594 
+  218          180.42134    156.89156   0.004587156 
+  205          180.30497    156.82322   0.004878049 
+  196          181.21823    156.755     0.005102041 
+  197          182.87473    156.68691   0.005076142 
+  192          181.56929    156.61894   0.005208333 
+  222          178.07397    156.55109   0.004504505 
+  244          175.7361     156.48337   0.004098361 
+  219          175.00292    156.41577   0.00456621 
+  231          175.63102    156.34829   0.004329004 
+  268          176.43534    156.28093   0.003731343 
+  263          176.21279    156.2137    0.003802281 
+  303          177.06515    156.14658   0.00330033 
+  282          180.01761    156.07959   0.003546099 
+  256          181.99534    156.01272   0.00390625 
+  280          180.44385    155.94597   0.003571429 
+  266          179.90149    155.87935   0.003759398 
+  293          182.23082    155.81284   0.003412969 
+  279          188.67748    155.74645   0.003584229 
+  286          201.65759    155.68018   0.003496503 
+  275          219.15396    155.61404   0.003636364 
+  268          224.25469    155.54801   0.003731343 
+  274          208.60262    155.4821    0.003649635 
+  246          194.93847    155.41632   0.004065041 
+  200          190.31756    155.35065   0.005     
+  209          193.66042    155.2851    0.004784689 
+  227          200.56766    155.21967   0.004405286 
+  249          199.1145     155.15436   0.004016064 
+  211          192.50076    155.08916   0.004739336 
+  191          187.32947    155.02409   0.005235602 
+  227          183.98253    154.95913   0.004405286 
+  220          182.81509    154.89429   0.004545455 
+  184          181.02656    154.82957   0.005434783 
+  192          180.21042    154.76496   0.005208333 
+  170          181.39228    154.70048   0.005882353 
+  195          183.65159    154.63611   0.005128205 
+  182          189.04662    154.57185   0.005494505 
+  208          199.45882    154.50771   0.004807692 
+  189          213.15934    154.44369   0.005291005 
+  201          214.83104    154.37979   0.004975124 
+  202          201.45279    154.316     0.004950495 
+  200          191.58657    154.25233   0.005     
+  206          189.02214    154.18877   0.004854369 
+  207          192.48336    154.12532   0.004830918 
+  194          197.58741    154.062     0.005154639 
+  186          194.35947    153.99879   0.005376344 
+  159          187.19362    153.93569   0.006289308 
+  211          182.8914     153.8727    0.004739336 
+  204          181.23208    153.80984   0.004901961 
+  209          181.13177    153.74708   0.004784689 
+  203          182.04812    153.68444   0.004926108 
+  158          183.91451    153.62191   0.006329114 
+  197          186.99285    153.5595    0.005076142 
+  213          191.52822    153.4972    0.004694836 
+  208          195.48248    153.43501   0.004807692 
+  228          196.75452    153.37294   0.004385965 
+  231          198.04073    153.31098   0.004329004 
+  234          201.31441    153.24913   0.004273504 
+  228          206.6888     153.1874    0.004385965 
+  227          213.86761    153.12577   0.004405286 
+  266          221.91448    153.06426   0.003759398 
+  273          230.42716    153.00286   0.003663004 
+  263          241.63948    152.94158   0.003802281 
+  302          256.69804    152.8804    0.003311258 
+  348          276.40959    152.81934   0.002873563 
+  325          301.90569    152.75839   0.003076923 
+  325          334.69664    152.69754   0.003076923 
+  446          376.15596    152.63681   0.002242152 
+  424          423.87178    152.57619   0.002358491 
+  444          462.52528    152.51568   0.002252252 
+  466          480.09168    152.45528   0.002145923 
+  474          484.3982     152.39499   0.002109705 
+  477          490.7461     152.33481   0.002096436 
+  464          503.9745     152.27475   0.002155172 
+  451          504.54606    152.21479   0.002217295 
+  424          484.9309     152.15494   0.002358491 
+  444          455.80138    152.0952    0.002252252 
+  406          420.75409    152.03556   0.002463054 
+  360          390.22062    151.97604   0.002777778 
+  369          365.664      151.91663   0.002710027 
+  339          337.96829    151.85732   0.002949853 
+  306          309.91279    151.79813   0.003267974 
+  273          285.71796    151.73904   0.003663004 
+  270          263.62516    151.68006   0.003703704 
+  255          245.29558    151.62118   0.003921569 
+  260          231.10677    151.56242   0.003846154 
+  241          220.11875    151.50376   0.004149378 
+  233          211.49117    151.44521   0.004291845 
+  239          204.62657    151.38677   0.0041841 
+  223          199.1096     151.32844   0.004484305 
+  231          194.64453    151.27021   0.004329004 
+  213          191.01882    151.21209   0.004694836 
+  216          188.07852    151.15408   0.00462963 
+  230          185.72003    151.09617   0.004347826 
+  207          183.87707    151.03837   0.004830918 
+  177          182.49236    150.98067   0.005649718 
+  218          181.50548    150.92308   0.004587156 
+  198          181.03409    150.8656    0.005050505 
+  204          181.36844    150.80822   0.004901961 
+  198          182.91434    150.75095   0.005050505 
+  202          185.63408    150.69378   0.004950495 
+  196          187.14388    150.63672   0.005102041 
+  196          187.13451    150.57977   0.005102041 
+  204          188.83847    150.52292   0.004901961 
+  204          190.53778    150.46617   0.004901961 
+  191          188.89079    150.40953   0.005235602 
+  195          187.16372    150.35299   0.005128205 
+  193          185.9551     150.29656   0.005181347 
+  212          185.37482    150.24023   0.004716981 
+  220          186.46573    150.18401   0.004545455 
+  252          187.68917    150.12789   0.003968254 
+  244          187.79395    150.07187   0.004098361 
+  193          188.86345    150.01596   0.005181347 
+  219          191.87046    149.96015   0.00456621 
+  227          197.22756    149.90445   0.004405286 
+  231          205.96489    149.84884   0.004329004 
+  251          220.29235    149.79334   0.003984064 
+  243          243.67538    149.73795   0.004115226 
+  264          277.13674    149.68265   0.003787879 
+  274          304.19305    149.62746   0.003649635 
+  295          297.91156    149.57237   0.003389831 
+  305          277.70368    149.51739   0.003278689 
+  258          272.85557    149.4625    0.003875969 
+  267          283.94083    149.40772   0.003745318 
+  287          287.10116    149.35304   0.003484321 
+  271          276.38188    149.29847   0.003690037 
+  250          255.16634    149.24399   0.004     
+  234          235.00429    149.18961   0.004273504 
+  244          225.51056    149.13534   0.004098361 
+  243          222.78559    149.08117   0.004115226 
+  222          214.42727    149.0271    0.004504505 
+  211          203.71449    148.97313   0.004739336 
+  185          197.3585     148.91926   0.005405405 
+  205          194.4919     148.86549   0.004878049 
+  194          192.3828     148.81182   0.005154639 
+  216          189.6162     148.75825   0.00462963 
+  181          187.61163    148.70479   0.005524862 
+  241          186.86682    148.65142   0.004149378 
+  201          187.26507    148.59815   0.004975124 
+  215          188.6854     148.54499   0.004651163 
+  209          190.71082    148.49192   0.004784689 
+  226          193.77925    148.43895   0.004424779 
+  215          200.25461    148.38608   0.004651163 
+  280          213.40709    148.33332   0.003571429 
+  259          237.54296    148.28065   0.003861004 
+  314          274.87324    148.22808   0.003184713 
+  371          328.69621    148.17561   0.002695418 
+  403          341.14732    148.12323   0.00248139 
+  406          284.51994    148.07096   0.002463054 
+  340          246.7523     148.01879   0.002941176 
+  283          238.36155    147.96671   0.003533569 
+  285          248.96887    147.91473   0.003508772 
+  327          274.28992    147.86285   0.003058104 
+  323          282.87703    147.81107   0.003095975 
+  275          264.93055    147.75939   0.003636364 
+  275          260.05814    147.7078    0.003636364 
+  238          251.09119    147.65632   0.004201681 
+  239          229.38951    147.60493   0.0041841 
+  215          214.03296    147.55363   0.004651163 
+  207          208.62259    147.50244   0.004830918 
+  212          211.25042    147.45134   0.004716981 
+  195          218.37539    147.40034   0.005128205 
+  239          218.88668    147.34944   0.0041841 
+  224          211.27683    147.29863   0.004464286 
+  221          206.90198    147.24792   0.004524887 
+  231          209.30725    147.19731   0.004329004 
+  217          221.05032    147.14679   0.004608295 
+  214          245.65507    147.09638   0.004672897 
+  276          264.42745    147.04605   0.003623188 
+  237          244.81769    146.99583   0.004219409 
+  223          223.93933    146.94569   0.004484305 
+  199          216.20504    146.89566   0.005025126 
+  212          218.60366    146.84572   0.004716981 
+  229          229.82177    146.79588   0.004366812 
+  220          239.87341    146.74613   0.004545455 
+  219          231.3262     146.69648   0.00456621 
+  220          222.05725    146.64692   0.004545455 
+  213          219.60203    146.59746   0.004694836 
+  215          221.16181    146.5481    0.004651163 
+  224          222.98567    146.49883   0.004464286 
+  231          224.7231     146.44965   0.004329004 
+  228          227.97647    146.40057   0.004385965 
+  245          232.6221     146.35158   0.004081633 
+  250          237.57676    146.30269   0.004     
+  251          242.85217    146.2539    0.003984064 
+  234          248.25954    146.20519   0.004273504 
+  276          254.02466    146.15659   0.003623188 
+  257          261.13244    146.10807   0.003891051 
+  243          269.66242    146.05965   0.004115226 
+  262          279.17052    146.01133   0.003816794 
+  334          289.86721    145.9631    0.002994012 
+  308          302.42498    145.91496   0.003246753 
+  319          317.29073    145.86692   0.003134796 
+  328          334.93785    145.81897   0.00304878 
+  356          356.24574    145.77111   0.002808989 
+  382          382.01829    145.72335   0.002617801 
+  474          410.85892    145.67568   0.002109705 
+  474          442.3331     145.6281    0.002109705 
+  571          481.22895    145.58062   0.001751313 
+  681          530.99712    145.53323   0.001468429 
+  657          594.90834    145.48593   0.00152207 
+  701          677.77211    145.43872   0.001426534 
+  714          786.12619    145.39161   0.00140056 
+  743          930.81856    145.34459   0.001345895 
+  892          1132.78394   145.29767   0.001121076 
+  1134         1427.95606   145.25083   0.000881834 
+  1423         1884.2188    145.20409   0.000702741 
+  2159         2644.63209   145.15744   0.000463177 
+  3580         4081.3022    145.11088   0.00027933 
+  6505         7261.86298   145.06442   0.000153728 
+  12065        14454.2594   145.01804   0.000082884 
+  19753        24992.38003  144.97176   0.000050625 
+  21318        22109.30292  144.92557   0.000046909 
+  13113        12155.0458   144.87947   0.00007626 
+  7589         7282.64924   144.83346   0.00013177 
+  5977         6285.68208   144.78755   0.000167308 
+  7081         8326.39999   144.74172   0.000141223 
+  9957         13015.91753  144.69599   0.000100432 
+  11162        12620.70683  144.65035   0.00008959 
+  7388         7089.57448   144.6048    0.000135355 
+  3879         3798.30403   144.55934   0.000257798 
+  2118         2331.48788   144.51397   0.000472144 
+  1328         1631.08209   144.46869   0.000753012 
+  1076         1239.15238   144.4235    0.000929368 
+  840          995.80639    144.3784    0.001190476 
+  745          836.0789     144.3334    0.001342282 
+  627          723.1817     144.28848   0.001594896 
+  575          631.5714     144.24365   0.00173913 
+  483          555.46809    144.19892   0.002070393 
+  411          496.47089    144.15427   0.00243309 
+  327          452.17596    144.10972   0.003058104 
+  372          419.2463     144.06525   0.002688172 
+  347          393.32364    144.02088   0.002881844 
+  304          368.20999    143.97659   0.003289474 
+  275          343.23428    143.93239   0.003636364 
+  285          321.69693    143.88829   0.003508772 
+  269          304.16557    143.84427   0.003717472 
+  250          289.81235    143.80034   0.004     
+  254          277.80213    143.7565    0.003937008 
+  255          267.5441     143.71275   0.003921569 
+  263          258.65188    143.66909   0.003802281 
+  260          250.8579     143.62552   0.003846154 
+  253          244.02632    143.58204   0.003952569 
+  235          238.05828    143.53865   0.004255319 
+  216          232.84552    143.49534   0.00462963 
+  207          228.29926    143.45213   0.004830918 
+  186          224.37258    143.409     0.005376344 
+  198          221.04104    143.36596   0.005050505 
+  225          218.28356    143.32301   0.004444444 
+  191          216.07677    143.28015   0.005235602 
+  235          214.40183    143.23737   0.004255319 
+  235          213.55618    143.19469   0.004255319 
+  192          213.06349    143.15209   0.005208333 
+  207          213.33166    143.10958   0.004830918 
+  240          214.60255    143.06716   0.004166667 
+  241          217.26456    143.02483   0.004149378 
+  244          220.61673    142.98258   0.004098361 
+  239          219.66479    142.94042   0.0041841 
+  207          215.94407    142.89835   0.004830918 
+  233          213.24305    142.85637   0.004291845 
+  211          212.17568    142.81447   0.004739336 
+  211          212.70039    142.77267   0.004739336 
+  206          214.26684    142.73094   0.004854369 
+  225          214.31463    142.68931   0.004444444 
+  220          211.42053    142.64776   0.004545455 
+  228          208.06445    142.6063    0.004385965 
+  227          205.21877    142.56493   0.004405286 
+  194          203.27467    142.52365   0.005154639 
+  219          202.26647    142.48245   0.00456621 
+  208          202.04564    142.44134   0.004807692 
+  219          202.41044    142.40031   0.00456621 
+  236          203.28137    142.35937   0.004237288 
+  210          204.78435    142.31852   0.004761905 
+  217          206.93033    142.27775   0.004608295 
+  227          209.45609    142.23707   0.004405286 
+  230          212.05894    142.19648   0.004347826 
+  254          214.87416    142.15597   0.003937008 
+  252          218.36448    142.11555   0.003968254 
+  261          220.12843    142.07522   0.003831418 
+  271          216.15499    142.03497   0.003690037 
+  247          211.0556     141.9948    0.004048583 
+  292          208.01066    141.95473   0.003424658 
+  275          207.32084    141.91473   0.003636364 
+  264          209.26151    141.87483   0.003787879 
+  242          210.94297    141.83501   0.004132231 
+  221          204.94647    141.79527   0.004524887 
+  237          195.56309    141.75562   0.004219409 
+  241          188.79053    141.71606   0.004149378 
+  239          184.88675    141.67658   0.0041841 
+  236          183.31411    141.63718   0.004237288 
+  223          183.23317    141.59787   0.004484305 
+  203          181.95465    141.55865   0.004926108 
+  205          179.41679    141.51951   0.004878049 
+  192          178.39386    141.48046   0.005208333 
+  205          179.92955    141.44149   0.004878049 
+  193          184.98564    141.4026    0.005181347 
+  227          194.47336    141.3638    0.004405286 
+  192          203.54186    141.32509   0.005208333 
+  195          203.04187    141.28646   0.005128205 
+  223          201.60627    141.24791   0.004484305 
+  188          200.96496    141.20945   0.005319149 
+  226          194.73038    141.17107   0.004424779 
+  183          190.29394    141.13278   0.005464481 
+  168          190.63583    141.09457   0.005952381 
+  193          189.83647    141.05644   0.005181347 
+  177          187.23143    141.0184    0.005649718 
+  170          186.70888    140.98044   0.005882353 
+  177          184.71683    140.94257   0.005649718 
+  162          182.18894    140.90478   0.00617284 
+  197          182.76679    140.86707   0.005076142 
+  185          184.05884    140.82945   0.005405405 
+  168          181.36179    140.79191   0.005952381 
+  178          178.0288     140.75446   0.005617978 
+  172          176.81356    140.71709   0.005813953 
+  174          177.63644    140.6798    0.005747126 
+  195          180.2941     140.64259   0.005128205 
+  190          184.28113    140.60547   0.005263158 
+  192          187.39245    140.56843   0.005208333 
+  213          189.74785    140.53147   0.004694836 
+  190          193.91951    140.4946    0.005263158 
+  195          200.41198    140.45781   0.005128205 
+  219          208.65209    140.42111   0.00456621 
+  265          219.89843    140.38448   0.003773585 
+  266          236.57915    140.34794   0.003759398 
+  280          247.36095    140.31148   0.003571429 
+  265          241.27638    140.2751    0.003773585 
+  268          234.71658    140.23881   0.003731343 
+  260          236.61445    140.2026    0.003846154 
+  266          246.95377    140.16647   0.003759398 
+  247          264.76349    140.13042   0.004048583 
+  297          282.94132    140.09446   0.003367003 
+  282          293.90643    140.05858   0.003546099 
+  278          307.52356    140.02278   0.003597122 
+  291          336.50054    139.98706   0.003436426 
+  356          388.87264    139.95142   0.002808989 
+  443          478.61097    139.91587   0.002257336 
+  549          641.78131    139.8804    0.001821494 
+  934          983.62319    139.84501   0.001070664 
+  1631         1759.34311   139.8097    0.000613121 
+  2619         3144.56632   139.77447   0.000381825 
+  3180         3478.00923   139.73933   0.000314465 
+  2247         2135.63153   139.70426   0.000445038 
+  1327         1260.77048   139.66928   0.00075358 
+  923          949.78327    139.63438   0.001083424 
+  1043         999.64085    139.59956   0.000958773 
+  1290         1425.71085   139.56482   0.000775194 
+  1649         2007.40396   139.53017   0.000606428 
+  1500         1620.41684   139.49559   0.000666667 
+  1047         955.07208    139.46109   0.00095511 
+  613          616.24634    139.42668   0.001631321 
+  406          461.90491    139.39235   0.002463054 
+  331          371.61714    139.35809   0.003021148 
+  281          313.55167    139.32392   0.003558719 
+  269          276.77686    139.28983   0.003717472 
+  246          253.92094    139.25582   0.004065041 
+  219          241.17523    139.22189   0.00456621 
+  211          234.20891    139.18804   0.004739336 
+  216          224.29498    139.15428   0.00462963 
+  221          211.07607    139.12059   0.004524887 
+  171          200.34973    139.08698   0.005847953 
+  187          192.47231    139.05345   0.005347594 
+  206          186.72475    139.02001   0.004854369 
+  165          182.50263    138.98664   0.006060606 
+  180          179.40402    138.95335   0.005555556 
+  208          177.22343    138.92014   0.004807692 
+  207          175.95822    138.88702   0.004830918 
+  166          175.81999    138.85397   0.006024096 
+  180          177.10943    138.821     0.005555556 
+  156          179.08198    138.78812   0.006410256 
+  184          178.07839    138.75531   0.005434783 
+  179          174.42125    138.72258   0.005586592 
+  187          171.76278    138.68993   0.005347594 
+  178          170.74656    138.65736   0.005617978 
+  157          171.18199    138.62487   0.006369427 
+  208          172.96799    138.59246   0.004807692 
+  172          175.22213    138.56013   0.005813953 
+  195          176.74373    138.52788   0.005128205 
+  171          178.36256    138.49571   0.005847953 
+  190          182.4385     138.46361   0.005263158 
+  167          190.23354    138.4316    0.005988024 
+  210          204.35819    138.39966   0.004761905 
+  210          231.61981    138.36781   0.004761905 
+  305          288.08992    138.33603   0.003278689 
+  348          399.11332    138.30433   0.002873563 
+  407          533.16339    138.27271   0.002457002 
+  393          491.43446    138.24117   0.002544529 
+  369          357.52396    138.20971   0.002710027 
+  297          281.31672    138.17832   0.003367003 
+  254          257.71557    138.14702   0.003937008 
+  269          272.36299    138.11579   0.003717472 
+  298          323.22339    138.08464   0.003355705 
+  330          365.31262    138.05357   0.003030303 
+  258          310.55142    138.02258   0.003875969 
+  245          243.28463    137.99167   0.004081633 
+  216          206.54403    137.96083   0.00462963 
+  213          189.00503    137.93007   0.004694836 
+  176          179.86452    137.89939   0.005681818 
+  202          174.10832    137.86879   0.004950495 
+  183          170.71328    137.83827   0.005464481 
+  185          169.74076    137.80782   0.005405405 
+  179          171.6825     137.77745   0.005586592 
+  197          176.11981    137.74716   0.005076142 
+  216          177.6246     137.71695   0.00462963 
+  186          172.86127    137.68681   0.005376344 
+  206          168.49172    137.65676   0.004854369 
+  174          167.06659    137.62677   0.005747126 
+  204          168.3821     137.59687   0.004901961 
+  194          172.77366    137.56705   0.005154639 
+  209          180.56934    137.5373    0.004784689 
+  190          185.56082    137.50763   0.005263158 
+  185          180.28597    137.47803   0.005405405 
+  202          172.5822     137.44851   0.004950495 
+  182          168.88596    137.41907   0.005494505 
+  194          169.25946    137.38971   0.005154639 
+  192          173.56253    137.36042   0.005208333 
+  171          181.40256    137.33122   0.005847953 
+  184          184.82169    137.30208   0.005434783 
+  170          177.58612    137.27303   0.005882353 
+  181          169.72678    137.24405   0.005524862 
+  167          165.74266    137.21514   0.005988024 
+  153          165.00201    137.18632   0.006535948 
+  189          166.81919    137.15757   0.005291005 
+  210          169.65186    137.1289    0.004761905 
+  192          169.16961    137.1003    0.005208333 
+  177          165.81733    137.07178   0.005649718 
+  177          163.73043    137.04333   0.005649718 
+  222          163.5896     137.01496   0.004504505 
+  163          164.10409    136.98667   0.006134969 
+  147          163.67649    136.95846   0.006802721 
+  166          162.90278    136.93032   0.006024096 
+  175          162.25393    136.90225   0.005714286 
+  188          162.17701    136.87426   0.005319149 
+  172          162.80771    136.84635   0.005813953 
+  194          164.0337     136.81851   0.005154639 
+  188          165.24565    136.79075   0.005319149 
+  173          165.9248     136.76307   0.005780347 
+  207          166.7597     136.73545   0.004830918 
+  179          168.12792    136.70792   0.005586592 
+  201          170.04032    136.68046   0.004975124 
+  183          172.57853    136.65308   0.005464481 
+  190          175.9777     136.62577   0.005263158 
+  189          180.25282    136.59853   0.005291005 
+  204          183.72066    136.57138   0.004901961 
+  204          185.10804    136.54429   0.004901961 
+  200          186.8152     136.51728   0.005     
+  191          190.00197    136.49035   0.005235602 
+  239          194.79731    136.46349   0.0041841 
+  199          201.57121    136.43671   0.005025126 
+  245          210.97917    136.41      0.004081633 
+  269          222.87341    136.38337   0.003717472 
+  280          234.83399    136.35681   0.003571429 
+  269          241.84875    136.33032   0.003717472 
+  276          247.82362    136.30391   0.003623188 
+  303          259.12157    136.27758   0.00330033 
+  305          277.58074    136.25132   0.003278689 
+  304          305.08599    136.22513   0.003289474 
+  307          344.20968    136.19902   0.003257329 
+  382          392.43599    136.17298   0.002617801 
+  389          443.76998    136.14701   0.002570694 
+  468          516.5084     136.12112   0.002136752 
+  577          638.96       136.09531   0.001733102 
+  867          853.96108    136.06957   0.001153403 
+  1277         1273.08596   136.0439    0.000783085 
+  2178         2192.55752   136.0183    0.000459137 
+  3922         4130.84578   135.99278   0.000254972 
+  5851         6416.34182   135.96734   0.000170911 
+  5322         5202.12375   135.94196   0.000187899 
+  3124         2932.68308   135.91666   0.000320102 
+  2048         1817.14474   135.89144   0.000488281 
+  1587         1483.72104   135.86628   0.00063012 
+  1631         1673.95441   135.84121   0.000613121 
+  2344         2488.75781   135.8162    0.000426621 
+  3006         3502.40625   135.79127   0.000332668 
+  2704         2771.68252   135.76641   0.000369822 
+  1669         1575.37579   135.74162   0.000599161 
+  972          947.55083    135.71691   0.001028807 
+  670          660.46996    135.69227   0.001492537 
+  464          509.36239    135.6677    0.002155172 
+  408          418.97783    135.64321   0.00245098 
+  321          362.46353    135.61879   0.003115265 
+  304          321.57273    135.59444   0.003289474 
+  263          289.11631    135.57017   0.003802281 
+  253          265.41524    135.54596   0.003952569 
+  233          247.55938    135.52183   0.004291845 
+  239          234.04027    135.49777   0.0041841 
+  212          224.37146    135.47379   0.004716981 
+  205          217.94747    135.44988   0.004878049 
+  212          211.99866    135.42604   0.004716981 
+  201          206.04639    135.40227   0.004975124 
+  204          200.90354    135.37857   0.004901961 
+  195          196.19709    135.35495   0.005128205 
+  195          191.94684    135.3314    0.005128205 
+  186          187.8591     135.30792   0.005376344 
+  187          184.71507    135.28451   0.005347594 
+  184          182.72411    135.26117   0.005434783 
+  190          181.69714    135.23791   0.005263158 
+  205          180.92148    135.21472   0.004878049 
+  189          179.95969    135.1916    0.005291005 
+  172          178.96437    135.16855   0.005813953 
+  173          177.54409    135.14557   0.005780347 
+  176          175.0638     135.12267   0.005681818 
+  162          172.01609    135.09983   0.00617284 
+  175          169.52649    135.07707   0.005714286 
+  186          167.7388     135.05438   0.005376344 
+  170          166.51234    135.03176   0.005882353 
+  178          165.73897    135.00921   0.005617978 
+  148          165.25563    134.98673   0.006756757 
+  164          164.58382    134.96432   0.006097561 
+  173          163.96389    134.94199   0.005780347 
+  163          164.32832    134.91972   0.006134969 
+  181          166.1569     134.89753   0.005524862 
+  162          168.70512    134.87541   0.00617284 
+  182          169.90125    134.85335   0.005494505 
+  180          171.45963    134.83137   0.005555556 
+  151          174.91686    134.80946   0.006622517 
+  167          176.7445     134.78762   0.005988024 
+  178          173.9884     134.76585   0.005617978 
+  166          170.34505    134.74415   0.006024096 
+  158          168.6481     134.72252   0.006329114 
+  164          168.28435    134.70096   0.006097561 
+  175          169.73097    134.67947   0.005714286 
+  178          173.5208     134.65806   0.005617978 
+  159          175.56659    134.63671   0.006289308 
+  171          171.90151    134.61543   0.005847953 
+  174          166.73556    134.59422   0.005747126 
+  200          163.39295    134.57308   0.005     
+  138          161.92511    134.55201   0.007246377 
+  169          161.86494    134.53101   0.00591716 
+  159          162.76074    134.51008   0.006289308 
+  171          163.38851    134.48922   0.005847953 
+  197          162.39581    134.46843   0.005076142 
+  167          160.98485    134.44771   0.005988024 
+  166          160.23248    134.42706   0.006024096 
+  146          160.10182    134.40648   0.006849315 
+  146          160.33761    134.38596   0.006849315 
+  180          160.78409    134.36552   0.005555556 
+  191          161.46355    134.34515   0.005235602 
+  189          162.67352    134.32484   0.005291005 
+  188          164.95278    134.3046    0.005319149 
+  148          168.37697    134.28444   0.006756757 
+  175          170.22007    134.26434   0.005714286 
+  200          168.09804    134.24431   0.005     
+  190          165.50887    134.22435   0.005263158 
+  177          164.39998    134.20446   0.005649718 
+  191          164.71284    134.18463   0.005235602 
+  170          166.42576    134.16488   0.005882353 
+  186          169.67959    134.14519   0.005376344 
+  158          173.87923    134.12557   0.006329114 
+  170          177.91422    134.10602   0.005882353 
+  217          182.7829     134.08654   0.004608295 
+  211          188.59244    134.06713   0.004739336 
+  216          198.94643    134.04778   0.00462963 
+  208          215.32324    134.0285    0.004807692 
+  241          223.14569    134.00929   0.004149378 
+  214          212.51879    133.99015   0.004672897 
+  219          200.23085    133.97108   0.00456621 
+  228          195.07436    133.95207   0.004385965 
+  210          195.33493    133.93313   0.004761905 
+  216          198.93889    133.91426   0.00462963 
+  233          206.29253    133.89546   0.004291845 
+  221          213.74417    133.87672   0.004524887 
+  234          214.19161    133.85806   0.004273504 
+  225          214.9606     133.83946   0.004444444 
+  220          223.87186    133.82092   0.004545455 
+  211          237.08735    133.80246   0.004739336 
+  218          237.69582    133.78406   0.004587156 
+  245          228.13205    133.76572   0.004081633 
+  257          223.15404    133.74746   0.003891051 
+  223          226.03056    133.72926   0.004484305 
+  258          237.09562    133.71113   0.003875969 
+  265          257.49161    133.69306   0.003773585 
+  304          283.29032    133.67507   0.003289474 
+  302          295.04348    133.65714   0.003311258 
+  311          292.72177    133.63927   0.003215434 
+  323          298.12028    133.62147   0.003095975 
+  372          317.60566    133.60374   0.002688172 
+  393          351.04022    133.58608   0.002544529 
+  397          396.69597    133.56848   0.002518892 
+  431          427.17664    133.55094   0.002320186 
+  411          439.00253    133.53348   0.00243309 
+  427          465.61573    133.51608   0.00234192 
+  471          522.66782    133.49874   0.002123142 
+  565          619.22617    133.48147   0.001769912 
+  694          771.40952    133.46427   0.001440922 
+  953          1021.38013   133.44713   0.001049318 
+  1447         1465.72942   133.43006   0.000691085 
+  2450         2371.59399   133.41305   0.000408163 
+  4363         4344.26013   133.39611   0.0002292 
+  6722         7602.24685   133.37924   0.000148765 
+  7416         8111.40092   133.36243   0.000134844 
+  5028         4951.27484   133.34569   0.000198886 
+  3027         2830.47593   133.32901   0.00033036 
+  2027         1961.94042   133.31239   0.00049334 
+  1940         1809.85283   133.29584   0.000515464 
+  2229         2280.46104   133.27936   0.000448632 
+  3280         3557.02089   133.26294   0.000304878 
+  3817         4627.89248   133.24659   0.000261986 
+  3093         3333.74866   133.2303    0.000323311 
+  1907         1880.32615   133.21407   0.000524384 
+  1231         1137.07599   133.19792   0.000812348 
+  836          787.15011    133.18182   0.001196172 
+  602          604.69951    133.16579   0.00166113 
+  500          496.6832     133.14982   0.002     
+  393          427.30202    133.13392   0.002544529 
+  373          380.45848    133.11808   0.002680965 
+  334          347.86633    133.10231   0.002994012 
+  320          324.8183     133.0866    0.003125  
+  317          308.50917    133.07096   0.003154574 
+  304          294.79524    133.05538   0.003289474 
+  281          280.72866    133.03986   0.003558719 
+  287          269.54551    133.02441   0.003484321 
+  252          262.45063    133.00902   0.003968254 
+  281          257.46551    132.99369   0.003558719 
+  265          252.41404    132.97843   0.003773585 
+  287          249.00759    132.96323   0.003484321 
+  259          249.16135    132.94809   0.003861004 
+  253          251.90306    132.93302   0.003952569 
+  228          252.21011    132.91801   0.004385965 
+  292          241.26307    132.90307   0.003424658 
+  212          226.81916    132.88818   0.004716981 
+  229          215.89821    132.87337   0.004366812 
+  251          208.28236    132.85861   0.003984064 
+  213          204.03975    132.84392   0.004694836 
+  219          203.30582    132.82928   0.00456621 
+  229          205.04245    132.81472   0.004366812 
+  236          203.82345    132.80021   0.004237288 
+  227          198.84136    132.78577   0.004405286 
+  217          196.74308    132.77139   0.004608295 
+  228          200.2999     132.75707   0.004385965 
+  219          209.17309    132.74282   0.00456621 
+  225          221.55836    132.72862   0.004444444 
+  216          233.13047    132.71449   0.00462963 
+  252          227.40731    132.70042   0.003968254 
+  236          211.01973    132.68642   0.004237288 
+  250          200.65345    132.67247   0.004     
+  233          198.79081    132.65859   0.004291845 
+  266          204.69573    132.64477   0.003759398 
+  247          217.55729    132.63101   0.004048583 
+  203          234.39454    132.61731   0.004926108 
+  218          240.27851    132.60367   0.004587156 
+  246          229.00265    132.5901    0.004065041 
+  217          219.0459     132.57658   0.004608295 
+  220          217.41592    132.56313   0.004545455 
+  225          223.22465    132.54974   0.004444444 
+  227          235.53344    132.53641   0.004405286 
+  256          250.29081    132.52314   0.00390625 
+  258          253.1235     132.50993   0.003875969 
+  240          241.87129    132.49679   0.004166667 
+  240          231.08562    132.4837    0.004166667 
+  223          221.28723    132.47067   0.004484305 
+  206          211.39078    132.45771   0.004854369 
+  210          206.02875    132.4448    0.004761905 
+  208          205.41576    132.43196   0.004807692 
+  206          204.92574    132.41918   0.004854369 
+  190          199.13842    132.40645   0.005263158 
+  219          192.91277    132.39379   0.00456621 
+  208          189.35125    132.38119   0.004807692 
+  191          186.50703    132.36865   0.005235602 
+  176          186.20189    132.35616   0.005681818 
+  209          188.08234    132.34374   0.004784689 
+  197          188.38187    132.33138   0.005076142 
+  187          183.54774    132.31907   0.005347594 
+  189          173.58795    132.30683   0.005291005 
+  177          166.91204    132.29465   0.005649718 
+  171          164.87228    132.28252   0.005847953 
+  150          166.75574    132.27046   0.006666667 
+  172          171.44748    132.25845   0.005813953 
+  163          175.15216    132.2465    0.006134969 
+  167          176.42043    132.23462   0.005988024 
+  198          176.58481    132.22279   0.005050505 
+  175          180.50879    132.21102   0.005714286 
+  186          192.80228    132.19931   0.005376344 
+  203          206.17841    132.18766   0.004926108 
+  189          201.06138    132.17606   0.005291005 
+  155          184.24591    132.16453   0.006451613 
+  185          171.02261    132.15305   0.005405405 
+  168          163.59081    132.14164   0.005952381 
+  162          161.32752    132.13028   0.00617284 
+  142          163.75584    132.11898   0.007042254 
+  161          170.12281    132.10773   0.00621118 
+  174          173.8666     132.09655   0.005747126 
+  158          167.24026    132.08542   0.006329114 
+  167          158.00349    132.07435   0.005988024 
+  151          151.7749     132.06334   0.006622517 
+  165          148.1707     132.05239   0.006060606 
+  185          146.14907    132.0415    0.005405405 
+  162          145.05845    132.03066   0.00617284 
+  156          144.62536    132.01988   0.006410256 
+  124          144.78439    132.00915   0.008064516 
+  156          145.56825    131.99849   0.006410256 
+  154          147.36006    131.98788   0.006493506 
+  158          150.6976     131.97733   0.006329114 
+  126          154.10839    131.96684   0.007936508 
+  131          153.00674    131.9564    0.007633588 
+  148          148.87573    131.94602   0.006756757 
+  154          145.84545    131.9357    0.006493506 
+  179          144.4554     131.92543   0.005586592 
+  133          144.21518    131.91522   0.007518797 
+  168          144.77052    131.90507   0.005952381 
+  145          146.11557    131.89497   0.006896552 
+  169          147.19825    131.88493   0.00591716 
+  175          146.01735    131.87494   0.005714286 
+  143          144.19361    131.86502   0.006993007 
+  141          143.33651    131.85514   0.007092199 
+  157          142.96349    131.84533   0.006369427 
+  149          142.08565    131.83557   0.006711409 
+  154          141.02298    131.82586   0.006493506 
+  162          140.26303    131.81621   0.00617284 
+  144          139.86705    131.80662   0.006944444 
+  134          139.76468    131.79708   0.007462687 
+  143          139.92079    131.7876    0.006993007 
+  125          140.28368    131.77817   0.008     
+  142          140.53655    131.7688    0.007042254 
+  149          140.44394    131.75949   0.006711409 
+  152          140.41065    131.75023   0.006578947 
+  147          140.68125    131.74102   0.006802721 
+  147          141.28533    131.73187   0.006802721 
+  150          142.14654    131.72277   0.006666667 
+  150          143.07767    131.71373   0.006666667 
+  156          144.09207    131.70474   0.006410256 
+  158          145.85822    131.69581   0.006329114 
+  140          149.21668    131.68693   0.007142857 
+  170          155.16912    131.67811   0.005882353 
+  163          163.95062    131.66934   0.006134969 
+  168          170.26527    131.66062   0.005952381 
+  164          168.01122    131.65196   0.006097561 
+  174          164.65087    131.64335   0.005747126 
+  173          164.82096    131.6348    0.005780347 
+  187          166.1619     131.6263    0.005347594 
+  165          164.59104    131.61785   0.006060606 
+  179          162.79925    131.60946   0.005586592 
+  151          163.88587    131.60112   0.006622517 
+  173          164.09174    131.59284   0.005780347 
+  152          161.02259    131.58461   0.006578947 
+  168          159.13087    131.57643   0.005952381 
+  174          160.15011    131.5683    0.005747126 
+  182          162.42405    131.56023   0.005494505 
+  179          164.12158    131.55221   0.005586592 
+  184          166.51485    131.54424   0.005434783 
+  151          167.43332    131.53633   0.006622517 
+  164          165.60202    131.52847   0.006097561 
+  159          165.64395    131.52066   0.006289308 
+  152          169.35038    131.5129    0.006578947 
+  171          171.34603    131.5052    0.005847953 
+  160          168.24977    131.49754   0.00625   
+  167          165.8341     131.48994   0.005988024 
+  164          166.52941    131.4824    0.006097561 
+  179          168.24681    131.4749    0.005586592 
+  190          170.46744    131.46746   0.005263158 
+  160          176.1209     131.46006   0.00625   
+  159          186.87334    131.45272   0.006289308 
+  196          202.72905    131.44544   0.005102041 
+  188          227.3194     131.4382    0.005319149 
+  246          274.43753    131.43101   0.004065041 
+  284          353.75364    131.42388   0.003521127 
+  305          397.49877    131.4168    0.003278689 
+  294          332.97043    131.40976   0.003401361 
+  251          264.9394     131.40278   0.003984064 
+  257          233.38506    131.39585   0.003891051 
+  215          229.65246    131.38897   0.004651163 
+  238          247.45729    131.38214   0.004201681 
+  247          281.72305    131.37537   0.004048583 
+  277          316.89739    131.36864   0.003610108 
+  240          321.56888    131.36196   0.004166667 
+  207          276.08035    131.35534   0.004830918 
+  223          236.24275    131.34876   0.004484305 
+  193          220.70217    131.34223   0.005181347 
+  256          224.29946    131.33576   0.00390625 
+  207          240.15728    131.32933   0.004830918 
+  210          252.98803    131.32295   0.004761905 
+  223          253.85505    131.31663   0.004484305 
+  239          257.75097    131.31035   0.0041841 
+  225          287.12607    131.30412   0.004444444 
+  289          360.26467    131.29794   0.003460208 
+  279          455.52215    131.29182   0.003584229 
+  319          443.91872    131.28574   0.003134796 
+  238          354.52759    131.27971   0.004201681 
+  235          295.42659    131.27372   0.004255319 
+  199          272.31124    131.26779   0.005025126 
+  231          280.28214    131.26191   0.004329004 
+  266          324.22122    131.25607   0.003759398 
+  290          414.75328    131.25029   0.003448276 
+  326          508.50773    131.24455   0.003067485 
+  294          465.89593    131.23886   0.003401361 
+  261          346.63829    131.23322   0.003831418 
+  231          267.67395    131.22763   0.004329004 
+  198          229.79308    131.22208   0.005050505 
+  204          216.74068    131.21659   0.004901961 
+  199          221.29773    131.21114   0.005025126 
+  199          242.38995    131.20574   0.005025126 
+  180          264.25608    131.20039   0.005555556 
+  195          246.48561    131.19508   0.005128205 
+  199          208.83552    131.18982   0.005025126 
+  200          183.63263    131.18461   0.005     
+  177          170.18791    131.17945   0.005649718 
+  195          163.17234    131.17434   0.005128205 
+  167          158.89742    131.16927   0.005988024 
+  172          155.68326    131.16425   0.005813953 
+  197          153.56565    131.15927   0.005076142 
+  160          152.5317     131.15435   0.00625   
+  152          152.47048    131.14946   0.006578947 
+  187          153.403      131.14463   0.005347594 
+  182          155.43601    131.13984   0.005494505 
+  184          157.9606     131.1351    0.005434783 
+  181          159.94946    131.13041   0.005524862 
+  192          162.88365    131.12576   0.005208333 
+  185          168.73463    131.12116   0.005405405 
+  194          177.38396    131.1166    0.005154639 
+  196          188.35613    131.11209   0.005102041 
+  222          196.15769    131.10762   0.004504505 
+  191          194.1335     131.1032    0.005235602 
+  183          192.30124    131.09883   0.005464481 
+  195          196.23615    131.0945    0.005128205 
+  212          201.33265    131.09022   0.004716981 
+  217          199.66178    131.08598   0.004608295 
+  225          193.18419    131.08179   0.004444444 
+  208          189.0273     131.07764   0.004807692 
+  201          187.59234    131.07354   0.004975124 
+  192          184.15642    131.06948   0.005208333 
+  197          182.07549    131.06547   0.005076142 
+  199          185.20846    131.0615    0.005025126 
+  194          190.2319     131.05758   0.005154639 
+  184          189.55556    131.0537    0.005434783 
+  211          184.47264    131.04987   0.004739336 
+  214          181.01854    131.04608   0.004672897 
+  194          181.45768    131.04233   0.005154639 
+  192          187.40509    131.03863   0.005208333 
+  212          202.10384    131.03497   0.004716981 
+  248          234.2776     131.03136   0.004032258 
+  332          302.15953    131.02779   0.003012048 
+  414          416.68951    131.02426   0.002415459 
+  448          465.21328    131.02078   0.002232143 
+  382          362.01911    131.01734   0.002617801 
+  306          275.26281    131.01394   0.003267974 
+  250          234.3333     131.01059   0.004     
+  241          218.3948     131.00728   0.004149378 
+  245          220.56       131.00401   0.004081633 
+  313          245.14933    131.00078   0.003194888 
+  325          302.13952    130.9976    0.003076923 
+  330          361.16865    130.99446   0.003030303 
+  317          341.19979    130.99137   0.003154574 
+  225          292.67285    130.98831   0.004444444 
+  234          249.83583    130.9853    0.004273504 
+  195          222.35333    130.98233   0.005128205 
+  194          208.82517    130.97941   0.005154639 
+  215          205.45305    130.97652   0.004651163 
+  209          214.00932    130.97368   0.004784689 
+  222          233.42849    130.97088   0.004504505 
+  226          247.56162    130.96812   0.004424779 
+  185          240.15548    130.9654    0.005405405 
+  210          221.56747    130.96272   0.004761905 
+  177          207.79365    130.96009   0.005649718 
+  202          201.34351    130.95749   0.004950495 
+  189          195.92077    130.95494   0.005291005 
+  181          191.75403    130.95243   0.005524862 
+  191          192.35609    130.94996   0.005235602 
+  180          193.7086     130.94753   0.005555556 
+  192          188.09239    130.94514   0.005208333 
+  195          181.258      130.94279   0.005128205 
+  204          179.86519    130.94048   0.004901961 
+  203          184.66572    130.93821   0.004926108 
+  211          194.85025    130.93599   0.004739336 
+  198          210.00665    130.9338    0.005050505 
+  178          221.91678    130.93165   0.005617978 
+  175          212.22601    130.92955   0.005714286 
+  162          191.79453    130.92748   0.00617284 
+  195          177.19026    130.92545   0.005128205 
+  152          169.26193    130.92346   0.006578947 
+  168          165.44048    130.92152   0.005952381 
+  172          165.55315    130.91961   0.005813953 
+  142          170.14272    130.91774   0.007042254 
+  148          177.4651     130.91591   0.006756757 
+  141          177.41354    130.91412   0.007092199 
+  167          167.80767    130.91237   0.005988024 
+  148          158.56849    130.91065   0.006756757 
+  149          152.71285    130.90898   0.006711409 
+  154          148.878      130.90734   0.006493506 
+  143          146.06258    130.90575   0.006993007 
+  148          144.00209    130.90419   0.006756757 
+  165          142.72267    130.90267   0.006060606 
+  150          141.89568    130.90119   0.006666667 
+  137          141.3792     130.89974   0.00729927 
+  149          141.09352    130.89834   0.006711409 
+  142          141.03309    130.89697   0.007042254 
+  138          141.15699    130.89564   0.007246377 
+  129          141.51732    130.89435   0.007751938 
+  158          142.18538    130.8931    0.006329114 
+  155          143.23799    130.89188   0.006451613 
+  155          144.50339    130.8907    0.006451613 
+  160          145.42645    130.88956   0.00625   
+  162          146.15378    130.88846   0.00617284 
+  165          147.62202    130.88739   0.006060606 
+  141          149.57797    130.88636   0.007092199 
+  145          149.88184    130.88536   0.006896552 
+  146          148.91715    130.88441   0.006849315 
+  160          149.00339    130.88349   0.00625   
+  154          150.97269    130.8826    0.006493506 
+  176          154.89613    130.88176   0.005681818 
+  164          159.91226    130.88094   0.006097561 
+  153          162.24389    130.88017   0.006535948 
+  145          160.28842    130.87943   0.006896552 
+  153          158.02879    130.87873   0.006535948 
+  162          156.81801    130.87806   0.00617284 
+  165          157.42808    130.87743   0.006060606 
+  165          160.00943    130.87684   0.006060606 
+  158          165.09979    130.87628   0.006329114 
+  152          173.939      130.87575   0.006578947 
+  198          185.56134    130.87526   0.005050505 
+  181          198.51921    130.87481   0.005524862 
+  222          211.7281     130.87439   0.004504505 
+  203          211.98282    130.87401   0.004926108 
+  154          198.52322    130.87366   0.006493506 
+  175          186.76587    130.87335   0.005714286 
+  178          181.04439    130.87307   0.005617978 
+  169          180.13478    130.87282   0.00591716 
+  174          182.47082    130.87261   0.005747126 
+  192          186.84023    130.87244   0.005208333 
+  184          193.37996    130.87229   0.005434783 
+  208          198.26733    130.87219   0.004807692 
+  177          194.46712    130.87211   0.005649718 
+  172          187.14983    130.87208   0.005813953 
+  158          182.52496    130.87207   0.006329114 
+  186          181.08023    130.8721    0.005376344 
+  167          181.91882    130.87216   0.005988024 
+  162          184.45814    130.87226   0.00617284 
+  193          188.53803    130.87238   0.005181347 
+  179          193.88913    130.87255   0.005586592 
+  192          198.39882    130.87274   0.005208333 
+  213          199.25891    130.87297   0.004694836 
+  204          198.70841    130.87323   0.004901961 
+  220          199.65146    130.87353   0.004545455 
+  197          203.13296    130.87385   0.005076142 
+  184          207.90707    130.87421   0.005434783 
+  185          209.5127     130.8746    0.005405405 
+  198          207.77097    130.87503   0.005050505 
+  181          207.82696    130.87549   0.005524862 
+  197          208.16704    130.87597   0.005076142 
+  189          206.57809    130.8765    0.005291005 
+  185          206.68277    130.87705   0.005405405 
+  187          210.60325    130.87763   0.005347594 
+  215          218.51417    130.87825   0.004651163 
+  218          228.55826    130.8789    0.004587156 
+  198          235.76649    130.87958   0.005050505 
+  211          238.95382    130.88029   0.004739336 
+  186          241.89245    130.88103   0.005376344 
+  225          243.30938    130.88181   0.004444444 
+  264          246.01858    130.88261   0.003787879 
+  250          259.44746    130.88345   0.004     
+  275          296.96876    130.88432   0.003636364 
+  314          378.18797    130.88521   0.003184713 
+  432          483.67672    130.88614   0.002314815 
+  398          458.73797    130.8871    0.002512563 
+  310          348.07962    130.88809   0.003225806 
+  256          277.05553    130.88911   0.00390625 
+  233          241.49543    130.89016   0.004291845 
+  211          225.26522    130.89124   0.004739336 
+  192          223.03589    130.89235   0.005208333 
+  219          238.1124     130.89349   0.00456621 
+  257          278.19503    130.89466   0.003891051 
+  295          317.17322    130.89586   0.003389831 
+  252          280.65089    130.89709   0.003968254 
+  215          225.03561    130.89835   0.004651163 
+  181          192.62629    130.89964   0.005524862 
+  174          176.12826    130.90095   0.005747126 
+  177          167.29247    130.9023    0.005649718 
+  162          162.09488    130.90368   0.00617284 
+  147          158.82711    130.90508   0.006802721 
+  154          156.45164    130.90651   0.006493506 
+  188          154.41124    130.90798   0.005319149 
+  169          152.95606    130.90947   0.00591716 
+  143          152.22577    130.91099   0.006993007 
+  172          152.25369    130.91254   0.005813953 
+  156          153.21805    130.91411   0.006410256 
+  136          155.45943    130.91572   0.007352941 
+  149          158.82315    130.91735   0.006711409 
+  137          160.47539    130.91901   0.00729927 
+  170          157.57614    130.9207    0.005882353 
+  167          153.45751    130.92241   0.005988024 
+  174          150.75331    130.92416   0.005747126 
+  160          149.33248    130.92593   0.00625   
+  151          148.43008    130.92773   0.006622517 
+  151          147.91997    130.92955   0.006622517 
+  147          148.23064    130.93141   0.006802721 
+  157          149.26839    130.93329   0.006369427 
+  142          149.46385    130.9352    0.007042254 
+  151          147.78487    130.93713   0.006622517 
+  158          146.18006    130.93909   0.006329114 
+  167          145.45354    130.94108   0.005988024 
+  161          145.11957    130.9431    0.00621118 
+  147          145.1161     130.94514   0.006802721 
+  162          146.04422    130.94721   0.00617284 
+  152          148.26646    130.9493    0.006578947 
+  172          150.42067    130.95142   0.005813953 
+  140          149.66963    130.95357   0.007142857 
+  161          146.90804    130.95574   0.00621118 
+  186          144.44474    130.95794   0.005376344 
+  141          143.00104    130.96016   0.007092199 
+  144          142.24032    130.96241   0.006944444 
+  155          142.05514    130.96469   0.006451613 
+  167          142.57302    130.96699   0.005988024 
+  152          143.76409    130.96932   0.006578947 
+  146          144.77726    130.97167   0.006849315 
+  150          144.23112    130.97404   0.006666667 
+  141          142.72412    130.97645   0.007092199 
+  166          141.41837    130.97887   0.006024096 
+  146          140.6616     130.98132   0.006849315 
+  141          140.38018    130.9838    0.007092199 
+  151          140.47868    130.9863    0.006622517 
+  153          140.8776     130.98883   0.006535948 
+  155          141.19351    130.99138   0.006451613 
+  132          140.84732    130.99395   0.007575758 
+  139          140.19811    130.99655   0.007194245 
+  138          139.7524     130.99917   0.007246377 
+  159          139.58113    131.00182   0.006289308 
+  134          139.65409    131.00449   0.007462687 
+  151          139.97119    131.00719   0.006622517 
+  137          140.58131    131.0099    0.00729927 
+  147          141.52059    131.01265   0.006802721 
+  163          142.51831    131.01541   0.006134969 
+  161          142.93705    131.0182    0.00621118 
+  154          143.00859    131.02101   0.006493506 
+  161          143.35686    131.02385   0.00621118 
+  148          144.09999    131.02671   0.006756757 
+  147          145.21362    131.02959   0.006802721 
+  180          146.54259    131.03249   0.005555556 
+  155          148.01465    131.03542   0.006451613 
+  177          149.77129    131.03837   0.005649718 
+  127          151.87208    131.04134   0.007874016 
+  171          154.35759    131.04434   0.005847953 
+  154          157.78302    131.04736   0.006493506 
+  164          163.48834    131.0504    0.006097561 
+  171          173.82049    131.05346   0.005847953 
+  211          192.61092    131.05654   0.004739336 
+  215          222.65725    131.05965   0.004651163 
+  268          248.44259    131.06278   0.003731343 
+  203          233.4655     131.06593   0.004926108 
+  198          202.12191    131.0691    0.005050505 
+  168          181.83444    131.07229   0.005952381 
+  189          171.90867    131.07551   0.005291005 
+  165          168.50444    131.07874   0.006060606 
+  202          170.15785    131.082     0.004950495 
+  193          177.63791    131.08528   0.005181347 
+  207          192.32235    131.08858   0.004830918 
+  230          208.23911    131.0919    0.004347826 
+  193          207.14002    131.09524   0.005181347 
+  200          198.72561    131.09861   0.005     
+  212          195.3268     131.10199   0.004716981 
+  179          189.85298    131.1054    0.005586592 
+  164          181.44142    131.10882   0.006097561 
+  141          175.43067    131.11227   0.007092199 
+  170          171.1171     131.11573   0.005882353 
+  174          167.05435    131.11922   0.005747126 
+  157          164.93327    131.12272   0.006369427 
+  170          165.74094    131.12625   0.005882353 
+  188          169.65334    131.1298    0.005319149 
+  178          175.16796    131.13336   0.005617978 
+  172          177.47837    131.13695   0.005813953 
+  177          176.12498    131.14055   0.005649718 
+  167          176.69957    131.14418   0.005988024 
+  184          181.28713    131.14783   0.005434783 
+  200          188.45401    131.15149   0.005     
+  168          192.21766    131.15517   0.005952381 
+  192          188.59214    131.15888   0.005208333 
+  187          185.0676     131.1626    0.005347594 
+  188          184.21897    131.16634   0.005319149 
+  184          185.70637    131.1701    0.005434783 
+  182          193.76262    131.17388   0.005494505 
+  208          216.23411    131.17768   0.004807692 
+  251          263.84694    131.18149   0.003984064 
+  336          329.08151    131.18533   0.00297619 
+  286          328.85581    131.18918   0.003496503 
+  265          265.0096     131.19305   0.003773585 
+  230          218.84897    131.19694   0.004347826 
+  224          196.73643    131.20085   0.004464286 
+  179          188.22627    131.20478   0.005586592 
+  190          188.386      131.20872   0.005263158 
+  214          195.56952    131.21268   0.004672897 
+  233          212.74221    131.21667   0.004291845 
+  238          239.98026    131.22066   0.004201681 
+  211          244.38659    131.22468   0.004739336 
+  188          210.33813    131.22871   0.005319149 
+  178          181.82509    131.23276   0.005617978 
+  195          167.21249    131.23683   0.005128205 
+  162          160.90071    131.24092   0.00617284 
+  172          158.52779    131.24502   0.005813953 
+  147          157.28348    131.24914   0.006802721 
+  148          156.10223    131.25328   0.006756757 
+  155          154.90968    131.25743   0.006451613 
+  164          153.16755    131.2616    0.006097561 
+  176          152.10241    131.26579   0.005681818 
+  165          152.85911    131.27      0.006060606 
+  199          155.39552    131.27422   0.005025126 
+  168          158.77362    131.27846   0.005952381 
+  167          160.51174    131.28271   0.005988024 
+  193          159.71984    131.28698   0.005181347 
+  153          159.33882    131.29127   0.006535948 
+  180          162.23953    131.29557   0.005555556 
+  179          169.92788    131.29989   0.005586592 
+  161          183.54549    131.30423   0.00621118 
+  187          200.61189    131.30858   0.005347594 
+  193          213.30317    131.31295   0.005181347 
+  190          216.57864    131.31733   0.005263158 
+  152          205.56743    131.32173   0.006578947 
+  161          187.42604    131.32614   0.00621118 
+  150          173.32679    131.33057   0.006666667 
+  159          165.80123    131.33502   0.006289308 
+  159          163.76702    131.33948   0.006289308 
+  158          166.48895    131.34396   0.006329114 
+  181          172.80851    131.34845   0.005524862 
+  155          178.70751    131.35295   0.006451613 
+  156          180.46419    131.35748   0.006410256 
+  150          175.77568    131.36201   0.006666667 
+  175          166.11286    131.36656   0.005714286 
+  147          157.56788    131.37113   0.006802721 
+  140          152.05991    131.37571   0.007142857 
+  149          148.83103    131.38031   0.006711409 
+  160          146.98892    131.38492   0.00625   
+  172          146.00053    131.38954   0.005813953 
+  133          145.59407    131.39418   0.007518797 
+  140          145.39391    131.39884   0.007142857 
+  124          145.0763     131.40351   0.008064516 
+  173          144.74149    131.40819   0.005780347 
+  138          144.68624    131.41289   0.007246377 
+  129          145.04726    131.4176    0.007751938 
+  136          145.90123    131.42232   0.007352941 
+  158          147.38431    131.42706   0.006329114 
+  122          149.79592    131.43181   0.008196721 
+  164          153.54666    131.43658   0.006097561 
+  147          158.39963    131.44136   0.006802721 
+  163          161.94549    131.44615   0.006134969 
+  192          162.45082    131.45096   0.005208333 
+  149          162.28532    131.45578   0.006711409 
+  164          162.84657    131.46061   0.006097561 
+  169          161.93469    131.46546   0.00591716 
+  150          160.05995    131.47032   0.006666667 
+  159          159.79712    131.4752    0.006289308 
+  156          162.0574     131.48008   0.006410256 
+  177          167.23731    131.48498   0.005649718 
+  185          175.69027    131.48989   0.005405405 
+  215          188.54193    131.49482   0.004651163 
+  233          210.84056    131.49976   0.004291845 
+  263          248.64154    131.50471   0.003802281 
+  276          285.24405    131.50968   0.003623188 
+  277          275.00015    131.51465   0.003610108 
+  224          241.51668    131.51964   0.004464286 
+  230          215.09489    131.52464   0.004347826 
+  230          194.94079    131.52966   0.004347826 
+  183          182.08394    131.53468   0.005464481 
+  164          176.87201    131.53972   0.006097561 
+  199          179.08092    131.54478   0.005025126 
+  202          190.03517    131.54984   0.004950495 
+  218          208.81963    131.55491   0.004587156 
+  189          217.28829    131.56      0.005291005 
+  227          203.34607    131.5651    0.004405286 
+  183          187.3844     131.57021   0.005464481 
+  167          174.82361    131.57534   0.005988024 
+  165          165.08275    131.58047   0.006060606 
+  153          158.68089    131.58562   0.006535948 
+  175          154.8558     131.59078   0.005714286 
+  145          152.65814    131.59595   0.006896552 
+  148          151.48231    131.60113   0.006756757 
+  148          150.99098    131.60632   0.006756757 
+  166          150.97534    131.61153   0.006024096 
+  150          151.22568    131.61674   0.006666667 
+  164          151.58126    131.62197   0.006097561 
+  165          152.08682    131.62721   0.006060606 
+  155          152.80581    131.63246   0.006451613 
+  160          153.76646    131.63772   0.00625   
+  190          155.01564    131.64299   0.005263158 
+  188          156.63277    131.64828   0.005319149 
+  152          158.7511     131.65357   0.006578947 
+  169          161.58149    131.65887   0.00591716 
+  188          165.31402    131.66419   0.005319149 
+  173          169.44103    131.66952   0.005780347 
+  161          172.36026    131.67485   0.00621118 
+  184          174.48438    131.6802    0.005434783 
+  162          177.78407    131.68556   0.00617284 
+  182          182.64407    131.69093   0.005494505 
+  187          188.67391    131.69631   0.005347594 
+  183          196.74395    131.7017    0.005464481 
+  220          208.46956    131.7071    0.004545455 
+  216          225.61333    131.71251   0.00462963 
+  240          250.77026    131.71793   0.004166667 
+  289          288.0233     131.72337   0.003460208 
+  361          346.35089    131.72881   0.002770083 
+  467          450.60649    131.73426   0.002141328 
+  731          655.9085     131.73972   0.001367989 
+  1108         1047.27453   131.7452    0.000902527 
+  1481         1562.6167    131.75068   0.000675219 
+  1415         1546.85951   131.75617   0.000706714 
+  958          1034.78427   131.76167   0.001043841 
+  692          663.96277    131.76719   0.001445087 
+  520          479.02552    131.77271   0.001923077 
+  417          398.41762    131.77824   0.002398082 
+  420          376.37341    131.78378   0.002380952 
+  417          404.75732    131.78933   0.002398082 
+  597          505.60854    131.79489   0.001675042 
+  729          714.70824    131.80046   0.001371742 
+  833          936.98454    131.80605   0.00120048 
+  721          825.96843    131.81164   0.001386963 
+  576          562.95023    131.81723   0.001736111 
+  393          397.01966    131.82284   0.002544529 
+  329          311.68415    131.82846   0.003039514 
+  251          263.93047    131.83409   0.003984064 
+  251          234.18819    131.83973   0.003984064 
+  198          214.31095    131.84537   0.005050505 
+  201          200.09364    131.85103   0.004975124 
+  180          190.5855     131.85669   0.005555556 
+  179          183.76451    131.86237   0.005586592 
+  171          178.37059    131.86805   0.005847953 
+  181          175.27813    131.87374   0.005524862 
+  158          174.18601    131.87945   0.006329114 
+  172          172.4229     131.88516   0.005813953 
+  156          168.28244    131.89088   0.006410256 
+  169          163.85951    131.89661   0.00591716 
+  162          159.84129    131.90234   0.00617284 
+  175          156.28468    131.90809   0.005714286 
+  164          153.62339    131.91385   0.006097561 
+  129          151.81048    131.91961   0.007751938 
+  140          150.63891    131.92538   0.007142857 
+  153          150.00735    131.93116   0.006535948 
+  148          149.72559    131.93696   0.006756757 
+  158          149.33196    131.94276   0.006329114 
+  154          148.72799    131.94856   0.006493506 
+  164          148.36865    131.95438   0.006097561 
+  164          148.46516    131.96021   0.006097561 
+  166          148.94573    131.96604   0.006024096 
+  170          149.54354    131.97188   0.005882353 
+  149          150.04567    131.97773   0.006711409 
+  160          150.46894    131.98359   0.00625   
+  149          150.85034    131.98946   0.006711409 
+  142          150.87896    131.99534   0.007042254 
+  158          150.8133     132.00123   0.006329114 
+  131          151.12626    132.00712   0.007633588 
+  164          152.03561    132.01302   0.006097561 
+  153          153.73944    132.01893   0.006535948 
+  163          156.51772    132.02485   0.006134969 
+  159          160.78535    132.03078   0.006289308 
+  156          167.22673    132.03672   0.006410256 
+  188          176.94274    132.04266   0.005319149 
+  190          192.67049    132.04862   0.005263158 
+  210          218.00419    132.05458   0.004761905 
+  203          246.91291    132.06055   0.004926108 
+  191          251.17627    132.06652   0.005235602 
+  210          227.0592     132.07251   0.004761905 
+  187          201.17526    132.0785    0.005347594 
+  177          183.47915    132.08451   0.005649718 
+  175          174.09771    132.09052   0.005714286 
+  151          170.73434    132.09654   0.006622517 
+  158          171.81166    132.10257   0.006329114 
+  181          177.67537    132.1086    0.005524862 
+  195          189.86085    132.11464   0.005128205 
+  193          205.33633    132.1207    0.005181347 
+  188          210.36584    132.12676   0.005319149 
+  192          203.84297    132.13283   0.005208333 
+  193          199.8594     132.1389    0.005181347 
+  187          200.94104    132.14499   0.005347594 
+  182          197.2323     132.15108   0.005494505 
+  176          184.71237    132.15718   0.005681818 
+  185          172.52487    132.16329   0.005405405 
+  185          164.75984    132.16941   0.005405405 
+  168          160.7929     132.17553   0.005952381 
+  170          159.41358    132.18167   0.005882353 
+  181          159.91555    132.18781   0.005524862 
+  179          162.64216    132.19396   0.005586592 
+  179          168.31128    132.20012   0.005586592 
+  193          176.07958    132.20628   0.005181347 
+  170          181.45043    132.21246   0.005882353 
+  189          182.92729    132.21864   0.005291005 
+  185          184.63448    132.22483   0.005405405 
+  174          186.60117    132.23103   0.005747126 
+  181          183.60744    132.23723   0.005524862 
+  183          175.65527    132.24345   0.005464481 
+  153          169.25595    132.24967   0.006535948 
+  152          166.7955     132.2559    0.006578947 
+  178          167.36384    132.26214   0.005617978 
+  167          167.84166    132.26839   0.005988024 
+  152          166.62304    132.27465   0.006578947 
+  136          166.21042    132.28091   0.007352941 
+  161          167.56535    132.28718   0.00621118 
+  162          169.40046    132.29346   0.00617284 
+  161          168.96769    132.29975   0.00621118 
+  168          165.64628    132.30605   0.005952381 
+  163          162.78974    132.31235   0.006134969 
+  189          161.92035    132.31867   0.005291005 
+  151          162.67016    132.32499   0.006622517 
+  139          163.56762    132.33132   0.007194245 
+  190          163.45837    132.33766   0.005263158 
+  185          163.34475    132.344     0.005405405 
+  187          164.08298    132.35036   0.005347594 
+  180          165.73266    132.35672   0.005555556 
+  177          168.23717    132.36309   0.005649718 
+  204          171.63909    132.36947   0.004901961 
+  181          176.10256    132.37586   0.005524862 
+  192          181.92294    132.38226   0.005208333 
+  189          189.43463    132.38866   0.005291005 
+  216          198.52328    132.39508   0.00462963 
+  240          208.46454    132.4015    0.004166667 
+  257          220.2919     132.40793   0.003891051 
+  258          236.72247    132.41437   0.003875969 
+  276          260.4673     132.42082   0.003623188 
+  346          295.42988    132.42728   0.002890173 
+  365          348.69449    132.43374   0.002739726 
+  476          434.13271    132.44022   0.00210084 
+  685          580.12815    132.4467    0.001459854 
+  962          844.68457    132.45319   0.001039501 
+  1651         1333.7449    132.45969   0.000605694 
+  2289         2054.20011   132.4662    0.000436872 
+  2269         2270.26903   132.47272   0.000440723 
+  1639         1614.05096   132.47924   0.000610128 
+  1061         1014.18488   132.48578   0.000942507 
+  780          690.98412    132.49233   0.001282051 
+  610          539.21467    132.49888   0.001639344 
+  512          479.14264    132.50544   0.001953125 
+  514          481.22183    132.51201   0.001945525 
+  641          551.38112    132.51859   0.001560062 
+  876          727.17724    132.52518   0.001141553 
+  1129         1046.11      132.53178   0.00088574 
+  1261         1277.32218   132.53839   0.000793021 
+  991          1024.55703   132.54501   0.001009082 
+  696          673.29758    132.55164   0.001436782 
+  549          461.79       132.55827   0.001821494 
+  372          351.4057     132.56492   0.002688172 
+  329          292.02617    132.57157   0.003039514 
+  254          256.74967    132.57824   0.003937008 
+  218          232.96954    132.58491   0.004587156 
+  213          215.30855    132.5916    0.004694836 
+  199          202.23335    132.59829   0.005025126 
+  207          192.67001    132.60499   0.004830918 
+  216          185.59135    132.61171   0.00462963 
+  197          180.28415    132.61843   0.005076142 
+  166          176.33344    132.62516   0.006024096 
+  182          173.55957    132.63191   0.005494505 
+  186          171.9608     132.63866   0.005376344 
+  167          171.56315    132.64542   0.005988024 
+  185          172.11083    132.65219   0.005405405 
+  175          173.44291    132.65898   0.005714286 
+  191          175.58307    132.66577   0.005235602 
+  171          175.99805    132.67257   0.005847953 
+  179          172.53469    132.67939   0.005586592 
+  157          168.33977    132.68621   0.006369427 
+  155          165.78627    132.69304   0.006451613 
+  172          164.58214    132.69989   0.005813953 
+  193          163.47873    132.70675   0.005181347 
+  178          162.46508    132.71361   0.005617978 
+  175          162.46735    132.72049   0.005714286 
+  176          163.94163    132.72738   0.005681818 
+  172          166.98395    132.73427   0.005813953 
+  165          170.81712    132.74118   0.006060606 
+  176          173.79028    132.7481    0.005681818 
+  184          176.892      132.75504   0.005434783 
+  190          183.62892    132.76198   0.005263158 
+  215          197.89473    132.76893   0.004651163 
+  209          223.88458    132.7759    0.004784689 
+  246          260.59445    132.78287   0.004065041 
+  257          278.89345    132.78986   0.003891051 
+  243          252.44833    132.79686   0.004115226 
+  233          219.13254    132.80387   0.004291845 
+  172          200.10805    132.81089   0.005813953 
+  202          193.25429    132.81793   0.004950495 
+  212          194.7773     132.82497   0.004716981 
+  206          204.07136    132.83203   0.004854369 
+  217          218.88736    132.8391    0.004608295 
+  221          228.00004    132.84618   0.004524887 
+  221          230.97196    132.85328   0.004524887 
+  203          236.28857    132.86039   0.004926108 
+  216          227.71201    132.8675    0.00462963 
+  203          206.34737    132.87464   0.004926108 
+  194          188.77405    132.88178   0.005154639 
+  170          178.1224     132.88894   0.005882353 
+  152          173.17525    132.8961    0.006578947 
+  150          172.67598    132.90329   0.006666667 
+  165          175.91716    132.91048   0.006060606 
+  147          178.85169    132.91769   0.006802721 
+  168          174.92154    132.92491   0.005952381 
+  159          168.14062    132.93214   0.006289308 
+  150          164.06968    132.93939   0.006666667 
+  169          162.99064    132.94665   0.00591716 
+  153          163.48932    132.95393   0.006535948 
+  155          164.38771    132.96121   0.006451613 
+  142          165.79527    132.96852   0.007042254 
+  181          167.24174    132.97583   0.005524862 
+  152          167.18673    132.98316   0.006578947 
+  154          167.00857    132.9905    0.006493506 
+  153          167.44866    132.99786   0.006535948 
+  178          165.84974    133.00523   0.005617978 
+  197          162.1955     133.01262   0.005076142 
+  192          159.17459    133.02002   0.005208333 
+  174          157.77665    133.02743   0.005747126 
+  149          157.7679     133.03486   0.006711409 
+  171          158.63023    133.04231   0.005847953 
+  191          160.00903    133.04977   0.005235602 
+  158          161.15487    133.05724   0.006329114 
+  181          161.65579    133.06473   0.005524862 
+  176          162.55014    133.07224   0.005681818 
+  166          163.61392    133.07976   0.006024096 
+  190          163.64033    133.08729   0.005263158 
+  187          163.30603    133.09484   0.005347594 
+  165          163.24315    133.10241   0.006060606 
+  203          162.95667    133.10999   0.004926108 
+  173          162.65996    133.11759   0.005780347 
+  197          162.83079    133.1252    0.005076142 
+  173          163.58011    133.13284   0.005780347 
+  163          164.75445    133.14048   0.006134969 
+  199          166.48643    133.14815   0.005025126 
+  200          168.67524    133.15583   0.005     
+  190          171.36347    133.16352   0.005263158 
+  190          174.62097    133.17124   0.005263158 
+  188          178.45431    133.17897   0.005319149 
+  174          182.62954    133.18672   0.005747126 
+  197          187.04457    133.19448   0.005076142 
+  188          192.17638    133.20227   0.005319149 
+  188          198.54192    133.21007   0.005319149 
+  206          206.55349    133.21788   0.004854369 
+  219          216.65543    133.22572   0.00456621 
+  235          229.6936     133.23358   0.004255319 
+  259          246.89058    133.24145   0.003861004 
+  277          270.495      133.24934   0.003610108 
+  303          304.46136    133.25725   0.00330033 
+  339          354.90678    133.26517   0.002949853 
+  407          426.17205    133.27312   0.002457002 
+  446          502.59586    133.28109   0.002242152 
+  546          568.85759    133.28907   0.001831502 
+  712          677.66598    133.29707   0.001404494 
+  950          904.53779    133.3051    0.001052632 
+  1529         1359.00154   133.31314   0.000654022 
+  2393         2195.74711   133.3212    0.000417885 
+  3062         3262.96524   133.32928   0.000326584 
+  2855         3300.05226   133.33738   0.000350263 
+  2098         2264.52777   133.34551   0.000476644 
+  1350         1441.45909   133.35365   0.000740741 
+  1019         1009.34992   133.36181   0.000981354 
+  886          801.81232    133.36999   0.001128668 
+  686          703.66381    133.3782    0.001457726 
+  791          691.85704    133.38642   0.001264223 
+  817          783.74306    133.39467   0.00122399 
+  1063         1019.90337   133.40294   0.000940734 
+  1467         1435.20648   133.41123   0.000681663 
+  1662         1896.57851   133.41954   0.000601685 
+  1586         1779.2551    133.42787   0.000630517 
+  1103         1212.09058   133.43622   0.000906618 
+  797          790.82113    133.4446    0.001254705 
+  572          558.8968     133.453     0.001748252 
+  438          435.34193    133.46142   0.002283105 
+  382          367.13531    133.46986   0.002617801 
+  309          329.51047    133.47833   0.003236246 
+  306          312.75586    133.48682   0.003267974 
+  304          307.76489    133.49533   0.003289474 
+  280          293.74202    133.50387   0.003571429 
+  257          267.40087    133.51243   0.003891051 
+  257          246.25951    133.52101   0.003891051 
+  259          234.87348    133.52962   0.003861004 
+  215          231.4749     133.53826   0.004651163 
+  226          232.78962    133.54691   0.004424779 
+  230          231.39689    133.55559   0.004347826 
+  201          222.62018    133.5643    0.004975124 
+  179          212.8554     133.57303   0.005586592 
+  200          206.06713    133.58179   0.005     
+  189          200.1362     133.59057   0.005291005 
+  182          194.06232    133.59937   0.005494505 
+  183          189.50629    133.60821   0.005464481 
+  177          187.28626    133.61707   0.005649718 
+  183          187.48394    133.62595   0.005464481 
+  174          190.1827     133.63486   0.005747126 
+  181          194.77866    133.6438    0.005524862 
+  195          198.06718    133.65276   0.005128205 
+  180          196.98914    133.66176   0.005555556 
+  184          193.11643    133.67077   0.005434783 
+  170          189.30665    133.67982   0.005882353 
+  188          186.8833     133.68889   0.005319149 
+  181          185.86229    133.698     0.005524862 
+  180          185.26431    133.70713   0.005555556 
+  191          183.47421    133.71628   0.005235602 
+  177          182.2889     133.72547   0.005649718 
+  177          183.82538    133.73468   0.005649718 
+  186          188.11837    133.74393   0.005376344 
+  172          193.44137    133.7532    0.005813953 
+  169          194.76393    133.7625    0.00591716 
+  188          189.33279    133.77184   0.005319149 
+  186          181.84081    133.7812    0.005376344 
+  162          176.53859    133.79059   0.00617284 
+  174          174.13834    133.80001   0.005747126 
+  174          173.40107    133.80947   0.005747126 
+  162          172.77354    133.81895   0.00617284 
+  186          172.74234    133.82847   0.005376344 
+  169          174.44836    133.83801   0.00591716 
+  175          178.14412    133.84759   0.005714286 
+  184          183.42959    133.8572    0.005434783 
+  177          188.39627    133.86684   0.005649718 
+  167          190.5444     133.87651   0.005988024 
+  210          188.02381    133.88622   0.004761905 
+  189          181.09307    133.89596   0.005291005 
+  180          173.93211    133.90573   0.005555556 
+  194          168.78911    133.91553   0.005154639 
+  166          165.5485     133.92537   0.006024096 
+  152          163.69208    133.93524   0.006578947 
+  189          162.89092    133.94515   0.005291005 
+  179          163.05461    133.95509   0.005586592 
+  161          164.3182     133.96507   0.00621118 
+  175          166.97354    133.97507   0.005714286 
+  167          170.97836    133.98512   0.005988024 
+  179          174.88157    133.9952    0.005586592 
+  201          176.75597    134.00531   0.004975124 
+  167          175.72492    134.01546   0.005988024 
+  142          172.18195    134.02565   0.007042254 
+  148          169.21642    134.03587   0.006756757 
+  163          168.90192    134.04613   0.006134969 
+  161          171.83693    134.05643   0.00621118 
+  163          177.83123    134.06676   0.006134969 
+  150          183.81191    134.07713   0.006666667 
+  160          183.61783    134.08754   0.00625   
+  163          177.65658    134.09799   0.006134969 
+  183          171.90911    134.10848   0.005464481 
+  167          168.86004    134.119     0.005988024 
+  181          167.37107    134.12956   0.005524862 
+  175          165.75676    134.14016   0.005714286 
+  180          164.65345    134.1508    0.005555556 
+  147          165.29892    134.16148   0.006802721 
+  180          168.28027    134.1722    0.005555556 
+  168          173.91004    134.18296   0.005952381 
+  177          181.22235    134.19376   0.005649718 
+  200          186.13554    134.20461   0.005     
+  162          186.28541    134.21549   0.00617284 
+  165          184.73394    134.22641   0.006060606 
+  183          181.91276    134.23738   0.005464481 
+  211          177.5581     134.24839   0.004739336 
+  212          173.98251    134.25944   0.004716981 
+  199          172.24199    134.27053   0.005025126 
+  178          172.08696    134.28167   0.005617978 
+  176          173.26073    134.29284   0.005681818 
+  167          175.97498    134.30407   0.005988024 
+  219          179.91942    134.31533   0.00456621 
+  214          183.91777    134.32664   0.004672897 
+  217          187.3202     134.338     0.004608295 
+  217          190.81507    134.3494    0.004608295 
+  231          195.12494    134.36084   0.004329004 
+  226          199.80014    134.37233   0.004424779 
+  230          206.2427     134.38387   0.004347826 
+  222          215.9884     134.39545   0.004504505 
+  260          229.81096    134.40708   0.003846154 
+  249          248.66084    134.41875   0.004016064 
+  292          272.73593    134.43047   0.003424658 
+  321          302.85763    134.44224   0.003115265 
+  384          347.60817    134.45406   0.002604167 
+  455          424.5896     134.46592   0.002197802 
+  652          566.16049    134.47784   0.001533742 
+  1014         831.3695     134.4898    0.000986193 
+  1350         1283.33138   134.50181   0.000740741 
+  1667         1743.3762    134.51387   0.00059988 
+  1421         1603.48208   134.52598   0.00070373 
+  1057         1096.17626   134.53814   0.000946074 
+  748          731.98252    134.55035   0.001336898 
+  592          536.97764    134.56261   0.001689189 
+  467          440.34564    134.57492   0.002141328 
+  435          397.98902    134.58728   0.002298851 
+  384          394.78861    134.5997    0.002604167 
+  459          433.87301    134.61217   0.002178649 
+  597          532.3021     134.62469   0.001675042 
+  726          708.93224    134.63726   0.00137741 
+  860          943.62628    134.64988   0.001162791 
+  929          1027.92866   134.66256   0.001076426 
+  784          798.56803    134.6753    0.00127551 
+  603          549.00614    134.68808   0.001658375 
+  386          397.75546    134.70092   0.002590674 
+  317          315.28489    134.71382   0.003154574 
+  285          269.56131    134.72677   0.003508772 
+  268          243.55806    134.73978   0.003731343 
+  252          229.94617    134.75285   0.003968254 
+  208          225.86578    134.76597   0.004807692 
+  248          227.45715    134.77914   0.004032258 
+  217          222.9128     134.79238   0.004608295 
+  208          207.81718    134.80567   0.004807692 
+  202          193.31185    134.81902   0.004950495 
+  211          183.67334    134.83243   0.004739336 
+  189          177.89885    134.8459    0.005291005 
+  191          174.38975    134.85942   0.005235602 
+  179          171.5009     134.87301   0.005586592 
+  192          168.19348    134.88665   0.005208333 
+  172          164.74662    134.90036   0.005813953 
+  145          161.81494    134.91413   0.006896552 
+  182          159.60267    134.92796   0.005494505 
+  149          157.97579    134.94184   0.006711409 
+  163          156.77352    134.9558    0.006134969 
+  157          156.01601    134.96981   0.006369427 
+  150          155.83384    134.98389   0.006666667 
+  157          156.36351    134.99803   0.006369427 
+  164          157.60861    135.01223   0.006097561 
+  160          158.94014    135.0265    0.00625   
+  163          159.09923    135.04083   0.006134969 
+  165          158.0296     135.05522   0.006060606 
+  188          156.80004    135.06968   0.005319149 
+  177          156.00763    135.08421   0.005649718 
+  176          156.07519    135.0988    0.005681818 
+  144          157.24017    135.11346   0.006944444 
+  152          159.4105     135.12819   0.006578947 
+  143          161.63676    135.14298   0.006993007 
+  157          161.53902    135.15784   0.006369427 
+  151          159.06804    135.17277   0.006622517 
+  154          156.6569     135.18777   0.006493506 
+  148          155.08723    135.20284   0.006756757 
+  156          153.93891    135.21797   0.006410256 
+  156          153.20533    135.23318   0.006410256 
+  147          153.08514    135.24846   0.006802721 
+  157          153.69049    135.2638    0.006369427 
+  155          155.33934    135.27922   0.006451613 
+  174          158.39005    135.29471   0.005747126 
+  157          163.16983    135.31027   0.006369427 
+  177          169.4989     135.32591   0.005649718 
+  174          175.8757     135.34161   0.005747126 
+  149          178.9475     135.3574    0.006711409 
+  162          175.23488    135.37325   0.00617284 
+  171          168.03758    135.38918   0.005847953 
+  162          162.29489    135.40518   0.00617284 
+  141          159.24757    135.42126   0.007092199 
+  144          158.66807    135.43742   0.006944444 
+  182          160.33773    135.45365   0.005494505 
+  161          163.85377    135.46996   0.00621118 
+  160          167.36453    135.48634   0.00625   
+  147          168.0462     135.5028    0.006802721 
+  148          167.60531    135.51934   0.006756757 
+  147          168.93692    135.53596   0.006802721 
+  151          170.47564    135.55266   0.006622517 
+  159          169.40534    135.56944   0.006289308 
+  161          166.08699    135.5863    0.00621118 
+  179          162.3049     135.60323   0.005586592 
+  162          159.50016    135.62025   0.00617284 
+  176          157.95494    135.63735   0.005681818 
+  138          157.54248    135.65453   0.007246377 
+  139          157.84321    135.6718    0.007194245 
+  151          157.79004    135.68915   0.006622517 
+  151          156.20591    135.70658   0.006622517 
+  169          154.15151    135.72409   0.00591716 
+  146          153.08685    135.74169   0.006849315 
+  125          153.17963    135.75938   0.008     
+  155          154.00729    135.77715   0.006451613 
+  176          154.89092    135.795     0.005681818 
+  165          155.90318    135.81294   0.006060606 
+  172          157.93146    135.83097   0.005813953 
+  187          161.58941    135.84909   0.005347594 
+  139          166.61546    135.86729   0.007194245 
+  174          170.47736    135.88559   0.005747126 
+  149          170.4353     135.90397   0.006711409 
+  167          167.39631    135.92244   0.005988024 
+  149          162.41613    135.941     0.006711409 
+  161          157.20583    135.95965   0.00621118 
+  133          153.35802    135.97839   0.007518797 
+  142          151.00987    135.99723   0.007042254 
+  147          149.82831    136.01616   0.006802721 
+  157          149.59431    136.03517   0.006369427 
+  133          150.29052    136.05429   0.007518797 
+  144          152.01882    136.07349   0.006944444 
+  162          154.61403    136.09279   0.00617284 
+  144          156.86125    136.11219   0.006944444 
+  157          157.35987    136.13168   0.006369427 
+  152          156.48537    136.15127   0.006578947 
+  131          154.79837    136.17095   0.007633588 
+  175          153.1972     136.19073   0.005714286 
+  154          152.56469    136.21061   0.006493506 
+  148          152.90909    136.23059   0.006756757 
+  136          153.64743    136.25066   0.007352941 
+  153          153.73226    136.27083   0.006535948 
+  148          153.24062    136.29111   0.006756757 
+  174          153.12442    136.31148   0.005747126 
+  135          153.49743    136.33196   0.007407407 
+  166          154.40031    136.35253   0.006024096 
+  157          155.89013    136.37321   0.006369427 
+  165          157.58702    136.394     0.006060606 
+  155          159.96653    136.41488   0.006451613 
+  135          161.29785    136.43587   0.007407407 
+  138          159.55785    136.45696   0.007246377 
+  146          156.38819    136.47816   0.006849315 
+  159          153.88528    136.49946   0.006289308 
+  156          152.05601    136.52087   0.006410256 
+  137          150.60586    136.54239   0.00729927 
+  154          149.76867    136.56402   0.006493506 
+  125          149.48333    136.58575   0.008     
+  152          149.6416     136.60759   0.006578947 
+  155          150.24947    136.62954   0.006451613 
+  166          151.08299    136.6516    0.006024096 
+  146          152.4045     136.67377   0.006849315 
+  150          153.60743    136.69605   0.006666667 
+  138          153.58715    136.71844   0.007246377 
+  156          152.96856    136.74095   0.006410256 
+  142          153.15162    136.76356   0.007042254 
+  137          154.1928     136.78629   0.00729927 
+  154          154.78753    136.80914   0.006493506 
+  160          154.00567    136.8321    0.00625   
+  140          152.46887    136.85517   0.007142857 
+  138          150.8788     136.87836   0.007246377 
+  137          149.69381    136.90167   0.00729927 
+  157          149.11308    136.9251    0.006369427 
+  145          149.1258     136.94864   0.006896552 
+  143          149.71952    136.9723    0.006993007 
+  152          150.89748    136.99608   0.006578947 
+  151          152.55176    137.01998   0.006622517 
+  159          154.4393     137.044     0.006289308 
+  160          156.25904    137.06814   0.00625   
+  153          157.51545    137.0924    0.006535948 
+  167          158.2837     137.11679   0.005988024 
+  164          158.96077    137.14129   0.006097561 
+  173          158.77373    137.16593   0.005780347 
+  140          156.89801    137.19068   0.007142857 
+  164          154.44289    137.21556   0.006097561 
+  157          152.50118    137.24057   0.006369427 
+  130          151.38302    137.2657    0.007692308 
+  157          151.0699     137.29096   0.006369427 
+  142          151.40676    137.31635   0.007042254 
+  154          152.14358    137.34186   0.006493506 
+  159          153.07715    137.36751   0.006289308 
+  147          154.20099    137.39328   0.006802721 
+  168          155.916      137.41919   0.005952381 
+  142          158.21244    137.44522   0.007042254 
+  149          159.39211    137.47139   0.006711409 
+  139          157.82802    137.49769   0.007194245 
+  133          154.88379    137.52412   0.007518797 
+  164          152.31565    137.55069   0.006097561 
+  180          150.56077    137.57739   0.005555556 
+  169          149.51167    137.60422   0.00591716 
+  133          148.99643    137.63119   0.007518797 
+  152          148.88433    137.6583    0.006578947 
+  144          149.09482    137.68555   0.006944444 
+  144          149.59987    137.71293   0.006944444 
+  155          150.41018    137.74045   0.006451613 
+  155          151.39881    137.76811   0.006451613 
+  132          152.10723    137.79591   0.007575758 
+  158          151.93133    137.82385   0.006329114 
+  151          151.15015    137.85194   0.006622517 
+  162          150.52646    137.88016   0.00617284 
+  161          150.31657    137.90853   0.00621118 
+  153          150.33504    137.93705   0.006535948 
+  138          150.32656    137.9657    0.007246377 
+  147          150.481      137.9945    0.006802721 
+  146          151.07386    138.02345   0.006849315 
+  158          152.27082    138.05255   0.006329114 
+  133          154.24516    138.08179   0.007518797 
+  148          157.07675    138.11118   0.006756757 
+  141          160.22005    138.14072   0.007092199 
+  161          161.91776    138.17041   0.00621118 
+  159          161.03663    138.20024   0.006289308 
+  160          159.17568    138.23023   0.00625   
+  152          158.12391    138.26038   0.006578947 
+  150          158.38096    138.29067   0.006666667 
+  171          159.80585    138.32112   0.005847953 
+  168          161.94901    138.35172   0.005952381 
+  156          163.80951    138.38248   0.006410256 
+  165          165.01709    138.41339   0.006060606 
+  161          166.96468    138.44446   0.00621118 
+  185          170.67474    138.47569   0.005405405 
+  172          175.45129    138.50707   0.005813953 
+  171          178.07251    138.53861   0.005847953 
+  175          175.42268    138.57032   0.005714286 
+  174          170.17124    138.60218   0.005747126 
+  158          166.01473    138.6342    0.006329114 
+  173          163.6688     138.66639   0.005780347 
+  148          162.75913    138.69874   0.006756757 
+  178          163.00158    138.73125   0.005617978 
+  210          163.96506    138.76393   0.004761905 
+  184          165.00676    138.79677   0.005434783 
+  179          166.18801    138.82978   0.005586592 
+  184          167.87091    138.86295   0.005434783 
+  202          169.65463    138.8963    0.004950495 
+  199          170.95477    138.92981   0.005025126 
+  184          170.87753    138.96349   0.005434783 
+  175          169.43874    138.99734   0.005714286 
+  176          168.48365    139.03136   0.005681818 
+  179          168.98819    139.06555   0.005586592 
+  203          171.01118    139.09991   0.004926108 
+  201          174.65962    139.13445   0.004975124 
+  196          178.46969    139.16917   0.005102041 
+  206          180.29476    139.20405   0.004854369 
+  183          179.52705    139.23912   0.005464481 
+  178          178.45634    139.27436   0.005617978 
+  193          178.34939    139.30977   0.005181347 
+  206          179.11953    139.34537   0.004854369 
+  198          180.80985    139.38115   0.005050505 
+  190          183.73247    139.4171    0.005263158 
+  194          188.17533    139.45324   0.005154639 
+  201          194.33492    139.48955   0.004975124 
+  201          201.80638    139.52606   0.004975124 
+  217          208.98301    139.56274   0.004608295 
+  243          215.03535    139.59961   0.004115226 
+  230          221.1049     139.63666   0.004347826 
+  246          227.76186    139.6739    0.004065041 
+  258          236.17154    139.71133   0.003875969 
+  257          247.996      139.74894   0.003891051 
+  279          264.9067     139.78675   0.003584229 
+  306          288.59426    139.82474   0.003267974 
+  359          321.86555    139.86292   0.002785515 
+  373          369.81698    139.9013    0.002680965 
+  500          442.17114    139.93987   0.002     
+  642          558.397      139.97863   0.001557632 
+  897          756.93345    140.01758   0.001114827 
+  1324         1104.6198    140.05673   0.000755287 
+  1940         1670.16733   140.09608   0.000515464 
+  2230         2272.70884   140.13562   0.00044843 
+  2026         2218.18825   140.17536   0.000493583 
+  1498         1594.40871   140.2153    0.000667557 
+  1124         1066.77103   140.25544   0.00088968 
+  763          755.79842    140.29578   0.001310616 
+  655          587.39348    140.33632   0.001526718 
+  612          499.2627     140.37706   0.001633987 
+  537          458.75378    140.41801   0.001862197 
+  545          453.03804    140.45916   0.001834862 
+  560          483.20739    140.50051   0.001785714 
+  658          564.19513    140.54208   0.001519757 
+  852          726.97377    140.58384   0.001173709 
+  1096         1002.58188   140.62582   0.000912409 
+  1189         1286.22261   140.66801   0.000841043 
+  1174         1228.59405   140.7104    0.000851789 
+  897          906.05785    140.75301   0.001114827 
+  709          641.3975     140.79582   0.001410437 
+  522          483.44187    140.83886   0.001915709 
+  440          393.63137    140.8821    0.002272727 
+  370          340.80505    140.92556   0.002702703 
+  320          307.63456    140.96923   0.003125  
+  293          285.55948    141.01312   0.003412969 
+  282          270.27456    141.05723   0.003546099 
+  253          259.22524    141.10156   0.003952569 
+  225          250.51663    141.14611   0.004444444 
+  223          243.18412    141.19087   0.004484305 
+  259          237.05583    141.23586   0.003861004 
+  239          231.96001    141.28107   0.0041841 
+  236          227.63564    141.32651   0.004237288 
+  226          223.93076    141.37217   0.004424779 
+  232          220.42531    141.41805   0.004310345 
+  223          216.13476    141.46416   0.004484305 
+  223          211.09264    141.5105    0.004484305 
+  205          206.35324    141.55707   0.004878049 
+  211          202.43128    141.60386   0.004739336 
+  182          199.32404    141.65089   0.005494505 
+  206          196.85766    141.69815   0.004854369 
+  199          194.83609    141.74564   0.005025126 
+  198          193.10674    141.79337   0.005050505 
+  212          191.59021    141.84133   0.004716981 
+  194          190.26073    141.88952   0.005154639 
+  174          189.13332    141.93795   0.005747126 
+  205          188.2682     141.98662   0.004878049 
+  207          187.61219    142.03553   0.004830918 
+  222          186.7618     142.08468   0.004504505 
+  190          185.68451    142.13406   0.005263158 
+  174          184.94618    142.1837    0.005747126 
+  225          184.86448    142.23357   0.004444444 
+  178          185.4161     142.28369   0.005617978 
+  168          186.44845    142.33405   0.005952381 
+  219          187.72263    142.38466   0.00456621 
+  181          188.9063     142.43551   0.005524862 
+  197          189.69094    142.48662   0.005076142 
+  188          189.94939    142.53797   0.005319149 
+  203          189.67525    142.58957   0.004926108 
+  177          188.9825     142.64143   0.005649718 
+  179          188.11493    142.69353   0.005586592 
+  200          187.35594    142.7459    0.005     
+  179          186.96984    142.79851   0.005586592 
+  181          187.1879     142.85138   0.005524862 
+  193          188.22099    142.90451   0.005181347 
+  189          190.27619    142.9579    0.005291005 
+  187          193.56105    143.01154   0.005347594 
+  203          198.17887    143.06545   0.004926108 
+  208          203.83454    143.11962   0.004807692 
+  219          209.52972    143.17405   0.00456621 
+  201          214.26621    143.22874   0.004975124 
+  213          218.14604    143.2837    0.004694836 
+  178          220.73377    143.33892   0.005617978 
+  158          219.91888    143.39441   0.006329114 
+  209          215.41669    143.45017   0.004784689 
+  195          209.64918    143.5062    0.005128205 
+  208          204.53009    143.56249   0.004807692 
+  204          200.39427    143.61906   0.004901961 
+  217          197.07276    143.67591   0.004608295 
+  193          194.50868    143.73302   0.005181347 
+  208          192.79145    143.79041   0.004807692 
+  216          191.97283    143.84808   0.00462963 
+  219          191.80631    143.90602   0.00456621 
+  211          191.79183    143.96424   0.004739336 
+  204          191.81443    144.02274   0.004901961 
+  181          191.92533    144.08153   0.005524862 
+  218          191.21632    144.14059   0.004587156 
+  186          188.8469     144.19994   0.005376344 
+  155          185.43894    144.25957   0.006451613 
+  207          182.04267    144.31948   0.004830918 
+  178          179.13739    144.37969   0.005617978 
+  182          176.76677    144.44018   0.005494505 
+  180          174.8614     144.50096   0.005555556 
+  182          173.30791    144.56203   0.005494505 
+  182          171.81971    144.62339   0.005494505 
+  174          170.17624    144.68504   0.005747126 
+  196          168.67468    144.74699   0.005102041 
+  202          167.74074    144.80923   0.004950495 
+  197          167.62081    144.87177   0.005076142 
+  191          168.5018     144.9346    0.005235602 
+  165          170.45996    144.99774   0.006060606 
+  181          172.85412    145.06117   0.005524862 
+  187          173.62165    145.12491   0.005347594 
+  200          171.42306    145.18894   0.005     
+  176          168.00099    145.25328   0.005681818 
+  177          165.20284    145.31793   0.005649718 
+  181          163.44193    145.38288   0.005524862 
+  173          162.48208    145.44814   0.005780347 
+  187          161.95317    145.5137    0.005347594 
+  161          161.68319    145.57958   0.00621118 
+  170          161.6565     145.64577   0.005882353 
+  180          161.76303    145.71227   0.005555556 
+  186          162.0547     145.77908   0.005376344 
+  172          162.80724    145.8462    0.005813953 
+  165          164.10772    145.91365   0.006060606 
+  162          165.40693    145.98141   0.00617284 
+  150          165.60796    146.04949   0.006666667 
+  165          164.69465    146.11789   0.006060606 
+  165          163.7614     146.1866    0.006060606 
+  182          163.42119    146.25565   0.005494505 
+  164          163.76231    146.32501   0.006097561 
+  176          164.7738     146.3947    0.005681818 
+  170          166.50294    146.46472   0.005882353 
+  161          169.07509    146.53506   0.00621118 
+  189          172.70312    146.60574   0.005291005 
+  206          177.83538    146.67674   0.004854369 
+  200          185.56679    146.74807   0.005     
+  184          198.22932    146.81974   0.005434783 
+  238          219.91402    146.89174   0.004201681 
+  257          255.50364    146.96408   0.003891051 
+  273          300.05556    147.03675   0.003663004 
+  268          315.08214    147.10976   0.003731343 
+  250          281.74122    147.18311   0.004     
+  241          242.57295    147.2568    0.004149378 
+  209          217.21339    147.33084   0.004784689 
+  189          203.75977    147.40521   0.005291005 
+  231          198.23559    147.47993   0.004329004 
+  204          198.41374    147.555     0.004901961 
+  196          203.7813     147.63042   0.005102041 
+  217          215.05775    147.70618   0.004608295 
+  212          233.86646    147.78229   0.004716981 
+  225          263.18894    147.85876   0.004444444 
+  235          303.7223     147.93558   0.004255319 
+  264          338.42726    148.01275   0.003787879 
+  270          341.37108    148.09027   0.003703704 
+  286          310.3184     148.16816   0.003496503 
+  216          265.43382    148.2464    0.00462963 
+  250          230.68391    148.32501   0.004     
+  212          209.2271     148.40397   0.004716981 
+  187          196.92391    148.4833    0.005347594 
+  187          190.39771    148.56299   0.005347594 
+  194          187.85058    148.64304   0.005154639 
+  182          188.63405    148.72346   0.005494505 
+  209          192.72032    148.80425   0.004784689 
+  182          200.31906    148.88542   0.005494505 
+  195          212.00422    148.96695   0.005128205 
+  186          226.02171    149.04885   0.005376344 
+  170          231.2399     149.13113   0.005882353 
+  197          219.96457    149.21378   0.005076142 
+  186          203.91182    149.29681   0.005376344 
+  199          191.41784    149.38022   0.005025126 
+  175          182.6503     149.464     0.005714286 
+  171          176.68728    149.54817   0.005847953 
+  164          172.80852    149.63272   0.006097561 
+  160          170.37187    149.71766   0.00625   
+  166          168.91728    149.80298   0.006024096 
+  186          168.15657    149.88868   0.005376344 
+  167          167.87994    149.97478   0.005988024 
+  167          167.87947    150.06126   0.005988024 
+  181          167.99086    150.14814   0.005524862 
+  164          168.10355    150.23541   0.006097561 
+  170          168.16837    150.32307   0.005882353 
+  143          168.30042    150.41113   0.006993007 
+  166          168.59811    150.49959   0.006024096 
+  155          168.88131    150.58844   0.006451613 
+  163          169.06169    150.6777    0.006134969 
+  147          169.41702    150.76735   0.006802721 
+  166          170.24008    150.85741   0.006024096 
+  165          171.37557    150.94787   0.006060606 
+  158          171.85603    151.03875   0.006329114 
+  149          170.98409    151.13002   0.006711409 
+  179          169.5199     151.22171   0.005586592 
+  148          168.36655    151.31381   0.006756757 
+  162          167.63781    151.40632   0.00617284 
+  160          167.02129    151.49924   0.00625   
+  154          166.41768    151.59258   0.006493506 
+  172          165.98702    151.68634   0.005813953 
+  164          165.82864    151.78051   0.006097561 
+  166          165.962      151.87511   0.006024096 
+  160          166.39778    151.97012   0.00625   
+  165          167.16691    152.06556   0.006060606 
+  153          168.31383    152.16143   0.006535948 
+  159          169.62324    152.25772   0.006289308 
+  151          170.25001    152.35443   0.006622517 
+  165          169.44769    152.45158   0.006060606 
+  167          167.80325    152.54916   0.005988024 
+  142          166.31826    152.64717   0.007042254 
+  176          165.30133    152.74561   0.005681818 
+  156          164.59533    152.84449   0.006410256 
+  152          164.0643     152.94381   0.006578947 
+  158          163.68299    153.04357   0.006329114 
+  170          163.39288    153.14376   0.005882353 
+  169          163.179      153.2444    0.00591716 
+  148          163.09368    153.34549   0.006756757 
+  150          163.17521    153.44701   0.006666667 
+  152          163.429      153.54899   0.006578947 
+  161          163.79111    153.65141   0.00621118 
+  177          164.07271    153.75428   0.005649718 
+  171          164.06069    153.85761   0.005847953 
+  163          163.81633    153.96139   0.006134969 
+  153          163.60648    154.06562   0.006535948 
+  152          163.57853    154.17031   0.006578947 
+  150          163.75102    154.27546   0.006666667 
+  153          164.08387    154.38107   0.006535948 
+  171          164.46158    154.48714   0.005847953 
+  172          164.73232    154.59367   0.005813953 
+  153          164.90938    154.70067   0.006535948 
+  167          165.13447    154.80813   0.005988024 
+  154          165.48458    154.91607   0.006493506 
+  153          165.9653     155.02447   0.006535948 
+  155          166.55277    155.13334   0.006451613 
+  181          167.21874    155.24269   0.005524862 
+  157          167.95531    155.35252   0.006369427 
+  157          168.71532    155.46282   0.006369427 
+  191          169.40437    155.57359   0.005235602 
+  149          170.06       155.68485   0.006711409 
+  169          170.85205    155.79659   0.00591716 
+  173          171.92765    155.90882   0.005780347 
+  160          173.40512    156.02153   0.00625   
+  182          175.41226    156.13472   0.005494505 
+  154          178.10787    156.24841   0.006493506 
+  170          181.40735    156.36258   0.005882353 
+  186          184.30213    156.47725   0.005376344 
+  171          185.13325    156.59241   0.005847953 
+  177          183.90102    156.70807   0.005649718 
+  188          182.33738    156.82422   0.005319149 
+  173          181.51913    156.94087   0.005780347 
+  177          181.58215    157.05803   0.005649718 
+  215          182.41038    157.17568   0.004651163 
+  193          183.96859    157.29384   0.005181347 
+  181          186.18128    157.41251   0.005524862 
+  181          188.50696    157.53169   0.005524862 
+  180          190.27157    157.65137   0.005555556 
+  182          191.68345    157.77157   0.005494505 
+  162          193.16519    157.89228   0.00617284 
+  181          194.85346    158.0135    0.005524862 
+  211          197.10426    158.13524   0.004739336 
+  187          199.83386    158.2575    0.005347594 
+  207          202.57577    158.38028   0.004830918 
+  195          205.49646    158.50359   0.005128205 
+  165          209.69238    158.62741   0.006060606 
+  215          215.81351    158.75176   0.004651163 
+  212          220.91868    158.87664   0.004716981 
+  184          222.04353    159.00205   0.005434783 
+  198          223.33101    159.128     0.005050505 
+  219          229.66927    159.25447   0.00456621 
+  244          243.87737    159.38148   0.004098361 
+  233          270.05193    159.50902   0.004291845 
+  316          314.11543    159.63711   0.003164557 
+  378          372.96386    159.76573   0.002645503 
+  369          404.21164    159.8949    0.002710027 
+  368          367.53137    160.02461   0.002717391 
+  315          310.07968    160.15487   0.003174603 
+  256          269.26387    160.28568   0.00390625 
+  255          245.87096    160.41703   0.003921569 
+  230          234.13978    160.54894   0.004347826 
+  208          229.27517    160.6814    0.004807692 
+  239          226.4165     160.81442   0.0041841 
+  232          223.22534    160.94799   0.004310345 
+  227          220.9943     161.08213   0.004405286 
+  208          221.68605    161.21682   0.004807692 
+  246          227.51697    161.35208   0.004065041 
+  253          241.04406    161.4879    0.003952569 
+  248          264.73984    161.62429   0.004032258 
+  311          292.6828     161.76125   0.003215434 
+  299          297.7784     161.89878   0.003344482 
+  265          273.24415    162.03688   0.003773585 
+  260          247.10985    162.17556   0.003846154 
+  234          229.72208    162.31481   0.004273504 
+  202          218.17308    162.45464   0.004950495 
+  215          209.6656     162.59506   0.004651163 
+  178          203.63871    162.73605   0.005617978 
+  193          199.71218    162.87763   0.005181347 
+  209          196.85235    163.0198    0.004784689 
+  179          194.5609     163.16255   0.005586592 
+  178          192.61025    163.30589   0.005617978 
+  159          190.97114    163.44983   0.006289308 
+  174          189.61287    163.59436   0.005747126 
+  191          188.74242    163.73949   0.005235602 
+  172          188.57149    163.88521   0.005813953 
+  187          189.08156    164.03153   0.005347594 
+  197          190.01166    164.17846   0.005076142 
+  203          190.85102    164.32599   0.004926108 
+  213          191.07372    164.47413   0.004694836 
+  176          190.49983    164.62288   0.005681818 
+  181          189.52809    164.77223   0.005524862 
+  191          188.70082    164.9222    0.005235602 
+  178          187.86514    165.07278   0.005617978 
+  191          186.96624    165.22398   0.005235602 
+  194          186.2286     165.3758    0.005154639 
+  173          185.79733    165.52823   0.005780347 
+  171          185.5166     165.68129   0.005847953 
+  196          185.3848     165.83498   0.005102041 
+  175          185.58537    165.98929   0.005714286 
+  201          186.19219    166.14423   0.004975124 
+  189          187.01017    166.2998    0.005291005 
+  194          187.54551    166.456     0.005154639 
+  199          187.51429    166.61284   0.005025126 
+  178          187.27666    166.77031   0.005617978 
+  193          187.30586    166.92843   0.005181347 
+  201          187.78446    167.08718   0.004975124 
+  183          188.65268    167.24658   0.005464481 
+  178          189.70293    167.40662   0.005617978 
+  165          190.78012    167.56731   0.006060606 
+  195          191.66834    167.72865   0.005128205 
+  200          191.92054    167.89064   0.005     
+  192          191.58639    168.05328   0.005208333 
+  177          191.24662    168.21658   0.005649718 
+  192          191.28177    168.38054   0.005208333 
+  195          191.74828    168.54516   0.005128205 
+  183          192.51482    168.71044   0.005464481 
+  187          193.34679    168.87639   0.005347594 
+  203          194.14808    169.043     0.004926108 
+  218          195.08461    169.21028   0.004587156 
+  223          196.33313    169.37823   0.004484305 
+  217          197.99717    169.54685   0.004608295 
+  191          200.18088    169.71615   0.005235602 
+  187          203.02908    169.88613   0.005347594 
+  229          206.69037    170.05678   0.004366812 
+  235          211.13969    170.22812   0.004255319 
+  230          215.91574    170.40014   0.004347826 
+  240          219.96035    170.57285   0.004166667 
+  244          222.17034    170.74625   0.004098361 
+  220          223.14417    170.92033   0.004545455 
+  209          224.46352    171.09511   0.004784689 
+  219          226.36673    171.27058   0.00456621 
+  200          227.67932    171.44676   0.005     
+  231          227.7217     171.62363   0.004329004 
+  198          227.1574     171.8012    0.005050505 
+  249          226.71648    171.97947   0.004016064 
+  209          226.68216    172.15845   0.004784689 
+  246          227.1792     172.33814   0.004065041 
+  255          228.30528    172.51854   0.003921569 
+  200          230.13085    172.69966   0.005     
+  242          232.702      172.88148   0.004132231 
+  235          235.91703    173.06403   0.004255319 
+  253          239.23273    173.24729   0.003952569 
+  246          241.79996    173.43128   0.004065041 
+  229          243.62175    173.61599   0.004366812 
+  223          245.61587    173.80143   0.004484305 
+  265          248.27464    173.98759   0.003773585 
+  247          251.26007    174.17449   0.004048583 
+  259          254.10974    174.36212   0.003861004 
+  254          256.95128    174.55048   0.003937008 
+  285          260.38958    174.73959   0.003508772 
+  283          265.66557    174.92943   0.003533569 
+  293          274.45149    175.12002   0.003412969 
+  315          288.15295    175.31135   0.003174603 
+  351          305.58504    175.50342   0.002849003 
+  351          317.87087    175.69625   0.002849003 
+  327          315.07426    175.88983   0.003058104 
+  292          304.1488     176.08416   0.003424658 
+  349          295.51271    176.27925   0.00286533 
+  308          291.31285    176.4751    0.003246753 
+  293          290.40767    176.67171   0.003412969 
+  316          291.92678    176.86909   0.003164557 
+  312          295.47618    177.06723   0.003205128 
+  297          300.73841    177.26613   0.003367003 
+  334          307.42966    177.46581   0.002994012 
+  337          315.42895    177.66626   0.002967359 
+  328          325.08864    177.86749   0.00304878 
+  351          337.26123    178.0695    0.002849003 
+  352          352.94163    178.27228   0.002840909 
+  335          372.62222    178.47585   0.002985075 
+  358          394.12949    178.6802    0.002793296 
+  394          411.85693    178.88534   0.002538071 
+  417          425.75574    179.09128   0.002398082 
+  434          442.38576    179.298     0.002304147 
+  456          465.31542    179.50552   0.002192982 
+  486          495.03983    179.71383   0.002057613 
+  549          531.80254    179.92295   0.001821494 
+  581          577.61695    180.13287   0.00172117 
+  692          636.98193    180.34359   0.001445087 
+  800          716.04035    180.55512   0.00125   
+  830          821.79567    180.76746   0.001204819 
+  1042         960.71814    180.98061   0.000959693 
+  1297         1144.17375   181.19457   0.00077101 
+  1688         1407.97423   181.40936   0.000592417 
+  2249         1820.04282   181.62496   0.000444642 
+  3170         2491.97025   181.84138   0.000315457 
+  4733         3598.16189   182.05863   0.000211282 
+  6899         5312.27054   182.27671   0.000144949 
+  8292         7317.69955   182.49561   0.000120598 
+  8081         7979.75696   182.71535   0.000123747 
+  6470         6468.50326   182.93592   0.00015456 
+  4979         4497.08177   183.15733   0.000200844 
+  3575         3086.56922   183.37958   0.00027972 
+  2724         2222.638     183.60267   0.000367107 
+  2123         1712.31522   183.8266    0.000471032 
+  1739         1413.47602   184.05139   0.000575043 
+  1562         1244.4845    184.27702   0.000640205 
+  1423         1161.95004   184.5035    0.000702741 
+  1409         1148.76896   184.73084   0.000709723 
+  1521         1212.75725   184.95904   0.000657462 
+  1732         1383.87431   185.1881    0.000577367 
+  2279         1720.51971   185.41802   0.000438789 
+  2971         2313.69186   185.6488    0.000336587 
+  3801         3219.85243   185.88045   0.000263089 
+  4262         4111.64435   186.11298   0.000234632 
+  3899         4076.44766   186.34637   0.000256476 
+  3195         3129.86047   186.58065   0.000312989 
+  2493         2180.43292   186.8158    0.000401123 
+  1744         1538.72171   187.05183   0.000573394 
+  1455         1143.02801   187.28874   0.000687285 
+  1088         898.7046     187.52654   0.000919118 
+  902          742.09552    187.76523   0.001108647 
+  717          636.25005    188.00482   0.0013947 
+  618          560.4074     188.24529   0.001618123 
+  562          502.90533    188.48666   0.001779359 
+  536          457.62754    188.72893   0.001865672 
+  469          421.81221    188.97211   0.002132196 
+  405          393.67252    189.21619   0.002469136 
+  371          371.65964    189.46117   0.002695418 
+  366          354.54735    189.70707   0.00273224 
+  327          341.4049     189.95388   0.003058104 
+  338          331.28031    190.2016    0.00295858 
+  304          322.822      190.45024   0.003289474 
+  296          314.73599    190.69981   0.003378378 
+  342          307.0071     190.95029   0.002923977 
+  299          300.40553    191.20171   0.003344482 
+  323          295.52145    191.45405   0.003095975 
+  265          292.2654     191.70732   0.003773585 
+  290          289.61117    191.96153   0.003448276 
+  282          286.13151    192.21668   0.003546099 
+  278          281.06371    192.47276   0.003597122 
+  259          274.93214    192.72979   0.003861004 
+  251          269.01875    192.98776   0.003984064 
+  259          264.2282     193.24669   0.003861004 
+  244          260.68864    193.50656   0.004098361 
+  253          258.16489    193.76739   0.003952569 
+  244          256.6237     194.02917   0.004098361 
+  241          256.10423    194.29191   0.004149378 
+  248          256.25768    194.55562   0.004032258 
+  231          256.52131    194.82029   0.004329004 
+  215          256.7991     195.08593   0.004651163 
+  234          257.63728    195.35253   0.004273504 
+  254          260.02931    195.62012   0.003937008 
+  250          264.82766    195.88867   0.004     
+  266          272.62506    196.15821   0.003759398 
+  233          284.15467    196.42873   0.004291845 
+  294          298.63481    196.70023   0.003401361 
+  295          308.44224    196.97273   0.003389831 
+  237          302.69292    197.24621   0.004219409 
+  231          285.91049    197.52068   0.004329004 
+  260          269.8905     197.79615   0.003846154 
+  226          258.62787    198.07262   0.004424779 
+  219          251.58394    198.3501    0.00456621 
+  230          247.69826    198.62857   0.004347826 
+  221          246.21025    198.90806   0.004524887 
+  227          246.65462    199.18855   0.004405286 
+  196          248.77647    199.47006   0.005102041 
+  236          252.63932    199.75258   0.004237288 
+  210          258.75407    200.03613   0.004761905 
+  219          268.13266    200.3207    0.00456621 
+  251          282.75302    200.60629   0.003984064 
+#--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--#
+
+# start Validation Reply Form
+_vrf_PLAT741_NEW2minmill_phase_1 # for all atoms in 1_quartz
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT741_NEW2minmill_phase_3 # for all atoms in 3_pyrrhotite
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT741_NEW2minmill_phase_4 # for all atoms in 4_rutile
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT741_NEW2minmill_phase_2 # for all atoms in 2_albite
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT155_NEW2minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT141_NEW2minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT142_NEW2minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT143_2_minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT144_NEW2minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT145_NEW2minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT146_NEW2minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT151_NEW2minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+# end Validation Reply Form

--- a/data/hamish/fixed/vb5042sup7.cif
+++ b/data/hamish/fixed/vb5042sup7.cif
@@ -1,0 +1,6669 @@
+
+data_NEW3minmill_publ
+_audit_creation_method  "created in GSAS-II"
+_audit_creation_date  2021-08-04T18:35
+_audit_author_name  "McDougall, Hamish"
+_audit_update_record
+   "2021-08-04T18:35  Initial software-generated CIF"
+_pd_block_id  2021-08-04T18:35|NEW3minmill|McDougallHamish|Overall
+# GSAS-II edited template follows Publication_Template
+#=============================================================================
+# this information describes the project, paper etc. for the CIF             #
+# Acta Cryst. Section C papers and editorial correspondence is generated     #
+# from the information in this section                                       #
+#                                                                            #
+#   (from)   CIF submission form for Rietveld refinements (Acta Cryst. C)    #
+#                                                 Version 14 December 1998   #
+#=============================================================================
+# 1. SUBMISSION DETAILS
+
+_publ_contact_author_name            "Suzanne Neville; Vanessa Peterson; Christophe Didier"   # Name of author for correspondence
+_publ_contact_author_address             # Address of author for correspondence
+; ?
+;
+_publ_contact_author_email           "s.neville@unsw.edu.au; vanessa.peterson@ansto.gov.au; drchristophedidier@gmail.com"
+_publ_contact_author_fax             ?
+_publ_contact_author_phone           ?
+
+_publ_contact_letter
+; ?
+;
+   
+_publ_requested_journal              ?
+_publ_requested_coeditor_name        ?
+_publ_requested_category             ?   # Acta C: one of CI/CM/CO/FI/FM/FO
+
+#==============================================================================
+
+# 2. PROCESSING SUMMARY (IUCr Office Use Only)
+
+_journal_data_validation_number      ?
+
+_journal_date_recd_electronic        ?
+_journal_date_to_coeditor            ?
+_journal_date_from_coeditor          ?
+_journal_date_accepted               ?
+_journal_date_printers_first         ?
+_journal_date_printers_final         ?
+_journal_date_proofs_out             ?
+_journal_date_proofs_in              ?
+_journal_coeditor_name               ?
+_journal_coeditor_code               ?
+_journal_coeditor_notes
+; ?
+;
+_journal_techeditor_code             ?
+_journal_techeditor_notes
+; ?
+;
+_journal_coden_ASTM                  ?
+_journal_name_full                   ?
+_journal_year                        ?
+_journal_volume                      ?
+_journal_issue                       ?
+_journal_page_first                  ?
+_journal_page_last                   ?
+_journal_paper_category              ?
+_journal_suppl_publ_number           ?
+_journal_suppl_publ_pages            ?
+
+#==============================================================================
+
+# 3. TITLE AND AUTHOR LIST
+
+_publ_section_title
+; ?
+;
+_publ_section_title_footnote
+; ?
+;         
+ 
+# The loop structure below should contain the names and addresses of all 
+# authors, in the required order of publication. Repeat as necessary.
+
+loop_
+	_publ_author_name
+        _publ_author_footnote
+	_publ_author_address
+ ?                                   #<--'Last name, first name' 
+; ?
+;
+; ?
+;
+
+#==============================================================================
+
+# 4. TEXT
+
+_publ_section_synopsis
+;  ?
+;
+_publ_section_abstract                         
+; ?
+;          
+_publ_section_comment                          
+; ?
+;
+_publ_section_exptl_prep      # Details of the preparation of the sample(s)
+                              # should be given here. 
+; ?
+;
+_publ_section_exptl_refinement                  
+; ?
+;
+_publ_section_references
+; ?
+;
+_publ_section_figure_captions
+; ?
+;
+_publ_section_acknowledgements
+; ?
+;
+
+#=============================================================================
+# 5. OVERALL REFINEMENT & COMPUTING DETAILS
+
+_refine_special_details
+; ?
+;
+_pd_proc_ls_special_details
+; ?
+;
+
+# The following items are used to identify the programs used.
+_computing_molecular_graphics     ?
+_computing_publication_material   ?
+
+_refine_ls_weighting_scheme       ?        
+_refine_ls_weighting_details      ?
+_refine_ls_hydrogen_treatment     ?        
+_refine_ls_extinction_method      ?        
+_refine_ls_extinction_coef        ?         
+_refine_ls_number_constraints     ?        
+
+_refine_ls_restrained_S_all       ?        
+_refine_ls_restrained_S_obs       ?
+
+#==============================================================================
+# 6. SAMPLE PREPARATION DATA
+
+# (In the unusual case where multiple samples are used in a single
+#  Rietveld study, this information should be moved into the phase
+#  blocks)
+
+# The following three fields describe the preparation of the material.
+# The cooling rate is in K/min.  The pressure at which the sample was  
+# prepared is in kPa.  The temperature of preparation is in K.
+               
+_pd_prep_cool_rate                N/A        
+_pd_prep_pressure                 101.3        
+_pd_prep_temperature              298          
+
+_pd_char_colour                   ?       # use ICDD colour descriptions
+
+data_NEW3minmill_overall
+_pd_proc_info_datetime  2021-08-04T18:35
+_pd_calc_method  "Rietveld Refinement"
+_computing_structure_refinement
+   "GSAS-II (Toby & Von Dreele, J. Appl. Cryst. 46, 544-549, 2013)"
+_refine_ls_number_parameters  27
+_refine_ls_goodness_of_fit_all  2.636
+_refine_ls_shift/su_max  0.7872
+
+# OVERALL WEIGHTED R-FACTOR
+_refine_ls_wR_factor_obs  0.10301
+_refine_ls_matrix_type  full
+# POINTERS TO PHASE AND HISTOGRAM BLOCKS
+loop_   _pd_phase_block_id
+  2021-08-04T18:35|NEW3minmill|phase_0|McDougallHamish
+  2021-08-04T18:35|NEW3minmill|phase_2|McDougallHamish
+  2021-08-04T18:35|NEW3minmill|phase_4|McDougallHamish
+  2021-08-04T18:35|NEW3minmill|phase_1|McDougallHamish
+  2021-08-04T18:35|NEW3minmill|phase_3|McDougallHamish
+_pd_block_diffractogram_id
+;
+2021-08-04T18:35|NEW3minmill|McDougallHamish|PANalytical,Co-EmpyreanII_hist_0
+;
+
+data_NEW3minmill_phase_0
+# Information for phase 0
+_pd_block_id  2021-08-04T18:35|NEW3minmill|phase_0|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for FeS2 follows
+_pd_phase_name  FeS2
+_cell_length_a  5.419481(29)
+_cell_length_b  5.419481(29)
+_cell_length_c  5.419481(29)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  90
+_cell_volume  159.1744(26)
+_exptl_crystal_density_diffrn  5.0061
+_symmetry_cell_setting  cubic
+_symmetry_space_group_name_H-M  "P a -3"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  z,x,y
+     3  y,z,x
+     4  1/2+x,y,1/2-z
+     5  1/2-z,1/2+x,y
+     6  y,1/2-z,1/2+x
+     7  -z,1/2+x,1/2-y
+     8  1/2-y,-z,1/2+x
+     9  1/2+y,1/2-z,-x
+    10  -x,1/2+y,1/2-z
+    11  1/2-z,-x,1/2+y
+    12  1/2+x,1/2-y,-z
+    13  -x,-y,-z
+    14  -z,-x,-y
+    15  -y,-z,-x
+    16  1/2-x,-y,1/2+z
+    17  1/2+z,1/2-x,-y
+    18  -y,1/2+z,1/2-x
+    19  z,1/2-x,1/2+y
+    20  1/2+y,z,1/2-x
+    21  1/2-y,1/2+z,x
+    22  x,1/2-y,1/2+z
+    23  1/2+z,x,1/2-y
+    24  1/2-x,1/2+y,z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Fe1    Fe   0.00000     0.00000     0.00000     1.000      Uiso 0.010      4   
+S2     S    0.38680     0.38680     0.38680     1.000      Uiso 0.010      8   
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Fe   4      11.7695    7.3573     3.5222     2.3045     4.7611     0.3072     15.3535    76.8805    1.0369     0.945
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S    8      6.9053     5.2034     1.4379     1.5863     1.4679     22.2151    0.2536     56.172     0.8669     0.2847
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Fe S2"
+_chemical_formula_weight  119.97
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Fe1    S2     2.2687       1_555    4_455 yes
+  Fe1    S2     2.2687       1_555    5_545 yes
+  Fe1    S2     2.2687       1_555    6_554 yes
+  Fe1    S2     2.2687       1_555    7_545 yes
+  Fe1    S2     2.2687       1_555    8_554 yes
+  Fe1    S2     2.2687       1_555    9_455 yes
+  S2     Fe1    2.2687       1_555    4_555 yes
+  S2     Fe1    2.2687       1_555    5_555 yes
+  S2     Fe1    2.2687       1_555    6_555 yes
+  S2     S2     2.12518      1_555   13_666 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.2508(19), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW3minmill_phase_2
+# Information for phase 2
+_pd_block_id  2021-08-04T18:35|NEW3minmill|phase_2|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for NaAlSi3O8 follows
+_pd_phase_name  NaAlSi3O8
+_cell_length_a  8.137
+_cell_length_b  12.785
+_cell_length_c  7.1583
+_cell_angle_alpha  94.26
+_cell_angle_beta   116.6
+_cell_angle_gamma  87.71
+_cell_volume  664.008
+_exptl_crystal_density_diffrn  2.6230
+_symmetry_cell_setting  triclinic
+_symmetry_space_group_name_H-M  "C -1"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -x,-y,-z
+     3  1/2+x,1/2+y,z
+     4  1/2-x,1/2-y,-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Al1    Al3+ 0.00887     0.16846     0.20805     1.000      Uani 0.007      4   
+Si1    Si4+ 0.00375     0.82051     0.23737     1.000      Uani 0.006      4   
+Si2    Si4+ 0.69162     0.11021     0.31466     1.000      Uani 0.006      4   
+Si3    Si4+ 0.68129     0.88190     0.36076     1.000      Uani 0.006      4   
+Na1    Na1+ 0.26799     0.98865     0.14650     1.000      Uani 0.031      4   
+O1     O2-  0.00490     0.13103     0.96660     1.000      Uani 0.012      4   
+O2     O2-  0.59176     0.99756     0.28040     1.000      Uani 0.008      4   
+O3     O2-  0.81230     0.10966     0.19010     1.000      Uani 0.014      4   
+O4     O2-  0.82000     0.85101     0.25870     1.000      Uani 0.018      4   
+O5     O2-  0.01288     0.30238     0.27060     1.000      Uani 0.011      4   
+O6     O2-  0.02329     0.69368     0.22910     1.000      Uani 0.011      4   
+O7     O2-  0.20780     0.10896     0.38900     1.000      Uani 0.011      4   
+O8     O2-  0.18400     0.86817     0.43620     1.000      Uani 0.012      4   
+
+loop_
+   _atom_site_aniso_label
+   _atom_site_aniso_U_11
+   _atom_site_aniso_U_22
+   _atom_site_aniso_U_33
+   _atom_site_aniso_U_12
+   _atom_site_aniso_U_13
+   _atom_site_aniso_U_23
+Al1    0.0074      0.0068      0.0061      -0.0009     0.0031      0.0004      
+Si1    0.0068      0.0065      0.0055      0.0011      0.0030      0.0008      
+Si2    0.0061      0.0055      0.0073      -0.0002     0.0025      0.0004      
+Si3    0.0060      0.0055      0.0074      0.0006      0.0028      0.0009      
+Na1    0.0136      0.0471      0.0315      -0.0050     0.0084      -0.0219     
+O1     0.0164      0.0122      0.0074      -0.0002     0.0067      0.0014      
+O2     0.0074      0.0056      0.0119      0.0003      0.0033      0.0020      
+O3     0.0117      0.0130      0.0162      -0.0040     0.0093      -0.0017     
+O4     0.0134      0.0179      0.0216      0.0046      0.0129      0.0020      
+O5     0.0103      0.0076      0.0150      -0.0020     0.0052      -0.0009     
+O6     0.0101      0.0071      0.0145      0.0022      0.0034      0.0012      
+O7     0.0120      0.0129      0.0080      0.0024      0.0013      0.0015      
+O8     0.0140      0.0140      0.0084      -0.0026     -0.0002     -0.0006     
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Al   4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Na   4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  O    32     ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si   12     ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Al Na O8 Si3"
+_chemical_formula_weight  262.22
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Al1    O1     1.74519      1_555    1_554 yes
+  Al1    O3     1.7429       1_555    1_455 yes
+  Al1    O5     1.73509      1_555    1_555 yes
+  Al1    O7     1.74556      1_555    1_555 yes
+  Si1    O1     1.59985      1_555    2_566 yes
+  Si1    O4     1.59997      1_555    1_455 yes
+  Si1    O6     1.62225      1_555    1_555 yes
+  Si1    O8     1.61907      1_555    1_555 yes
+  Si2    O2     1.63011      1_555    1_545 yes
+  Si2    O3     1.59435      1_555    1_555 yes
+  Si2    O6     1.61836      1_555    3_545 yes
+  Si2    O8     1.6168       1_555    2_666 yes
+  Si3    O2     1.64718      1_555    1_555 yes
+  Si3    O4     1.61975      1_555    1_555 yes
+  Si3    O5     1.59682      1_555    3_555 yes
+  Si3    O7     1.60203      1_555    2_666 yes
+  Na1    O1     2.66887      1_555    1_564 yes
+  Na1    O1     2.53079      1_555    2_566 yes
+  Na1    O2     2.3704       1_555    1_555 yes
+  Na1    O3     2.45321      1_555    2_665 yes
+  Na1    O7     2.43384      1_555    1_565 yes
+  O1     Al1    1.74519      1_555    1_556 yes
+  O1     Si1    1.59985      1_555    2_566 yes
+  O1     Na1    2.66887      1_555    1_546 yes
+  O1     Na1    2.53079      1_555    2_566 yes
+  O2     Si2    1.63011      1_555    1_565 yes
+  O2     Si3    1.64718      1_555    1_555 yes
+  O2     Na1    2.3704       1_555    1_555 yes
+  O3     Al1    1.7429       1_555    1_655 yes
+  O3     Si2    1.59435      1_555    1_555 yes
+  O3     Na1    2.45321      1_555    2_665 yes
+  O4     Si1    1.59997      1_555    1_655 yes
+  O4     Si3    1.61975      1_555    1_555 yes
+  O5     Al1    1.73509      1_555    1_555 yes
+  O5     Si3    1.59682      1_555    3_445 yes
+  O6     Si1    1.62225      1_555    1_555 yes
+  O6     Si2    1.61836      1_555    3_455 yes
+  O7     Al1    1.74556      1_555    1_555 yes
+  O7     Si3    1.60203      1_555    2_666 yes
+  O7     Na1    2.43384      1_555    1_545 yes
+  O8     Si1    1.61907      1_555    1_555 yes
+  O8     Si2    1.6168       1_555    2_666 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Al1    O3     102.836       1_554  1_555    1_455 yes
+  O1     Al1    O5     116.047       1_554  1_555    1_555 yes
+  O3     Al1    O5     112.215       1_455  1_555    1_555 yes
+  O1     Al1    O7     104.004       1_554  1_555    1_555 yes
+  O3     Al1    O7     111.151       1_455  1_555    1_555 yes
+  O5     Al1    O7     110.14        1_555  1_555    1_555 yes
+  O1     Si1    O4     109.433       2_566  1_555    1_455 yes
+  O1     Si1    O6     112.47        2_566  1_555    1_555 yes
+  O4     Si1    O6     108.187       1_455  1_555    1_555 yes
+  O1     Si1    O8     107.176       2_566  1_555    1_555 yes
+  O4     Si1    O8     111.446       1_455  1_555    1_555 yes
+  O6     Si1    O8     108.16        1_555  1_555    1_555 yes
+  O2     Si2    O3     111.144       1_545  1_555    1_555 yes
+  O2     Si2    O6     104.24        1_545  1_555    3_545 yes
+  O3     Si2    O6     112.114       1_555  1_555    3_545 yes
+  O2     Si2    O8     106.97        1_545  1_555    2_666 yes
+  O3     Si2    O8     111.591       1_555  1_555    2_666 yes
+  O6     Si2    O8     110.422       3_545  1_555    2_666 yes
+  O2     Si3    O4     107.269       1_555  1_555    1_555 yes
+  O2     Si3    O5     105.914       1_555  1_555    3_555 yes
+  O4     Si3    O5     110.224       1_555  1_555    3_555 yes
+  O2     Si3    O7     108.565       1_555  1_555    2_666 yes
+  O4     Si3    O7     110.208       1_555  1_555    2_666 yes
+  O5     Si3    O7     114.328       3_555  1_555    2_666 yes
+  Al1    O1     Si1    141.397       1_556  1_555    2_566 yes
+  Si2    O2     Si3    130.019       1_565  1_555    1_555 yes
+  Si2    O2     Na1    120.351       1_565  1_555    1_555 yes
+  Si3    O2     Na1    108.811       1_555  1_555    1_555 yes
+  Al1    O3     Si2    139.461       1_655  1_555    1_555 yes
+  Si1    O4     Si3    161.151       1_655  1_555    1_555 yes
+  Al1    O5     Si3    129.689       1_555  1_555    3_445 yes
+  Si1    O6     Si2    135.676       1_555  1_555    3_455 yes
+  Al1    O7     Si3    133.943       1_555  1_555    2_666 yes
+  Si1    O8     Si2    151.747       1_555  1_555    2_666 yes
+_pd_proc_ls_pref_orient_corr  none
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.143(10), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW3minmill_phase_4
+# Information for phase 4
+_pd_block_id  2021-08-04T18:35|NEW3minmill|phase_4|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Pyrrhotite 4M follows
+_pd_phase_name  "Pyrrhotite 4M"
+_cell_length_a  11.933(22)
+_cell_length_b  6.868(3)
+_cell_length_c  12.827(25)
+_cell_angle_alpha  90
+_cell_angle_beta   117.23(4)
+_cell_angle_gamma  90
+_cell_volume  934.8(4)
+_exptl_crystal_density_diffrn  4.6003
+_symmetry_cell_setting  monoclinic
+_symmetry_space_group_name_H-M  "C 2/c"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -x,y,1/2-z
+     3  -x,-y,-z
+     4  x,-y,1/2+z
+     5  1/2+x,1/2+y,z
+     6  1/2-x,1/2+y,1/2-z
+     7  1/2-x,1/2-y,-z
+     8  1/2+x,1/2-y,1/2+z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+S1     S    0.01800     0.38330     0.11960     1.000      Uiso 0.010      8   
+S2     S    0.02910     0.11420     0.63900     1.000      Uiso 0.010      8   
+Fe3    Fe   0.10860     0.10250     0.49980     1.000      Uiso 0.010      8   
+S4     S    0.23410     0.13550     0.38260     1.000      Uiso 0.010      8   
+Fe5    Fe   0.24180     0.36600     0.24680     1.000      Uiso 0.010      8   
+S6     S    0.26790     0.13400     0.12360     1.000      Uiso 0.010      8   
+Fe7    Fe   0.38720     0.15000     0.01260     1.000      Uiso 0.010      8   
+Fe8    Fe   0.00000     0.14720     0.25000     1.000      Uiso 0.010      4   
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Fe   28     11.7695    7.3573     3.5222     2.3045     4.7611     0.3072     15.3535    76.8805    1.0369     0.945
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S    32     6.9053     5.2034     1.4379     1.5863     1.4679     22.2151    0.2536     56.172     0.8669     0.2847
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Fe7 S8"
+_chemical_formula_weight  647.41
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  S1     Fe3    2.49598      1_555    2_555 yes
+  S1     Fe5    2.4127       1_555    1_555 yes
+  S1     Fe7    2.39055      1_555    5_455 yes
+  S1     Fe7    2.44193      1_555    7_555 yes
+  S1     Fe8    2.40875      1_555    1_555 yes
+  S2     Fe3    2.37585      1_555    1_555 yes
+  S2     Fe3    2.32549      1_555    3_556 yes
+  S2     Fe5    2.4441       1_555    7_556 yes
+  S2     Fe7    2.3678       1_555    8_456 yes
+  S2     Fe8    2.41316      1_555    3_556 yes
+  Fe3    S1     2.49598      1_555    2_555 yes
+  Fe3    S2     2.37585      1_555    1_555 yes
+  Fe3    S2     2.32549      1_555    3_556 yes
+  Fe3    S6     2.45179      1_555    4_556 yes
+  S4     Fe5    2.3865       1_555    1_555 yes
+  Fe5    S1     2.4127       1_555    1_555 yes
+  Fe5    S2     2.4441       1_555    7_556 yes
+  Fe5    S4     2.3865       1_555    1_555 yes
+  Fe5    S6     2.36297      1_555    1_555 yes
+  S6     Fe3    2.45179      1_555    4_555 yes
+  S6     Fe5    2.36297      1_555    1_555 yes
+  S6     Fe7    2.43326      1_555    1_555 yes
+  S6     Fe7    2.39158      1_555    7_555 yes
+  Fe7    S1     2.39055      1_555    5_545 yes
+  Fe7    S1     2.44193      1_555    7_555 yes
+  Fe7    S2     2.3678       1_555    8_555 yes
+  Fe7    S6     2.43326      1_555    1_555 yes
+  Fe7    S6     2.39158      1_555    7_555 yes
+  Fe8    S1     2.40875      1_555    1_555 yes
+  Fe8    S1     2.40875      1_555    2_555 yes
+  Fe8    S2     2.41316      1_555    3_556 yes
+  Fe8    S2     2.41316      1_555    4_555 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.040(3), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW3minmill_phase_1
+# Information for phase 1
+_pd_block_id  2021-08-04T18:35|NEW3minmill|phase_1|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for SiO2 follows
+_pd_phase_name  SiO2
+_cell_length_a  4.9151(4)
+_cell_length_b  4.9151(4)
+_cell_length_c  5.4055(3)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  120
+_cell_volume  113.092(9)
+_exptl_crystal_density_diffrn  2.6467
+_symmetry_cell_setting  trigonal
+_symmetry_space_group_name_H-M  "P 32 2 1"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -y,x-y,2/3+z
+     3  y-x,-x,1/3+z
+     4  y,x,-z
+     5  -x,y-x,2/3-z
+     6  x-y,-y,1/3-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Si1    Si4+ 0.47000     0.00000     0.66670     1.000      Uani 0.006      3   
+O1     O2-  0.41460     0.26780     0.78543     1.000      Uani 0.011      6   
+
+loop_
+   _atom_site_aniso_label
+   _atom_site_aniso_U_11
+   _atom_site_aniso_U_22
+   _atom_site_aniso_U_33
+   _atom_site_aniso_U_12
+   _atom_site_aniso_U_13
+   _atom_site_aniso_U_23
+Si1    0.0073      0.0059      0.0053      0.0029      0.0003      0.0006      
+O1     0.0120      0.0105      0.0118      0.0065      -0.0029     -0.0040     
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  O    6      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si   3      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  3
+_chemical_formula_sum  "O2 Si"
+_chemical_formula_weight  60.08
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Si1    O1     1.60531      1_555    1_555 yes
+  Si1    O1     1.61161      1_555    2_654 yes
+  Si1    O1     1.61135      1_555    5_656 yes
+  Si1    O1     1.60545      1_555    6_556 yes
+  O1     Si1    1.60531      1_555    1_555 yes
+  O1     Si1    1.61161      1_555    3_665 yes
+  O1     Si1    1.61135      1_555    5_666 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Si1    O1     110.254       1_555  1_555    2_654 yes
+  O1     Si1    O1     108.749       1_555  1_555    5_656 yes
+  O1     Si1    O1     109.682       2_654  1_555    5_656 yes
+  O1     Si1    O1     109.16        1_555  1_555    6_556 yes
+  O1     Si1    O1     108.729       2_654  1_555    6_556 yes
+  O1     Si1    O1     110.26        5_656  1_555    6_556 yes
+  Si1    O1     Si1    143.831       1_555  1_555    3_665 yes
+  Si1    O1     Si1    143.835       1_555  1_555    5_666 yes
+  Si1    O1     Si1    0.009         3_665  1_555    5_666 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.205(11), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW3minmill_phase_3
+# Information for phase 3
+_pd_block_id  2021-08-04T18:35|NEW3minmill|phase_3|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for TiO2 follows
+_pd_phase_name  TiO2
+_cell_length_a  4.5969(7)
+_cell_length_b  4.5969(7)
+_cell_length_c  2.9612(7)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  90
+_cell_volume  62.575(16)
+_exptl_crystal_density_diffrn  4.2405
+_symmetry_cell_setting  tetragonal
+_symmetry_space_group_name_H-M  "P 42/m n m"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  1/2-y,1/2+x,1/2+z
+     3  -x,-y,z
+     4  1/2+y,1/2-x,1/2+z
+     5  1/2-x,1/2+y,1/2+z
+     6  -y,-x,z
+     7  1/2+x,1/2-y,1/2+z
+     8  y,x,z
+     9  -x,-y,-z
+    10  1/2+y,1/2-x,1/2-z
+    11  x,y,-z
+    12  1/2-y,1/2+x,1/2-z
+    13  1/2+x,1/2-y,1/2-z
+    14  y,x,-z
+    15  1/2-x,1/2+y,1/2-z
+    16  -y,-x,-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Ti1    Ti4+ 0.00000     0.00000     0.00000     1.000      Uani 0.006      2   
+O1     O2-  0.30493     0.30493     0.00000     1.000      Uani 0.006      4   
+
+loop_
+   _atom_site_aniso_label
+   _atom_site_aniso_U_11
+   _atom_site_aniso_U_22
+   _atom_site_aniso_U_33
+   _atom_site_aniso_U_12
+   _atom_site_aniso_U_13
+   _atom_site_aniso_U_23
+Ti1    0.0070      0.0070      0.0047      -0.0002     0.0000      0.0000      
+O1     0.0060      0.0060      0.0045      -0.0019     0.0000      0.0000      
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  O    4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Ti   2      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  2
+_chemical_formula_sum  "O2 Ti"
+_chemical_formula_weight  79.9
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Ti1    O1     1.98237      1_555    1_555 yes
+  Ti1    O1     1.94945      1_555    2_544 yes
+  Ti1    O1     1.94945      1_555    2_545 yes
+  Ti1    O1     1.98237      1_555    3_555 yes
+  Ti1    O1     1.94945      1_555    4_454 yes
+  Ti1    O1     1.94945      1_555    4_455 yes
+  O1     Ti1    1.98237      1_555    1_555 yes
+  O1     Ti1    1.94945      1_555    2_554 yes
+  O1     Ti1    1.94945      1_555    2_555 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Ti1    O1     90            1_555  1_555    2_544 yes
+  O1     Ti1    O1     90            1_555  1_555    2_545 yes
+  O1     Ti1    O1     98.838        2_544  1_555    2_545 yes
+  O1     Ti1    O1     180           1_555  1_555    3_555 yes
+  O1     Ti1    O1     90            2_544  1_555    3_555 yes
+  O1     Ti1    O1     90            2_545  1_555    3_555 yes
+  O1     Ti1    O1     90            1_555  1_555    4_454 yes
+  O1     Ti1    O1     81.162        2_544  1_555    4_454 yes
+  O1     Ti1    O1     180           2_545  1_555    4_454 yes
+  O1     Ti1    O1     90            3_555  1_555    4_454 yes
+  O1     Ti1    O1     90            1_555  1_555    4_455 yes
+  O1     Ti1    O1     180           2_544  1_555    4_455 yes
+  O1     Ti1    O1     81.162        2_545  1_555    4_455 yes
+  O1     Ti1    O1     90            3_555  1_555    4_455 yes
+  O1     Ti1    O1     98.838        4_454  1_555    4_455 yes
+  Ti1    O1     Ti1    130.581       1_555  1_555    2_554 yes
+  Ti1    O1     Ti1    130.581       1_555  1_555    2_555 yes
+  Ti1    O1     Ti1    98.838        2_554  1_555    2_555 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.200, 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW3minmill_pwd_0
+_pd_proc_ls_profile_function
+;
+Finger-Cox-Jephcoat function parameters U, V, W, X, Y, SH/L:
+  peak variance(Gauss) = Utan(Th)^2^+Vtan(Th)+W:
+  peak HW(Lorentz) = X/cos(Th)+Ytan(Th); SH/L = S/L+H/L
+  U, V, W in (centideg)^2^, X & Y in centideg
+    0.000, 0.000, 1.089, 0.882, 1.689, 0.058, 
+;
+# Information for histogram 0: PWDR BAT3_3min_milla_30mm_MonicaHamish_Ruoming_step size 0_3_min_mill_a.xrdml Scan 1
+_pd_block_id
+;
+2021-08-04T18:35|NEW3minmill|McDougallHamish|PANalytical,Co-EmpyreanII_hist_0
+;
+# GSAS-II edited template follows Instrument_Template
+#==============================================================================
+# 9. INSTRUMENT CHARACTERIZATION
+
+_exptl_special_details
+; ?
+;
+
+# if regions of the data are excluded, the reason(s) are supplied here:
+_pd_proc_info_excluded_regions
+; ?
+;
+
+# The following item is used to identify the equipment used to record 
+# the powder pattern when the diffractogram was measured at a laboratory 
+# other than the authors' home institution, e.g. when neutron or synchrotron
+# radiation is used.
+
+_pd_instr_location
+; ?
+;
+_pd_calibration_special_details           # description of the method used
+                                          # to calibrate the instrument
+; ?
+;
+
+_diffrn_source                    Co-Ka       
+_diffrn_source_target             Co
+_diffrn_source_type               Graded_Flat
+_diffrn_measurement_device_type   Panalytical_Reflection_Transmission       
+_diffrn_detector                  PIXcel1D       
+_diffrn_detector_type             Empyrean_II       # make or model of detector
+
+_pd_meas_scan_method              ?       # options are 'step', 'cont',
+                                          # 'tof', 'fixed' or
+                                          # 'disp' (= dispersive)
+_pd_meas_special_details
+;  ?
+;
+
+# The following two items identify the program(s) used (if appropriate).
+_computing_data_collection        ?        
+_computing_data_reduction         ?                   
+
+# Describe any processing performed on the data, prior to refinement.
+# For example: a manual Lp correction or a precomputed absorption correction
+_pd_proc_info_data_reduction      ?
+
+# The following item is used for angular dispersive measurements only.
+
+_diffrn_radiation_monochromator   ?        
+
+# The following items are used to define the size of the instrument.
+# Not all distances are appropriate for all instrument types.
+
+_pd_instr_dist_src/mono           ?
+_pd_instr_dist_mono/spec          ?
+_pd_instr_dist_src/spec           ?
+_pd_instr_dist_spec/anal          ?
+_pd_instr_dist_anal/detc          ?
+_pd_instr_dist_spec/detc          ?
+
+# 10. Specimen size and mounting information
+
+# The next three fields give the specimen dimensions in mm.  The equatorial 
+# plane contains the incident and diffracted beam.
+
+_pd_spec_size_axial               ?       # perpendicular to 
+                                          # equatorial plane
+
+_pd_spec_size_equat               ?       # parallel to 
+                                          # scattering vector 
+                                          # in transmission
+
+_pd_spec_size_thick               ?       # parallel to 
+                                          # scattering vector 
+                                          # in reflection
+
+_pd_spec_mounting                         # This field should be
+                                          # used to give details of the 
+                                          # container.
+; ?
+;
+
+_pd_spec_mount_mode               ?       # options are 'reflection' 
+                                          # or 'transmission'
+    
+_pd_spec_shape                    ?       # options are 'cylinder' 
+                                          # 'flat_sheet' or 'irregular'
+
+
+loop_
+     _atom_type_symbol
+     _atom_type_scat_dispersion_real
+     _atom_type_scat_dispersion_imag
+     _atom_type_scat_dispersion_source
+  Al        0.255   0.328   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Fe       -3.332   0.490   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Na        0.167   0.167   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  O         0.063   0.044   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S         0.371   0.733   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si        0.298   0.438   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Ti       -0.063   2.321   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+_diffrn_radiation_type  K\a~1,2~
+loop_
+   _diffrn_radiation_wavelength
+   _diffrn_radiation_wavelength_wt
+   _diffrn_radiation_wavelength_id
+  1.78892         1.0             1     
+  1.79278         0.5000          2     
+
+# PHASE TABLE
+loop_
+   _pd_phase_id
+   _pd_phase_block_id
+   _pd_phase_mass_%
+  0  2021-08-04T18:35|NEW3minmill|phase_0|McDougallHamish  0.7917(27)
+  2  2021-08-04T18:35|NEW3minmill|phase_2|McDougallHamish  0.0992(24)
+  4  2021-08-04T18:35|NEW3minmill|phase_4|McDougallHamish  0.0419(13)
+  1  2021-08-04T18:35|NEW3minmill|phase_1|McDougallHamish  0.0594(9)
+  3  2021-08-04T18:35|NEW3minmill|phase_3|McDougallHamish  0.0079(5)
+loop_
+   _gsas_proc_phase_R_F_factor
+   _gsas_proc_phase_R_Fsqd_factor
+   _gsas_proc_phase_id
+   _gsas_proc_phase_block_id
+    0.04890  0.08090  0  2021-08-04T18:35|NEW3minmill|phase_0|McDougallHamish
+    0.07803  0.17816  2  2021-08-04T18:35|NEW3minmill|phase_2|McDougallHamish
+    0.06155  0.07652  4  2021-08-04T18:35|NEW3minmill|phase_4|McDougallHamish
+    0.05724  0.12959  1  2021-08-04T18:35|NEW3minmill|phase_1|McDougallHamish
+    0.09604  0.26511  3  2021-08-04T18:35|NEW3minmill|phase_3|McDougallHamish
+_pd_proc_ls_prof_R_factor     0.07864
+_pd_proc_ls_prof_wR_factor    0.10301
+_gsas_proc_ls_prof_R_B_factor   0.09823
+_gsas_proc_ls_prof_wR_B_factor  0.12387
+_pd_proc_ls_prof_wR_expected  0.03921
+_diffrn_radiation_probe  x-ray
+_diffrn_radiation_polarisn_ratio  0.7000
+_pd_proc_ls_background_function
+;
+Background function: "chebyschev-1" function with 7 terms:
+    449.5(16), -519.0(25), 386.7(24), -191.6(21), 100.5(20), 
+    -31.9(15), 14.9(14), 
+;
+_diffrn_ambient_temperature  300
+_diffrn_ambient_pressure  100
+
+# STRUCTURE FACTOR TABLE
+loop_
+   _pd_refln_phase_id
+   _refln_index_h
+   _refln_index_k
+   _refln_index_l
+   _refln_F_squared_meas
+   _refln_F_squared_calc
+   _refln_phase_calc
+   _refln_d_spacing
+   _gsas_i100_meas
+  0  1    1    1    951.9285   782.7112   0.0     3.12894  25.49  
+  0  2    0    0    6736.0912  6547.9992  -0.0    2.70974  100.00 
+  0  2    1    0    3629.5032  3206.1761  0.0     2.42367  85.12  
+  0  2    1    1    1731.2821  1663.0482  -180.0  2.21249  66.93  
+  0  2    2    0    2925.7300  3284.9049  -0.0    1.91608  41.75  
+  0  2    2    1    44.9286    49.7153    -0.0    1.80649  1.13   
+  0  3    1    1    4588.9307  4960.9514  -0.0    1.63404  94.68  
+  0  2    2    2    2084.6901  2257.2851  0.0     1.56447  13.19  
+  0  3    0    2    2834.5771  3034.3018  -0.0    1.50309  24.99  
+  0  3    1    2    472.7347   490.9171   0.0     1.44842  7.81   
+  0  3    2    1    1598.4301  1659.9093  180.0   1.44842  26.42  
+  0  4    0    0    365.4323   329.8038   -180.0  1.35487  1.36   
+  0  3    2    2    43.3298    55.5070    -0.0    1.31442  0.62   
+  0  4    1    0    103.2726   132.2957   -0.0    1.31442  0.74   
+  0  4    1    1    58.7608    73.0023    180.0   1.27738  0.81   
+  0  3    3    1    530.0764   591.7270   -0.0    1.24331  7.14   
+  0  4    0    2    885.4471   761.5114   0.0     1.21183  5.85   
+  0  4    2    0    885.4471   761.5114   0.0     1.21183  5.85   
+  0  4    1    2    2.5536     2.4873     -0.0    1.18263  0.03   
+  0  4    2    1    1225.5436  1193.7099  -180.0  1.18263  16.00  
+  0  3    3    2    682.4533   602.5946   0.0     1.15544  8.86   
+  0  4    2    2    1003.0557  918.9398   0.0     1.10625  13.14  
+  0  4    3    0    130.6112   167.0559   -0.0    1.08390  0.87   
+  0  4    1    3    75.2723    92.8043    -180.0  1.06285  1.02   
+  0  4    3    1    22.2617    27.4468    0.0     1.06285  0.30   
+  0  5    1    1    3457.2414  3062.3683  -0.0    1.04298  48.47  
+  0  3    3    3    1499.6348  1328.3521  -0.0    1.04298  7.01   
+  1  1    0    0    270.5106   242.5062   -180.0  4.25660  0.58   
+  1  1    0    1    701.0564   634.4377   120.0   3.34421  0.91   
+  1  1    0    -1   1667.7655  1509.2841  -120.0  3.34421  2.16   
+  1  1    1    0    371.2282   343.7933   -155.6  2.45755  0.25   
+  1  1    0    2    281.5448   298.8427   -120.0  2.28166  0.16   
+  1  1    0    -2   81.1534    86.1394    -60.0   2.28166  0.05   
+  1  1    1    1    93.7278    96.0404    82.9    2.23719  0.10   
+  1  2    0    0    304.2401   308.9271   0.0     2.12830  0.15   
+  1  2    0    -1   77.1268    77.2058    60.0    1.98033  0.03   
+  1  2    0    1    184.7769   184.9662   -60.0   1.98033  0.08   
+  1  1    1    2    533.2100   602.7589   9.8     1.81827  0.38   
+  1  0    0    3    93.1370    94.4758    0.0     1.80183  0.01   
+  1  2    0    2    88.2847    82.0680    60.0    1.67210  0.03   
+  1  2    0    -2   391.7218   364.1379   120.0   1.67210  0.12   
+  1  1    0    -3   199.6986   203.8151   180.0   1.65929  0.06   
+  1  1    0    3    2.5294     2.5815     0.0     1.65929  0.00   
+  1  2    1    0    15.9829    14.6360    -38.9   1.60884  0.01   
+  1  2    1    -1   373.6375   356.2772   95.9    1.54199  0.19   
+  1  2    1    1    321.6431   306.6986   -109.6  1.54199  0.17   
+  1  1    1    3    138.9825   142.5487   117.5   1.45311  0.06   
+  1  3    0    0    83.3352    76.3414    -180.0  1.41887  0.02   
+  1  2    1    -2   397.9721   413.7432   -123.3  1.38245  0.17   
+  1  2    1    2    123.5531   128.4493   143.4   1.38245  0.05   
+  1  2    0    -3   246.9166   292.6410   -0.0    1.37519  0.05   
+  1  2    0    3    869.2357   1030.2021  0.0     1.37519  0.19   
+  1  3    0    -1   686.1960   815.7068   -120.0  1.37238  0.15   
+  1  3    0    1    0.8527     1.0136     -60.0   1.37238  0.00   
+  1  1    0    -4   96.4260    120.2766   -120.0  1.28802  0.02   
+  1  1    0    4    317.7597   396.3564   120.0   1.28802  0.06   
+  1  3    0    -2   188.4026   208.2678   120.0   1.25628  0.04   
+  1  3    0    2    429.5599   474.8527   -120.0  1.25628  0.08   
+  1  2    2    0    275.2944   370.9996   -16.5   1.22877  0.05   
+  1  2    1    -3   68.8129    70.9918    179.1   1.20008  0.03   
+  1  2    1    3    292.0815   301.3302   -134.8  1.20008  0.11   
+  1  2    2    1    93.4680    105.5681   88.6    1.19821  0.03   
+  1  1    1    4    351.4539   334.0963   -14.4   1.18415  0.13   
+  1  3    1    0    371.8672   361.4751   121.4   1.18057  0.14   
+  1  3    1    -1   224.2378   189.8720   -18.5   1.15338  0.08   
+  1  3    1    1    74.8696    63.3954    16.4    1.15338  0.03   
+  1  2    0    4    78.3332    70.6602    120.0   1.14083  0.01   
+  1  2    0    -4   1.6319     1.4720     -120.0  1.14083  0.00   
+  1  2    2    2    2.5014     3.3490     -9.8    1.11860  0.00   
+  1  3    0    -3   7.2410     6.6828     -0.0    1.11474  0.00   
+  1  3    0    3    67.9469    62.7087    -180.0  1.11474  0.01   
+  1  3    1    -2   233.8808   304.2779   -8.9    1.08186  0.09   
+  1  3    1    2    95.5579    124.3204   59.1    1.08186  0.04   
+  1  4    0    0    132.2682   168.1572   -0.0    1.06415  0.03   
+  1  1    0    -5   390.6058   346.1824   120.0   1.04783  0.08   
+  1  1    0    5    146.5596   129.8915   -120.0  1.04783  0.03   
+  1  4    0    -1   37.1078    31.3997    60.0    1.04411  0.01   
+  1  4    0    1    342.2726   289.6232   120.0   1.04411  0.07   
+  1  2    1    -4   7.6184     10.8607    51.2    1.03477  0.00   
+  1  2    1    4    168.9357   240.8341   -129.5  1.03477  0.07   
+  2  0    0    1    2208.6215  685.7541   180.0   6.38786  0.09   
+  2  0    2    0    1202.7419  396.3962   180.0   6.37466  0.02   
+  2  1    1    0    646.5094   238.2363   -0.0    6.33955  0.01   
+  2  1    -1   0    735.6956   287.4879   -0.0    6.29869  0.01   
+  2  1    1    -1   862.1738   406.2352   180.0   5.91009  0.01   
+  2  1    -1   -1   507.9976   415.6378   -180.0  5.58552  0.01   
+  2  0    2    -1   4.9647     16.5792    0.0     4.66174  0.00   
+  2  0    2    1    1.0538     1.8371     180.0   4.37623  0.00   
+  2  2    0    -1   20221.9887 21037.4763 -0.0    4.02732  0.13   
+  2  1    -1   1    4799.2653  3767.3897  -0.0    3.85265  0.05   
+  2  1    1    1    10804.9168 10390.3834 0.0     3.77565  0.12   
+  2  1    3    0    7338.7389  5886.9121  180.0   3.68167  0.04   
+  2  1    3    -1   5589.1170  4505.3267  0.0     3.66562  0.03   
+  2  1    -3   0    12279.8835 11675.3013 180.0   3.65766  0.06   
+  2  2    0    0    1.4215     2.5781     0.0     3.63776  0.00   
+  2  1    1    -2   5776.7095  4328.5159  0.0     3.50520  0.05   
+  2  2    2    -1   2968.8541  1650.0035  180.0   3.48122  0.01   
+  2  1    -3   -1   62.6040    12.1276    0.0     3.43616  0.00   
+  2  1    -1   -2   6496.3829  5251.4578  0.0     3.37264  0.06   
+  2  2    -2   -1   341.0325   364.8637   0.0     3.33313  0.00   
+  2  2    0    -2   27264.8367 26655.4799 -180.0  3.21484  0.15   
+  2  0    0    2    38871.0538 37071.8044 -180.0  3.19393  0.40   
+  2  0    4    0    25340.6197 25362.8195 180.0   3.18733  0.10   
+  2  2    2    0    14370.3614 13873.6743 180.0   3.16977  0.07   
+  2  2    -2   0    16786.1259 14946.6082 -180.0  3.14934  0.07   
+  2  1    -3   1    12182.5407 11175.2497 -180.0  2.96418  0.05   
+  2  2    2    -2   6818.3191  7187.5067  0.0     2.95504  0.03   
+  2  0    2    -2   6154.2768  5310.5610  0.0     2.93060  0.04   
+  2  0    4    -1   9249.8826  8585.7945  0.0     2.92677  0.03   
+  2  1    3    1    6335.1513  6897.0276  180.0   2.86133  0.03   
+  2  1    3    -2   1429.2721  1923.0466  -0.0    2.83885  0.01   
+  2  2    -2   -2   139.7816   183.4547   -0.0    2.79276  0.00   
+  2  0    2    2    156.8508   191.6414   0.0     2.78600  0.00   
+  2  0    4    1    311.4777   387.5360   -0.0    2.78271  0.00   
+  2  2    0    1    107.8810   109.5836   -0.0    2.68712  0.00   
+  2  3    1    -1   416.5005   431.0071   -180.0  2.66293  0.00   
+  2  1    -3   -2   6989.8388  6171.6319  -0.0    2.63839  0.03   
+  2  3    -1   -1   39.8753    33.5476    -180.0  2.62530  0.00   
+  2  2    4    -1   14310.9248 12550.4891 -180.0  2.55995  0.04   
+  2  3    1    -2   2142.0134  1812.0722  180.0   2.53704  0.01   
+  2  1    -1   2    1020.5273  667.2869   180.0   2.51139  0.00   
+  2  2    -2   1    2245.2701  1686.7859  -180.0  2.49495  0.01   
+  2  3    -1   -2   683.8159   451.5613   180.0   2.48043  0.00   
+  2  1    1    2    127.1711   110.2849   180.0   2.46610  0.00   
+  2  2    2    1    1489.2105  1367.0046  -180.0  2.45771  0.01   
+  2  2    -4   -1   11746.7915 10453.7459 -180.0  2.44277  0.03   
+  2  1    5    -1   4744.4729  4093.1663  -0.0    2.42941  0.01   
+  2  1    5    0    61.2791    64.0884    180.0   2.41202  0.00   
+  2  2    4    0    3924.1883  3944.1458  -0.0    2.40628  0.01   
+  2  1    -5   0    2247.6751  2230.8323  180.0   2.40074  0.00   
+  2  2    -4   0    2226.3396  2079.3222  -0.0    2.38844  0.00   
+  2  3    1    0    1680.4293  1565.2946  -0.0    2.38575  0.00   
+  2  3    -1   0    2243.2393  2090.0863  -0.0    2.37918  0.01   
+  2  2    0    -3   7.3452     7.3701     180.0   2.35133  0.00   
+  2  2    4    -2   2.9437     2.9331     0.0     2.34729  0.00   
+  2  1    1    -3   130.1463   110.8373   -0.0    2.33656  0.00   
+  2  0    4    -2   1294.9209  884.3144   -180.0  2.33087  0.00   
+  2  3    3    -1   20851.5070 9809.7794  180.0   2.31766  0.04   
+  2  1    -5   -1   2286.3640  1044.9800  0.0     2.31526  0.01   
+  2  1    -1   -3   2114.1417  2291.2470  -0.0    2.27750  0.01   
+  2  2    2    -3   182.6011   155.6865   -0.0    2.26146  0.00   
+  2  3    3    -2   18.9776    15.9172    0.0     2.25070  0.00   
+  2  3    -3   -1   2867.6980  2703.2457  -180.0  2.24518  0.01   
+  2  1    -3   2    862.2371   824.7896   -0.0    2.22556  0.00   
+  2  0    4    2    1733.8097  2085.0250  0.0     2.18812  0.01   
+  2  2    -4   -2   1190.7373  1431.8638  0.0     2.18799  0.00   
+  2  1    -5   1    3475.2255  4194.8986  180.0   2.18493  0.01   
+  2  2    -2   -3   961.8479   1851.4932  0.0     2.15451  0.00   
+  2  1    5    -2   151.8819   312.7232   -180.0  2.15169  0.00   
+  2  3    1    -3   163.8289   204.6119   0.0     2.13824  0.00   
+  2  3    -3   -2   428.5483   512.1941   180.0   2.13724  0.00   
+  2  1    3    2    146.0927   174.4523   -180.0  2.13433  0.00   
+  2  0    0    3    425.5574   454.6548   -0.0    2.12929  0.00   
+  2  0    6    0    10517.9332 11042.6256 -0.0    2.12489  0.02   
+  2  1    3    -3   647.4780   674.2906   -180.0  2.11876  0.00   
+  2  1    5    1    4414.3889  4734.7647  180.0   2.11595  0.01   
+  2  3    3    0    1299.0212  1496.6439  -180.0  2.11318  0.00   
+  2  3    -3   0    136.6508   182.7827   -180.0  2.09956  0.00   
+  2  3    -1   -3   1437.6235  2416.5634  0.0     2.08973  0.00   
+  2  2    -4   1    7199.9440  8370.0925  180.0   2.07604  0.01   
+  2  0    2    -3   278.2752   286.8930   -180.0  2.05903  0.00   
+  2  0    6    -1   76.2357    83.9001    -0.0    2.05549  0.00   
+  2  2    4    1    2497.3133  2723.1302  180.0   2.03350  0.01   
+  2  4    0    -2   1276.8523  1673.8545  -0.0    2.01366  0.00   
+  2  1    -5   -2   788.0327   976.2191   -0.0    2.00557  0.00   
+  2  4    0    -1   2878.1571  3207.5402  -0.0    2.00025  0.00   
+  2  2    0    2    821.9683   914.6787   0.0     1.99827  0.00   
+  2  1    -3   -3   1743.7547  2006.9284  -0.0    1.99351  0.01   
+  2  0    2    3    1241.5073  1320.4879  0.0     1.98235  0.00   
+  2  0    6    1    4985.7074  4760.1395  0.0     1.97919  0.01   
+  2  3    -1   1    1723.8536  1778.1424  0.0     1.97162  0.00   
+  2  3    3    -3   741.2621   747.2487   -180.0  1.97003  0.00   
+  2  3    1    1    1135.4473  1049.8991  0.0     1.96352  0.00   
+  2  2    4    -3   226.3944   210.6125   -180.0  1.96339  0.00   
+  2  4    2    -2   1244.5618  1505.1300  0.0     1.94723  0.00   
+  2  2    -2   2    4127.2928  4434.5615  -0.0    1.92633  0.01   
+  2  4    2    -1   180.3803   195.3738   0.0     1.92397  0.00   
+  2  2    6    -1   23.1703    25.7092    -0.0    1.91781  0.00   
+  2  4    -2   -2   12969.6562 14612.2943 -0.0    1.89414  0.02   
+  2  4    -2   -1   72.8875    83.9894    180.0   1.89341  0.00   
+  2  3    5    -1   2923.1695  3253.1319  -180.0  1.88804  0.00   
+  2  2    2    2    10093.9919 11147.4650 -0.0    1.88782  0.03   
+  2  3    -3   -3   281.3605   242.1347   -0.0    1.86184  0.00   
+  2  3    5    -2   169.2791   151.7748   -180.0  1.86122  0.00   
+  2  4    0    -3   14387.7888 17227.6438 -180.0  1.84958  0.02   
+  2  2    -6   -1   564.0997   630.1904   -180.0  1.84310  0.00   
+  2  1    -5   2    29.8311    32.7906    -180.0  1.84286  0.00   
+  2  2    6    0    6494.6296  5973.8074  -0.0    1.84084  0.01   
+  2  2    6    -2   2832.8387  2234.4122  -180.0  1.83281  0.00   
+  2  1    -1   3    2622.8699  2403.8627  -180.0  1.82957  0.01   
+  2  2    -6   0    11504.2956 11170.3478 0.0     1.82883  0.01   
+  2  2    -4   -3   354.0224   351.5785   -0.0    1.82817  0.00   
+  2  0    4    -3   6480.9071  6600.1943  180.0   1.82454  0.01   
+  2  3    -5   -1   522.1012   547.0575   -180.0  1.82305  0.00   
+  2  0    6    -2   8944.7488  9376.7847  -180.0  1.82300  0.01   
+  2  4    0    0    14955.9387 16544.7345 -0.0    1.81888  0.02   
+  2  3    -3   1    1233.4497  1388.1619  -0.0    1.81269  0.00   
+  2  4    2    -3   1544.9477  1698.2109  -0.0    1.80678  0.00   
+  2  1    1    3    12920.4897 13204.6231 -180.0  1.80269  0.04   
+  2  3    3    1    598.6252   659.8672   -0.0    1.79396  0.00   
+  2  1    5    -3   32.2795    36.9138    180.0   1.79152  0.00   
+  2  1    7    -1   288.4321   370.2527   -180.0  1.78554  0.00   
+  2  2    0    -4   23450.2066 29304.7955 0.0     1.78457  0.06   
+  2  1    7    0    1666.6594  1186.7943  -0.0    1.76994  0.00   
+  2  3    5    0    556.0992   192.4714   -180.0  1.76391  0.00   
+  2  1    -7   0    5515.6112  1861.7091  0.0     1.76369  0.01   
+  2  1    5    2    5567.1767  1478.1411  -180.0  1.75728  0.01   
+  2  3    -5   -2   928.0740   292.8600   -180.0  1.75539  0.00   
+  2  2    2    -4   11587.3873 5374.4235  180.0   1.75260  0.02   
+  2  4    2    0    6953.7656  3240.2714  180.0   1.75255  0.01   
+  2  3    -5   0    1.3416     0.6787     -180.0  1.75073  0.00   
+  2  4    -2   -3   2581.5965  1498.9920  -180.0  1.74735  0.00   
+  2  4    -2   0    2382.3394  1478.3757  -180.0  1.74562  0.00   
+  2  4    4    -2   14241.3470 11156.5991 -180.0  1.74061  0.02   
+  2  3    1    -4   14.6668    11.6942    0.0     1.73791  0.00   
+  2  1    1    -4   1090.2557  931.5858   180.0   1.73044  0.00   
+  2  0    4    3    1564.5479  1649.4123  180.0   1.72108  0.00   
+  2  1    -7   -1   515.8402   544.5769   -0.0    1.72100  0.00   
+  2  2    -4   2    4818.4880  5111.9528  -180.0  1.72066  0.01   
+  2  0    6    2    3771.7848  4043.0244  180.0   1.71979  0.01   
+  2  2    -6   -2   5332.2607  5843.5104  180.0   1.71808  0.01   
+  2  1    -3   3    3545.9084  3889.7621  0.0     1.71755  0.01   
+  2  4    4    -1   3205.9050  3425.3612  -0.0    1.71605  0.00   
+  2  3    -1   -4   37.1273    26.3196    -0.0    1.70384  0.00   
+  2  3    5    -3   2710.2623  1781.5059  180.0   1.70048  0.00   
+  2  1    -1   -4   1747.3585  1087.2281  180.0   1.69839  0.00   
+  2  2    -2   -4   7190.5430  6607.2640  -0.0    1.68632  0.02   
+  2  2    -6   1    132.4830   111.8094   180.0   1.68403  0.00   
+  2  1    -7   1    1392.7460  1037.6002  0.0     1.67991  0.00   
+  2  1    7    -2   3490.9849  3014.1863  0.0     1.67337  0.00   
+  2  4    -4   -1   3580.0486  3113.5342  -0.0    1.67328  0.00   
+  2  1    -5   -3   327.6954   322.6770   -180.0  1.66739  0.00   
+  2  2    4    2    7078.7568  6980.1241  -180.0  1.66673  0.01   
+  2  4    -4   -2   3044.2358  2996.9232  -180.0  1.66656  0.00   
+  2  1    3    3    608.5262   605.4945   0.0     1.65314  0.00   
+  2  3    3    -4   493.6974   474.5918   180.0   1.65084  0.00   
+  2  2    6    1    15.5850    15.0623    180.0   1.64996  0.00   
+  2  4    4    -3   86.5064    81.5092    0.0     1.64497  0.00   
+  2  1    3    -4   1345.9506  1267.0308  -180.0  1.64299  0.00   
+  2  2    6    -3   398.7997   438.3802   0.0     1.63845  0.00   
+  2  1    7    1    884.8436   959.6711   0.0     1.63566  0.00   
+  2  5    1    -2   60.0864    62.3555    -180.0  1.62122  0.00   
+  2  2    4    -4   7.2474     6.6299     0.0     1.60885  0.00   
+  2  3    -1   2    251.6169   237.1891   -180.0  1.60779  0.00   
+  2  4    0    -4   27.0644    25.5451    0.0     1.60742  0.00   
+  2  5    -1   -2   110.2936   104.4782   -0.0    1.60481  0.00   
+  2  3    1    2    5.3228     3.3755     -180.0  1.59704  0.00   
+  2  0    0    4    2720.7781  1719.5025  -0.0    1.59697  0.01   
+  2  0    8    0    7071.1915  4104.7411  -0.0    1.59366  0.01   
+  2  3    -5   -3   8469.1807  7048.0684  -180.0  1.58673  0.01   
+  2  4    2    -4   6831.6014  5767.4424  -180.0  1.58523  0.01   
+  2  4    4    0    95.6690    80.5872    180.0   1.58489  0.00   
+  2  3    -5   1    4004.0452  3541.7994  0.0     1.57987  0.00   
+  2  1    -7   -2   103.7896   106.0592   180.0   1.57566  0.00   
+  2  4    -4   0    984.1853   972.7791   180.0   1.57467  0.00   
+  2  4    0    1    1333.2907  1313.3627  0.0     1.57405  0.00   
+  2  0    2    -4   6995.1432  6835.8768  -180.0  1.57267  0.01   
+  2  5    1    -1   1882.2711  1838.8969  0.0     1.57223  0.00   
+  2  5    1    -3   4.6364     4.5305     0.0     1.57056  0.00   
+  2  0    8    -1   5075.1381  5105.5113  -180.0  1.56971  0.00   
+  2  3    -3   -4   211.0597   222.0271   -180.0  1.56739  0.00   
+  2  1    -3   -4   1102.7658  1168.3240  -180.0  1.56437  0.00   
+  2  5    -1   -1   3430.4154  3532.8589  -0.0    1.56314  0.00   
+  2  3    5    1    6600.9758  6630.5027  -0.0    1.55930  0.01   
+  2  2    0    3    1758.7910  1763.6711  -180.0  1.55911  0.00   
+  2  4    -4   -3   680.0758   668.2938   0.0     1.55805  0.00   
+  2  0    6    -3   55.7641    50.4752    180.0   1.55391  0.00   
+  2  5    -1   -3   3553.1600  3177.9812  180.0   1.54983  0.00   
+  2  5    3    -2   2108.7417  1684.3120  0.0     1.53962  0.00   
+  2  3    7    -1   393.8420   255.3064   -0.0    1.53554  0.00   
+  2  4    -2   -4   6563.5523  4566.3850  180.0   1.53333  0.01   
+  2  4    -2   1    531.4210   360.2122   -0.0    1.53138  0.00   
+  2  2    -2   3    5153.0729  3884.5431  0.0     1.52972  0.01   
+  2  1    -5   3    148.5598   114.2358   180.0   1.52775  0.00   
+  2  0    2    4    2549.3399  1999.2534  180.0   1.52655  0.01   
+  2  3    7    -2   1808.8948  1417.6951  180.0   1.52649  0.00   
+  2  4    2    1    72.5895    55.0425    -0.0    1.52494  0.00   
+  2  0    8    1    73.2661    53.4117    0.0     1.52385  0.00   
+  2  3    -3   2    997.6576   713.5252   0.0     1.52351  0.00   
+  2  2    -6   -3   1515.9944  972.3599   180.0   1.52111  0.00   
+  2  1    -7   2    2658.5588  2092.8268  180.0   1.51406  0.00   
+  2  2    -4   -4   3887.1756  3475.0688  -180.0  1.51008  0.01   
+  2  2    8    -1   8609.7091  8932.7653  0.0     1.50687  0.01   
+  2  5    3    -3   10740.5827 11216.4371 -0.0    1.50125  0.01   
+  2  2    2    3    245.0774   261.4234   0.0     1.49966  0.00   
+  2  5    -3   -2   1204.2906  1283.3165  0.0     1.49852  0.00   
+  2  4    6    -2   1540.6206  1643.4734  -180.0  1.49804  0.00   
+  2  3    3    2    2662.6306  2828.3266  0.0     1.49651  0.00   
+  2  5    3    -1   1352.4707  1375.8687  180.0   1.49230  0.00   
+  2  1    7    -3   984.5418   963.7100   -0.0    1.49138  0.00   
+  2  3    5    -4   1232.4396  976.7543   0.0     1.48741  0.00   
+  2  3    -7   -1   5.3928     4.1505     -180.0  1.48641  0.00   
+  2  2    -6   2    3189.9341  2225.9899  -180.0  1.48209  0.00   
+  2  1    5    -4   852.4287   569.2303   -0.0    1.48061  0.00   
+  2  4    4    -4   1372.4194  936.8644   -0.0    1.47752  0.00   
+  2  4    6    -1   3603.1611  2425.3077  -0.0    1.47727  0.00   
+  2  2    8    -2   2926.2485  2036.6290  -0.0    1.46947  0.00   
+  2  5    -3   -1   3228.1648  2250.7625  180.0   1.46932  0.00   
+  2  0    4    -4   2241.7650  1799.2981  0.0     1.46530  0.00   
+  2  2    8    0    20112.9925 17372.8918 180.0   1.46378  0.02   
+  2  0    8    -2   3053.1508  2670.5014  0.0     1.46338  0.00   
+  2  3    7    0    1582.2958  1344.4772  -0.0    1.46164  0.00   
+  2  0    6    3    10929.0880 9727.2084  -180.0  1.45874  0.02   
+  2  2    -8   -1   313.7054   277.6153   0.0     1.45806  0.00   
+  2  2    -8   0    16049.6902 14971.6548 -180.0  1.45572  0.01   
+  2  1    5    3    84.5619    84.4701    0.0     1.45352  0.00   
+  2  3    -7   0    1808.1500  1874.7884  -0.0    1.45113  0.00   
+  2  5    -3   -3   3877.3016  3973.0050  -0.0    1.44873  0.00   
+  2  1    7    2    337.3835   339.6716   180.0   1.44736  0.00   
+  2  5    1    0    465.4865   468.7582   0.0     1.44694  0.00   
+  2  5    -1   0    270.9314   282.6566   0.0     1.44450  0.00   
+  2  3    -7   -2   390.7335   407.5222   -180.0  1.44435  0.00   
+  2  5    1    -4   360.5796   376.0669   -0.0    1.44434  0.00   
+  2  4    6    -3   4786.2702  4799.2632  180.0   1.44037  0.00   
+  2  3    7    -3   2276.5626  2066.9126  0.0     1.43858  0.00   
+  2  4    -6   -1   16293.1935 13974.0377 -0.0    1.43651  0.01   
+  2  1    -1   4    2204.5236  1747.7612  -0.0    1.43156  0.00   
+  2  2    6    2    17029.4262 14127.5120 -180.0  1.43067  0.02   
+  2  4    -6   -2   11646.6498 11494.7453 -180.0  1.42772  0.01   
+  2  3    1    -5   50.5729    54.5453    0.0     1.42498  0.00   
+  2  2    -4   3    8630.6587  9304.7725  -0.0    1.42492  0.01   
+  2  5    -1   -4   5977.3242  6191.0063  0.0     1.42367  0.01   
+  2  2    0    -5   553.8396   530.6717   -0.0    1.41970  0.00   
+  2  2    6    -4   4312.9751  4109.1661  -0.0    1.41942  0.00   
+  2  4    -4   1    2281.2613  2328.2327  -180.0  1.41643  0.00   
+  2  1    1    4    9452.3707  9765.5200  -0.0    1.41417  0.02   
+  2  2    2    -5   142.0814   102.1798   180.0   1.40774  0.00   
+  2  4    4    1    4558.0931  4251.1055  -180.0  1.40628  0.00   
+  2  1    9    -1   417.3748   313.3806   180.0   1.40427  0.00   
+  2  3    -1   -5   677.8213   559.2035   180.0   1.40173  0.00   
+  2  5    5    -2   203.0635   121.8591   180.0   1.39689  0.00   
+  2  4    -4   -4   535.4056   333.7965   -180.0  1.39638  0.00   
+  2  5    3    -4   13258.0389 10290.7248 -180.0  1.39407  0.01   
+  2  0    4    4    768.3836   603.2489   180.0   1.39300  0.00   
+  2  1    9    0    7594.9685  6061.3448  -180.0  1.39244  0.01   
+  2  0    8    2    954.3958   841.8614   -0.0    1.39135  0.00   
+  2  1    -7   -3   9.9752     8.6161     0.0     1.39082  0.00   
+  2  2    -8   -2   447.7001   389.1003   0.0     1.38958  0.00   
+  2  1    -9   0    5177.7812  5032.6219  -180.0  1.38852  0.00   
+  2  3    -5   -4   731.1608   712.8918   180.0   1.38828  0.00   
+  2  1    -5   -4   12.5202    12.2841    -0.0    1.38705  0.00   
+  2  4    6    0    6956.4639  6881.9956  0.0     1.38694  0.01   
+  2  2    -8   1    2491.3610  2583.5813  -0.0    1.38353  0.00   
+  2  3    -5   2    111.5387   107.7060   180.0   1.38139  0.00   
+  2  1    -3   4    10833.8710 11498.8556 180.0   1.38001  0.02   
+  2  3    3    -5   561.4461   601.2645   -0.0    1.37984  0.00   
+  2  5    3    0    1925.8815  2064.1961  180.0   1.37983  0.00   
+  2  2    4    3    7067.0475  7682.9819  -0.0    1.37735  0.01   
+  2  4    -6   0    2651.7381  2929.6322  0.0     1.37669  0.00   
+  2  5    -3   0    1633.3982  1846.9850  -180.0  1.37349  0.00   
+  2  4    0    -5   8540.4517  9852.1453  -0.0    1.37263  0.01   
+  2  5    5    -3   893.0132   1000.1841  -0.0    1.37203  0.00   
+  2  1    1    -5   65.3153    51.8333    180.0   1.36876  0.00   
+  2  2    8    -3   1277.3373  897.0709   0.0     1.36740  0.00   
+  2  2    -2   -5   1167.1423  890.9937   -180.0  1.36475  0.00   
+  2  1    -9   -1   2745.4317  2521.2414  180.0   1.36346  0.00   
+  2  4    2    -5   11562.6227 11335.5971 180.0   1.36264  0.01   
+  2  2    8    1    3412.7204  3611.9875  -180.0  1.35827  0.00   
+  2  5    5    -1   889.6336   870.4892   -180.0  1.35737  0.00   
+  2  4    -6   -3   4468.2741  4126.3352  180.0   1.35385  0.00   
+  2  3    -7   1    621.7437   576.4772   0.0     1.35312  0.00   
+  2  1    9    -2   14770.0833 16147.0686 0.0     1.35152  0.01   
+  2  6    0    -2   15282.7153 16981.3924 180.0   1.35133  0.01   
+  2  1    -9   1    3205.1524  3741.5161  -0.0    1.35032  0.00   
+  2  1    -1   -5   8675.2637  10683.9602 -0.0    1.34891  0.02   
+  2  3    5    2    163.1386   209.3398   0.0     1.34817  0.00   
+  2  5    -5   -2   452.4398   568.7530   180.0   1.34647  0.00   
+  2  4    0    2    17087.1954 20266.7951 180.0   1.34356  0.02   
+  2  6    0    -3   414.5552   424.9852   0.0     1.34244  0.00   
+  2  3    -7   -3   1016.2144  987.1236   180.0   1.34218  0.00   
+  2  5    -3   -4   24.2000    19.4544    -0.0    1.34037  0.00   
+  2  3    7    1    807.6586   545.2034   0.0     1.33504  0.00   
+  2  1    3    4    440.8804   303.9072   180.0   1.33473  0.00   
+  2  2    4    -5   2633.4464  2138.1647  -0.0    1.33359  0.00   
+  2  6    2    -2   7542.8993  7470.5514  0.0     1.33146  0.01   
+  2  3    -1   3    514.6388   551.6386   -0.0    1.32984  0.00   
+  2  5    -5   -1   2722.4075  3077.6343  -180.0  1.32879  0.00   
+  2  1    -7   3    709.6764   845.5145   -180.0  1.32789  0.00   
+  2  1    3    -5   10864.4185 12956.3684 180.0   1.32785  0.01   
+  2  4    6    -4   1019.2188  1219.1637  0.0     1.32754  0.00   
+  2  6    2    -3   5.4082     6.0091     -0.0    1.32656  0.00   
+  2  4    -2   -5   2977.4294  3146.4347  0.0     1.32203  0.00   
+  2  1    9    1    972.4129   1105.1306  -0.0    1.32057  0.00   
+  2  4    -2   2    1919.3249  2255.4357  0.0     1.32028  0.00   
+  2  3    1    3    2716.7202  3237.6008  0.0     1.32015  0.00   
+  2  2    -6   -4   93.0619    114.0134   0.0     1.31919  0.00   
+  2  3    -3   -5   1779.2674  2179.7868  180.0   1.31918  0.00   
+  2  0    6    -4   2887.5269  3685.3963  0.0     1.31717  0.00   
+  2  0    8    -3   3558.2650  4546.6333  -0.0    1.31636  0.00   
+  2  6    -2   -2   309.3130   330.6363   180.0   1.31265  0.00   
+  2  4    2    2    653.5713   505.4413   0.0     1.30914  0.00   
+  2  5    -5   -3   9335.7288  6208.9517  0.0     1.30653  0.01   
+  2  3    7    -4   18.2112    11.5530    -180.0  1.30602  0.00   
+  2  6    0    -1   1005.1324  635.2341   -0.0    1.30261  0.00   
+  2  6    -2   -3   5779.6274  4797.6968  0.0     1.30107  0.00   
+  2  1    7    -4   952.2546   816.7390   180.0   1.30069  0.00   
+  2  4    4    -5   973.1466   839.8412   -180.0  1.29576  0.00   
+  2  5    -1   1    675.1013   560.8179   -180.0  1.29287  0.00   
+  2  5    5    -4   120.9988   102.0732   -0.0    1.29210  0.00   
+  2  5    1    1    240.8796   213.0414   180.0   1.29128  0.00   
+  2  5    1    -5   1112.6046  1297.0866  -180.0  1.28850  0.00   
+  2  1    -9   -2   6474.6986  7594.2794  0.0     1.28440  0.01   
+  2  3    -3   3    3280.6940  3821.2749  180.0   1.28422  0.00   
+  2  2    -6   3    88.3462    97.9036    -0.0    1.28363  0.00   
+  2  3    5    -5   2804.2867  3037.5557  -0.0    1.28334  0.00   
+  2  6    2    -1   2015.6369  2446.8719  180.0   1.28151  0.00   
+  2  4    8    -2   13204.0170 16043.2073 -0.0    1.27998  0.01   
+  2  6    0    -4   3858.8604  4642.8182  0.0     1.27913  0.00   
+  2  1    -5   4    0.2297     0.2762     -0.0    1.27885  0.00   
+  2  0    0    5    1241.8045  1504.7953  0.0     1.27757  0.00   
+  2  2    -8   -3   859.2502   969.8153   0.0     1.27578  0.00   
+  2  1    -3   -5   1439.1232  1649.0848  -180.0  1.27554  0.00   
+  2  0    10   0    4678.0959  5612.4673  -0.0    1.27493  0.00   
+  2  3    9    -1   522.5074   567.6734   180.0   1.27318  0.00   
+  2  3    9    -2   166.8493   209.3409   0.0     1.27118  0.00   
+  2  6    -2   -1   485.5023   604.9530   -180.0  1.27102  0.00   
+  2  5    -1   -5   2657.5653  3287.3648  -0.0    1.27057  0.00   
+  2  4    -6   1    1741.7618  2157.0193  180.0   1.27033  0.00   
+  2  2    0    4    4668.2232  5970.9564  -0.0    1.26862  0.01   
+  2  6    2    -4   2035.2237  2642.8907  -180.0  1.26852  0.00   
+  2  0    2    -5   3052.0787  4140.6925  180.0   1.26818  0.00   
+  2  2    -8   2    11347.6417 15669.9235 0.0     1.26800  0.01   
+  2  5    5    0    1106.2284  1539.1640  -0.0    1.26791  0.00   
+  2  0    10   -1   609.7398   722.1628   -180.0  1.26570  0.00   
+  2  4    8    -1   113.4013   116.1733   180.0   1.26381  0.00   
+  2  2    -4   -5   35.6047    34.2839    180.0   1.26302  0.00   
+  2  1    -9   2    415.4875   407.6104   0.0     1.26267  0.00   
+  2  6    4    -2   3446.9678  4060.9393  -0.0    1.26012  0.00   
+  2  1    7    3    1185.7548  1423.0605  -180.0  1.25993  0.00   
+  2  5    -5   0    1029.0679  1251.7915  -0.0    1.25974  0.00   
+  2  4    6    1    28.3040    35.4122    180.0   1.25938  0.00   
+  2  6    4    -3   4441.0151  5742.7030  -180.0  1.25904  0.00   
+  2  3    3    3    26.4392    34.1056    0.0     1.25855  0.00   
+  2  2    -2   4    2449.5812  2630.4316  180.0   1.25569  0.00   
+  2  5    3    -5   7423.0677  7849.9862  180.0   1.25548  0.01   
+  2  1    9    -3   479.8840   446.4585   -180.0  1.25310  0.00   
+  2  4    -4   2    3006.5457  2913.1494  0.0     1.24747  0.00   
+  2  4    8    -3   1564.5047  1591.0184  -180.0  1.24643  0.00   
+  2  5    -3   1    147.2570   154.1169   -180.0  1.24419  0.00   
+  2  4    -6   -4   4297.5470  4649.8078  0.0     1.24074  0.00   
+  2  1    5    -5   19.2289    20.8490    -0.0    1.24058  0.00   
+  2  6    -2   -4   107.5398   116.0421   -0.0    1.24022  0.00   
+  2  5    3    1    808.3957   865.0651   -180.0  1.23993  0.00   
+  2  0    6    4    4131.0947  4402.8269  -0.0    1.23960  0.01   
+  2  0    8    3    2305.5874  2523.8232  0.0     1.23892  0.00   
+  2  5    7    -2   46.3529    48.4702    -180.0  1.23815  0.00   
+  2  0    2    5    6.2571     6.1649     -0.0    1.23770  0.00   
+  2  3    -9   -1   2105.5184  1878.7146  -180.0  1.23697  0.00   
+  2  0    10   1    77.9482    69.0195    180.0   1.23540  0.00   
+  2  2    8    -4   0.7993     0.6712     -0.0    1.23509  0.00   
+  2  2    2    4    280.1421   202.3679   180.0   1.23305  0.00   
+  2  2    10   -1   908.4587   674.5837   -0.0    1.23266  0.00   
+  2  2    6    3    776.7644   591.5126   -0.0    1.23202  0.00   
+  2  4    -8   -1   1583.4102  1660.8265  180.0   1.22975  0.00   
+  2  4    4    2    5674.6586  7216.8110  -0.0    1.22886  0.01   
+  2  6    -4   -2   5779.6530  7429.0559  0.0     1.22874  0.00   
+  2  4    -4   -5   4544.8944  5935.8119  180.0   1.22833  0.00   
+  2  3    9    0    175.5992   207.1256   180.0   1.22722  0.00   
+  2  2    8    2    16107.1218 16367.8700 -0.0    1.22501  0.02   
+  2  3    -7   2    4.4027     4.4310     -180.0  1.22493  0.00   
+  2  5    7    -3   875.9329   701.3947   180.0   1.22357  0.00   
+  2  5    -5   -4   598.7639   527.2945   -180.0  1.22255  0.00   
+  2  2    6    -5   104.2186   93.3157    -0.0    1.22244  0.00   
+  2  3    9    -3   4331.8871  3989.5508  -0.0    1.22187  0.00   
+  2  4    -8   -2   17493.7362 15576.6760 0.0     1.22139  0.01   
+  2  1    5    4    3685.8636  2923.6151  -180.0  1.22003  0.01   
+  2  3    -9   0    81.5922    63.1939    -0.0    1.21922  0.00   
+  2  6    -4   -3   2.4782     1.6171     -180.0  1.21643  0.00   
+  2  6    4    -1   13.3468    10.2523    180.0   1.21473  0.00   
+  2  2    10   -2   4150.8609  3195.8904  -180.0  1.21471  0.00   
+  2  3    -7   -4   11.8062    9.5153     0.0     1.21279  0.00   
+  2  6    0    0    16190.0341 13100.2263 0.0     1.21259  0.01   
+  2  1    9    2    2162.3168  1749.7864  0.0     1.21259  0.00   
+  2  0    4    -5   63.5185    51.4047    -180.0  1.21258  0.00   
+  2  1    -7   -4   831.5463   673.8718   0.0     1.21254  0.00   
+  2  6    4    -4   236.9247   199.9465   0.0     1.21185  0.00   
+  2  0    10   -2   2896.2810  2393.1814  180.0   1.21068  0.00   
+  2  3    -9   -2   2.9108     2.4088     0.0     1.20966  0.00   
+  2  5    7    -1   1110.2154  919.5910   -0.0    1.20764  0.00   
+  2  5    -3   -5   2019.5595  1669.4106  -180.0  1.20756  0.00   
+  2  2    10   0    14.8285    11.8619    180.0   1.20601  0.00   
+  2  3    -5   -5   6304.7294  5223.5291  -0.0    1.20426  0.01   
+  2  4    8    0    2405.5662  2036.1638  -180.0  1.20314  0.00   
+  2  2    -10  0    1224.9461  1234.3417  180.0   1.20037  0.00   
+  2  2    -10  -1   1804.1427  1881.5821  0.0     1.19900  0.00   
+  2  2    -4   4    0.0039     0.0043     180.0   1.19841  0.00   
+  2  3    -5   3    4682.7586  5149.8089  -180.0  1.19827  0.00   
+  2  6    -4   -1   3951.9377  4013.4094  180.0   1.19705  0.00   
+  2  4    -8   0    1863.3338  1701.7086  -180.0  1.19422  0.00   
+  2  4    6    -5   6330.2243  5356.2972  -0.0    1.19366  0.00   
+  2  6    2    0    7534.0488  6359.8747  -180.0  1.19287  0.01   
+  2  3    1    -6   204.8531   172.0799   180.0   1.19278  0.00   
+  2  3    7    2    253.8880   210.6961   180.0   1.19262  0.00   
+  2  6    -2   0    2656.7599  1825.4606  -180.0  1.18959  0.00   
+  2  5    -7   -2   346.1118   235.2689   -180.0  1.18926  0.00   
+  2  5    5    -5   676.5005   652.0282   -0.0    1.18202  0.00   
+  2  6    0    -5   1959.2525  1859.8386  -0.0    1.18139  0.00   
+  2  5    -7   -1   1162.6264  1170.6276  -0.0    1.17956  0.00   
+  2  3    -1   -6   9065.6887  10651.6340 0.0     1.17652  0.01   
+  2  1    -9   -3   2783.9447  3479.3329  -0.0    1.17569  0.00   
+  2  4    0    -6   556.0294   694.8770   -180.0  1.17567  0.00   
+  2  6    2    -5   555.0350   690.4314   180.0   1.17553  0.00   
+  2  4    8    -4   4317.0355  5262.2410  180.0   1.17365  0.00   
+  2  1    -1   5    36.2112    44.3347    0.0     1.17349  0.00   
+  2  2    0    -6   2773.3358  3262.2227  -180.0  1.17258  0.00   
+  2  4    2    -6   682.0746   785.7923   0.0     1.17185  0.00   
+  2  4    -8   -3   442.4039   512.5086   -0.0    1.17167  0.00   
+  2  1    -5   -5   4690.2978  5414.4867  -180.0  1.17131  0.01   
+  2  3    3    -6   3025.9524  3178.6335  180.0   1.16840  0.00   
+  2  5    7    -4   5662.3741  5932.4007  0.0     1.16833  0.00   
+  2  2    2    -6   425.2877   444.4424   0.0     1.16828  0.00   
+  2  0    8    -4   6290.5931  6734.2463  -180.0  1.16544  0.00   
+  2  3    5    3    8644.5672  9033.3981  -180.0  1.16397  0.01   
+  2  6    -4   -4   1249.5573  1331.0105  -180.0  1.16381  0.00   
+  2  3    7    -5   1103.5341  1180.8749  180.0   1.16377  0.00   
+  2  3    -9   1    29.2168    24.5109    -0.0    1.16177  0.00   
+  2  1    1    5    2376.9700  1984.2370  0.0     1.16142  0.00   
+  2  2    -10  1    489.9378   408.7012   -180.0  1.16134  0.00   
+  2  0    4    5    4431.9590  3674.6390  -180.0  1.16082  0.01   
+  2  6    6    -3   692.3545   572.9928   0.0     1.16041  0.00   
+  2  5    -5   1    9.8611     8.2052     180.0   1.16017  0.00   
+  2  7    1    -3   392.3611   326.8856   180.0   1.15995  0.00   
+  2  2    4    4    402.0167   334.7388   180.0   1.15990  0.00   
+  2  0    10   2    2448.4025  1953.1670  -180.0  1.15916  0.00   
+  2  5    -7   -3   17.5856    13.9221    0.0     1.15905  0.00   
+  2  6    6    -2   1353.8085  1062.5954  180.0   1.15883  0.00   
+  2  2    -10  -2   1133.4703  927.1428   -180.0  1.15763  0.00   
+  2  2    10   -3   560.7517   456.9863   180.0   1.15752  0.00   
+  2  1    -7   4    9788.7410  7894.1741  -0.0    1.15699  0.01   
+  2  1    11   -1   201.1446   172.4013   -0.0    1.15488  0.00   
+  2  5    5    1    17.3492    14.5872    180.0   1.15443  0.00   
+  2  4    0    3    444.5482   372.8509   -0.0    1.15214  0.00   
+  2  7    -1   -3   228.6421   190.7937   -0.0    1.15103  0.00   
+  2  1    -9   3    465.1198   390.2848   -180.0  1.15086  0.00   
+  2  7    1    -2   487.3760   417.6649   180.0   1.14957  0.00   
+  2  6    -2   -5   3.7614     3.3422     180.0   1.14818  0.00   
+  2  2    -8   -4   1358.9326  1241.1393  -0.0    1.14713  0.00   
+  2  3    9    1    922.6384   840.9132   -180.0  1.14703  0.00   
+  2  1    -3   5    144.8481   131.0137   -0.0    1.14691  0.00   
+  2  4    -6   2    1023.6274  884.2580   -180.0  1.14653  0.00   
+  2  1    11   0    793.3555   673.8595   0.0     1.14593  0.00   
+  2  3    -9   -3   7855.3155  6842.7549  -0.0    1.14539  0.01   
+  2  1    -11  0    56.7732    56.5171    180.0   1.14326  0.00   
+  2  7    -1   -2   256.1012   258.5173   180.0   1.14319  0.00   
+  2  2    10   1    2034.2258  2221.3310  -180.0  1.14260  0.00   
+  2  2    -6   -5   7599.7867  8280.7099  -0.0    1.14253  0.01   
+  2  5    -1   2    0.2350     0.2523     -180.0  1.14237  0.00   
+  2  4    -2   -6   178.8784   159.9954   -0.0    1.14109  0.00   
+  2  5    7    0    1766.9420  1584.2307  0.0     1.14103  0.00   
+  2  3    9    -4   3915.8636  3452.1120  -180.0  1.13977  0.00   
+  2  4    -2   3    778.9282   675.3480   180.0   1.13965  0.00   
+  2  2    -8   3    1114.9888  940.5804   180.0   1.13923  0.00   
+  2  5    1    2    177.3464   151.0052   180.0   1.13897  0.00   
+  2  2    -2   -6   531.5345   457.5743   180.0   1.13875  0.00   
+  2  5    1    -6   100.9961   92.8501    180.0   1.13644  0.00   
+  2  6    4    0    10306.6178 9886.1889  -180.0  1.13618  0.01   
+  2  1    9    -4   6885.1394  6387.1239  180.0   1.13575  0.00   
+  2  7    1    -4   112.0925   104.3489   0.0     1.13318  0.00   
+  2  5    -7   0    666.8924   561.3250   0.0     1.13270  0.00   
+  2  6    4    -5   4648.2983  3560.8356  -0.0    1.13225  0.00   
+  2  7    3    -3   2209.6003  1752.7599  180.0   1.13164  0.00   
+  2  1    7    -5   2221.7823  1876.4532  -0.0    1.13113  0.00   
+  2  4    4    -6   87.6282    74.0198    180.0   1.13073  0.00   
+  2  6    -4   0    10786.0951 8996.3605  -180.0  1.13052  0.01   
+  2  1    1    -6   15.4246    12.7255    180.0   1.13041  0.00   
+  2  4    2    3    35.2630    26.9687    0.0     1.12798  0.00   
+  2  1    11   -2   4508.9342  4054.5939  -180.0  1.12721  0.00   
+  2  2    4    -6   661.2322   617.9103   -180.0  1.12706  0.00   
+  2  1    -11  -1   84.0829    80.5660    180.0   1.12692  0.00   
+  2  0    6    -5   844.3575   825.3110   -0.0    1.12677  0.00   
+  2  0    10   -3   27.6591    25.1309    180.0   1.12560  0.00   
+  2  6    6    -4   1167.6875  1116.6065  -0.0    1.12535  0.00   
+  2  4    -8   1    1370.1935  1428.0735  -0.0    1.12500  0.00   
+  2  4    6    2    469.9281   491.6513   180.0   1.12497  0.00   
+  2  3    -3   -6   2626.0079  2679.1058  0.0     1.12421  0.00   
+  2  1    -11  1    545.7014   520.4388   180.0   1.12385  0.00   
+  2  3    -1   4    64.4957    62.3074    180.0   1.12290  0.00   
+  2  7    -1   -4   327.3067   340.7362   180.0   1.12266  0.00   
+  2  6    -6   -2   5.5388     5.8815     -0.0    1.12259  0.00   
+  2  5    -1   -6   3072.7142  3679.1020  -180.0  1.12188  0.00   
+  2  6    6    -1   16.7304    18.5196    -180.0  1.12105  0.00   
+  2  7    3    -2   403.6745   466.2613   -180.0  1.11981  0.00   
+  2  5    -5   -5   3491.6291  3254.1700  180.0   1.11710  0.00   
+  2  1    -1   -6   1715.6187  1573.1101  -180.0  1.11699  0.00   
+  2  4    -6   -5   13.0547    12.1624    -180.0  1.11621  0.00   
+  2  5    3    -6   3654.2001  3572.8767  0.0     1.11574  0.00   
+  2  3    1    4    595.2313   557.2568   180.0   1.11489  0.00   
+  2  4    8    1    3254.9027  3030.2470  -0.0    1.11486  0.00   
+  2  1    3    5    259.9757   208.8946   -180.0  1.11404  0.00   
+  2  2    -6   4    1972.5933  1626.0861  -0.0    1.11278  0.00   
+  2  6    -6   -3   12054.8218 9170.8262  180.0   1.11104  0.01   
+  2  5    -3   2    30.2131    23.9804    -180.0  1.11049  0.00   
+  2  3    5    -6   94.0408    75.3696    -0.0    1.11017  0.00   
+  2  1    3    -6   4562.6591  3749.4968  0.0     1.10915  0.01   
+  2  7    3    -4   1026.3013  851.8273   -0.0    1.10885  0.00   
+  2  7    -3   -3   9.5167     8.0510     -0.0    1.10731  0.00   
+  2  7    1    -1   620.2918   540.2195   -180.0  1.10485  0.00   
+  2  6    0    1    3169.3145  2851.2916  180.0   1.10441  0.00   
+  2  1    11   1    377.4256   353.4958   0.0     1.10278  0.00   
+  2  7    -3   -2   8.0729     7.6618     -0.0    1.10240  0.00   
+  2  4    10   -2   296.7663   293.9448   -180.0  1.10139  0.00   
+  2  7    -1   -1   568.8858   560.8360   -180.0  1.10125  0.00   
+  2  5    3    2    93.9965    92.4856    -180.0  1.10119  0.00   
+  2  2    8    -5   3811.6058  3728.5603  180.0   1.10077  0.00   
+  2  6    -6   -1   6.4090     6.2337     0.0     1.10033  0.00   
+  2  5    -7   -4   137.3671   136.6182   0.0     1.09716  0.00   
+  2  3    -3   4    143.4515   143.6453   -0.0    1.09706  0.00   
+  2  1    7    4    54.9678    57.0295    -0.0    1.09661  0.00   
+  2  0    8    4    2904.1769  2959.2417  180.0   1.09406  0.00   
+  2  4    -8   -4   3639.3329  3685.4545  -180.0  1.09399  0.00   
+  2  4    -4   3    2195.1776  2186.7268  180.0   1.09385  0.00   
+  2  3    -7   3    1822.7839  1814.2931  0.0     1.09384  0.00   
+  2  1    9    3    310.1889   308.2223   180.0   1.09383  0.00   
+  2  2    -10  2    3.6755     3.3265     -0.0    1.09247  0.00   
+  2  2    8    3    427.8097   379.8198   0.0     1.09126  0.00   
+  2  5    9    -2   1839.3867  1582.6840  -0.0    1.09021  0.00   
+  2  4    10   -1   1.7791     1.7369     -180.0  1.08903  0.00   
+  2  6    -2   1    1.5507     1.5406     -180.0  1.08894  0.00   
+  2  1    -5   5    5578.0082  5646.2565  0.0     1.08884  0.01   
+  2  6    2    1    250.2603   245.3481   -0.0    1.08745  0.00   
+  2  2    -10  -3   624.4303   617.4947   180.0   1.08733  0.00   
+  2  5    7    -5   87.8896    91.0318    -180.0  1.08704  0.00   
+  2  6    -4   -5   385.6511   422.0173   180.0   1.08477  0.00   
+  2  3    -7   -5   2689.9850  3180.2930  0.0     1.08232  0.00   
+  2  5    9    -3   30.5025    37.0056    -180.0  1.08217  0.00   
+  2  4    10   -3   389.1158   496.5346   180.0   1.08176  0.00   
+  2  4    8    -5   357.4595   416.8216   0.0     1.08002  0.00   
+  2  7    -3   -4   408.0059   475.9937   -180.0  1.08002  0.00   
+  2  3    11   -2   960.8294   1209.7235  180.0   1.07973  0.00   
+  2  3    -9   2    874.6878   1162.0253  -0.0    1.07952  0.00   
+  2  1    -11  -2   374.5168   505.5742   -0.0    1.07909  0.00   
+  2  3    11   -1   1892.6081  2531.9784  -180.0  1.07901  0.00   
+  2  4    -4   -6   54.5702    79.4879    0.0     1.07725  0.00   
+  2  7    3    -1   289.7702   517.9063   0.0     1.07642  0.00   
+  2  7    1    -5   13.8447    25.2106    -0.0    1.07626  0.00   
+  2  5    -3   -6   776.9945   1371.1187  180.0   1.07586  0.00   
+  2  2    10   -4   1615.6761  2842.5457  0.0     1.07584  0.00   
+  2  2    -4   -6   110.9013   186.5753   0.0     1.07568  0.00   
+  2  3    3    4    369.5962   560.4316   180.0   1.07511  0.00   
+  2  1    -11  2    397.4269   558.2780   -180.0  1.07370  0.00   
+  2  7    5    -3   707.7108   928.6481   180.0   1.07351  0.00   
+  2  4    4    3    630.7711   818.8776   180.0   1.07348  0.00   
+  2  1    -3   -6   110.4363   135.6225   180.0   1.07233  0.00   
+  2  6    0    -6   3.8636     4.1780     -180.0  1.07161  0.00   
+  2  1    11   -3   503.2134   540.3856   180.0   1.07008  0.00   
+  2  6    2    -6   101.9627   107.8329   0.0     1.06912  0.00   
+  2  6    -6   -4   610.4901   552.9788   0.0     1.06862  0.00   
+  2  5    9    -1   891.8488   1026.4794  0.0     1.06732  0.00   
+  2  2    6    4    3502.7753  4143.5979  0.0     1.06716  0.00   
+  2  7    -3   -1   141.8442   173.9010   0.0     1.06652  0.00   
+  2  2    0    5    1714.6064  1937.9253  0.0     1.06580  0.00   
+  2  0    6    5    312.4134   358.8678   0.0     1.06561  0.00   
+  2  7    -1   -5   2802.6536  3288.8085  0.0     1.06535  0.00   
+  2  5    5    -6   378.9910   447.2840   -180.0  1.06509  0.00   
+  2  0    0    6    44.7813    53.4823    180.0   1.06464  0.00   
+  2  0    10   3    2740.4512  3276.3246  0.0     1.06463  0.00   
+  2  4    6    -6   26.0667    31.3322    -180.0  1.06282  0.00   
+  2  6    6    -5   366.6816   434.3157   -0.0    1.06260  0.00   
+  2  0    12   0    97.0622    112.6819   180.0   1.06244  0.00   
+  2  4    -10  -1   1023.6427  1132.6677  180.0   1.06171  0.00   
+  2  7    5    -2   4091.7282  4496.3914  -180.0  1.06153  0.00   
+  2  0    2    -6   688.9413   748.1993   0.0     1.06104  0.00   
+  2  5    -7   1    880.4884   969.1237   180.0   1.06052  0.00   
+  2  1    -9   -4   1578.2950  1706.8793  -180.0  1.06015  0.00   
+  2  2    -2   5    3082.8878  3313.4198  -180.0  1.05994  0.00   
+  2  3    -9   -4   12.7169    13.6703    -180.0  1.05993  0.00   
+  2  2    6    -6   266.3175   288.6216   -180.0  1.05938  0.00   
+  2  0    12   -1   1292.8769  1340.4500  -0.0    1.05892  0.00   
+  2  1    -7   -5   7.2964     7.5059     -180.0  1.05860  0.00   
+  2  1    5    -6   46.0631    47.4061    -180.0  1.05858  0.00   
+  2  2    10   2    1186.5592  1237.1699  -0.0    1.05797  0.00   
+  2  3    7    3    12.2999    12.9031    -180.0  1.05758  0.00   
+  2  7    3    -5   2101.5128  2239.1302  -180.0  1.05718  0.00   
+  2  6    6    0    440.9747   461.7745   -0.0    1.05659  0.00   
+  2  7    5    -4   1683.2886  2051.4003  0.0     1.05581  0.00   
+  2  4    -10  -2   3085.9148  3145.7849  0.0     1.05450  0.00   
+  2  5    7    1    36.2287    37.2884    180.0   1.05440  0.00   
+  2  6    8    -3   7783.5543  8866.7538  -0.0    1.05196  0.01   
+  2  3    -11  -1   229.7340   261.5320   -0.0    1.05193  0.00   
+  2  5    -5   2    4899.1112  5387.0808  -180.0  1.05131  0.00   
+  2  3    9    2    803.6207   862.2832   -0.0    1.05108  0.00   
+  2  3    11   -3   647.4236   673.7850   180.0   1.05082  0.00   
+  2  6    -6   0    484.7602   488.9045   -0.0    1.04978  0.00   
+  2  6    8    -2   366.2591   331.3808   0.0     1.04899  0.00   
+  2  3    11   0    460.6132   407.0557   -0.0    1.04881  0.00   
+  2  3    -5   -6   1410.3793  1235.7557  -180.0  1.04872  0.00   
+  2  4    10   0    69.3855    61.4161    -0.0    1.04771  0.00   
+  2  5    -9   -2   2521.8515  2208.3085  -0.0    1.04729  0.00   
+  2  5    9    -4   255.0413   228.7958   -180.0  1.04516  0.00   
+  2  6    -2   -6   1459.4695  1293.5044  -0.0    1.04487  0.00   
+  2  6    -4   1    3568.3588  3160.5795  -0.0    1.04485  0.00   
+  2  3    -5   4    2735.0932  2301.6767  -0.0    1.04377  0.00   
+  2  3    9    -5   2124.7490  1817.7670  180.0   1.04328  0.00   
+  2  1    5    5    1853.9616  1623.2967  -0.0    1.04294  0.00   
+  2  3    -11  0    1586.6805  1387.3612  0.0     1.04270  0.00   
+  2  2    2    5    302.4130   264.3036   0.0     1.04269  0.00   
+  2  5    -9   -1   73.1339    62.5557    0.0     1.04240  0.00   
+  2  6    4    1    1211.1268  1021.8291  -0.0    1.04223  0.00   
+  2  4    -10  0    628.4200   554.7785   -0.0    1.04034  0.00   
+  2  2    12   -1   4330.9466  3828.0670  -180.0  1.03971  0.00   
+  2  0    2    6    1672.8453  1492.8101  0.0     1.03949  0.00   
+  2  7    -5   -3   3929.3390  3517.5593  180.0   1.03943  0.00   
+  2  5    5    2    4504.7069  4324.4718  -180.0  1.03825  0.00   
+  2  4    -8   2    304.3145   298.1823   -0.0    1.03802  0.00   
+  2  6    4    -6   1271.2246  1251.2761  -180.0  1.03798  0.00   
+  2  0    12   1    314.4062   335.8693   -0.0    1.03750  0.00   
+  2  7    -5   -2   1331.7016  1492.9651  -180.0  1.03709  0.00   
+  2  7    1    0    1109.4450  1264.8986  -0.0    1.03656  0.00   
+  2  1    -9   4    2.3272     2.8086     180.0   1.03594  0.00   
+  2  1    11   2    1383.0668  1702.3367  180.0   1.03580  0.00   
+  2  7    -1   0    1335.4030  1823.6465  -0.0    1.03529  0.00   
+  2  4    10   -4   6.5283     9.1218     0.0     1.03486  0.00   
+  2  3    -11  -2   1090.4215  1522.0493  -180.0  1.03326  0.00   
+  3  1    1    0    1650.0779  1271.8362  -0.0    3.25053  0.05   
+  3  1    0    1    663.1565   492.3113   -0.0    2.48939  0.02   
+  3  2    0    0    245.8448   149.3210   -0.0    2.29847  0.00   
+  3  1    1    1    311.4178   374.9378   180.0   2.18903  0.01   
+  3  2    1    0    137.4917   152.7063   0.0     2.05581  0.00   
+  3  2    1    1    873.1617   880.1063   -0.0    1.68873  0.03   
+  3  2    2    0    1033.3961  1142.5848  -0.0    1.62526  0.01   
+  3  0    0    2    2158.1296  1418.7512  -0.0    1.48058  0.01   
+  3  3    1    0    358.0959   356.6537   -0.0    1.45368  0.00   
+  3  2    2    1    25.6838    28.2249    180.0   1.42477  0.00   
+  3  3    0    1    845.0413   1054.9284  -0.0    1.36090  0.01   
+  3  1    1    2    402.4404   541.7701   -0.0    1.34739  0.00   
+  3  3    1    1    57.3192    32.7359    0.0     1.30492  0.00   
+  3  3    2    0    12.4211    15.0136    180.0   1.27496  0.00   
+  3  2    0    2    137.9878   145.3496   -0.0    1.24470  0.00   
+  3  2    1    2    46.5608    42.1765    0.0     1.20143  0.00   
+  3  3    2    1    135.2056   154.4569   -0.0    1.17103  0.00   
+  3  4    0    0    495.1209   421.9544   -0.0    1.14924  0.00   
+  3  4    1    0    82.1883    78.6279    180.0   1.11492  0.00   
+  3  2    2    2    532.7163   562.6941   -0.0    1.09451  0.01   
+  3  3    3    0    490.1220   591.9554   -0.0    1.08351  0.00   
+  3  4    1    1    323.2085   271.6222   -0.0    1.04341  0.01   
+  3  3    1    2    196.9284   220.8343   -0.0    1.03729  0.00   
+  4  1    1    0    8319.2412  5230.8975  0.0     5.76555  0.01   
+  4  1    1    -1   2184.5526  1404.6948  0.0     5.75354  0.00   
+  4  0    0    2    10288.0565 6635.0705  0.0     5.70305  0.00   
+  4  2    0    0    710.1380   777.6758   180.0   5.30534  0.00   
+  4  2    0    -2   9663.1365  11507.8256 0.0     5.26818  0.00   
+  4  1    1    1    3812.1828  5912.0003  -180.0  4.69686  0.00   
+  4  1    1    -2   304.7925   470.9216   -180.0  4.67743  0.00   
+  4  1    1    2    1455.1746  1807.7676  -180.0  3.62858  0.00   
+  4  1    1    -3   5346.1865  6212.3576  180.0   3.61365  0.00   
+  4  0    2    0    7123.2869  1738.4352  180.0   3.43395  0.00   
+  4  3    1    -1   2309.1875  1015.6499  -0.0    3.40713  0.00   
+  4  3    1    -2   6205.4066  3189.2181  180.0   3.39969  0.00   
+  4  0    2    1    6132.1253  5007.9341  -0.0    3.28817  0.00   
+  4  2    0    2    12762.9222 11586.9372 -0.0    3.21884  0.00   
+  4  2    0    -4   5309.5047  4998.0528  180.0   3.19396  0.00   
+  4  3    1    0    2454.4753  2138.0352  0.0     3.14442  0.00   
+  4  3    1    -3   3159.5267  2676.2849  180.0   3.12697  0.00   
+  4  4    0    -2   94800.1139 80939.0869 -180.0  2.98311  0.01   
+  4  2    2    -1   90018.8321 75055.6669 -0.0    2.97619  0.02   
+  4  0    2    2    801.3809   793.0056   0.0     2.94183  0.00   
+  4  2    2    0    963.3578   1809.8986  0.0     2.88278  0.00   
+  4  2    2    -2   305.5644   529.5412   -0.0    2.87677  0.00   
+  4  1    1    3    1917.4844  2484.6750  -0.0    2.86366  0.00   
+  4  1    1    -4   4664.6596  5799.3026  -0.0    2.85338  0.00   
+  4  0    0    4    8233.8760  10330.0128 -0.0    2.85152  0.00   
+  4  3    1    1    2864.8061  3753.7637  -180.0  2.75756  0.00   
+  4  3    1    -4   2668.4721  3263.6308  -0.0    2.73799  0.00   
+  4  4    0    0    74856.9508 71065.3522 0.0     2.65267  0.01   
+  4  2    2    1    147225.6063 133018.2915 0.0     2.64315  0.02   
+  4  2    2    -3   74145.9591 66287.2123 -180.0  2.63390  0.01   
+  4  4    0    -4   157240.3959 140601.5020 180.0   2.63409  0.01   
+  4  0    2    3    16113.7630 14182.3578 180.0   2.54839  0.00   
+  4  3    1    2    10127.5374 9773.7716  -180.0  2.37524  0.00   
+  4  3    1    -5   5924.5595  5861.4597  -0.0    2.35774  0.00   
+  4  2    2    2    153.4404   143.8207   -180.0  2.34843  0.00   
+  4  2    2    -4   1040.9352  881.6551   180.0   2.33872  0.00   
+  4  1    1    4    3736.7731  2964.2005  -0.0    2.33565  0.00   
+  4  1    1    -5   455.7801   299.6843   -0.0    2.32848  0.00   
+  4  4    2    -2   1577.3771  1408.3961  -0.0    2.25202  0.00   
+  4  5    1    -2   2261.7406  2124.2649  180.0   2.24512  0.00   
+  4  5    1    -3   555.3663   539.4431   180.0   2.24157  0.00   
+  4  1    3    0    53.0892    52.4920    0.0     2.23781  0.00   
+  4  1    3    -1   4226.2493  4185.4865  -0.0    2.23711  0.00   
+  4  4    2    -1   908.0041   918.6950   0.0     2.21209  0.00   
+  4  4    2    -3   12467.8131 13302.6909 -0.0    2.20666  0.00   
+  4  0    2    4    824.6309   967.0855   180.0   2.19377  0.00   
+  4  5    1    -1   8176.0337  11524.8599 -0.0    2.16607  0.00   
+  4  1    3    1    647.3532   1032.2056  -0.0    2.15698  0.00   
+  4  1    3    -2   6789.7370  10974.1049 0.0     2.15509  0.00   
+  4  5    1    -4   443.5413   710.2140   -180.0  2.15655  0.00   
+  4  2    0    4    1324.0103  1631.1816  0.0     2.13688  0.00   
+  4  2    0    -6   6549.2701  7205.4541  0.0     2.12472  0.00   
+  4  4    2    0    516.7090   728.6225   -180.0  2.09927  0.00   
+  4  4    2    -4   376.4777   548.8603   -180.0  2.09002  0.00   
+  4  4    0    2    272830.1719 285819.3975 180.0   2.07015  0.01   
+  4  2    2    3    290471.7930 292811.2059 0.0     2.06340  0.03   
+  4  2    2    -5   279438.2344 297121.0150 0.0     2.05462  0.03   
+  4  4    0    -6   284757.2508 302255.2171 -180.0  2.05252  0.01   
+  4  3    1    3    1038.8312  1081.3390  -180.0  2.04824  0.00   
+  4  3    1    -6   141.5870   154.7174   -0.0    2.03380  0.00   
+  4  5    1    0    640.4147   771.2571   180.0   2.02755  0.00   
+  4  1    3    2    10536.1323 14025.8755 -0.0    2.01802  0.00   
+  4  1    3    -3   951.4253   1239.2459  -0.0    2.01544  0.00   
+  4  5    1    -5   10987.9103 14161.8097 -0.0    2.01457  0.00   
+  4  3    3    -1   6981.9249  7028.1588  -0.0    1.97739  0.00   
+  4  3    3    -2   187.6456   188.2835   0.0     1.97593  0.00   
+  4  1    1    5    4495.7771  4613.5735  180.0   1.96098  0.00   
+  4  6    0    -2   958.9710   971.2900   180.0   1.96202  0.00   
+  4  1    1    -6   1433.0288  1561.1079  -0.0    1.95579  0.00   
+  4  6    0    -4   15909.8581 17271.3905 -180.0  1.95635  0.00   
+  4  4    2    1    17480.8589 20969.0382 -0.0    1.94314  0.00   
+  4  4    2    -5   62.0981    70.9606    180.0   1.93216  0.00   
+  4  3    3    0    8928.8817  9842.9144  180.0   1.92185  0.00   
+  4  3    3    -3   2491.5227  2771.3393  -0.0    1.91785  0.00   
+  4  0    0    6    1558.9764  1705.9742  -0.0    1.90102  0.00   
+  4  0    2    5    82.9473    90.1521    -180.0  1.90015  0.00   
+  4  5    1    1    2822.4259  2501.9487  -180.0  1.86099  0.00   
+  4  1    3    3    3302.1961  3425.2133  0.0     1.85201  0.00   
+  4  1    3    -4   477.7307   509.1266   -180.0  1.84922  0.00   
+  4  5    1    -6   2718.5113  2899.2946  -180.0  1.84697  0.00   
+  4  3    3    1    3263.8533  3297.9941  -0.0    1.82236  0.00   
+  4  3    3    -4   14294.0882 15085.8470 -180.0  1.81668  0.00   
+  4  2    2    4    1880.9426  2005.0453  180.0   1.81429  0.00   
+  4  2    2    -6   105.9589   110.9061   -0.0    1.80682  0.00   
+  4  3    1    4    1137.4136  1171.2225  -0.0    1.78216  0.00   
+  4  4    2    2    782.3770   570.1032   -0.0    1.77291  0.00   
+  4  3    1    -7   1131.8410  721.1980   -180.0  1.77053  0.00   
+  4  6    0    0    59782.1732 33133.1198 180.0   1.76845  0.00   
+  4  4    2    -6   3512.8811  1198.9309  -0.0    1.76180  0.00   
+  4  6    0    -6   5.8176     2.0503     0.0     1.75606  0.00   
+  4  6    2    -3   388756.2840 370223.1653 -180.0  1.72096  0.02   
+  4  0    4    0    362390.0004 349094.6184 -180.0  1.71698  0.01   
+  4  6    2    -2   535.5774   389.7845   -0.0    1.70356  0.00   
+  4  6    2    -4   2274.6481  1560.6809  180.0   1.69985  0.00   
+  4  0    4    1    4845.0128  3260.3097  -0.0    1.69785  0.00   
+  4  3    3    2    5349.5416  3601.7812  -0.0    1.69795  0.00   
+  4  3    3    -5   13988.6257 10539.6761 0.0     1.69153  0.00   
+  4  5    1    2    3373.5709  2567.9366  -180.0  1.69126  0.00   
+  4  1    1    6    887.2197   741.9382   -0.0    1.68512  0.00   
+  4  1    3    4    55.1564    44.9721    -0.0    1.68331  0.00   
+  4  1    1    -7   15655.8909 12427.4639 -180.0  1.68122  0.00   
+  4  1    3    -5   5923.8565  4682.3563  0.0     1.68062  0.00   
+  4  5    1    -7   334.7556   265.9545   -180.0  1.67774  0.00   
+  4  0    2    6    1061.1460  1003.9433  0.0     1.66317  0.00   
+  4  2    4    -1   2958.3410  2845.3491  180.0   1.65001  0.00   
+  4  6    2    -1   897.3654   866.2401   -180.0  1.65097  0.00   
+  4  7    1    -3   36.7715    35.5149    180.0   1.65109  0.00   
+  4  5    3    -2   352.0071   336.9892   -180.0  1.64846  0.00   
+  4  7    1    -4   581.8513   558.0282   -0.0    1.64911  0.00   
+  4  5    3    -3   1291.9187  1233.8660  -180.0  1.64705  0.00   
+  4  0    4    2    637.8122   611.9468   -180.0  1.64408  0.00   
+  4  6    2    -5   527.3448   505.6692   -180.0  1.64422  0.00   
+  4  2    4    0    725.8900   753.9382   -0.0    1.63356  0.00   
+  4  2    4    -2   4301.3285  4464.8969  180.0   1.63246  0.00   
+  4  7    1    -2   3649.2739  3574.0709  180.0   1.61941  0.00   
+  4  5    3    -1   1023.5333  967.2983   0.0     1.61640  0.00   
+  4  7    1    -5   994.4656   917.7709   -0.0    1.61383  0.00   
+  4  5    3    -4   4205.0683  3838.3842  -180.0  1.61243  0.00   
+  4  4    0    4    71409.4264 64381.9461 180.0   1.60942  0.00   
+  4  4    2    3    30.4933    27.4318    180.0   1.60785  0.00   
+  4  2    2    5    42237.9212 37134.0233 -180.0  1.60520  0.00   
+  4  2    2    -7   91578.5556 66541.2306 0.0     1.59899  0.00   
+  4  4    2    -7   3742.4238  2583.0374  -0.0    1.59749  0.00   
+  4  4    0    -8   54378.8021 36952.8051 0.0     1.59698  0.00   
+  4  2    4    1    2434.2253  1925.9734  0.0     1.58601  0.00   
+  4  2    4    -3   2298.7776  1877.8066  0.0     1.58400  0.00   
+  4  2    0    6    30456.3372 28897.4638 -0.0    1.57530  0.00   
+  4  6    2    0    329.6208   317.5013   -0.0    1.57221  0.00   
+  4  2    0    -8   5006.0797  4975.6390  -180.0  1.56847  0.00   
+  4  3    1    5    1743.3082  1738.5834  180.0   1.56804  0.00   
+  4  3    3    3    481.4802   485.0224   0.0     1.56562  0.00   
+  4  0    4    3    2895.3865  2916.6659  -0.0    1.56481  0.00   
+  4  6    2    -6   1243.1212  1248.0060  -180.0  1.56348  0.00   
+  4  3    3    -6   1531.1187  1493.3859  -180.0  1.55914  0.00   
+  4  3    1    -8   1915.1601  1859.0381  0.0     1.55867  0.00   
+  4  7    1    -1   2088.0415  2043.5569  -0.0    1.55949  0.00   
+  4  5    3    0    3971.5322  3765.4430  180.0   1.55632  0.00   
+  4  7    1    -6   4188.9415  3788.8467  -180.0  1.55121  0.00   
+  4  5    3    -5   1571.0818  1408.2677  0.0     1.55043  0.00   
+  4  5    1    3    1095.9528  787.2913   0.0     1.53242  0.00   
+  4  1    3    5    9.9058     7.3882     -180.0  1.52560  0.00   
+  4  1    3    -6   1618.4811  1156.1808  0.0     1.52315  0.00   
+  4  5    1    -8   7.8646     5.3626     0.0     1.52012  0.00   
+  4  2    4    2    5594.2539  4258.2315  180.0   1.51493  0.00   
+  4  2    4    -4   2991.2636  2489.4083  -0.0    1.51231  0.00   
+  4  6    0    2    9111.6777  8933.0441  180.0   1.50546  0.00   
+  4  6    0    -8   4536.7318  4388.1258  -180.0  1.49275  0.00   
+  4  8    0    -4   21403.1010 20124.4891 0.0     1.49155  0.00   
+  4  4    4    -2   24529.3783 20516.6042 -0.0    1.48809  0.00   
+  4  7    1    0    733.1584   522.5481   0.0     1.48019  0.00   
+  4  6    2    1    712.1334   506.2593   180.0   1.47827  0.00   
+  4  5    3    1    2078.5122  1471.0036  180.0   1.47707  0.00   
+  4  4    4    -1   255.6976   180.6123   180.0   1.47640  0.00   
+  4  1    1    7    12900.6279 9078.3301  -0.0    1.47499  0.00   
+  4  4    4    -3   2374.8847  1670.1467  180.0   1.47478  0.00   
+  4  1    1    -8   10332.9350 7396.6827  0.0     1.47197  0.00   
+  4  0    2    7    3501.3581  2501.2121  180.0   1.47212  0.00   
+  4  0    4    4    805.8542   584.8425   180.0   1.47091  0.00   
+  4  5    3    -6   0.2445     0.1792     -180.0  1.47003  0.00   
+  4  7    1    -7   317.8257   232.1950   -180.0  1.47030  0.00   
+  4  6    2    -7   1448.1003  1083.3730  180.0   1.46861  0.00   
+  4  4    2    4    343.4415   309.1562   -180.0  1.45730  0.00   
+  4  4    2    -8   305.2822   302.7739   -180.0  1.44805  0.00   
+  4  8    0    -2   52590.0962 52330.8230 0.0     1.44605  0.00   
+  4  4    4    0    41712.6576 40429.3778 -180.0  1.44139  0.00   
+  4  8    0    -6   41832.4530 39529.4275 -180.0  1.44000  0.00   
+  4  4    4    -4   59639.7017 54156.0501 0.0     1.43838  0.00   
+  4  3    3    4    5287.3269  4621.2299  -180.0  1.43672  0.00   
+  4  2    2    6    0.9634     0.8067     -180.0  1.43183  0.00   
+  4  3    3    -7   1689.8053  1449.6465  0.0     1.43061  0.00   
+  4  2    4    3    3066.1159  2700.3242  180.0   1.42962  0.00   
+  4  2    2    -8   1905.5891  1820.9010  -0.0    1.42669  0.00   
+  4  2    4    -5   1751.2476  1673.4947  180.0   1.42669  0.00   
+  4  0    0    8    274600.1432 266702.1198 -0.0    1.42576  0.01   
+  4  3    1    6    1260.0796  938.5133   180.0   1.39490  0.00   
+  4  5    1    4    879.0204   766.5576   0.0     1.39016  0.00   
+  4  7    1    1    58.4751    50.2176    -180.0  1.39072  0.00   
+  4  3    1    -9   745.1162   708.1614   -0.0    1.38728  0.00   
+  4  4    4    1    3861.4245  3625.4850  -0.0    1.38775  0.00   
+  4  5    3    2    472.6317   443.0593   -180.0  1.38780  0.00   
+  4  1    3    6    3177.9226  3150.0852  0.0     1.38440  0.00   
+  4  4    4    -5   1231.9173  1225.1621  0.0     1.38373  0.00   
+  4  1    3    -7   486.9450   485.8196   -180.0  1.38224  0.00   
+  4  5    3    -7   1061.5536  1076.1947  180.0   1.38030  0.00   
+  4  7    1    -8   227.9675   231.5071   0.0     1.38019  0.00   
+  4  5    1    -9   3077.7139  3164.8132  -0.0    1.37931  0.00   
+  4  6    2    2    247.0076   255.5793   -180.0  1.37878  0.00   
+  4  0    4    5    363.9512   361.2698   -180.0  1.37183  0.00   
+  4  6    2    -8   3.3380     2.8506     0.0     1.36899  0.00   
+  4  8    2    -4   902.6292   739.6027   180.0   1.36807  0.00   
+  4  7    3    -3   3944.2750  3200.8888  -180.0  1.36535  0.00   
+  4  7    3    -4   539.4662   462.8739   -180.0  1.36423  0.00   
+  4  1    5    0    4533.4102  4375.6610  -180.0  1.36221  0.00   
+  4  1    5    -1   59.0555    57.4577    -0.0    1.36206  0.00   
+  4  8    2    -3   1887.5785  1924.2275  180.0   1.35960  0.00   
+  4  8    2    -5   14650.4732 14164.8560 180.0   1.35708  0.00   
+  4  7    3    -2   6187.9802  6977.6508  0.0     1.34727  0.00   
+  4  1    5    1    7427.9141  7444.3720  0.0     1.34334  0.00   
+  4  7    3    -5   2318.8860  2393.1905  180.0   1.34405  0.00   
+  4  1    5    -2   2870.4485  2804.6259  180.0   1.34289  0.00   
+  4  2    4    4    284.3693   204.8344   -180.0  1.33845  0.00   
+  4  2    4    -6   5900.8938  4278.1404  180.0   1.33544  0.00   
+  4  8    2    -2   223.3683   192.3915   0.0     1.33271  0.00   
+  4  8    2    -6   110.3665   116.8197   0.0     1.32797  0.00   
+  4  8    0    0    119739.8316 126741.6843 0.0     1.32634  0.00   
+  4  4    2    5    12241.0704 12813.0878 0.0     1.32419  0.00   
+  4  4    4    2    106181.8748 113935.1500 0.0     1.32157  0.00   
+  4  0    2    8    320.7775   368.4296   180.0   1.31677  0.00   
+  4  4    4    -6   105062.9337 120764.9996 0.0     1.31695  0.00   
+  4  3    3    5    1083.3043  1245.7871  -0.0    1.31725  0.00   
+  4  4    2    -9   4845.6469  5527.4645  180.0   1.31609  0.00   
+  4  8    0    -8   121156.0685 139298.5816 -0.0    1.31704  0.00   
+  4  3    3    -8   7562.7663  7103.8611  180.0   1.31168  0.00   
+  4  7    3    -1   1065.8428  1033.1476  180.0   1.31217  0.00   
+  4  1    1    8    183.9969   157.0065   180.0   1.31024  0.00   
+  4  1    1    -9   974.6043   715.4446   180.0   1.30784  0.00   
+  4  1    5    2    2385.5718  1740.2895  180.0   1.30770  0.00   
+  4  1    5    -3   10308.1650 7329.8703  -0.0    1.30700  0.00   
+  4  7    3    -6   10535.5412 7549.3128  -0.0    1.30723  0.00   
+  4  6    4    -3   2838.6817  2359.8971  -0.0    1.29963  0.00   
+  4  9    1    -4   1034.9589  841.6525   0.0     1.30030  0.00   
+  4  9    1    -5   304.7984   257.0573   0.0     1.29906  0.00   
+  4  7    1    2    4672.4760  3973.2248  -180.0  1.29857  0.00   
+  4  3    5    -1   730.4803   623.7421   0.0     1.29645  0.00   
+  4  3    5    -2   2583.9825  2194.6100  -0.0    1.29604  0.00   
+  4  5    3    3    395.8740   335.5558   180.0   1.29592  0.00   
+  4  6    4    -2   28.9563    25.6557    0.0     1.29209  0.00   
+  4  4    0    6    19546.1361 18457.9678 180.0   1.29069  0.00   
+  4  6    4    -4   7480.0317  7150.3866  -0.0    1.29046  0.00   
+  4  8    2    -1   9358.3623  8926.3544  180.0   1.29051  0.00   
+  4  5    3    -8   3299.9142  3487.9767  180.0   1.28846  0.00   
+  4  7    1    -9   124.5778   133.2219   180.0   1.28810  0.00   
+  4  2    2    7    15036.4118 16132.0134 -0.0    1.28797  0.00   
+  4  2    2    -9   17796.0421 19772.4866 0.0     1.28370  0.00   
+  4  8    2    -7   387.7377   429.9160   -180.0  1.28407  0.00   
+  4  9    1    -3   5004.4363  5511.7443  180.0   1.28492  0.00   
+  4  4    0    -10  18195.8788 20663.2288 -180.0  1.28212  0.00   
+  4  3    5    0    620.9775   722.7977   -0.0    1.28041  0.00   
+  4  9    1    -6   161.9463   186.6873   -0.0    1.28133  0.00   
+  4  6    2    3    0.3277     0.3811     180.0   1.28055  0.00   
+  4  3    5    -3   5194.6475  6055.8158  -0.0    1.27923  0.00   
+  4  0    4    6    103.3834   118.7931   180.0   1.27420  0.00   
+  4  6    2    -9   393.7876   465.5651   180.0   1.27115  0.00   
+  4  6    4    -1   397.8794   482.3971   -180.0  1.26868  0.00   
+  4  6    4    -5   503.6962   582.4177   -180.0  1.26561  0.00   
+  4  5    1    5    4004.5797  4611.0614  180.0   1.26549  0.00   
+  4  6    0    4    6256.4030  7261.8554  180.0   1.26573  0.00   
+  4  7    3    0    744.3224   803.3752   180.0   1.26387  0.00   
+  4  1    3    7    7768.5771  8425.0002  -0.0    1.26063  0.00   
+  4  1    5    3    31.3603    35.3370    180.0   1.25912  0.00   
+  4  1    3    -8   2748.5072  3098.0510  180.0   1.25875  0.00   
+  4  1    5    -4   2776.2465  3108.3397  180.0   1.25824  0.00   
+  4  7    3    -7   2196.4576  2425.1160  180.0   1.25770  0.00   
+  4  5    1    -10  6728.6174  7049.3284  -180.0  1.25604  0.00   
+  4  6    0    -10  116.1147   117.7654   -180.0  1.25515  0.00   
+  4  3    1    7    1701.8665  1612.3476  -0.0    1.25338  0.00   
+  4  9    1    -2   364.4918   362.0494   0.0     1.25462  0.00   
+  4  3    5    1    9376.9652  8362.0871  0.0     1.24968  0.00   
+  4  4    4    3    18.0909    16.4611    0.0     1.24880  0.00   
+  4  9    1    -7   9684.5467  8740.6456  -180.0  1.24906  0.00   
+  4  3    5    -4   1160.9692  1094.7657  -0.0    1.24785  0.00   
+  4  3    1    -10  3089.1695  2988.3394  180.0   1.24712  0.00   
+  4  2    4    5    1209.6250  1152.6329  0.0     1.24756  0.00   
+  4  2    4    -7   774.2027   792.0635   0.0     1.24464  0.00   
+  4  4    4    -7   6356.7630  6549.1904  -0.0    1.24393  0.00   
+  4  2    0    8    26.7786    27.7310    -0.0    1.24185  0.00   
+  4  2    0    -10  2109.4533  2005.3709  180.0   1.23753  0.00   
+  4  8    2    0    781.0604   732.9650   180.0   1.23725  0.00   
+  4  6    4    0    16955.0885 14166.3731 -0.0    1.23188  0.00   
+  4  8    2    -8   643.4343   628.2707   180.0   1.22970  0.00   
+  4  6    4    -6   122.6446   129.8084   -180.0  1.22767  0.00   
+  4  9    1    -1   3360.0244  2739.1076  -0.0    1.21242  0.00   
+  4  3    3    6    1021.3794  849.7648   0.0     1.20953  0.00   
+  4  4    2    6    494.2204   411.8534   -0.0    1.20817  0.00   
+  4  7    1    3    87.8793    73.2733    180.0   1.20880  0.00   
+  4  3    5    2    4520.3552  3751.2810  0.0     1.20730  0.00   
+  4  5    3    4    9105.4811  7536.3316  -180.0  1.20644  0.00   
+  4  7    3    1    3308.0249  2739.0596  180.0   1.20680  0.00   
+  4  3    5    -5   58.4480    48.9052    180.0   1.20499  0.00   
+  4  3    3    -9   1124.4761  946.3437   -0.0    1.20455  0.00   
+  4  9    1    -8   2790.4914  2323.6447  0.0     1.20542  0.00   
+  4  1    5    4    4406.9587  3945.7493  180.0   1.20201  0.00   
+  4  4    2    -10  179.3582   165.7189   -0.0    1.20113  0.00   
+  4  1    5    -5   709.2981   658.0206   0.0     1.20103  0.00   
+  4  7    3    -8   5.6579     5.4469     0.0     1.19990  0.00   
+  4  5    3    -9   308.2038   300.8905   180.0   1.19932  0.00   
+  4  7    1    -10  8424.1812  8303.3471  -180.0  1.19881  0.00   
+  4  0    2    9    364.4479   269.5198   -0.0    1.18896  0.00   
+  4  5    5    -2   4102.7532  3032.8365  -0.0    1.18912  0.00   
+  4  5    5    -3   0.1365     0.1013     -0.0    1.18859  0.00   
+  4  6    2    4    351.0060   267.9725   180.0   1.18762  0.00   
+  4  10   0    -4   8978.9429  6799.2490  0.0     1.18782  0.00   
+  4  10   0    -6   13103.3720 11101.1633 0.0     1.18572  0.00   
+  4  6    4    1    1512.9901  1321.7259  0.0     1.18510  0.00   
+  4  0    4    7    301.7880   286.3156   180.0   1.18192  0.00   
+  4  6    4    -7   1816.1781  1789.0894  0.0     1.18011  0.00   
+  4  6    2    -10  2.1817     2.2223     -0.0    1.17887  0.00   
+  4  1    1    9    116.9930   122.6223   -0.0    1.17791  0.00   
+  4  8    0    2    30210.2800 31220.8212 180.0   1.17837  0.00   
+  4  5    5    -1   6759.6114  7332.3903  -180.0  1.17692  0.00   
+  4  1    1    -10  682.1621   763.1089   180.0   1.17597  0.00   
+  4  8    2    1    5461.2561  5832.8061  -180.0  1.17735  0.00   
+  4  5    5    -4   4929.0765  5571.7291  -0.0    1.17538  0.00   
+  4  4    4    4    29704.7266 33802.0952 0.0     1.17421  0.00   
+  4  4    4    -8   27637.2319 28621.5898 -180.0  1.16936  0.00   
+  4  8    2    -9   8153.2398  8422.9400  180.0   1.16922  0.00   
+  4  8    0    -10  37418.6238 38278.1410 0.0     1.16862  0.00   
+  4  2    2    8    99.4831    100.3637   0.0     1.16783  0.00   
+  4  2    2    -10  565.9596   559.8646   -0.0    1.16424  0.00   
+  4  2    4    6    15995.2960 13795.2627 180.0   1.16077  0.00   
+  4  9    1    0    195.7040   175.9851   180.0   1.16197  0.00   
+  4  2    4    -8   2900.9398  2419.5319  0.0     1.15802  0.00   
+  4  3    5    3    3749.1829  3138.2953  0.0     1.15688  0.00   
+  4  5    1    6    60.3418    50.4263    0.0     1.15718  0.00   
+  4  3    5    -6   60.9973    51.9951    -0.0    1.15426  0.00   
+  4  9    1    -9   663.7626   565.9331   180.0   1.15406  0.00   
+  4  1    3    8    3232.8100  2762.9987  0.0     1.15308  0.00   
+  4  5    5    0    7812.7502  6676.9914  -0.0    1.15311  0.00   
+  4  1    3    -9   1.5622     1.3349     -0.0    1.15145  0.00   
+  4  5    5    -5   9932.1858  8525.8413  -180.0  1.15071  0.00   
+  4  5    1    -11  1735.5224  1514.2809  0.0     1.14899  0.00   
+  4  9    3    -4   483.1532   427.3228   0.0     1.14629  0.00   
+  4  0    6    0    2895.2819  2615.5401  -0.0    1.14465  0.00   
+  4  9    3    -5   72.9624    64.9448    -0.0    1.14543  0.00   
+  4  7    3    2    5476.5700  4901.6765  -0.0    1.14510  0.00   
+  4  0    0    10   469.7342   424.1488   -0.0    1.14061  0.00   
+  4  1    5    5    5615.4242  5051.9554  -0.0    1.14045  0.00   
+  4  10   0    -2   17434.1353 15994.2642 0.0     1.14128  0.00   
+  4  1    5    -6   6066.1717  5316.7856  180.0   1.13942  0.00   
+  4  0    6    1    1906.8702  1651.7973  180.0   1.13893  0.00   
+  4  7    3    -9   5493.7803  4667.3076  180.0   1.13790  0.00   
+  4  3    1    8    78.9548    68.5373    180.0   1.13627  0.00   
+  4  10   0    -8   1664.5333  1449.5013  0.0     1.13572  0.00   
+  4  9    3    -3   1638.7690  1427.0322  -180.0  1.13571  0.00   
+  4  9    3    -6   2137.1630  1857.0308  -0.0    1.13323  0.00   
+  4  3    1    -11  36.9086    30.9608    0.0     1.13105  0.00   
+  4  6    4    2    3367.8886  2829.0009  0.0     1.13196  0.00   
+  4  6    4    -8   2297.1294  2100.5904  -0.0    1.12652  0.00   
+  4  10   2    -5   7049.4540  6273.0076  0.0     1.12713  0.00   
+  4  8    4    -4   4481.7221  4167.9645  -180.0  1.12601  0.00   
+  4  2    6    -1   3664.0290  3572.9337  180.0   1.12415  0.00   
+  4  7    1    4    5056.9873  4926.0778  -0.0    1.12430  0.00   
+  4  0    6    2    1330.5228  1379.3367  -180.0  1.12227  0.00   
+  4  5    3    5    1896.6458  1970.5581  -180.0  1.12222  0.00   
+  4  10   2    -4   8.8627     9.0494     180.0   1.12256  0.00   
+  4  8    4    -3   3107.5798  3323.0752  -180.0  1.12127  0.00   
+  4  10   2    -6   160.3322   172.4634   180.0   1.12078  0.00   
+  4  5    5    1    654.2548   712.2485   0.0     1.11974  0.00   
+  4  8    4    -5   949.3100   1032.3692  180.0   1.11986  0.00   
+  4  2    6    0    4905.3939  5322.4758  180.0   1.11890  0.00   
+  4  2    6    -2   927.1866   994.3573   180.0   1.11855  0.00   
+  4  5    5    -6   2615.6887  2508.4811  0.0     1.11667  0.00   
+  4  5    3    -10  1716.5325  1596.9477  -0.0    1.11562  0.00   
+  4  7    1    -11  2291.4325  2083.8079  180.0   1.11504  0.00   
+  4  3    3    7    8357.6054  7164.3298  0.0     1.11376  0.00   
+  4  9    3    -2   2268.0489  2020.5894  0.0     1.11462  0.00   
+  4  8    2    2    135.8207   120.7256   0.0     1.11458  0.00   
+  4  9    3    -7   2165.4331  1752.2705  -180.0  1.11072  0.00   
+  4  3    3    -10  317.2785   264.2304   -0.0    1.10935  0.00   
+  4  4    2    7    10776.2730 9265.6668  0.0     1.10753  0.00   
+  4  8    2    -10  41.4765    36.5514    0.0     1.10631  0.00   
+  4  10   2    -3   40826.5523 35155.7336 -180.0  1.10745  0.00   
+  4  9    1    1    4359.3891  3807.3992  -180.0  1.10676  0.00   
+  4  8    4    -2   33186.1678 29375.1685 -180.0  1.10604  0.00   
+  4  2    6    1    29637.0445 27649.7218 -180.0  1.10326  0.00   
+  4  10   2    -7   38103.5824 34974.9980 0.0     1.10405  0.00   
+  4  8    4    -6   32365.5184 30158.4734 0.0     1.10333  0.00   
+  4  2    6    -3   31692.8738 29925.8627 0.0     1.10259  0.00   
+  4  4    2    -11  2259.0827  2173.9599  -0.0    1.10143  0.00   
+  4  3    5    4    73.7008    70.5133    0.0     1.10185  0.00   
+  4  6    2    5    138338.8131 132168.0212 -180.0  1.10194  0.00   
+  4  4    4    5    2796.9686  2698.4902  180.0   1.10116  0.00   
+  4  3    5    -7   3014.7727  2941.2963  0.0     1.09909  0.00   
+  4  9    1    -10  286.2793   280.1095   0.0     1.09842  0.00   
+  4  0    4    8    134535.1882 133981.2566 -180.0  1.09689  0.00   
+  4  4    4    -9   134.0072   134.2336   0.0     1.09649  0.00   
+  4  0    6    3    3388.0182  3404.3078  -0.0    1.09606  0.00   
+  4  6    2    -11  152994.3547 149862.1931 -180.0  1.09395  0.01   
+  4  9    3    -1   997.7906   1114.9248  0.0     1.08472  0.00   
+  4  0    2    10   115.2997   133.8813   0.0     1.08246  0.00   
+  4  10   2    -2   764.9270   879.5887   -0.0    1.08304  0.00   
+  4  7    3    3    5128.0322  5996.8924  180.0   1.08212  0.00   
+  4  8    4    -1   5.5387     6.5208     0.0     1.08156  0.00   
+  4  2    4    7    119.8232   143.6971   180.0   1.08007  0.00   
+  4  9    3    -8   13.9312    16.9827    180.0   1.07970  0.00   
+  4  5    5    2    4290.8647  5313.2455  0.0     1.07932  0.00   
+  4  2    6    2    378.6191   479.4050   0.0     1.07849  0.00   
+  4  2    4    -9   983.1253   1304.1589  -180.0  1.07754  0.00   
+  4  1    5    6    5724.2513  7502.1332  180.0   1.07772  0.00   
+  4  2    6    -4   2382.6735  3161.0844  -0.0    1.07754  0.00   
+  4  10   2    -8   236.8140   301.8089   0.0     1.07827  0.00   
+  4  8    4    -7   678.0715   885.9156   -0.0    1.07776  0.00   
+  4  1    5    -7   7921.7231  11200.7018 0.0     1.07669  0.00   
+  4  5    5    -7   11.4366    16.4754    0.0     1.07578  0.00   
+  4  6    4    3    1056.9098  1519.8317  -180.0  1.07568  0.00   
+  4  7    3    -10  8750.0937  12275.5661 0.0     1.07494  0.00   
+  4  6    0    6    730.3604   879.7019   180.0   1.07295  0.00   
+  4  6    4    -9   783.7445   818.3390   -180.0  1.07009  0.00   
+  4  1    1    10   2467.5211  2600.3949  -180.0  1.06945  0.00   
+  4  11   1    -5   152.0229   157.0576   180.0   1.07073  0.00   
+  4  11   1    -6   5.4160     5.6848     -180.0  1.06988  0.00   
+  4  4    6    -2   2383.3624  2493.4475  -180.0  1.06868  0.00   
+  4  1    1    -11  39.2991    42.1000    0.0     1.06784  0.00   
+  4  7    5    -3   1273.5177  1332.3527  -180.0  1.06865  0.00   
+  4  4    0    8    22459.0960 23538.6581 -0.0    1.06844  0.00   
+  4  7    5    -4   159.5789   168.7888   180.0   1.06812  0.00   
+  4  2    2    9    21524.5589 24390.1592 -0.0    1.06659  0.00   
+  4  6    0    -12  2524.4355  2934.1980  -180.0  1.06465  0.00   
+  4  4    6    -1   1.7500     2.0408     -0.0    1.06432  0.00   
+  4  2    2    -11  18055.6374 21016.5666 -180.0  1.06355  0.00   
+  4  4    6    -3   2427.9760  2830.7068  180.0   1.06372  0.00   
+  4  4    0    -12  24937.8901 28284.0182 -180.0  1.06236  0.00   
+  4  5    1    7    2816.0810  3264.9405  0.0     1.06328  0.00   
+  4  0    6    4    1480.6273  1674.6879  0.0     1.06226  0.00   
+  4  11   1    -4   4525.8387  5116.2715  0.0     1.06224  0.00   
+  4  1    3    9    1490.4381  1611.5969  0.0     1.05980  0.00   
+  4  10   0    0    745.0959   820.0000   0.0     1.06107  0.00   
+  4  7    5    -2   1.5190     1.6452     -0.0    1.05992  0.00   
+  4  11   1    -7   61.2219    66.1688    -180.0  1.05976  0.00   
+  4  1    3    -10  2217.2054  2358.9910  0.0     1.05838  0.00   
+  4  7    5    -5   3655.4967  3888.9960  -180.0  1.05835  0.00   
+  4  5    1    -12  1917.9034  2095.6591  -180.0  1.05617  0.00   
+  4  10   0    -10  4258.5181  4657.4859  0.0     1.05364  0.00   
+  4  4    6    0    1530.6050  1593.6779  0.0     1.05098  0.00   
+  4  8    2    3    20938.7030 22562.3961 180.0   1.05182  0.00   
+  4  10   2    -1   55305.5281 57970.1040 0.0     1.05113  0.00   
+  4  4    6    -4   1189.4175  1172.3456  0.0     1.04981  0.00   
+  4  8    4    0    63672.2411 62179.2569 -180.0  1.04963  0.00   
+  4  9    1    2    135.0397   132.5823   -0.0    1.04974  0.00   
+  4  9    3    0    2575.9890  2357.8098  0.0     1.04814  0.00   
+  4  2    6    3    62286.2225 55933.9917 -180.0  1.04639  0.00   
+  4  7    1    5    1140.1910  1024.0070  0.0     1.04644  0.00   
+  4  2    6    -5   62902.8905 56248.6950 -180.0  1.04524  0.00   
+  4  3    5    5    4086.3244  3649.2329  -0.0    1.04511  0.00   
+  4  10   2    -9   75209.6160 67309.6323 0.0     1.04533  0.00   
+  4  8    4    -8   75798.0048 67605.2429 -180.0  1.04501  0.00   
+  4  5    3    6    1579.1148  1400.7430  -180.0  1.04462  0.00   
+  4  8    2    -11  5.5390     4.8615     0.0     1.04372  0.00   
+  4  11   1    -3   30.7319    27.4309    180.0   1.04507  0.00   
+  4  3    5    -8   437.5924   382.6413   -0.0    1.04233  0.00   
+  4  7    5    -1   5322.3782  4658.8352  -180.0  1.04257  0.00   
+  4  9    3    -9   564.1420   493.2925   -180.0  1.04232  0.00   
+  4  9    1    -11  5625.8249  4944.7798  180.0   1.04133  0.00   
+  4  11   1    -8   6052.5254  5337.9279  0.0     1.04115  0.00   
+  4  7    5    -6   22.7458    20.5786    180.0   1.04009  0.00   
+  4  5    3    -11  173.4824   166.7868   -0.0    1.03858  0.00   
+  4  7    1    -12  564.4331   564.4186   -180.0  1.03797  0.00   
+  4  3    1    9    995.6411   984.3570   -180.0  1.03814  0.00   
+_reflns_number_total  1184
+_reflns_d_resolution_low    6.388
+_reflns_d_resolution_high   1.033
+
+# POWDER DATA TABLE
+_pd_meas_2theta_range_min  10.01313
+_pd_meas_2theta_range_max  119.99238
+_pd_meas_2theta_range_inc  0.02626
+_pd_proc_2theta_range_min  9.98829
+_pd_proc_2theta_range_max  119.96754
+_pd_proc_2theta_range_inc  0.02626
+_pd_proc_number_of_points  4189
+
+loop_
+   _pd_meas_intensity_total
+   _pd_calc_intensity_total
+   _pd_proc_intensity_bkg_calc
+   _pd_proc_ls_weight
+  2813         0            0           0         
+  2745         0            0           0         
+  2776         0            0           0         
+  2785         0            0           0         
+  2782         0            0           0         
+  2882         0            0           0         
+  2803         0            0           0         
+  2814         0            0           0         
+  2742         0            0           0         
+  2818         0            0           0         
+  2748         0            0           0         
+  2745         0            0           0         
+  2804         0            0           0         
+  2716         0            0           0         
+  2742         0            0           0         
+  2710         0            0           0         
+  2727         0            0           0         
+  2722         0            0           0         
+  2626         0            0           0         
+  2702         0            0           0         
+  2593         0            0           0         
+  2680         0            0           0         
+  2577         0            0           0         
+  2644         0            0           0         
+  2632         0            0           0         
+  2627         0            0           0         
+  2612         0            0           0         
+  2572         0            0           0         
+  2598         0            0           0         
+  2619         0            0           0         
+  2601         0            0           0         
+  2574         0            0           0         
+  2534         0            0           0         
+  2532         0            0           0         
+  2549         0            0           0         
+  2613         0            0           0         
+  2502         0            0           0         
+  2641         0            0           0         
+  2604         0            0           0         
+  2615         0            0           0         
+  2489         0            0           0         
+  2479         0            0           0         
+  2485         0            0           0         
+  2477         0            0           0         
+  2494         0            0           0         
+  2492         0            0           0         
+  2534         0            0           0         
+  2466         0            0           0         
+  2520         0            0           0         
+  2512         0            0           0         
+  2461         0            0           0         
+  2497         0            0           0         
+  2540         0            0           0         
+  2353         0            0           0         
+  2493         0            0           0         
+  2449         0            0           0         
+  2389         0            0           0         
+  2451         0            0           0         
+  2435         0            0           0         
+  2384         0            0           0         
+  2416         0            0           0         
+  2343         0            0           0         
+  2442         0            0           0         
+  2367         0            0           0         
+  2424         0            0           0         
+  2391         0            0           0         
+  2392         0            0           0         
+  2464         0            0           0         
+  2440         0            0           0         
+  2374         0            0           0         
+  2423         0            0           0         
+  2302         0            0           0         
+  2241         0            0           0         
+  2306         0            0           0         
+  2428         0            0           0         
+  2281         0            0           0         
+  2201         0            0           0         
+  2327         0            0           0         
+  2295         0            0           0         
+  2342         0            0           0         
+  2191         0            0           0         
+  2319         0            0           0         
+  2355         0            0           0         
+  2336         0            0           0         
+  2206         0            0           0         
+  2250         0            0           0         
+  2308         0            0           0         
+  2293         0            0           0         
+  2247         0            0           0         
+  2230         0            0           0         
+  2204         0            0           0         
+  2325         0            0           0         
+  2294         0            0           0         
+  2211         0            0           0         
+  2215         0            0           0         
+  2283         0            0           0         
+  2216         0            0           0         
+  2151         0            0           0         
+  2138         0            0           0         
+  2214         0            0           0         
+  2158         0            0           0         
+  2125         0            0           0         
+  2042         0            0           0         
+  2136         0            0           0         
+  2146         0            0           0         
+  2184         0            0           0         
+  2068         0            0           0         
+  2152         0            0           0         
+  2168         0            0           0         
+  2080         0            0           0         
+  2112         0            0           0         
+  2177         0            0           0         
+  2128         0            0           0         
+  2089         0            0           0         
+  2060         0            0           0         
+  2089         0            0           0         
+  2097         0            0           0         
+  2165         0            0           0         
+  2069         0            0           0         
+  2028         0            0           0         
+  2009         0            0           0         
+  2160         0            0           0         
+  2066         0            0           0         
+  2044         0            0           0         
+  2038         0            0           0         
+  2001         0            0           0         
+  2100         0            0           0         
+  2076         0            0           0         
+  1993         0            0           0         
+  1941         0            0           0         
+  2004         0            0           0         
+  2054         0            0           0         
+  1963         0            0           0         
+  2057         0            0           0         
+  1997         0            0           0         
+  2003         0            0           0         
+  2041         0            0           0         
+  1962         0            0           0         
+  1978         0            0           0         
+  2009         0            0           0         
+  1916         0            0           0         
+  2044         0            0           0         
+  1989         0            0           0         
+  1903         0            0           0         
+  1988         0            0           0         
+  1981         0            0           0         
+  1948         0            0           0         
+  1923         0            0           0         
+  1955         0            0           0         
+  1948         0            0           0         
+  1973         0            0           0         
+  1891         0            0           0         
+  1962         0            0           0         
+  1842         0            0           0         
+  1916         0            0           0         
+  1978         0            0           0         
+  1955         0            0           0         
+  1867         0            0           0         
+  2006         0            0           0         
+  1840         0            0           0         
+  1863         0            0           0         
+  1866         0            0           0         
+  1858         0            0           0         
+  1852         0            0           0         
+  1784         0            0           0         
+  1812         0            0           0         
+  1862         0            0           0         
+  1889         0            0           0         
+  1888         0            0           0         
+  1846         0            0           0         
+  1851         0            0           0         
+  1843         0            0           0         
+  1843         0            0           0         
+  1772         0            0           0         
+  1793         0            0           0         
+  1858         0            0           0         
+  1864         0            0           0         
+  1812         0            0           0         
+  1849         0            0           0         
+  1752         0            0           0         
+  1762         0            0           0         
+  1788         0            0           0         
+  1765         1694.6668    1694.1131   0.000566572 
+  1777         1691.32582   1690.7553   0.000562746 
+  1844         1687.99244   1687.40419  0.000542299 
+  1709         1684.66675   1684.05973  0.000585138 
+  1756         1681.34882   1680.72193  0.000569476 
+  1778         1678.039     1677.39077  0.00056243 
+  1673         1674.73685   1674.06625  0.000597729 
+  1710         1671.44275   1670.74834  0.000584795 
+  1722         1668.15696   1667.43704  0.00058072 
+  1744         1664.87936   1664.13234  0.000573394 
+  1713         1661.61024   1660.83422  0.000583771 
+  1749         1658.34979   1657.54268  0.000571755 
+  1715         1655.09822   1654.2577   0.00058309 
+  1777         1651.85579   1650.97928  0.000562746 
+  1788         1648.62278   1647.70739  0.000559284 
+  1684         1645.39951   1644.44204  0.000593824 
+  1777         1642.18639   1641.18321  0.000562746 
+  1760         1638.98385   1637.93088  0.000568182 
+  1699         1635.79244   1634.68505  0.000588582 
+  1604         1632.61279   1631.44571  0.000623441 
+  1682         1629.44565   1628.21284  0.00059453 
+  1583         1626.29191   1624.98644  0.000631712 
+  1707         1623.15268   1621.76649  0.000585823 
+  1713         1620.02926   1618.55299  0.000583771 
+  1631         1616.92331   1615.34591  0.000613121 
+  1677         1613.83706   1612.14525  0.000596303 
+  1611         1610.77261   1608.95101  0.000620732 
+  1677         1607.73342   1605.76316  0.000596303 
+  1694         1604.7238    1602.5817   0.000590319 
+  1548         1601.74904   1599.40661  0.000645995 
+  1698         1598.81671   1596.23789  0.000588928 
+  1643         1595.93709   1593.07553  0.000608643 
+  1610         1593.12513   1589.91951  0.000621118 
+  1673         1590.40219   1586.76982  0.000597729 
+  1574         1587.80325   1583.62646  0.000635324 
+  1632         1585.38894   1580.4894   0.000612745 
+  1690         1583.27544   1577.35865  0.000591716 
+  1548         1581.6874    1574.23419  0.000645995 
+  1611         1580.96045   1571.116    0.000620732 
+  1608         1581.03459   1568.00409  0.000621891 
+  1600         1581.48806   1564.89843  0.000625  
+  1622         1583.45571   1561.79902  0.000616523 
+  1668         1587.378     1558.70585  0.00059952 
+  1587         1591.35583   1555.6189   0.00063012 
+  1629         1597.42391   1552.53816  0.000613874 
+  1649         1606.3412    1549.46363  0.000606428 
+  1707         1617.01225   1546.39529  0.000585823 
+  1688         1632.70884   1543.33314  0.000592417 
+  1743         1651.28677   1540.27715  0.000573723 
+  1830         1671.29581   1537.22733  0.000546448 
+  1811         1676.15624   1534.18366  0.000552181 
+  1703         1655.40901   1531.14613  0.000587199 
+  1647         1622.24397   1528.11473  0.000607165 
+  1655         1594.11104   1525.08945  0.00060423 
+  1605         1576.787     1522.07028  0.000623053 
+  1587         1564.72102   1519.05721  0.00063012 
+  1565         1554.60379   1516.05022  0.000638978 
+  1563         1546.62384   1513.04931  0.000639795 
+  1515         1540.89554   1510.05447  0.000660066 
+  1481         1533.94076   1507.06568  0.000675219 
+  1553         1524.72969   1504.08294  0.000643915 
+  1520         1515.67803   1501.10623  0.000657895 
+  1517         1508.52019   1498.13555  0.000659196 
+  1563         1503.11196   1495.17088  0.000639795 
+  1517         1498.68468   1492.21222  0.000659196 
+  1464         1494.77397   1489.25955  0.00068306 
+  1539         1491.15726   1486.31286  0.000649773 
+  1574         1487.72658   1483.37215  0.000635324 
+  1482         1484.42372   1480.4374   0.000674764 
+  1526         1481.21401   1477.5086   0.000655308 
+  1558         1478.07541   1474.58574  0.000641849 
+  1483         1474.99325   1471.66882  0.000674309 
+  1469         1471.95747   1468.75781  0.000680735 
+  1511         1468.96101   1465.85272  0.000661813 
+  1461         1465.99887   1462.95353  0.000684463 
+  1522         1463.06754   1460.06022  0.00065703 
+  1506         1460.1646    1457.1728   0.000664011 
+  1416         1457.2885    1454.29125  0.000706215 
+  1431         1454.43844   1451.41555  0.000698812 
+  1466         1451.61432   1448.54571  0.000682128 
+  1443         1448.8167    1445.6817   0.000693001 
+  1489         1446.04695   1442.82353  0.000671592 
+  1470         1443.30739   1439.97117  0.000680272 
+  1502         1440.60168   1437.12462  0.000665779 
+  1407         1437.93549   1434.28388  0.000710732 
+  1489         1435.31794   1431.44891  0.000671592 
+  1442         1432.76495   1428.61973  0.000693481 
+  1479         1430.30671   1425.79632  0.000676133 
+  1490         1427.99934   1422.97866  0.000671141 
+  1411         1425.91817   1420.16676  0.000708717 
+  1422         1424.02608   1417.36059  0.000703235 
+  1400         1422.32656   1414.56014  0.000714286 
+  1431         1421.07347   1411.76542  0.000698812 
+  1448         1419.97043   1408.97641  0.000690608 
+  1461         1419.22549   1406.19309  0.000684463 
+  1425         1419.45091   1403.41546  0.000701754 
+  1438         1419.4378    1400.64351  0.00069541 
+  1424         1420.92237   1397.87723  0.000702247 
+  1440         1423.18093   1395.1166   0.000694444 
+  1397         1424.92567   1392.36163  0.00071582 
+  1477         1423.42098   1389.61229  0.000677048 
+  1453         1416.51909   1386.86858  0.000688231 
+  1431         1408.44844   1384.13049  0.000698812 
+  1406         1402.25874   1381.398    0.000711238 
+  1380         1398.7376    1378.67112  0.000724638 
+  1410         1396.99403   1375.94983  0.00070922 
+  1353         1396.42886   1373.23411  0.000739098 
+  1381         1396.74794   1370.52396  0.000724113 
+  1470         1397.72809   1367.81938  0.000680272 
+  1384         1399.16247   1365.12034  0.000722543 
+  1337         1400.87858   1362.42684  0.000747943 
+  1412         1402.85516   1359.73888  0.000708215 
+  1364         1405.20625   1357.05643  0.000733138 
+  1399         1407.9463    1354.37949  0.000714796 
+  1413         1410.66248   1351.70806  0.000707714 
+  1404         1412.40958   1349.04212  0.000712251 
+  1380         1412.09464   1346.38165  0.000724638 
+  1391         1409.16445   1343.72666  0.000718907 
+  1316         1403.992     1341.07713  0.000759878 
+  1377         1397.62327   1338.43306  0.000726216 
+  1393         1391.14241   1335.79443  0.000717875 
+  1384         1385.12976   1333.16123  0.000722543 
+  1340         1379.49241   1330.53345  0.000746269 
+  1447         1373.70929   1327.91109  0.000691085 
+  1372         1367.33087   1325.29413  0.000728863 
+  1348         1360.34847   1322.68256  0.00074184 
+  1394         1353.16056   1320.07639  0.00071736 
+  1322         1346.28509   1317.47558  0.00075643 
+  1292         1340.13017   1314.88015  0.000773994 
+  1336         1334.88817   1312.29006  0.000748503 
+  1370         1330.3633    1309.70533  0.000729927 
+  1255         1326.60293   1307.12594  0.000796813 
+  1253         1323.9591    1304.55187  0.000798085 
+  1363         1321.91453   1301.98312  0.000733676 
+  1302         1320.31706   1299.41968  0.000768049 
+  1337         1320.13218   1296.86154  0.000747943 
+  1304         1320.50014   1294.30869  0.000766871 
+  1375         1322.0653    1291.76112  0.000727273 
+  1323         1322.72221   1289.21882  0.000755858 
+  1280         1318.9057    1286.68178  0.00078125 
+  1316         1309.96387   1284.15     0.000759878 
+  1243         1300.09977   1281.62346  0.000804505 
+  1266         1292.02049   1279.10215  0.000789889 
+  1282         1286.31829   1276.58606  0.000780031 
+  1278         1282.01284   1274.0752   0.000782473 
+  1317         1278.41054   1271.56953  0.000759301 
+  1289         1275.17927   1269.06907  0.000775795 
+  1306         1272.16711   1266.57379  0.000765697 
+  1261         1269.2987    1264.08369  0.000793021 
+  1242         1266.53253   1261.59876  0.000805153 
+  1227         1263.84842   1259.11898  0.000814996 
+  1235         1261.22215   1256.64436  0.000809717 
+  1291         1258.65069   1254.17488  0.000774593 
+  1227         1256.12376   1251.71053  0.000814996 
+  1243         1253.64007   1249.2513   0.000804505 
+  1214         1251.19826   1246.79718  0.000823723 
+  1219         1248.79775   1244.34817  0.000820345 
+  1256         1246.43944   1241.90426  0.000796178 
+  1231         1244.12641   1239.46543  0.000812348 
+  1276         1241.86308   1237.03167  0.000783699 
+  1227         1239.65511   1234.60298  0.000814996 
+  1253         1237.51032   1232.17936  0.000798085 
+  1198         1235.43966   1229.76078  0.000834725 
+  1304         1233.45709   1227.34724  0.000766871 
+  1166         1231.58066   1224.93873  0.000857633 
+  1200         1229.83328   1222.53524  0.000833333 
+  1181         1228.24305   1220.13677  0.00084674 
+  1212         1226.843     1217.7433   0.000825083 
+  1231         1225.67045   1215.35482  0.000812348 
+  1229         1224.76711   1212.97133  0.00081367 
+  1172         1224.1809    1210.59282  0.000853242 
+  1178         1223.97653   1208.21927  0.000848896 
+  1221         1224.15559   1205.85069  0.000819001 
+  1201         1224.69467   1203.48705  0.000832639 
+  1174         1225.46437   1201.12835  0.000851789 
+  1176         1226.26198   1198.77459  0.00085034 
+  1188         1226.9754    1196.42575  0.000841751 
+  1141         1227.60084   1194.08182  0.000876424 
+  1167         1228.09222   1191.7428   0.000856898 
+  1154         1228.11085   1189.40867  0.000866551 
+  1206         1226.98254   1187.07943  0.000829187 
+  1195         1224.06232   1184.75507  0.00083682 
+  1213         1219.22817   1182.43558  0.000824402 
+  1178         1212.99097   1180.12095  0.000848896 
+  1220         1206.16368   1177.81117  0.000819672 
+  1137         1199.45083   1175.50624  0.000879507 
+  1131         1193.25287   1173.20614  0.000884173 
+  1186         1187.69815   1170.91086  0.00084317 
+  1157         1182.75857   1168.62041  0.000864304 
+  1106         1178.34485   1166.33475  0.000904159 
+  1118         1174.35768   1164.0539   0.000894454 
+  1146         1170.70824   1161.77784  0.0008726 
+  1087         1167.32395   1159.50656  0.000919963 
+  1175         1164.14784   1157.24006  0.000851064 
+  1085         1161.13594   1154.97831  0.000921659 
+  1101         1158.25461   1152.72133  0.000908265 
+  1068         1155.47819   1150.46909  0.00093633 
+  1151         1152.78691   1148.22158  0.00086881 
+  1135         1150.16557   1145.97881  0.000881057 
+  1078         1147.60658   1143.74076  0.000927644 
+  1177         1145.09211   1141.50742  0.000849618 
+  1142         1142.62119   1139.27879  0.000875657 
+  1138         1140.18363   1137.05485  0.000878735 
+  1143         1137.77972   1134.83559  0.000874891 
+  1098         1135.39981   1132.62101  0.000910747 
+  1124         1133.0439    1130.41111  0.00088968 
+  1121         1130.7176    1128.20586  0.000892061 
+  1173         1128.40148   1126.00527  0.000852515 
+  1085         1126.10629   1123.80932  0.000921659 
+  1106         1123.82291   1121.618    0.000904159 
+  1137         1121.55384   1119.43131  0.000879507 
+  1176         1119.29801   1117.24924  0.00085034 
+  1045         1117.0545    1115.07178  0.000956938 
+  1063         1114.82252   1112.89892  0.000940734 
+  1091         1112.6014    1110.73065  0.00091659 
+  1074         1110.39082   1108.56696  0.000931099 
+  1078         1108.18979   1106.40786  0.000927644 
+  1086         1105.99814   1104.25331  0.00092081 
+  1086         1103.8155    1102.10333  0.00092081 
+  1013         1101.64171   1099.9579   0.000987167 
+  1040         1099.47625   1097.81701  0.000961538 
+  1099         1097.31903   1095.68065  0.000909918 
+  1091         1095.16988   1093.54882  0.00091659 
+  1028         1093.02866   1091.42151  0.000972763 
+  1050         1090.89524   1089.2987   0.000952381 
+  1030         1088.76957   1087.1804   0.000970874 
+  1056         1086.65157   1085.06659  0.00094697 
+  1072         1084.54124   1082.95726  0.000932836 
+  1079         1082.43858   1080.8524   0.000926784 
+  1098         1080.34363   1078.75202  0.000910747 
+  1050         1078.25644   1076.65609  0.000952381 
+  1038         1076.17713   1074.56461  0.000963391 
+  1093         1074.10582   1072.47757  0.000914913 
+  1026         1072.04267   1070.39497  0.000974659 
+  1067         1069.98791   1068.31679  0.000937207 
+  986          1067.94178   1066.24304  0.001014199 
+  1037         1065.90459   1064.17369  0.00096432 
+  1057         1063.87671   1062.10874  0.000946074 
+  1032         1061.85858   1060.04818  0.000968992 
+  1038         1059.8507    1057.99201  0.000963391 
+  989          1057.8537    1055.94022  0.001011122 
+  1022         1055.86828   1053.89279  0.000978474 
+  1105         1053.89531   1051.84973  0.000904977 
+  1008         1051.93581   1049.81102  0.000992063 
+  1041         1049.99096   1047.77665  0.000960615 
+  1024         1048.06223   1045.74662  0.000976562 
+  1014         1046.15135   1043.72091  0.000986193 
+  1029         1044.26039   1041.69953  0.000971817 
+  1025         1042.39189   1039.68245  0.00097561 
+  1041         1040.54895   1037.66969  0.000960615 
+  1004         1038.73534   1035.66121  0.000996016 
+  1046         1036.95577   1033.65703  0.000956023 
+  1066         1035.2161    1031.65712  0.000938086 
+  1013         1033.52364   1029.66149  0.000987167 
+  967          1031.89223   1027.67012  0.001034126 
+  1029         1030.32492   1025.683    0.000971817 
+  1028         1028.84151   1023.70013  0.000972763 
+  920          1027.46435   1021.72151  0.001086957 
+  988          1026.21528   1019.74711  0.001012146 
+  1020         1025.13076   1017.77694  0.000980392 
+  966          1024.25578   1015.81098  0.001035197 
+  997          1023.64856   1013.84923  0.001003009 
+  997          1023.38319   1011.89169  0.001003009 
+  1029         1023.54875   1009.93833  0.000971817 
+  1014         1024.23607   1007.98916  0.000986193 
+  947          1025.52263   1006.04417  0.001055966 
+  993          1027.4012    1004.10334  0.001007049 
+  963          1029.66824   1002.16668  0.001038422 
+  1002         1031.81821   1000.23416  0.000998004 
+  953          1033.01767   998.3058    0.001049318 
+  1034         1032.48208   996.38157   0.000967118 
+  984          1029.88659   994.46147   0.00101626 
+  931          1025.53228   992.54549   0.001074114 
+  981          1020.08325   990.63362   0.001019368 
+  962          1014.28616   988.72587   0.001039501 
+  1004         1008.64958   986.82221   0.000996016 
+  1007         1003.43406   984.92264   0.000993049 
+  977          998.77821    983.02715   0.001023541 
+  957          994.6437     981.13574   0.001044932 
+  976          990.90256    979.2484    0.00102459 
+  944          987.403      977.36511   0.001059322 
+  950          984.11852    975.48588   0.001052632 
+  894          981.06825    973.6107    0.001118568 
+  969          978.24819    971.73955   0.001031992 
+  898          975.63629    969.87243   0.001113586 
+  925          973.17833    968.00933   0.001081081 
+  949          970.83366    966.15024   0.001053741 
+  935          968.57579    964.29516   0.001069519 
+  911          966.38673    962.44408   0.001097695 
+  925          964.25361    960.59699   0.001081081 
+  910          962.16679    958.75389   0.001098901 
+  919          960.11881    956.91476   0.001088139 
+  930          958.10387    955.0796    0.001075269 
+  916          956.11736    953.2484    0.001091703 
+  942          954.15556    951.42115   0.001061571 
+  887          952.21548    949.59785   0.001127396 
+  903          950.29469    947.77849   0.00110742 
+  948          948.39115    945.96306   0.001054852 
+  915          946.50322    944.15155   0.001092896 
+  868          944.62951    942.34396   0.001152074 
+  967          942.77487    940.54027   0.001034126 
+  958          940.92638    938.74049   0.001043841 
+  887          939.09218    936.9446    0.001127396 
+  955          937.26564    935.15259   0.00104712 
+  927          935.44915    933.36447   0.001078749 
+  893          933.64227    931.58021   0.001119821 
+  977          931.84458    929.79982   0.001023541 
+  937          930.05578    928.02329   0.001067236 
+  939          928.2756     926.2506    0.001064963 
+  894          926.50383    924.48176   0.001118568 
+  881          924.74033    922.71675   0.001135074 
+  943          922.985      920.95557   0.001060445 
+  936          921.23776    919.1982    0.001068376 
+  937          919.4986     917.44465   0.001067236 
+  937          917.76773    915.69491   0.001067236 
+  959          916.04482    913.94896   0.001042753 
+  945          914.33016    912.2068    0.001058201 
+  928          912.624      910.46842   0.001077586 
+  842          910.92634    908.73382   0.001187648 
+  862          909.23751    907.00299   0.001160093 
+  952          907.55782    905.27592   0.00105042 
+  852          905.88762    903.55261   0.001173709 
+  859          904.22735    901.83304   0.001164144 
+  890          902.57754    900.11721   0.001123596 
+  867          900.93884    898.40511   0.001153403 
+  872          899.31207    896.69674   0.001146789 
+  852          897.69925    894.99208   0.001173709 
+  886          896.09993    893.29114   0.001128668 
+  824          894.51656    891.5939    0.001213592 
+  893          892.95013    889.90036   0.001119821 
+  858          891.40277    888.2105    0.001165501 
+  882          889.87863    886.52433   0.001133787 
+  837          888.37608    884.84183   0.001194743 
+  858          886.90246    883.163     0.001165501 
+  845          885.45549    881.48784   0.001183432 
+  843          884.02615    879.81632   0.00118624 
+  856          882.61086    878.14845   0.001168224 
+  836          881.22763    876.48423   0.001196172 
+  900          879.89027    874.82363   0.001111111 
+  839          878.61426    873.16666   0.001191895 
+  827          877.41203    871.51331   0.00120919 
+  852          876.29453    869.86357   0.001173709 
+  807          875.27795    868.21743   0.001239157 
+  852          874.38568    866.57489   0.001173709 
+  900          873.6504     864.93595   0.001111111 
+  808          873.11765    863.30058   0.001237624 
+  789          872.8526     861.66879   0.001267427 
+  850          872.95149    860.04057   0.001176471 
+  881          873.56165    858.41592   0.001135074 
+  826          874.92203    856.79482   0.001210654 
+  878          877.45335    855.17727   0.001138952 
+  879          882.01481    853.56326   0.001137656 
+  885          890.63461    851.95278   0.001129944 
+  913          907.59727    850.34583   0.00109529 
+  924          934.71893    848.74241   0.001082251 
+  888          968.91006    847.1425    0.001126126 
+  950          1032.95428   845.54609   0.001052632 
+  1118         1098.73732   843.95319   0.000894454 
+  1196         1211.24303   842.36378   0.00083612 
+  1436         1344.30526   840.77785   0.000696379 
+  1742         1498.84125   839.19541   0.000574053 
+  1706         1500.46507   837.61644   0.000586166 
+  1432         1347.93576   836.04093   0.000698324 
+  1298         1195.67171   834.46889   0.000770416 
+  1055         1035.00725   832.9003    0.000947867 
+  925          942.7817     831.33515   0.001081081 
+  884          899.4625     829.77344   0.001131222 
+  847          876.84254    828.21517   0.001180638 
+  833          863.04685    826.66032   0.00120048 
+  802          853.60102    825.10889   0.001246883 
+  791          846.70584    823.56088   0.001264223 
+  843          841.32763    822.01626   0.00118624 
+  807          836.96393    820.47505   0.001239157 
+  821          833.30053    818.93723   0.001218027 
+  838          830.12288    817.4028    0.001193317 
+  821          827.30543    815.87174   0.001218027 
+  838          824.75934    814.34405   0.001193317 
+  866          822.43051    812.81974   0.001154734 
+  811          820.25896    811.29878   0.001233046 
+  789          818.22087    809.78117   0.001267427 
+  838          816.2968     808.26691   0.001193317 
+  831          814.46146    806.75598   0.001203369 
+  849          812.70606    805.24839   0.001177856 
+  778          811.02114    803.74413   0.001285347 
+  787          809.39991    802.24318   0.001270648 
+  794          807.83777    800.74555   0.001259446 
+  769          806.34939    799.25123   0.00130039 
+  805          804.89859    797.7602    0.001242236 
+  798          803.50814    796.27247   0.001253133 
+  796          802.17357    794.78802   0.001256281 
+  738          800.89587    793.30685   0.001355014 
+  847          799.68409    791.82896   0.001180638 
+  756          798.54564    790.35433   0.001322751 
+  810          797.49074    788.88297   0.001234568 
+  808          796.53309    787.41485   0.001237624 
+  794          795.69082    785.94999   0.001259446 
+  777          794.98839    784.48837   0.001287001 
+  763          794.45896    783.02998   0.001310616 
+  845          794.14777    781.57482   0.001183432 
+  788          794.11848    780.12288   0.001269036 
+  793          794.4626     778.67416   0.001261034 
+  784          795.31485    777.22864   0.00127551 
+  763          796.88294    775.78633   0.001310616 
+  774          799.50328    774.34722   0.00129199 
+  845          803.76373    772.91129   0.001183432 
+  818          810.80371    771.47855   0.001222494 
+  811          822.92104    770.04898   0.001233046 
+  850          844.25955    768.62259   0.001176471 
+  886          878.52109    767.19936   0.001128668 
+  905          916.92326    765.77929   0.001104972 
+  1010         966.07955    764.36237   0.000990099 
+  1153         1055.80983   762.9486    0.000867303 
+  1321         1158.76472   761.53796   0.000757002 
+  1372         1246.51631   760.13046   0.000728863 
+  1302         1307.54719   758.72608   0.000768049 
+  1140         1224.53989   757.32483   0.000877193 
+  945          1120.4834    755.92669   0.001058201 
+  915          1004.12524   754.53166   0.001092896 
+  760          906.01533    753.13973   0.001315789 
+  735          848.85556    751.75089   0.001360544 
+  821          817.04936    750.36514   0.001218027 
+  752          798.05938    748.98248   0.001329787 
+  746          785.59584    747.60289   0.001340483 
+  748          776.74764    746.22638   0.001336898 
+  731          770.09049    744.85293   0.001367989 
+  690          764.85026    743.48253   0.001449275 
+  789          760.56897    742.11519   0.001267427 
+  759          756.96147    740.7509    0.001317523 
+  732          753.84316    739.38964   0.00136612 
+  716          751.08949    738.03142   0.001396648 
+  808          748.61443    736.67622   0.001237624 
+  742          746.35739    735.32405   0.001347709 
+  729          744.2744     733.9749    0.001371742 
+  704          742.33331    732.62875   0.001420455 
+  698          740.51059    731.2856    0.001432665 
+  733          738.78862    729.94545   0.001364256 
+  716          737.15457    728.6083    0.001396648 
+  700          735.59923    727.27413   0.001428571 
+  712          734.11653    725.94293   0.001404494 
+  770          732.70294    724.61471   0.001298701 
+  737          731.35755    723.28946   0.001356852 
+  763          730.082      721.96717   0.001310616 
+  695          728.88092    720.64783   0.001438849 
+  744          727.76318    719.33144   0.001344086 
+  771          726.74079    718.018     0.001297017 
+  751          725.83439    716.70749   0.001331558 
+  711          725.07444    715.39991   0.00140647 
+  696          724.50834    714.09526   0.001436782 
+  720          724.21039    712.79353   0.001388889 
+  772          724.30803    711.49471   0.001295337 
+  751          725.03567    710.1988    0.001331558 
+  738          726.86479    708.90579   0.001355014 
+  703          730.70171    707.61567   0.001422475 
+  755          737.86798    706.32844   0.001324503 
+  713          747.90307    705.0441    0.001402525 
+  785          759.36232    703.76263   0.001273885 
+  837          780.01538    702.48404   0.001194743 
+  885          808.34614    701.20831   0.001129944 
+  932          831.4944     699.93545   0.001072961 
+  895          850.0013     698.66543   0.001117318 
+  875          833.19881    697.39827   0.001142857 
+  809          805.35101    696.13395   0.001236094 
+  760          776.54887    694.87246   0.001315789 
+  736          748.59836    693.61381   0.001358696 
+  712          731.43156    692.35798   0.001404494 
+  725          722.11487    691.10497   0.00137931 
+  702          717.03369    689.85478   0.001424501 
+  693          714.31349    688.60739   0.001443001 
+  695          713.1769     687.3628    0.001438849 
+  739          713.38248    686.12101   0.00135318 
+  679          715.04428    684.88202   0.001472754 
+  679          718.63775    683.6458    0.001472754 
+  709          725.26463    682.41237   0.001410437 
+  754          737.22286    681.18171   0.00132626 
+  747          758.54954    679.95382   0.001338688 
+  789          791.79029    678.72869   0.001267427 
+  838          829.45388    677.50631   0.001193317 
+  899          886.89397    676.28669   0.001112347 
+  1013         980.21184    675.06981   0.000987167 
+  1113         1063.87524   673.85567   0.000898473 
+  1282         1135.19598   672.64427   0.000780031 
+  1238         1116.85792   671.43559   0.000807754 
+  1069         1025.55228   670.22963   0.000935454 
+  913          939.64561    669.0264    0.00109529 
+  824          843.3109     667.82587   0.001213592 
+  728          776.9101     666.62805   0.001373626 
+  713          739.77274    665.43293   0.001402525 
+  662          718.65889    664.2405    0.001510574 
+  648          705.62153    663.05077   0.00154321 
+  661          696.86714    661.86371   0.001512859 
+  643          690.62356    660.67934   0.00155521 
+  698          685.98785    659.49763   0.001432665 
+  678          682.45929    658.3186    0.001474926 
+  678          679.74755    657.14222   0.001474926 
+  698          677.68615    655.9685    0.001432665 
+  669          676.1913     654.79743   0.001494768 
+  674          675.24399    653.62901   0.00148368 
+  657          674.89104    652.46322   0.00152207 
+  657          675.26962    651.30007   0.00152207 
+  637          676.67706    650.13955   0.001569859 
+  665          679.72695    648.98165   0.001503759 
+  676          685.56973    647.82636   0.00147929 
+  682          695.62385    646.67369   0.001466276 
+  708          708.8404     645.52363   0.001412429 
+  744          726.6118     644.37616   0.001344086 
+  737          757.64163    643.2313    0.001356852 
+  877          792.93796    642.08902   0.001140251 
+  924          827.10576    640.94932   0.001082251 
+  960          846.38173    639.81221   0.001041667 
+  919          846.3177     638.67767   0.001088139 
+  910          861.01451    637.5457    0.001098901 
+  996          874.09756    636.41629   0.001004016 
+  1027         908.10497    635.28944   0.00097371 
+  1156         942.21314    634.16514   0.000865052 
+  1051         956.42254    633.04339   0.000951475 
+  950          950.41658    631.92419   0.001052632 
+  855          887.27413    630.80752   0.001169591 
+  771          829.27436    629.69337   0.001297017 
+  688          772.15679    628.58176   0.001453488 
+  653          725.39451    627.47267   0.001531394 
+  622          698.26584    626.36609   0.001607717 
+  678          683.46201    625.26202   0.001474926 
+  613          675.0063     624.16046   0.001631321 
+  638          669.80697    623.06139   0.001567398 
+  586          666.26544    621.96482   0.001706485 
+  647          663.37343    620.87074   0.001545595 
+  671          660.39854    619.77915   0.001490313 
+  670          656.9177     618.69003   0.001492537 
+  645          652.86364    617.60339   0.001550388 
+  635          648.42502    616.51921   0.001574803 
+  632          643.89869    615.4375    0.001582278 
+  625          639.57281    614.35824   0.0016    
+  608          635.6343     613.28144   0.001644737 
+  629          632.14813    612.20709   0.001589825 
+  631          629.09731    611.13517   0.001584786 
+  627          626.42682    610.0657    0.001594896 
+  608          624.07314    608.99865   0.001644737 
+  626          621.97819    607.93404   0.001597444 
+  609          620.09411    606.87184   0.001642036 
+  610          618.38291    605.81207   0.001639344 
+  618          616.81567    604.7547    0.001618123 
+  632          615.37086    603.69974   0.001582278 
+  597          614.03306    602.64718   0.001675042 
+  621          612.79166    601.59702   0.001610306 
+  598          611.64067    600.54925   0.001672241 
+  616          610.57779    599.50386   0.001623377 
+  644          609.60508    598.46086   0.001552795 
+  622          608.72917    597.42023   0.001607717 
+  639          607.96249    596.38197   0.001564945 
+  645          607.32508    595.34608   0.001550388 
+  619          606.8489     594.31255   0.001615509 
+  593          606.58312    593.28138   0.001686341 
+  641          606.60713    592.25255   0.001560062 
+  698          607.05442    591.22608   0.001432665 
+  603          608.16775    590.20194   0.001658375 
+  661          610.42342    589.18014   0.001512859 
+  571          614.75235    588.16067   0.001751313 
+  595          622.66412    587.14352   0.001680672 
+  591          634.63886    586.1287    0.001692047 
+  604          649.28184    585.1162    0.001655629 
+  681          674.16637    584.106     0.001468429 
+  715          706.08124    583.09811   0.001398601 
+  780          730.04343    582.09252   0.001282051 
+  827          737.00884    581.08923   0.00120919 
+  740          713.12809    580.08823   0.001351351 
+  733          689.51051    579.08951   0.001364256 
+  675          663.22163    578.09308   0.001481481 
+  627          639.8843     577.09893   0.001594896 
+  678          629.17633    576.10704   0.001474926 
+  659          626.7557     575.11743   0.001517451 
+  633          626.16038    574.13007   0.001579779 
+  622          623.40678    573.14497   0.001607717 
+  645          615.43827    572.16213   0.001550388 
+  624          608.23223    571.18153   0.001602564 
+  638          600.60667    570.20318   0.001567398 
+  636          593.91746    569.22706   0.001572327 
+  662          589.64209    568.25318   0.001510574 
+  637          586.98501    567.28153   0.001569859 
+  651          585.23462    566.31209   0.001536098 
+  675          584.02226    565.34488   0.001481481 
+  719          583.17708    564.37988   0.001390821 
+  690          582.61229    563.4171    0.001449275 
+  733          582.26582    562.45651   0.001364256 
+  685          582.08936    561.49813   0.001459854 
+  688          582.02702    560.54194   0.001453488 
+  717          582.00271    559.58794   0.0013947 
+  705          581.99725    558.63612   0.00141844 
+  704          582.01759    557.68649   0.001420455 
+  688          582.18141    556.73904   0.001453488 
+  641          582.57485    555.79375   0.001560062 
+  646          583.27434    554.85063   0.001547988 
+  658          584.35478    553.90968   0.001519757 
+  628          585.82855    552.97088   0.001592357 
+  571          587.65676    552.03423   0.001751313 
+  596          589.7555     551.09973   0.001677852 
+  623          592.01201    550.16738   0.001605136 
+  665          594.32538    549.23716   0.001503759 
+  628          596.69221    548.30908   0.001592357 
+  590          599.30215    547.38313   0.001694915 
+  610          602.57854    546.4593    0.001639344 
+  613          607.2295     545.5376    0.001631321 
+  655          614.43166    544.61801   0.001526718 
+  625          626.1365     543.70053   0.0016    
+  666          644.7474     542.78515   0.001501502 
+  680          669.58837    541.87188   0.001470588 
+  648          703.84135    540.96071   0.00154321 
+  753          756.44667    540.05163   0.001328021 
+  852          807.94011    539.14463   0.001173709 
+  947          846.55403    538.23972   0.001055966 
+  969          851.50812    537.33689   0.001031992 
+  909          855.64335    536.43614   0.00110011 
+  1011         884.61333    535.53745   0.00098912 
+  1026         956.25239    534.64083   0.000974659 
+  1181         1131.86811   533.74627   0.00084674 
+  1399         1408.91981   532.85377   0.000714796 
+  1833         1866.19687   531.96332   0.000545554 
+  2623         2578.27608   531.07492   0.000381243 
+  3827         3443.36442   530.18856   0.000261301 
+  5119         4232.46793   529.30424   0.000195351 
+  4549         3842.77482   528.42195   0.000219829 
+  3113         3116.08451   527.5417    0.000321234 
+  2791         2606.64798   526.66346   0.000358295 
+  1745         1815.63877   525.78725   0.000573066 
+  979          1235.11583   524.91306   0.00102145 
+  846          956.23256    524.04088   0.001182033 
+  689          819.6372     523.1707    0.001451379 
+  621          742.03961    522.30253   0.001610306 
+  635          692.87585    521.43636   0.001574803 
+  632          659.7977     520.57218   0.001582278 
+  619          636.55134    519.70999   0.001615509 
+  600          619.68967    518.84979   0.001666667 
+  612          607.21356    517.99157   0.001633987 
+  635          597.90504    517.13533   0.001574803 
+  606          590.96726    516.28105   0.001650165 
+  612          585.81872    515.42875   0.001633987 
+  583          581.95529    514.57841   0.001715266 
+  646          578.87775    513.73003   0.001547988 
+  558          576.13469    512.88361   0.001792115 
+  566          573.44489    512.03913   0.001766784 
+  576          570.75614    511.19661   0.001736111 
+  578          568.18997    510.35602   0.001730104 
+  586          565.97082    509.51738   0.001706485 
+  562          564.36326    508.68066   0.001779359 
+  595          563.66383    507.84588   0.001680672 
+  583          564.21172    507.01302   0.001715266 
+  594          566.51546    506.18209   0.001683502 
+  627          571.64246    505.35307   0.001594896 
+  617          582.17394    504.52596   0.001620746 
+  633          603.37449    503.70076   0.001579779 
+  681          637.48812    502.87746   0.001468429 
+  738          676.98293    502.05607   0.001355014 
+  797          758.5848     501.23657   0.001254705 
+  842          852.75795    500.41896   0.001187648 
+  1078         913.31417    499.60324   0.000927644 
+  1083         877.2335     498.7894    0.000923361 
+  941          807.13978    497.97744   0.001062699 
+  840          766.83263    497.16736   0.001190476 
+  793          696.03725    496.35914   0.001261034 
+  659          649.02711    495.55279   0.001517451 
+  687          635.07644    494.74831   0.001455604 
+  639          641.08164    493.94568   0.001564945 
+  642          664.16846    493.14491   0.001557632 
+  694          706.71486    492.34598   0.001440922 
+  721          770.46785    491.5489    0.001386963 
+  915          855.28951    490.75367   0.001092896 
+  974          988.60624    489.96027   0.001026694 
+  1158         1126.83689   489.1687    0.000863558 
+  1287         1211.13703   488.37896   0.000777001 
+  1213         1191.52452   487.59105   0.000824402 
+  1090         1155.96948   486.80496   0.000917431 
+  1110         1169.12415   486.02069   0.000900901 
+  1095         1214.19395   485.23822   0.000913242 
+  1224         1334.7353    484.45757   0.000816993 
+  1626         1606.04399   483.67872   0.000615006 
+  2153         1975.4756    482.90168   0.000464468 
+  2596         2242.38574   482.12643   0.000385208 
+  2487         2263.49841   481.35297   0.000402091 
+  2268         2098.00144   480.5813    0.000440917 
+  1972         1920.49775   479.81142   0.000507099 
+  1460         1605.39495   479.04332   0.000684932 
+  1195         1303.07286   478.27699   0.00083682 
+  944          1116.83408   477.51244   0.001059322 
+  841          991.0346     476.74965   0.001189061 
+  884          941.47922    475.98863   0.001131222 
+  972          938.23679    475.22937   0.001028807 
+  936          932.80785    474.47187   0.001068376 
+  902          891.3578     473.71612   0.001108647 
+  854          847.1559     472.96212   0.00117096 
+  865          820.4542     472.20986   0.001156069 
+  942          799.16567    471.45935   0.001061571 
+  855          801.97472    470.71057   0.001169591 
+  969          826.34002    469.96353   0.001031992 
+  950          891.14732    469.21821   0.001052632 
+  937          966.29569    468.47462   0.001067236 
+  960          982.96477    467.73275   0.001041667 
+  1089         1029.69059   466.9926    0.000918274 
+  1270         1168.88513   466.25416   0.000787402 
+  1598         1457.75719   465.51744   0.000625782 
+  2221         1925.79947   464.78242   0.000450248 
+  3232         2774.48789   464.0491    0.000309406 
+  5143         4064.6201    463.31748   0.000194439 
+  7421         5755.59678   462.58755   0.000134753 
+  8427         6483.42702   461.85931   0.000118666 
+  5878         4964.71097   461.13277   0.000170126 
+  4824         4166.13197   460.4079    0.000207297 
+  4000         3447.75171   459.68471   0.00025   
+  2122         2091.52811   458.9632    0.000471254 
+  1146         1310.38539   458.24336   0.0008726 
+  935          979.52289    457.52519   0.001069519 
+  843          820.01476    456.80868   0.00118624 
+  726          727.48656    456.09383   0.00137741 
+  684          667.80184    455.38064   0.001461988 
+  690          626.69022    454.6691    0.001449275 
+  679          596.95964    453.95921   0.001472754 
+  653          574.63865    453.25097   0.001531394 
+  603          557.36461    452.54436   0.001658375 
+  540          543.67354    451.8394    0.001851852 
+  548          532.5735     451.13606   0.001824818 
+  558          523.4277     450.43436   0.001792115 
+  550          515.76582    449.73429   0.001818182 
+  532          509.26644    449.03583   0.001879699 
+  548          503.69511    448.339     0.001824818 
+  522          498.86039    447.64378   0.001915709 
+  553          494.63447    446.95017   0.001808318 
+  461          490.90649    446.25817   0.002169197 
+  545          487.59834    445.56778   0.001834862 
+  543          484.64495    444.87898   0.001841621 
+  500          481.99543    444.19179   0.002     
+  482          479.6089     443.50618   0.002074689 
+  471          477.45227    442.82217   0.002123142 
+  519          475.49907    442.13974   0.001926782 
+  489          473.72797    441.45889   0.00204499 
+  457          472.10662    440.77962   0.002188184 
+  499          470.65248    440.10193   0.002004008 
+  516          469.33089    439.42581   0.001937984 
+  458          468.14971    438.75126   0.002183406 
+  453          467.09621    438.07827   0.002207506 
+  481          466.16646    437.40684   0.002079002 
+  460          465.35954    436.73697   0.002173913 
+  477          464.67651    436.06865   0.002096436 
+  452          464.12057    435.40189   0.002212389 
+  476          463.69725    434.73666   0.00210084 
+  480          463.41485    434.07299   0.002083333 
+  442          463.28481    433.41085   0.002262443 
+  455          463.32157    432.75024   0.002197802 
+  397          463.54456    432.09117   0.002518892 
+  501          463.97827    431.43363   0.001996008 
+  439          464.6535     430.77761   0.002277904 
+  480          465.60986    430.12312   0.002083333 
+  438          466.89738    429.47014   0.002283105 
+  458          468.57983    428.81868   0.002183406 
+  421          470.73938    428.16872   0.002375297 
+  463          473.4817     427.52028   0.002159827 
+  456          476.94329    426.87334   0.002192982 
+  477          481.29976    426.2279    0.002096436 
+  488          486.77891    425.58396   0.00204918 
+  460          493.66992    424.94151   0.002173913 
+  485          502.33428    424.30055   0.002061856 
+  553          513.19899    423.66108   0.001808318 
+  560          526.71742    423.02309   0.001785714 
+  556          543.26793    422.38658   0.001798561 
+  566          562.92717    421.75155   0.001766784 
+  620          585.16183    421.11799   0.001612903 
+  665          608.61596    420.4859    0.001503759 
+  638          631.28506    419.85528   0.001567398 
+  738          650.95877    419.22612   0.001355014 
+  787          665.44594    418.59841   0.001270648 
+  754          672.99292    417.97217   0.00132626 
+  773          673.72484    417.34738   0.001293661 
+  860          670.95593    416.72403   0.001162791 
+  807          670.67075    416.10214   0.001239157 
+  822          676.49141    415.48168   0.001216545 
+  802          683.56654    414.86266   0.001246883 
+  791          706.07819    414.24508   0.001264223 
+  740          734.09478    413.62894   0.001351351 
+  660          713.41941    413.01422   0.001515152 
+  662          686.76393    412.40092   0.001510574 
+  655          681.5781     411.78905   0.001526718 
+  629          669.89701    411.1786    0.001589825 
+  590          629.88683    410.56957   0.001694915 
+  578          584.69727    409.96194   0.001730104 
+  553          560.51604    409.35573   0.001808318 
+  540          536.60943    408.75092   0.001851852 
+  478          512.10782    408.14752   0.00209205 
+  475          498.76825    407.54551   0.002105263 
+  502          496.80461    406.9449    0.001992032 
+  543          506.28524    406.34568   0.001841621 
+  551          526.84904    405.74785   0.001814882 
+  572          554.88938    405.15141   0.001748252 
+  667          597.20714    404.55635   0.00149925 
+  736          633.8091     403.96267   0.001358696 
+  762          641.2317     403.37037   0.001312336 
+  695          634.06513    402.77944   0.001438849 
+  637          600.16344    402.18988   0.001569859 
+  559          560.57116    401.60169   0.001788909 
+  481          527.2195     401.01486   0.002079002 
+  465          491.88502    400.42939   0.002150538 
+  433          466.05802    399.84528   0.002309469 
+  425          450.71273    399.26252   0.002352941 
+  439          441.48714    398.68112   0.002277904 
+  430          435.49895    398.10106   0.002325581 
+  391          431.33129    397.52234   0.002557545 
+  407          428.26329    396.94497   0.002457002 
+  427          425.95536    396.36894   0.00234192 
+  394          424.1795     395.79424   0.002538071 
+  401          422.82686    395.22087   0.002493766 
+  419          421.83299    394.64883   0.002386635 
+  400          421.14903    394.07811   0.0025    
+  403          420.7551     393.50872   0.00248139 
+  424          420.62617    392.94065   0.002358491 
+  393          420.72873    392.37389   0.002544529 
+  403          421.01513    391.80845   0.00248139 
+  366          421.4506     391.24432   0.00273224 
+  396          422.04887    390.68149   0.002525253 
+  392          422.89746    390.11997   0.00255102 
+  367          424.16549    389.55975   0.002724796 
+  387          426.14288    389.00082   0.002583979 
+  421          429.34881    388.44319   0.002375297 
+  435          434.75685    387.88685   0.002298851 
+  382          444.19215    387.3318    0.002617801 
+  449          460.45523    386.77804   0.002227171 
+  518          483.54311    386.22556   0.001930502 
+  500          507.81424    385.67435   0.002     
+  534          541.85911    385.12442   0.001872659 
+  576          564.09754    384.57577   0.001736111 
+  546          542.81222    384.02839   0.001831502 
+  530          522.92004    383.48227   0.001886792 
+  532          511.52545    382.93742   0.001879699 
+  465          486.42533    382.39382   0.002150538 
+  459          462.72904    381.85149   0.002178649 
+  442          448.3834     381.31041   0.002262443 
+  402          440.87428    380.77059   0.002487562 
+  413          438.00671    380.23201   0.002421308 
+  428          437.47587    379.69468   0.002336449 
+  439          439.17361    379.15859   0.002277904 
+  437          442.53496    378.62374   0.00228833 
+  400          438.07359    378.09013   0.0025    
+  437          430.24347    377.55775   0.00228833 
+  435          425.94265    377.02661   0.002298851 
+  388          420.43212    376.49669   0.00257732 
+  354          413.76882    375.968     0.002824859 
+  434          409.16288    375.44053   0.002304147 
+  344          406.35288    374.91428   0.002906977 
+  377          404.57705    374.38925   0.00265252 
+  355          403.38034    373.86543   0.002816901 
+  368          402.53749    373.34282   0.002717391 
+  380          402.53756    372.82142   0.002631579 
+  369          402.12588    372.30122   0.002710027 
+  421          401.86325    371.78223   0.002375297 
+  370          402.02761    371.26443   0.002702703 
+  360          402.01512    370.74784   0.002777778 
+  398          402.11823    370.23243   0.002512563 
+  410          402.34199    369.71822   0.002439024 
+  394          402.70311    369.20519   0.002538071 
+  342          403.23699    368.69335   0.002923977 
+  376          404.01074    368.18269   0.002659574 
+  391          405.09913    367.67321   0.002557545 
+  389          406.45705    367.16491   0.002570694 
+  373          408.22038    366.65778   0.002680965 
+  435          410.48212    366.15182   0.002298851 
+  377          412.46377    365.64703   0.00265252 
+  453          414.61653    365.1434    0.002207506 
+  385          417.78453    364.64094   0.002597403 
+  412          420.41206    364.13964   0.002427184 
+  421          421.82346    363.63949   0.002375297 
+  422          422.49973    363.14049   0.002369668 
+  414          422.4445     362.64265   0.002415459 
+  411          422.68842    362.14596   0.00243309 
+  402          423.36849    361.65041   0.002487562 
+  380          424.16037    361.156     0.002631579 
+  391          425.7543     360.66274   0.002557545 
+  424          428.22486    360.17061   0.002358491 
+  414          431.39937    359.67961   0.002415459 
+  422          435.17419    359.18975   0.002369668 
+  432          439.49401    358.70102   0.002314815 
+  419          444.30154    358.21341   0.002386635 
+  405          449.52262    357.72693   0.002469136 
+  406          455.00102    357.24157   0.002463054 
+  444          460.97214    356.75732   0.002252252 
+  431          467.4618     356.27419   0.002320186 
+  450          474.61319    355.79218   0.002222222 
+  443          482.76185    355.31127   0.002257336 
+  449          492.13001    354.83147   0.002227171 
+  489          503.025      354.35278   0.00204499 
+  517          515.765      353.87518   0.001934236 
+  499          530.69701    353.39869   0.002004008 
+  514          548.19277    352.92329   0.001945525 
+  478          568.71478    352.44899   0.00209205 
+  517          592.93011    351.97578   0.001934236 
+  559          621.82375    351.50366   0.001788909 
+  588          656.80725    351.03262   0.00170068 
+  613          699.86305    350.56267   0.001631321 
+  649          753.80019    350.0938    0.001540832 
+  738          822.72388    349.626     0.001355014 
+  754          912.79454    349.15928   0.00132626 
+  953          1033.73042   348.69364   0.001049318 
+  1126         1201.69553   348.22906   0.000888099 
+  1486         1445.43504   347.76555   0.000672948 
+  2008         1822.23968   347.30311   0.000498008 
+  2567         2470.81738   346.84173   0.00038956 
+  3797         3760.56042   346.3814    0.000263366 
+  5951         6392.64773   345.92214   0.000168039 
+  10083        10232.17254  345.46393   0.000099177 
+  17681        17019.20747  345.00677   0.000056558 
+  28614        25194.93853  344.55066   0.000034948 
+  31160        26784.9446   344.0956    0.000032092 
+  18903        18864.62881  343.64159   0.000052902 
+  15969        16347.60252  343.18861   0.000062621 
+  16488        15304.0714   342.73667   0.00006065 
+  9784         9727.6059    342.28578   0.000102208 
+  4062         5075.47652   341.83591   0.000246184 
+  2277         3035.93992   341.38708   0.000439174 
+  1664         2122.20562   340.93927   0.000600962 
+  1367         1626.883     340.49249   0.000731529 
+  1230         1320.4124    340.04674   0.000813008 
+  997          1116.16204   339.60201   0.001003009 
+  974          972.85857    339.15829   0.001026694 
+  884          868.37765    338.7156    0.001131222 
+  798          789.45828    338.27391   0.001253133 
+  724          728.39311    337.83324   0.001381215 
+  680          680.66308    337.39358   0.001470588 
+  673          642.758      336.95493   0.001485884 
+  651          612.23472    336.51727   0.001536098 
+  601          587.7449     336.08062   0.001663894 
+  567          568.21794    335.64497   0.001763668 
+  520          552.84062    335.21032   0.001923077 
+  511          541.07459    334.77666   0.001956947 
+  536          532.62758    334.34399   0.001865672 
+  518          527.40002    333.91231   0.001930502 
+  551          525.28813    333.48162   0.001814882 
+  494          526.23211    333.05191   0.002024291 
+  516          530.41357    332.62318   0.001937984 
+  518          536.82317    332.19544   0.001930502 
+  534          545.87844    331.76867   0.001872659 
+  573          558.70542    331.34288   0.001745201 
+  521          574.38164    330.91805   0.001919386 
+  568          592.32298    330.4942    0.001760563 
+  648          612.83153    330.07132   0.00154321 
+  655          636.25556    329.6494    0.001526718 
+  738          662.80982    329.22844   0.001355014 
+  772          691.57481    328.80845   0.001295337 
+  792          721.10986    328.38941   0.001262626 
+  868          750.90961    327.97133   0.001152074 
+  890          781.53689    327.5542    0.001123596 
+  892          809.68494    327.13802   0.001121076 
+  908          837.078      326.72279   0.001101322 
+  881          848.68037    326.30851   0.001135074 
+  888          821.46687    325.89517   0.001126126 
+  872          785.18656    325.48277   0.001146789 
+  801          751.88094    325.07131   0.001248439 
+  727          705.20692    324.66079   0.001375516 
+  688          652.05643    324.2512    0.001453488 
+  660          605.00488    323.84255   0.001515152 
+  621          564.78811    323.43482   0.001610306 
+  616          530.54197    323.02802   0.001623377 
+  535          501.69228    322.62215   0.001869159 
+  540          477.75957    322.2172    0.001851852 
+  492          458.05469    321.81318   0.00203252 
+  428          441.78659    321.41007   0.002336449 
+  459          428.31162    321.00787   0.002178649 
+  439          417.09311    320.60659   0.002277904 
+  416          407.67236    320.20622   0.002403846 
+  382          399.68539    319.80676   0.002617801 
+  396          392.8493     319.40821   0.002525253 
+  356          386.94494    319.01056   0.002808989 
+  389          381.8038     318.61382   0.002570694 
+  362          377.29265    318.21797   0.002762431 
+  380          373.30697    317.82303   0.002631579 
+  369          369.76404    317.42898   0.002710027 
+  362          366.59758    317.03582   0.002762431 
+  361          363.75481    316.64355   0.002770083 
+  379          361.1932     316.25218   0.002638522 
+  338          358.87819    315.86169   0.00295858 
+  359          356.78368    315.47208   0.002785515 
+  370          354.88934    315.08336   0.002702703 
+  353          353.17059    314.69552   0.002832861 
+  336          351.62017    314.30855   0.00297619 
+  330          350.22804    313.92246   0.003030303 
+  330          348.98932    313.53725   0.003030303 
+  350          347.90718    313.1529    0.002857143 
+  343          346.98306    312.76943   0.002915452 
+  355          346.23044    312.38682   0.002816901 
+  347          345.67175    312.00508   0.002881844 
+  313          345.34246    311.6242    0.003194888 
+  361          345.29949    311.24418   0.002770083 
+  393          345.63505    310.86502   0.002544529 
+  329          346.50306    310.48672   0.003039514 
+  353          348.1794     310.10927   0.002832861 
+  296          351.19721    309.73267   0.003378378 
+  355          356.63834    309.35692   0.002816901 
+  386          366.57647    308.98202   0.002590674 
+  395          383.77002    308.60797   0.002531646 
+  439          406.77947    308.23476   0.002277904 
+  489          432.52417    307.86239   0.00204499 
+  482          456.03775    307.49086   0.002074689 
+  452          447.21394    307.12016   0.002212389 
+  436          427.04928    306.7503    0.002293578 
+  445          419.28435    306.38128   0.002247191 
+  405          410.51353    306.01308   0.002469136 
+  401          390.6435     305.64572   0.002493766 
+  351          374.74483    305.27918   0.002849003 
+  378          365.31412    304.91347   0.002645503 
+  379          359.43839    304.54857   0.002638522 
+  374          355.25082    304.1845    0.002673797 
+  358          352.14115    303.82125   0.002793296 
+  341          350.1125     303.45881   0.002932551 
+  335          349.50016    303.09719   0.002985075 
+  351          349.88118    302.73638   0.002849003 
+  364          351.11497    302.37638   0.002747253 
+  330          351.11326    302.01719   0.003030303 
+  324          346.58065    301.6588    0.00308642 
+  367          342.19572    301.30122   0.002724796 
+  363          339.83655    300.94444   0.002754821 
+  373          336.67267    300.58846   0.002680965 
+  355          332.56932    300.23328   0.002816901 
+  330          330.14064    299.87889   0.003030303 
+  361          328.30187    299.5253    0.002770083 
+  361          327.1604     299.1725    0.002770083 
+  356          326.45125    298.82049   0.002808989 
+  346          326.35322    298.46927   0.002890173 
+  353          326.3285     298.11884   0.002832861 
+  346          326.75439    297.76918   0.002890173 
+  351          327.8845     297.42031   0.002849003 
+  345          329.91512    297.07222   0.002898551 
+  356          332.42881    296.72491   0.002808989 
+  367          335.32567    296.37838   0.002724796 
+  356          336.50429    296.03261   0.002808989 
+  357          334.82597    295.68762   0.00280112 
+  341          333.77023    295.34341   0.002932551 
+  344          334.00998    294.99995   0.002906977 
+  360          333.61424    294.65727   0.002777778 
+  359          333.25258    294.31535   0.002785515 
+  343          334.55593    293.97419   0.002915452 
+  385          338.06644    293.63379   0.002597403 
+  376          344.26469    293.29415   0.002659574 
+  390          353.23966    292.95527   0.002564103 
+  398          366.97909    292.61714   0.002512563 
+  385          386.75315    292.27977   0.002597403 
+  399          414.3879     291.94315   0.002506266 
+  480          445.49469    291.60727   0.002083333 
+  516          489.92949    291.27214   0.001937984 
+  601          481.57909    290.93776   0.001663894 
+  453          439.17886    290.60412   0.002207506 
+  481          423.74167    290.27122   0.002079002 
+  514          424.95213    289.93906   0.001945525 
+  456          397.56319    289.60764   0.002192982 
+  421          371.84057    289.27696   0.002375297 
+  387          359.21152    288.94701   0.002583979 
+  426          353.33594    288.61779   0.002347418 
+  400          351.21694    288.2893    0.0025    
+  367          351.19388    287.96154   0.002724796 
+  392          352.00202    287.63451   0.00255102 
+  381          353.8371     287.3082    0.002624672 
+  412          357.13196    286.98261   0.002427184 
+  370          362.03237    286.65774   0.002702703 
+  376          368.81808    286.3336    0.002659574 
+  384          378.31992    286.01017   0.002604167 
+  401          392.18845    285.68745   0.002493766 
+  437          416.11269    285.36545   0.00228833 
+  443          461.43598    285.04416   0.002257336 
+  546          531.53613    284.72358   0.001831502 
+  609          608.01882    284.40371   0.001642036 
+  725          698.33239    284.08455   0.00137931 
+  669          661.57312    283.76609   0.001494768 
+  620          596.80951    283.44833   0.001612903 
+  561          588.95365    283.13128   0.001782531 
+  616          598.2526     282.81492   0.001623377 
+  611          550.37063    282.49926   0.001636661 
+  591          519.36571    282.1843    0.001692047 
+  621          521.71699    281.87003   0.001610306 
+  630          546.43028    281.55645   0.001587302 
+  652          583.56668    281.24356   0.001533742 
+  642          629.17093    280.93136   0.001557632 
+  626          664.666      280.61985   0.001597444 
+  744          691.97704    280.30902   0.001344086 
+  737          738.87048    279.99888   0.001356852 
+  860          811.34946    279.68942   0.001162791 
+  1003         903.07325    279.38063   0.000997009 
+  1217         1033.71623   279.07253   0.000821693 
+  1449         1238.72498   278.7651    0.000690131 
+  1733         1567.57527   278.45835   0.000577034 
+  2546         2137.93455   278.15226   0.000392773 
+  3778         3264.98477   277.84685   0.00026469 
+  6324         5618.71057   277.54211   0.000158128 
+  11104        9539.71028   277.23804   0.000090058 
+  19360        15939.15256  276.93463   0.000051653 
+  26577        20980.093    276.63189   0.000037627 
+  19862        17210.96212  276.32981   0.000050347 
+  12414        11922.73478  276.02839   0.000080554 
+  12614        11767.6262   275.72763   0.000079277 
+  13109        11661.34743  275.42753   0.000076283 
+  7472         7430.49672   275.12808   0.000133833 
+  3380         3909.46977   274.82929   0.000295858 
+  2025         2349.7543    274.53115   0.000493827 
+  1426         1649.10378   274.23366   0.000701262 
+  1162         1272.32073   273.93682   0.000860585 
+  974          1043.19346   273.64063   0.001026694 
+  854          894.03458    273.34508   0.00117096 
+  765          792.17364    273.05018   0.00130719 
+  737          713.91967    272.75592   0.001356852 
+  653          648.50268    272.4623    0.001531394 
+  606          599.7169     272.16932   0.001650165 
+  550          564.15905    271.87698   0.001818182 
+  523          530.14614    271.58527   0.001912046 
+  529          495.37074    271.2942    0.001890359 
+  479          467.95681    271.00376   0.002087683 
+  437          447.77031    270.71395   0.00228833 
+  390          430.74377    270.42477   0.002564103 
+  435          416.24061    270.13622   0.002298851 
+  409          406.33347    269.8483    0.002444988 
+  394          400.55042    269.56099   0.002538071 
+  394          397.93386    269.27432   0.002538071 
+  452          394.81228    268.98826   0.002212389 
+  385          389.27995    268.70282   0.002597403 
+  361          383.48886    268.41801   0.002770083 
+  398          377.55564    268.1338    0.002512563 
+  389          373.36235    267.85022   0.002570694 
+  391          370.53404    267.56724   0.002557545 
+  381          368.08324    267.28488   0.002624672 
+  369          362.0507     267.00313   0.002710027 
+  384          353.61756    266.72199   0.002604167 
+  337          347.34786    266.44145   0.002967359 
+  335          342.92623    266.16152   0.002985075 
+  351          337.23001    265.8822    0.002849003 
+  320          330.55011    265.60348   0.003125  
+  318          325.00257    265.32535   0.003144654 
+  315          320.59099    265.04783   0.003174603 
+  316          316.99512    264.77091   0.003164557 
+  324          314.03139    264.49458   0.00308642 
+  264          311.60756    264.21884   0.003787879 
+  332          309.64799    263.9437    0.003012048 
+  284          308.06072    263.66915   0.003521127 
+  294          306.70674    263.3952    0.003401361 
+  308          305.42654    263.12183   0.003246753 
+  309          304.07974    262.84904   0.003236246 
+  300          302.60685    262.57685   0.003333333 
+  310          301.03038    262.30523   0.003225806 
+  308          299.40002    262.0342    0.003246753 
+  271          297.75376    261.76375   0.003690037 
+  284          296.13336    261.49388   0.003521127 
+  303          294.57889    261.22459   0.00330033 
+  316          293.14772    260.95588   0.003164557 
+  265          291.90487    260.68774   0.003773585 
+  284          290.10577    260.42017   0.003521127 
+  306          289.27382    260.15318   0.003267974 
+  311          288.65055    259.88675   0.003215434 
+  278          287.87505    259.6209    0.003597122 
+  267          287.72414    259.35562   0.003745318 
+  282          287.82855    259.0909    0.003546099 
+  293          288.14836    258.82674   0.003412969 
+  278          288.59756    258.56315   0.003597122 
+  284          289.03409    258.30012   0.003521127 
+  327          289.39035    258.03765   0.003058104 
+  267          290.3084     257.77574   0.003745318 
+  305          291.67773    257.51439   0.003278689 
+  316          292.83005    257.2536    0.003164557 
+  294          291.78838    256.99335   0.003401361 
+  318          289.95547    256.73367   0.003144654 
+  287          289.41363    256.47453   0.003484321 
+  332          290.06138    256.21595   0.003012048 
+  307          290.99292    255.95791   0.003257329 
+  351          293.54689    255.70042   0.002849003 
+  344          300.19773    255.44348   0.002906977 
+  378          312.82216    255.18708   0.002645503 
+  433          329.84608    254.93123   0.002309469 
+  445          347.58371    254.67592   0.002247191 
+  463          352.67971    254.42115   0.002159827 
+  468          340.88076    254.16691   0.002136752 
+  424          331.43435    253.91322   0.002358491 
+  432          327.14671    253.66006   0.002314815 
+  383          320.15885    253.40744   0.002610966 
+  389          305.80945    253.15535   0.002570694 
+  376          293.56773    252.9038    0.002659574 
+  355          286.21623    252.65277   0.002816901 
+  335          282.18253    252.40228   0.002985075 
+  288          280.06236    252.15231   0.003472222 
+  306          279.21506    251.90287   0.003267974 
+  303          279.63631    251.65395   0.00330033 
+  321          281.89609    251.40556   0.003115265 
+  319          286.12952    251.15769   0.003134796 
+  312          291.16201    250.91035   0.003205128 
+  332          294.69306    250.66352   0.003012048 
+  340          290.28243    250.41721   0.002941176 
+  284          287.42131    250.17142   0.003521127 
+  294          288.06332    249.92615   0.003401361 
+  311          289.55573    249.68139   0.003215434 
+  331          287.91426    249.43715   0.003021148 
+  273          287.86921    249.19341   0.003663004 
+  286          291.07358    248.95019   0.003496503 
+  317          298.07437    248.70748   0.003154574 
+  339          311.59264    248.46527   0.002949853 
+  338          339.00042    248.22357   0.00295858 
+  367          392.38668    247.98238   0.002724796 
+  428          464.07842    247.74169   0.002336449 
+  559          545.84567    247.50151   0.001788909 
+  500          550.87238    247.26182   0.002     
+  426          486.07636    247.02264   0.002347418 
+  415          464.72367    246.78396   0.002409639 
+  443          465.03865    246.54577   0.002257336 
+  439          437.205      246.30808   0.002277904 
+  344          377.69812    246.07089   0.002906977 
+  325          341.68646    245.83419   0.003076923 
+  298          318.22335    245.59798   0.003355705 
+  305          302.71685    245.36226   0.003278689 
+  298          293.65345    245.12704   0.003355705 
+  309          288.44588    244.8923    0.003236246 
+  271          285.43317    244.65805   0.003690037 
+  292          283.7568     244.42429   0.003424658 
+  252          283.02289    244.19101   0.003968254 
+  310          283.04878    243.95822   0.003225806 
+  319          283.45584    243.72591   0.003134796 
+  279          283.59803    243.49408   0.003584229 
+  296          283.84904    243.26273   0.003378378 
+  306          284.6529     243.03186   0.003267974 
+  269          285.8847     242.80146   0.003717472 
+  286          287.18067    242.57155   0.003496503 
+  278          288.67793    242.34211   0.003597122 
+  303          290.62165    242.11314   0.00330033 
+  306          293.06711    241.88464   0.003267974 
+  332          296.09528    241.65662   0.003012048 
+  297          299.93777    241.42907   0.003367003 
+  323          305.18807    241.20199   0.003095975 
+  347          312.77716    240.97537   0.002881844 
+  351          322.90805    240.74922   0.002849003 
+  342          330.71619    240.52354   0.002923977 
+  313          332.70213    240.29832   0.003194888 
+  334          336.68038    240.07357   0.002994012 
+  318          346.93232    239.84928   0.003144654 
+  366          363.9616     239.62544   0.00273224 
+  363          390.47166    239.40207   0.002754821 
+  438          427.36679    239.17916   0.002283105 
+  470          469.2126     238.9567    0.00212766 
+  468          476.84674    238.7347    0.002136752 
+  447          447.24045    238.51316   0.002237136 
+  435          442.62585    238.29206   0.002298851 
+  420          458.05546    238.07142   0.002380952 
+  466          467.99731    237.85124   0.002145923 
+  440          458.54216    237.6315    0.002272727 
+  474          462.34662    237.41221   0.002109705 
+  450          481.86148    237.19337   0.002222222 
+  528          513.15863    236.97498   0.001893939 
+  574          553.00592    236.75703   0.00174216 
+  649          603.47997    236.53953   0.001540832 
+  742          672.55319    236.32247   0.001347709 
+  864          768.7731     236.10585   0.001157407 
+  988          904.22337    235.88967   0.001012146 
+  1061         1103.02012   235.67394   0.000942507 
+  1351         1416.24003   235.45864   0.000740192 
+  2074         1961.53427   235.24378   0.00048216 
+  3063         3064.20939   235.02936   0.000326477 
+  5532         5513.90957   234.81537   0.000180766 
+  9916         9871.88992   234.60182   0.000100847 
+  16911        14891.47851  234.3887    0.000059133 
+  20003        17816.49514  234.17601   0.000049993 
+  13211        11899.08322  233.96376   0.000075694 
+  8660         8862.62653   233.75193   0.000115473 
+  9311         9102.28299   233.54053   0.0001074 
+  10533        10086.61815  233.32957   0.00009494 
+  7024         6559.78493   233.11902   0.000142369 
+  3123         3447.93098   232.90891   0.000320205 
+  1696         2056.66674   232.69921   0.000589623 
+  1132         1433.51802   232.48994   0.000883392 
+  904          1098.71314   232.2811    0.001106195 
+  738          892.3465     232.07267   0.001355014 
+  666          754.93118    231.86467   0.001501502 
+  570          658.62711    231.65708   0.001754386 
+  532          588.73413    231.44991   0.001879699 
+  498          536.93009    231.24316   0.002008032 
+  433          498.49218    231.03683   0.002309469 
+  407          471.27645    230.83091   0.002457002 
+  409          455.88484    230.6254    0.002444988 
+  438          456.01152    230.42031   0.002283105 
+  432          471.81109    230.21563   0.002314815 
+  444          494.73606    230.01136   0.002252252 
+  464          486.53379    229.8075    0.002155172 
+  409          449.33685    229.60405   0.002444988 
+  401          433.36047    229.401     0.002493766 
+  377          425.77838    229.19836   0.00265252 
+  354          408.60916    228.99613   0.002824859 
+  355          374.91424    228.7943    0.002816901 
+  323          350.74792    228.59288   0.003095975 
+  321          333.72244    228.39186   0.003115265 
+  305          318.57879    228.19123   0.003278689 
+  279          307.37219    227.99101   0.003584229 
+  340          299.55995    227.79119   0.002941176 
+  325          293.91658    227.59177   0.003076923 
+  273          289.65658    227.39275   0.003663004 
+  256          286.36886    227.19412   0.00390625 
+  295          283.83827    226.99588   0.003389831 
+  253          281.93604    226.79804   0.003952569 
+  234          280.55686    226.6006    0.004273504 
+  267          279.56658    226.40354   0.003745318 
+  257          278.78569    226.20688   0.003891051 
+  266          278.01483    226.01061   0.003759398 
+  259          277.10274    225.81473   0.003861004 
+  249          276.05117    225.61923   0.004016064 
+  273          274.973      225.42413   0.003663004 
+  263          274.00456    225.22941   0.003802281 
+  266          273.2763     225.03507   0.003759398 
+  266          272.95085    224.84112   0.003759398 
+  243          273.3185     224.64756   0.004115226 
+  226          274.87636    224.45437   0.004424779 
+  271          278.39604    224.26157   0.003690037 
+  259          284.23951    224.06915   0.003861004 
+  265          288.16501    223.8771    0.003773585 
+  233          284.09193    223.68544   0.004291845 
+  237          278.62102    223.49416   0.004219409 
+  224          275.91982    223.30325   0.004464286 
+  252          274.3683     223.11271   0.003968254 
+  257          270.19104    222.92256   0.003891051 
+  258          264.55924    222.73277   0.003875969 
+  227          260.22608    222.54336   0.004405286 
+  233          256.97607    222.35432   0.004291845 
+  262          254.65772    222.16565   0.003816794 
+  244          253.14411    221.97736   0.004098361 
+  232          252.27298    221.78943   0.004310345 
+  258          251.99156    221.60187   0.003875969 
+  238          252.38863    221.41468   0.004201681 
+  235          253.65789    221.22785   0.004255319 
+  255          255.73975    221.04139   0.003921569 
+  245          257.63797    220.85529   0.004081633 
+  283          258.78701    220.66956   0.003533569 
+  223          260.86248    220.48419   0.004484305 
+  241          264.73636    220.29919   0.004149378 
+  292          270.84909    220.11454   0.003424658 
+  285          280.64022    219.93026   0.003508772 
+  251          300.52492    219.74633   0.003984064 
+  344          340.12553    219.56276   0.002906977 
+  403          397.14733    219.37955   0.00248139 
+  477          455.56185    219.1967    0.002096436 
+  504          459.6966     219.0142    0.001984127 
+  415          425.70036    218.83206   0.002409639 
+  371          418.88968    218.65027   0.002695418 
+  406          410.99306    218.46883   0.002463054 
+  402          396.83548    218.28775   0.002487562 
+  386          357.94227    218.10701   0.002590674 
+  344          332.94606    217.92663   0.002906977 
+  302          315.22695    217.7466    0.003311258 
+  294          301.76475    217.56691   0.003401361 
+  289          298.13712    217.38758   0.003460208 
+  272          302.17579    217.20859   0.003676471 
+  323          298.825      217.02994   0.003095975 
+  295          289.24244    216.85165   0.003389831 
+  313          283.50196    216.67369   0.003194888 
+  294          279.99678    216.49608   0.003401361 
+  285          275.23076    216.31881   0.003508772 
+  237          266.49939    216.14189   0.004219409 
+  236          259.44141    215.9653    0.004237288 
+  230          254.12195    215.78906   0.004347826 
+  203          249.47091    215.61315   0.004926108 
+  232          246.37866    215.43759   0.004310345 
+  195          244.59884    215.26236   0.005128205 
+  241          243.65217    215.08747   0.004149378 
+  224          243.25537    214.91291   0.004464286 
+  234          243.28665    214.73869   0.004273504 
+  226          243.70065    214.5648    0.004424779 
+  258          244.34068    214.39125   0.003875969 
+  250          244.78316    214.21803   0.004     
+  238          245.18123    214.04514   0.004201681 
+  254          245.94286    213.87258   0.003937008 
+  215          247.15155    213.70035   0.004651163 
+  200          248.71737    213.52846   0.005     
+  251          250.74331    213.35689   0.003984064 
+  237          253.88999    213.18564   0.004219409 
+  233          259.02562    213.01473   0.004291845 
+  233          266.57425    212.84414   0.004291845 
+  249          272.69488    212.67388   0.004016064 
+  235          271.76762    212.50394   0.004255319 
+  239          269.78793    212.33433   0.0041841 
+  252          271.28395    212.16503   0.003968254 
+  240          275.37837    211.99607   0.004166667 
+  273          278.01068    211.82742   0.003663004 
+  245          279.03293    211.65909   0.004081633 
+  256          281.76973    211.49108   0.00390625 
+  278          286.95384    211.32339   0.003597122 
+  300          294.69374    211.15603   0.003333333 
+  288          305.69171    210.98897   0.003472222 
+  316          321.64715    210.82224   0.003164557 
+  292          345.14999    210.65582   0.003424658 
+  377          375.4024     210.48971   0.00265252 
+  347          396.06247    210.32392   0.002881844 
+  392          401.54605    210.15845   0.00255102 
+  341          412.62516    209.99329   0.002932551 
+  434          435.3486     209.82843   0.002304147 
+  398          462.59946    209.6639    0.002512563 
+  455          481.60024    209.49967   0.002197802 
+  467          496.02695    209.33575   0.002141328 
+  545          512.75755    209.17214   0.001834862 
+  583          532.71411    209.00884   0.001715266 
+  644          555.50996    208.84585   0.001552795 
+  645          579.64801    208.68316   0.001550388 
+  680          602.34222    208.52078   0.001470588 
+  658          620.43199    208.3587    0.001519757 
+  733          632.17707    208.19693   0.001364256 
+  680          638.65705    208.03547   0.001470588 
+  674          643.13672    207.87431   0.00148368 
+  652          648.82545    207.71345   0.001533742 
+  714          656.9886     207.55289   0.00140056 
+  655          668.30538    207.39263   0.001526718 
+  652          685.01777    207.23268   0.001533742 
+  663          704.69932    207.07302   0.001508296 
+  624          718.38664    206.91366   0.001602564 
+  613          711.67492    206.7546    0.001631321 
+  618          695.76085    206.59584   0.001618123 
+  573          677.33889    206.43738   0.001745201 
+  592          654.20399    206.27921   0.001689189 
+  588          621.6704     206.12133   0.00170068 
+  561          580.1417     205.96376   0.001782531 
+  595          538.13247    205.80647   0.001680672 
+  485          497.7179     205.64948   0.002061856 
+  488          459.84957    205.49278   0.00204918 
+  406          425.63802    205.33637   0.002463054 
+  401          395.79323    205.18026   0.002493766 
+  360          370.43755    205.02443   0.002777778 
+  362          349.25083    204.8689    0.002762431 
+  336          331.70168    204.71365   0.00297619 
+  303          317.23342    204.5587    0.00330033 
+  318          305.3617     204.40403   0.003144654 
+  328          295.72593    204.24964   0.00304878 
+  295          288.1437     204.09555   0.003389831 
+  279          282.72206    203.94174   0.003584229 
+  290          279.97184    203.78821   0.003448276 
+  284          280.58993    203.63497   0.003521127 
+  249          282.71437    203.48202   0.004016064 
+  261          278.51629    203.32934   0.003831418 
+  282          269.4926     203.17695   0.003546099 
+  263          263.28835    203.02484   0.003802281 
+  244          260.96393    202.87301   0.004098361 
+  257          259.39111    202.72147   0.003891051 
+  271          254.50735    202.5702    0.003690037 
+  262          249.0366     202.41921   0.003816794 
+  227          245.23995    202.2685    0.004405286 
+  217          242.81836    202.11807   0.004608295 
+  239          241.34076    201.96791   0.0041841 
+  219          240.54017    201.81804   0.00456621 
+  213          240.29326    201.66843   0.004694836 
+  228          240.53775    201.51911   0.004385965 
+  257          241.2265     201.37005   0.003891051 
+  209          242.22739    201.22127   0.004784689 
+  237          243.4067     201.07277   0.004219409 
+  196          244.63142    200.92454   0.005102041 
+  234          245.89387    200.77658   0.004273504 
+  243          247.37891    200.62889   0.004115226 
+  215          249.36523    200.48147   0.004651163 
+  245          251.30132    200.33432   0.004081633 
+  232          250.20174    200.18744   0.004310345 
+  231          246.19881    200.04084   0.004329004 
+  235          242.75264    199.8945    0.004255319 
+  223          240.74906    199.74842   0.004484305 
+  245          239.36187    199.60262   0.004081633 
+  234          237.01893    199.45708   0.004273504 
+  237          234.83636    199.31181   0.004219409 
+  241          234.30646    199.1668    0.004149378 
+  210          234.61339    199.02205   0.004761905 
+  224          233.10566    198.87758   0.004464286 
+  232          231.11912    198.73336   0.004310345 
+  206          231.30641    198.58941   0.004854369 
+  231          234.53507    198.44572   0.004329004 
+  238          240.23327    198.30229   0.004201681 
+  233          244.33383    198.15912   0.004291845 
+  248          243.1285     198.01622   0.004032258 
+  234          240.94652    197.87357   0.004273504 
+  227          238.88753    197.73118   0.004405286 
+  262          238.70346    197.58905   0.003816794 
+  241          240.66718    197.44718   0.004149378 
+  229          243.87695    197.30557   0.004366812 
+  235          248.04138    197.16421   0.004255319 
+  238          245.05045    197.02311   0.004201681 
+  234          237.04837    196.88227   0.004273504 
+  220          232.30126    196.74168   0.004545455 
+  231          231.93736    196.60135   0.004329004 
+  231          233.16218    196.46127   0.004329004 
+  224          231.4684     196.32144   0.004464286 
+  216          228.90565    196.18187   0.00462963 
+  245          228.49839    196.04255   0.004081633 
+  222          230.73829    195.90348   0.004504505 
+  244          236.21478    195.76467   0.004098361 
+  228          246.68339    195.6261    0.004385965 
+  246          265.31964    195.48778   0.004065041 
+  273          295.51427    195.34972   0.003663004 
+  325          345.9867     195.2119    0.003076923 
+  389          396.62759    195.07433   0.002570694 
+  400          370.02602    194.93701   0.0025    
+  369          326.56266    194.79994   0.002710027 
+  327          307.21472    194.66311   0.003058104 
+  284          314.9997     194.52653   0.003521127 
+  327          321.7703     194.3902    0.003058104 
+  297          293.96395    194.25411   0.003367003 
+  302          266.53724    194.11826   0.003311258 
+  259          251.26468    193.98266   0.003861004 
+  245          245.59037    193.84731   0.004081633 
+  222          242.7127     193.71219   0.004504505 
+  242          238.01269    193.57732   0.004132231 
+  216          233.43196    193.44269   0.00462963 
+  256          230.27084    193.30831   0.00390625 
+  225          229.38086    193.17416   0.004444444 
+  216          228.83886    193.04026   0.00462963 
+  220          227.68848    192.90659   0.004545455 
+  226          227.33266    192.77316   0.004424779 
+  264          228.4323     192.63998   0.003787879 
+  229          229.632      192.50703   0.004366812 
+  227          227.6592     192.37432   0.004405286 
+  239          225.79205    192.24184   0.0041841 
+  224          225.47466    192.10961   0.004464286 
+  242          226.50195    191.97761   0.004132231 
+  232          227.10032    191.84584   0.004310345 
+  208          226.5169     191.71431   0.004807692 
+  210          225.7852     191.58302   0.004761905 
+  233          225.46632    191.45196   0.004291845 
+  215          225.3507     191.32113   0.004651163 
+  214          225.29329    191.19054   0.004672897 
+  214          225.29834    191.06018   0.004672897 
+  217          225.42714    190.93005   0.004608295 
+  227          225.7333     190.80016   0.004405286 
+  232          226.29223    190.67049   0.004310345 
+  233          227.25803    190.54106   0.004291845 
+  229          228.91037    190.41186   0.004366812 
+  250          231.62343    190.28288   0.004     
+  217          235.32686    190.15414   0.004608295 
+  218          237.9354     190.02562   0.004587156 
+  245          238.42747    189.89734   0.004081633 
+  196          239.33648    189.76928   0.005102041 
+  244          241.48409    189.64145   0.004098361 
+  229          244.24566    189.51384   0.004366812 
+  226          246.01682    189.38646   0.004424779 
+  244          246.4116     189.25931   0.004098361 
+  242          246.76962    189.13239   0.004132231 
+  237          247.53265    189.00568   0.004219409 
+  227          248.65059    188.87921   0.004405286 
+  231          250.05656    188.75296   0.004329004 
+  242          251.77706    188.62693   0.004132231 
+  221          253.93395    188.50112   0.004524887 
+  248          256.68365    188.37554   0.004032258 
+  226          260.17478    188.25018   0.004424779 
+  235          264.54524    188.12504   0.004255319 
+  249          269.93463    188.00012   0.004016064 
+  273          276.5185     187.87543   0.003663004 
+  288          284.54695    187.75095   0.003472222 
+  296          294.39777    187.62669   0.003378378 
+  278          306.69353    187.50266   0.003597122 
+  314          322.50541    187.37884   0.003184713 
+  319          343.56781    187.25524   0.003134796 
+  365          371.7235     187.13186   0.002739726 
+  410          403.95801    187.0087    0.002439024 
+  421          430.14415    186.88575   0.002375297 
+  456          457.56856    186.76302   0.002192982 
+  499          499.48437    186.64051   0.002004008 
+  556          561.32421    186.51822   0.001798561 
+  576          647.11986    186.39614   0.001736111 
+  712          763.30316    186.27427   0.001404494 
+  785          936.3605     186.15262   0.001273885 
+  1032         1219.64004   186.03118   0.000968992 
+  1613         1732.65185   185.90996   0.000619963 
+  2685         2805.03278   185.78895   0.000372439 
+  4912         5201.8325    185.66815   0.000203583 
+  8649         9282.13757   185.54757   0.00011562 
+  11769        12823.89767  185.4272    0.000084969 
+  9157         10106.65545  185.30704   0.000109206 
+  5255         5966.73151   185.18709   0.000190295 
+  4217         4899.68429   185.06735   0.000237135 
+  5239         5962.97612   184.94782   0.000190876 
+  6169         7171.50451   184.82851   0.000162101 
+  4641         5342.15602   184.7094    0.000215471 
+  2345         2877.48731   184.5905    0.000426439 
+  1334         1667.40759   184.47181   0.000749625 
+  866          1128.57697   184.35333   0.001154734 
+  687          851.79038    184.23505   0.001455604 
+  598          686.22526    184.11699   0.001672241 
+  507          577.8691     183.99913   0.001972387 
+  462          502.6993     183.88147   0.002164502 
+  399          448.26242    183.76403   0.002506266 
+  336          407.52425    183.64679   0.00297619 
+  327          376.2723     183.52975   0.003058104 
+  359          351.85256    183.41292   0.002785515 
+  300          332.54613    183.2963    0.003333333 
+  310          317.24477    183.17988   0.003225806 
+  268          305.28367    183.06366   0.003731343 
+  304          296.39761    182.94764   0.003289474 
+  289          290.83417    182.83183   0.003460208 
+  291          289.64958    182.71623   0.003436426 
+  307          295.02887    182.60082   0.003257329 
+  342          309.06221    182.48562   0.002923977 
+  289          323.75974    182.37062   0.003460208 
+  267          316.38971    182.25582   0.003745318 
+  273          297.26759    182.14122   0.003663004 
+  286          287.76975    182.02682   0.003496503 
+  286          291.79237    181.91262   0.003496503 
+  281          305.6676     181.79862   0.003558719 
+  280          320.15955    181.68482   0.003571429 
+  298          340.27012    181.57121   0.003355705 
+  315          355.39716    181.45781   0.003174603 
+  321          332.31575    181.3446    0.003115265 
+  279          298.42499    181.2316    0.003584229 
+  258          281.37901    181.11879   0.003875969 
+  272          281.50761    181.00617   0.003676471 
+  270          285.04174    180.89376   0.003703704 
+  262          270.65524    180.78154   0.003816794 
+  243          248.65168    180.66951   0.004115226 
+  243          232.85075    180.55768   0.004115226 
+  221          223.11207    180.44605   0.004524887 
+  266          216.96726    180.33461   0.003759398 
+  228          212.78711    180.22337   0.004385965 
+  222          209.71732    180.11232   0.004504505 
+  240          207.32984    180.00146   0.004166667 
+  213          205.39441    179.8908    0.004694836 
+  200          203.77939    179.78033   0.005     
+  214          202.40189    179.67005   0.004672897 
+  214          201.20755    179.55996   0.004672897 
+  203          200.15404    179.45007   0.004926108 
+  205          199.227      179.34037   0.004878049 
+  217          198.40169    179.23086   0.004608295 
+  205          197.66555    179.12154   0.004878049 
+  200          197.01004    179.01241   0.005     
+  221          196.42542    178.90347   0.004524887 
+  199          195.91685    178.79472   0.005025126 
+  194          195.47608    178.68616   0.005154639 
+  192          195.10815    178.57779   0.005208333 
+  222          194.81944    178.46961   0.004504505 
+  219          194.62256    178.36162   0.00456621 
+  185          194.54051    178.25381   0.005405405 
+  212          194.62097    178.14619   0.004716981 
+  204          194.92989    178.03876   0.004901961 
+  196          195.50007    177.93152   0.005102041 
+  219          196.02092    177.82447   0.00456621 
+  192          195.90091    177.7176    0.005208333 
+  191          195.45814    177.61091   0.005235602 
+  194          195.25193    177.50442   0.005154639 
+  200          195.41968    177.39811   0.005     
+  175          195.82142    177.29198   0.005714286 
+  180          196.14922    177.18604   0.005555556 
+  228          196.50931    177.08028   0.004385965 
+  186          197.25663    176.97471   0.005376344 
+  194          198.62014    176.86932   0.005154639 
+  213          200.84612    176.76411   0.004694836 
+  173          204.43769    176.65909   0.005780347 
+  212          210.47673    176.55425   0.004716981 
+  233          221.1029     176.44959   0.004291845 
+  261          239.57252    176.34512   0.003831418 
+  260          265.76296    176.24083   0.003846154 
+  234          279.30737    176.13671   0.004273504 
+  196          262.92418    176.03278   0.005102041 
+  243          243.71807    175.92904   0.004115226 
+  250          236.67052    175.82547   0.004     
+  229          240.69049    175.72208   0.004366812 
+  233          245.31289    175.61887   0.004291845 
+  204          236.68143    175.51584   0.004901961 
+  196          224.53437    175.413     0.005102041 
+  189          218.13868    175.31033   0.005291005 
+  213          217.05814    175.20784   0.004694836 
+  206          220.80414    175.10552   0.004854369 
+  248          226.28306    175.00339   0.004032258 
+  221          223.63675    174.90144   0.004524887 
+  242          215.63598    174.79966   0.004132231 
+  207          210.55567    174.69806   0.004830918 
+  208          209.67174    174.59663   0.004807692 
+  209          211.65105    174.49539   0.004784689 
+  206          211.35246    174.39432   0.004854369 
+  222          207.74694    174.29342   0.004504505 
+  260          205.6417     174.1927    0.003846154 
+  215          206.57762    174.09216   0.004651163 
+  226          210.33391    173.9918    0.004424779 
+  243          214.90722    173.8916    0.004115226 
+  215          218.54983    173.79159   0.004651163 
+  279          225.61387    173.69174   0.003584229 
+  281          240.47       173.59207   0.003558719 
+  273          262.22805    173.49258   0.003663004 
+  229          277.50564    173.39326   0.004366812 
+  266          272.30129    173.29411   0.003759398 
+  252          260.37571    173.19513   0.003968254 
+  263          259.70282    173.09633   0.003802281 
+  286          273.83715    172.9977    0.003496503 
+  298          297.58634    172.89924   0.003355705 
+  295          315.50915    172.80096   0.003389831 
+  314          318.62206    172.70284   0.003184713 
+  307          319.64438    172.6049    0.003257329 
+  304          318.62742    172.50713   0.003289474 
+  331          329.11763    172.40953   0.003021148 
+  398          367.91122    172.3121    0.002512563 
+  456          449.53693    172.21484   0.002192982 
+  510          606.39438    172.11775   0.001960784 
+  664          814.19563    172.02083   0.001506024 
+  694          803.25878    171.92408   0.001440922 
+  618          589.38768    171.8275    0.001618123 
+  448          465.83023    171.73108   0.002232143 
+  425          454.02278    171.63484   0.002352941 
+  453          520.56854    171.53876   0.002207506 
+  420          550.45695    171.44286   0.002380952 
+  420          442.11829    171.34712   0.002380952 
+  320          344.34131    171.25155   0.003125  
+  297          292.40589    171.15614   0.003367003 
+  272          266.98935    171.0609    0.003676471 
+  251          256.38407    170.96583   0.003984064 
+  235          256.20404    170.87093   0.004255319 
+  247          267.35122    170.77619   0.004048583 
+  250          298.50379    170.68162   0.004     
+  335          376.4696     170.58721   0.002985075 
+  428          524.55012    170.49297   0.002336449 
+  493          566.01668    170.3989    0.002028398 
+  437          430.87309    170.30499   0.00228833 
+  391          361.47913    170.21124   0.002557545 
+  391          376.81127    170.11766   0.002557545 
+  454          462.46139    170.02425   0.002202643 
+  497          536.42089    169.93099   0.002012072 
+  448          451.52924    169.83791   0.002232143 
+  357          349.38779    169.74498   0.00280112 
+  296          299.19812    169.65222   0.003378378 
+  280          286.88249    169.55962   0.003571429 
+  285          288.78887    169.46719   0.003508772 
+  259          275.42378    169.37491   0.003861004 
+  263          248.91831    169.2828    0.003802281 
+  235          226.91836    169.19085   0.004255319 
+  201          213.74745    169.09907   0.004975124 
+  220          206.62748    169.00744   0.004545455 
+  194          203.08075    168.91598   0.005154639 
+  194          201.03193    168.82468   0.005154639 
+  191          198.78253    168.73354   0.005235602 
+  218          197.05101    168.64255   0.004587156 
+  202          196.61183    168.55173   0.004950495 
+  184          197.4682     168.46107   0.005434783 
+  191          199.48241    168.37057   0.005235602 
+  183          202.30571    168.28023   0.005464481 
+  207          206.54783    168.19005   0.004830918 
+  199          213.96565    168.10003   0.005025126 
+  211          227.0334     168.01017   0.004739336 
+  210          250.40447    167.92047   0.004761905 
+  256          292.08497    167.83092   0.00390625 
+  299          358.5141     167.74154   0.003344482 
+  295          421.18831    167.65231   0.003389831 
+  378          404.82482    167.56324   0.002645503 
+  302          342.74228    167.47433   0.003311258 
+  270          304.21371    167.38557   0.003703704 
+  262          299.48939    167.29697   0.003816794 
+  283          316.87586    167.20853   0.003533569 
+  287          317.4684     167.12025   0.003484321 
+  261          281.08915    167.03212   0.003831418 
+  246          244.14354    166.94415   0.004065041 
+  199          220.66124    166.85634   0.005025126 
+  197          206.98039    166.76868   0.005076142 
+  206          198.83545    166.68118   0.004854369 
+  190          193.72393    166.59383   0.005263158 
+  179          191.4528     166.50664   0.005586592 
+  174          189.22842    166.4196    0.005747126 
+  199          187.7956     166.33272   0.005025126 
+  166          186.9813     166.246     0.006024096 
+  205          186.7168     166.15942   0.004878049 
+  194          187.02368    166.07301   0.005154639 
+  216          188.01224    165.98674   0.00462963 
+  190          190.28524    165.90063   0.005263158 
+  164          191.9883     165.81468   0.006097561 
+  190          192.01331    165.72887   0.005263158 
+  218          191.07822    165.64322   0.004587156 
+  198          190.45706    165.55773   0.005050505 
+  191          190.3632     165.47238   0.005235602 
+  187          190.72448    165.38719   0.005347594 
+  205          190.99402    165.30215   0.004878049 
+  252          191.0783     165.21727   0.003968254 
+  205          191.93804    165.13253   0.004878049 
+  208          192.85406    165.04795   0.004807692 
+  214          191.31928    164.96352   0.004672897 
+  226          188.50083    164.87924   0.004424779 
+  235          186.67353    164.79511   0.004255319 
+  258          186.21279    164.71113   0.003875969 
+  263          186.85179    164.62731   0.003802281 
+  308          187.52314    164.54363   0.003246753 
+  302          187.72734    164.46011   0.003311258 
+  315          189.02844    164.37673   0.003174603 
+  307          191.73189    164.29351   0.003257329 
+  307          193.11798    164.21043   0.003257329 
+  283          192.28511    164.12751   0.003533569 
+  324          192.68861    164.04473   0.00308642 
+  294          195.94765    163.96211   0.003401361 
+  263          203.39479    163.87963   0.003802281 
+  304          216.28355    163.7973    0.003289474 
+  291          230.61574    163.71512   0.003436426 
+  277          231.99074    163.63309   0.003610108 
+  253          218.90306    163.55121   0.003952569 
+  262          207.91335    163.46947   0.003816794 
+  247          204.39381    163.38789   0.004048583 
+  250          207.4619     163.30645   0.004     
+  239          212.05696    163.22516   0.0041841 
+  232          209.79755    163.14401   0.004310345 
+  233          204.14912    163.06302   0.004291845 
+  241          199.42116    162.98217   0.004149378 
+  234          196.46322    162.90147   0.004273504 
+  218          195.04191    162.82091   0.004587156 
+  196          193.53945    162.7405    0.005102041 
+  213          193.25329    162.66024   0.004694836 
+  208          194.70472    162.58012   0.004807692 
+  212          197.64536    162.50015   0.004716981 
+  230          203.73687    162.42033   0.004347826 
+  251          213.85398    162.34065   0.003984064 
+  217          224.56374    162.26112   0.004608295 
+  208          223.81193    162.18173   0.004807692 
+  228          213.2058     162.10248   0.004385965 
+  221          205.59325    162.02339   0.004524887 
+  215          203.93241    161.94443   0.004651163 
+  233          207.05727    161.86562   0.004291845 
+  216          210.22304    161.78696   0.00462963 
+  203          206.94396    161.70844   0.004926108 
+  218          201.38089    161.63006   0.004587156 
+  202          198.05466    161.55183   0.004950495 
+  201          196.96855    161.47374   0.004975124 
+  198          197.40225    161.3958    0.005050505 
+  205          198.96985    161.318     0.004878049 
+  216          201.63899    161.24034   0.00462963 
+  177          205.60724    161.16282   0.005649718 
+  200          210.80508    161.08545   0.005     
+  254          215.42439    161.00822   0.003937008 
+  203          218.0915     160.93114   0.004926108 
+  230          221.28846    160.85419   0.004347826 
+  273          226.51234    160.77739   0.003663004 
+  257          233.97055    160.70073   0.003891051 
+  240          243.45484    160.62421   0.004166667 
+  313          253.62519    160.54784   0.003194888 
+  310          265.4329     160.4716    0.003225806 
+  274          280.19301    160.39551   0.003649635 
+  313          298.69894    160.31956   0.003194888 
+  320          321.29126    160.24374   0.003125  
+  368          348.01938    160.16807   0.002717391 
+  351          379.32468    160.09255   0.002849003 
+  412          414.60684    160.01716   0.002427184 
+  404          450.02096    159.94191   0.002475248 
+  446          474.42178    159.8668    0.002242152 
+  471          483.72145    159.79183   0.002123142 
+  462          486.12444    159.71701   0.002164502 
+  431          492.44498    159.64232   0.002320186 
+  446          501.29061    159.56777   0.002242152 
+  420          497.48276    159.49336   0.002380952 
+  433          478.28792    159.41909   0.002309469 
+  383          451.8294     159.34497   0.002610966 
+  372          422.05262    159.27097   0.002688172 
+  347          396.36518    159.19712   0.002881844 
+  351          373.9032     159.12341   0.002849003 
+  320          349.11568    159.04984   0.003125  
+  275          324.72614    158.9764    0.003636364 
+  310          302.91249    158.9031    0.003225806 
+  328          282.75102    158.82994   0.00304878 
+  273          265.47669    158.75692   0.003663004 
+  239          251.39438    158.68404   0.0041841 
+  263          239.9671     158.61129   0.003802281 
+  209          230.64753    158.53869   0.004784689 
+  268          223.01343    158.46622   0.003731343 
+  226          216.7337     158.39388   0.004424779 
+  223          211.55515    158.32169   0.004484305 
+  228          207.28365    158.24963   0.004385965 
+  241          203.77352    158.17771   0.004149378 
+  219          200.92021    158.10592   0.00456621 
+  208          198.65075    158.03427   0.004807692 
+  211          196.90316    157.96276   0.004739336 
+  216          195.64779    157.89139   0.00462963 
+  207          195.01039    157.82015   0.004830918 
+  187          195.23812    157.74904   0.005347594 
+  204          196.59011    157.67807   0.004901961 
+  232          198.66866    157.60724   0.004310345 
+  224          199.61544    157.53655   0.004464286 
+  236          199.86755    157.46598   0.004237288 
+  218          201.33977    157.39556   0.004587156 
+  243          202.132      157.32527   0.004115226 
+  222          200.56593    157.25511   0.004504505 
+  195          199.02528    157.18509   0.005128205 
+  231          197.9113     157.11521   0.004329004 
+  255          197.60445    157.04545   0.003921569 
+  243          198.56708    156.97584   0.004115226 
+  227          199.42361    156.90636   0.004405286 
+  215          199.72089    156.83701   0.004651163 
+  246          201.04468    156.76779   0.004065041 
+  264          204.2045     156.69871   0.003787879 
+  278          209.8161     156.62977   0.003597122 
+  251          219.47843    156.56095   0.003984064 
+  243          237.49507    156.49227   0.004115226 
+  312          273.85491    156.42373   0.003205128 
+  308          343.87658    156.35532   0.003246753 
+  346          426.26901    156.28704   0.002890173 
+  330          404.9972     156.21889   0.003030303 
+  332          335.13833    156.15088   0.003012048 
+  302          306.19393    156.083     0.003311258 
+  311          310.96407    156.01525   0.003215434 
+  302          329.24267    155.94763   0.003311258 
+  315          346.12117    155.88015   0.003174603 
+  275          313.2268     155.8128    0.003636364 
+  292          268.78962    155.74558   0.003424658 
+  270          246.93907    155.67849   0.003703704 
+  234          237.48282    155.61154   0.004273504 
+  265          226.71526    155.54472   0.003773585 
+  241          216.13265    155.47802   0.004149378 
+  238          209.45632    155.41146   0.004201681 
+  224          205.84374    155.34504   0.004464286 
+  217          203.12774    155.27874   0.004608295 
+  224          200.48187    155.21257   0.004464286 
+  208          198.74119    155.14654   0.004807692 
+  196          198.16283    155.08063   0.005102041 
+  244          198.7024     155.01486   0.004098361 
+  216          200.31385    154.94921   0.00462963 
+  217          202.84454    154.8837    0.004608295 
+  222          207.10571    154.81832   0.004504505 
+  268          215.36084    154.75307   0.003731343 
+  261          230.90165    154.68794   0.003831418 
+  275          258.07375    154.62295   0.003636364 
+  285          301.13085    154.55809   0.003508772 
+  337          355.92278    154.49336   0.002967359 
+  347          349.86553    154.42875   0.002881844 
+  332          293.04608    154.36428   0.003012048 
+  297          260.63403    154.29993   0.003367003 
+  257          255.59207    154.23572   0.003891051 
+  277          269.96239    154.17163   0.003610108 
+  300          296.22381    154.10768   0.003333333 
+  300          296.34627    154.04385   0.003333333 
+  261          277.92668    153.98015   0.003831418 
+  283          270.97465    153.91658   0.003533569 
+  216          259.38761    153.85314   0.00462963 
+  240          240.74724    153.78982   0.004166667 
+  257          227.96162    153.72664   0.003891051 
+  218          223.62026    153.66358   0.004587156 
+  214          226.14375    153.60065   0.004672897 
+  229          231.18771    153.53785   0.004366812 
+  239          230.07786    153.47518   0.0041841 
+  248          224.07558    153.41263   0.004032258 
+  219          221.36172    153.35022   0.00456621 
+  235          225.27767    153.28793   0.004255319 
+  255          239.00534    153.22576   0.003921569 
+  257          264.8695     153.16373   0.003891051 
+  272          279.57747    153.10182   0.003676471 
+  250          258.48687    153.04004   0.004     
+  239          238.88674    152.97838   0.0041841 
+  265          232.13703    152.91685   0.003773585 
+  230          235.62514    152.85545   0.004347826 
+  217          247.66155    152.79418   0.004608295 
+  247          255.98989    152.73303   0.004048583 
+  229          246.88718    152.67201   0.004366812 
+  226          238.46677    152.61111   0.004424779 
+  233          236.50786    152.55034   0.004291845 
+  254          238.10648    152.4897    0.003937008 
+  219          240.1898     152.42918   0.00456621 
+  245          242.71208    152.36879   0.004081633 
+  251          246.67105    152.30853   0.003984064 
+  263          251.82994    152.24839   0.003802281 
+  266          257.45298    152.18837   0.003759398 
+  264          263.543      152.12848   0.003787879 
+  257          269.90684    152.06872   0.003891051 
+  303          276.94279    152.00908   0.00330033 
+  309          285.3716     151.94957   0.003236246 
+  302          295.24304    151.89018   0.003311258 
+  302          306.34992    151.83091   0.003311258 
+  323          319.03003    151.77177   0.003095975 
+  315          333.87926    151.71276   0.003174603 
+  356          351.38285    151.65387   0.002808989 
+  382          372.12462    151.5951    0.002617801 
+  396          396.98416    151.53646   0.002525253 
+  455          426.49509    151.47794   0.002197802 
+  534          459.67494    151.41955   0.001872659 
+  621          497.5063     151.36128   0.001610306 
+  627          544.28754    151.30313   0.001594896 
+  713          603.66069    151.24511   0.001402525 
+  719          679.64318    151.18721   0.001390821 
+  743          778.03191    151.12944   0.001345895 
+  820          907.04826    151.07179   0.001219512 
+  864          1080.81751   151.01426   0.001157407 
+  1153         1324.7473    150.95686   0.000867303 
+  1379         1683.44875   150.89957   0.000725163 
+  1881         2241.70756   150.84242   0.000531632 
+  2731         3184.53738   150.78538   0.000366166 
+  4343         5001.38867   150.72847   0.000230256 
+  8024         9012.53582   150.67168   0.000124626 
+  14671        17601.24327  150.61501   0.000068162 
+  23139        27863.85335  150.55846   0.000043217 
+  22682        22359.98355  150.50204   0.000044088 
+  13825        12426.93107  150.44574   0.000072333 
+  8333         7867.73826   150.38956   0.000120005 
+  6901         7233.15015   150.33351   0.000144907 
+  8544         9893.40587   150.27757   0.000117041 
+  11554        14712.30387  150.22176   0.00008655 
+  11953        12896.1867   150.16607   0.000083661 
+  7470         7188.55937   150.1105    0.000133869 
+  4025         3966.5502    150.05506   0.000248447 
+  2379         2495.3438    149.99973   0.000420345 
+  1579         1768.44187   149.94453   0.000633312 
+  1177         1352.64376   149.88944   0.000849618 
+  1010         1092.29762   149.83448   0.000990099 
+  775          925.29282    149.77964   0.001290323 
+  721          818.61676    149.72492   0.001386963 
+  679          726.04652    149.67032   0.001472754 
+  580          628.54189    149.61585   0.001724138 
+  558          552.74468    149.56149   0.001792115 
+  447          499.49008    149.50725   0.002237136 
+  434          463.50375    149.45314   0.002304147 
+  386          441.24735    149.39914   0.002590674 
+  371          419.52093    149.34526   0.002695418 
+  345          385.95592    149.29151   0.002898551 
+  362          355.85111    149.23787   0.002762431 
+  337          333.45617    149.18436   0.002967359 
+  318          316.26262    149.13096   0.003144654 
+  294          302.30881    149.07769   0.003401361 
+  276          290.56924    149.02453   0.003623188 
+  294          280.49516    148.9715    0.003401361 
+  275          271.74421    148.91858   0.003636364 
+  290          264.11407    148.86578   0.003448276 
+  272          257.46161    148.8131    0.003676471 
+  246          251.66463    148.76055   0.004065041 
+  245          246.94462    148.70811   0.004081633 
+  244          242.62238    148.65579   0.004098361 
+  248          238.95628    148.60358   0.004032258 
+  227          235.91168    148.5515    0.004405286 
+  242          233.45915    148.49954   0.004132231 
+  242          231.58278    148.44769   0.004132231 
+  235          230.28759    148.39597   0.004255319 
+  243          229.60282    148.34436   0.004115226 
+  240          229.79844    148.29287   0.004166667 
+  252          230.87664    148.2415    0.003968254 
+  263          233.40853    148.19024   0.003802281 
+  259          235.56229    148.13911   0.003861004 
+  231          232.96646    148.08809   0.004329004 
+  233          229.33122    148.03719   0.004291845 
+  231          227.0765     147.98641   0.004329004 
+  224          226.19075    147.93574   0.004464286 
+  231          226.56045    147.8852    0.004329004 
+  228          227.44999    147.83477   0.004385965 
+  199          226.1878     147.78445   0.005025126 
+  218          223.21456    147.73426   0.004587156 
+  215          220.55678    147.68418   0.004651163 
+  215          218.59711    147.63422   0.004651163 
+  247          217.43073    147.58438   0.004048583 
+  218          217.00348    147.53465   0.004587156 
+  239          217.19943    147.48504   0.0041841 
+  230          217.87639    147.43555   0.004347826 
+  215          218.91934    147.38618   0.004651163 
+  213          220.23285    147.33692   0.004694836 
+  230          221.6373     147.28777   0.004347826 
+  275          222.99007    147.23875   0.003636364 
+  240          224.41732    147.18984   0.004166667 
+  249          226.3851     147.14104   0.004016064 
+  277          228.84249    147.09236   0.003610108 
+  280          228.88862    147.0438    0.003571429 
+  273          224.47706    146.99536   0.003663004 
+  264          219.49168    146.94703   0.003787879 
+  297          216.38091    146.89881   0.003367003 
+  267          215.66396    146.85071   0.003745318 
+  273          217.09611    146.80273   0.003663004 
+  278          217.04095    146.75486   0.003597122 
+  230          210.94184    146.70711   0.004347826 
+  257          202.95487    146.65947   0.003891051 
+  262          197.1337     146.61195   0.003816794 
+  247          193.80965    146.56454   0.004048583 
+  255          192.53277    146.51725   0.003921569 
+  219          192.23553    146.47007   0.00456621 
+  227          190.92147    146.42301   0.004405286 
+  229          189.16214    146.37606   0.004366812 
+  231          188.95876    146.32923   0.004329004 
+  215          191.26264    146.28251   0.004651163 
+  225          196.88786    146.2359    0.004444444 
+  211          205.69745    146.18941   0.004739336 
+  204          212.29217    146.14304   0.004901961 
+  202          212.00266    146.09678   0.004950495 
+  217          211.19351    146.05063   0.004608295 
+  203          209.34347    146.00459   0.004926108 
+  198          204.00813    145.95867   0.005050505 
+  210          200.77318    145.91287   0.004761905 
+  197          200.60153    145.86718   0.005076142 
+  212          199.25308    145.8216    0.004716981 
+  215          197.28397    145.77613   0.004651163 
+  226          196.43529    145.73078   0.004424779 
+  223          194.40627    145.68554   0.004484305 
+  216          192.69837    145.64042   0.00462963 
+  220          193.26964    145.5954    0.004545455 
+  198          193.57438    145.55051   0.005050505 
+  182          191.14507    145.50572   0.005494505 
+  191          188.74982    145.46105   0.005235602 
+  198          188.17206    145.41649   0.005050505 
+  211          189.43975    145.37204   0.004739336 
+  198          192.34778    145.3277    0.005050505 
+  171          196.14178    145.28348   0.005847953 
+  193          199.22749    145.23937   0.005181347 
+  168          202.28676    145.19537   0.005952381 
+  226          207.1928     145.15149   0.004424779 
+  220          214.3415     145.10771   0.004545455 
+  202          223.58955    145.06405   0.004950495 
+  233          236.12675    145.0205    0.004291845 
+  256          251.6154     144.97706   0.00390625 
+  278          259.15044    144.93374   0.003597122 
+  262          254.97826    144.89052   0.003816794 
+  237          252.00716    144.84742   0.004219409 
+  297          256.57817    144.80443   0.003367003 
+  290          268.99444    144.76155   0.003448276 
+  287          287.60318    144.71878   0.003484321 
+  298          305.91037    144.67612   0.003355705 
+  295          320.78281    144.63358   0.003389831 
+  332          341.98238    144.59114   0.003012048 
+  374          380.72139    144.54882   0.002673797 
+  407          447.15593    144.5066    0.002457002 
+  499          560.5915     144.4645    0.002004008 
+  758          770.83732    144.42251   0.001319261 
+  1177         1216.55706   144.38063   0.000849618 
+  1926         2187.96863   144.33886   0.000519211 
+  2968         3688.49948   144.2972    0.000336927 
+  3336         3625.66874   144.25565   0.00029976 
+  2217         2183.16568   144.21421   0.00045106 
+  1368         1341.04223   144.17288   0.000730994 
+  1046         1064.6922    144.13166   0.000956023 
+  1114         1178.92456   144.09055   0.000897666 
+  1479         1705.29256   144.04955   0.000676133 
+  1775         2222.8033    144.00866   0.00056338 
+  1564         1661.1782    143.96788   0.000639386 
+  1026         988.9526     143.92721   0.000974659 
+  646          651.01352    143.88665   0.001547988 
+  494          490.02191    143.84619   0.002024291 
+  366          396.31833    143.80585   0.00273224 
+  340          336.4483     143.76562   0.002941176 
+  261          297.85575    143.72549   0.003831418 
+  296          273.38468    143.68548   0.003378378 
+  264          258.74642    143.64557   0.003787879 
+  239          248.74919    143.60577   0.0041841 
+  224          236.67758    143.56609   0.004464286 
+  236          223.4075     143.52651   0.004237288 
+  225          212.55896    143.48703   0.004444444 
+  227          204.34919    143.44767   0.004405286 
+  208          198.21769    143.40842   0.004807692 
+  201          193.6384     143.36927   0.004975124 
+  165          190.24007    143.33023   0.006060606 
+  167          187.82319    143.2913    0.005988024 
+  211          186.36977    143.25248   0.004739336 
+  205          186.03126    143.21377   0.004878049 
+  195          186.87873    143.17516   0.005128205 
+  181          187.73925    143.13666   0.005524862 
+  185          186.07091    143.09827   0.005405405 
+  180          182.93945    143.05999   0.005555556 
+  181          181.19459    143.02181   0.005524862 
+  170          180.45477    142.98374   0.005882353 
+  208          181.07496    142.94578   0.004807692 
+  183          182.88907    142.90793   0.005464481 
+  186          184.99891    142.87018   0.005376344 
+  228          186.70109    142.83254   0.004385965 
+  201          189.58278    142.79501   0.004975124 
+  207          195.37445    142.75758   0.004830918 
+  239          206.09615    142.72026   0.0041841 
+  230          225.25495    142.68305   0.004347826 
+  254          262.62177    142.64594   0.003937008 
+  300          337.69543    142.60894   0.003333333 
+  418          468.73737    142.57205   0.002392344 
+  475          565.4901     142.53526   0.002105263 
+  487          470.67098    142.49858   0.002053388 
+  400          349.28649    142.46201   0.0025    
+  350          288.84866    142.42554   0.002857143 
+  275          276.31503    142.38918   0.003636364 
+  307          302.53218    142.35292   0.003257329 
+  340          359.86386    142.31677   0.002941176 
+  365          372.8541     142.28072   0.002739726 
+  311          302.99172    142.24478   0.003215434 
+  270          243.44862    142.20895   0.003703704 
+  227          211.7931     142.17322   0.004405286 
+  220          196.03688    142.13759   0.004545455 
+  250          187.36656    142.10207   0.004     
+  214          181.98376    142.06666   0.004672897 
+  193          179.00763    142.03135   0.005181347 
+  213          178.45979    141.99614   0.004694836 
+  186          180.50718    141.96104   0.005376344 
+  222          183.86464    141.92605   0.004504505 
+  186          183.84164    141.89116   0.005376344 
+  188          179.77418    141.85637   0.005319149 
+  200          176.47778    141.82169   0.005     
+  207          175.73043    141.78711   0.004830918 
+  219          177.57406    141.75264   0.00456621 
+  192          182.29888    141.71827   0.005208333 
+  205          188.9613     141.68401   0.004878049 
+  196          191.48797    141.64985   0.005102041 
+  204          186.41712    141.61579   0.004901961 
+  194          180.40349    141.58184   0.005154639 
+  206          177.78003    141.54799   0.004854369 
+  179          178.81741    141.51424   0.005586592 
+  197          183.40053    141.4806    0.005076142 
+  196          189.764      141.44706   0.005102041 
+  185          190.5969     141.41362   0.005405405 
+  196          183.99836    141.38029   0.005102041 
+  192          177.54022    141.34706   0.005208333 
+  178          174.23344    141.31393   0.005617978 
+  188          173.76431    141.28091   0.005319149 
+  172          175.44032    141.24798   0.005813953 
+  192          177.28188    141.21516   0.005208333 
+  195          176.19478    141.18245   0.005128205 
+  191          173.45143    141.14983   0.005235602 
+  177          171.86175    141.11732   0.005649718 
+  168          171.75265    141.08491   0.005952381 
+  207          171.94507    141.05261   0.004830918 
+  181          171.51007    141.0204    0.005524862 
+  176          170.89665    140.9883    0.005681818 
+  191          170.5034     140.9563    0.005235602 
+  210          170.68224    140.9244    0.004761905 
+  205          171.51203    140.8926    0.004878049 
+  209          172.8058     140.8609    0.004784689 
+  230          174.01884    140.82931   0.004347826 
+  177          174.95801    140.79782   0.005649718 
+  193          176.15005    140.76642   0.005181347 
+  200          177.85539    140.73513   0.005     
+  207          180.13721    140.70394   0.004830918 
+  199          183.10807    140.67285   0.005025126 
+  220          186.92117    140.64187   0.004545455 
+  209          191.28441    140.61098   0.004784689 
+  202          194.70327    140.58019   0.004950495 
+  200          196.9024     140.54951   0.005     
+  210          199.69272    140.51892   0.004761905 
+  193          203.94012    140.48844   0.005181347 
+  201          209.92369    140.45805   0.004975124 
+  255          218.06324    140.42777   0.003921569 
+  250          228.78229    140.39758   0.004     
+  269          241.51563    140.3675    0.003717472 
+  288          253.60094    140.33752   0.003472222 
+  270          262.31227    140.30763   0.003703704 
+  319          271.98858    140.27785   0.003134796 
+  318          287.36559    140.24816   0.003144654 
+  312          310.50025    140.21857   0.003205128 
+  316          343.54473    140.18909   0.003164557 
+  379          388.40044    140.1597    0.002638522 
+  388          442.71953    140.13041   0.00257732 
+  459          507.58212    140.10122   0.002178649 
+  544          603.4955     140.07213   0.001838235 
+  729          761.83641    140.04314   0.001371742 
+  959          1041.12903   140.01425   0.001042753 
+  1483         1594.09891   139.98546   0.000674309 
+  2601         2790.22829   139.95676   0.000384468 
+  4626         5133.20294   139.92817   0.000216169 
+  6246         7159.54278   139.89967   0.000160102 
+  5101         5286.81022   139.87127   0.00019604 
+  3026         3022.66849   139.84297   0.000330469 
+  1929         1966.95177   139.81476   0.000518403 
+  1621         1695.31626   139.78666   0.000616903 
+  1973         2012.96943   139.75865   0.000506842 
+  2615         3018.96947   139.73074   0.000382409 
+  3248         3883.37      139.70293   0.000307882 
+  2600         2825.68706   139.67521   0.000384615 
+  1567         1620.68027   139.6476    0.000638162 
+  935          1001.6791    139.62008   0.001069519 
+  699          708.65867    139.59265   0.001430615 
+  533          551.13268    139.56533   0.001876173 
+  402          455.61764    139.5381    0.002487562 
+  371          393.70819    139.51097   0.002695418 
+  353          348.43291    139.48393   0.002832861 
+  293          313.67628    139.45699   0.003412969 
+  259          287.97414    139.43015   0.003861004 
+  248          268.64761    139.40341   0.004032258 
+  241          253.13532    139.37676   0.004149378 
+  220          242.40895    139.35021   0.004545455 
+  222          234.5217     139.32375   0.004504505 
+  240          227.24499    139.29739   0.004166667 
+  207          220.42669    139.27113   0.004830918 
+  218          214.3081     139.24496   0.004587156 
+  207          208.37774    139.21889   0.004830918 
+  214          203.26817    139.19291   0.004672897 
+  163          198.67808    139.16703   0.006134969 
+  190          195.15635    139.14124   0.005263158 
+  196          192.7691     139.11555   0.005102041 
+  179          191.20383    139.08996   0.005586592 
+  167          189.81694    139.06446   0.005988024 
+  201          188.38909    139.03905   0.004975124 
+  222          186.92868    139.01374   0.004504505 
+  171          185.09052    138.98852   0.005847953 
+  188          182.48458    138.9634    0.005319149 
+  208          179.67449    138.93838   0.004807692 
+  199          177.36091    138.91345   0.005025126 
+  170          175.63654    138.88861   0.005882353 
+  182          174.42559    138.86386   0.005494505 
+  192          173.66087    138.83922   0.005208333 
+  212          173.15603    138.81466   0.004716981 
+  185          172.61759    138.7902    0.005405405 
+  181          172.4192     138.76583   0.005524862 
+  164          173.2772     138.74156   0.006097561 
+  182          175.53118    138.71738   0.005494505 
+  217          178.62151    138.69329   0.004608295 
+  200          182.45732    138.6693    0.005     
+  231          190.17324    138.6454    0.004329004 
+  237          200.36646    138.62159   0.004219409 
+  237          197.88121    138.59788   0.004219409 
+  237          186.37779    138.57426   0.004219409 
+  190          179.33362    138.55073   0.005263158 
+  202          177.18845    138.52729   0.004950495 
+  181          178.08614    138.50395   0.005524862 
+  175          182.49344    138.4807    0.005714286 
+  215          189.41558    138.45754   0.004651163 
+  232          189.42299    138.43448   0.004310345 
+  197          181.27719    138.4115    0.005076142 
+  199          174.46832    138.38862   0.005025126 
+  156          170.86306    138.36583   0.006410256 
+  189          169.42262    138.34313   0.005291005 
+  187          169.34005    138.32053   0.005347594 
+  182          169.97302    138.29801   0.005494505 
+  209          170.15909    138.27559   0.004784689 
+  197          169.22814    138.25326   0.005076142 
+  202          168.14959    138.23102   0.004950495 
+  178          167.54814    138.20887   0.005617978 
+  184          167.37646    138.18681   0.005434783 
+  163          167.49923    138.16484   0.006134969 
+  178          167.88967    138.14297   0.005617978 
+  171          168.70098    138.12118   0.005847953 
+  176          170.1874     138.09949   0.005681818 
+  199          172.66554    138.07788   0.005025126 
+  208          175.61225    138.05637   0.004807692 
+  190          176.54645    138.03494   0.005263158 
+  203          174.75525    138.01361   0.004926108 
+  192          172.92286    137.99236   0.005208333 
+  189          172.35221    137.97121   0.005291005 
+  181          173.15371    137.95014   0.005524862 
+  191          175.34046    137.92917   0.005235602 
+  189          178.94155    137.90828   0.005291005 
+  211          183.26131    137.88749   0.004739336 
+  195          187.83567    137.86678   0.005128205 
+  218          193.27549    137.84616   0.004587156 
+  205          200.18943    137.82563   0.004878049 
+  231          211.32045    137.80519   0.004329004 
+  244          224.75888    137.78484   0.004098361 
+  217          228.03892    137.76458   0.004608295 
+  198          218.93324    137.7444    0.005050505 
+  228          209.93874    137.72432   0.004385965 
+  225          206.51901    137.70432   0.004444444 
+  238          207.50245    137.68441   0.004201681 
+  233          211.73685    137.66459   0.004291845 
+  214          218.89087    137.64486   0.004672897 
+  246          224.73255    137.62521   0.004065041 
+  240          226.18708    137.60565   0.004166667 
+  262          229.64545    137.58618   0.003816794 
+  218          239.35272    137.5668    0.004587156 
+  271          249.2575     137.54751   0.003690037 
+  237          248.15599    137.5283    0.004219409 
+  281          241.62776    137.50918   0.003558719 
+  264          239.69985    137.49014   0.003787879 
+  251          244.98217    137.4712    0.003984064 
+  271          258.07171    137.45234   0.003690037 
+  286          278.96732    137.43356   0.003496503 
+  358          301.00938    137.41488   0.002793296 
+  316          310.58471    137.39628   0.003164557 
+  340          313.86524    137.37776   0.002941176 
+  384          327.70292    137.35933   0.002604167 
+  359          359.91421    137.34099   0.002785515 
+  415          407.11509    137.32273   0.002409639 
+  440          451.29281    137.30456   0.002272727 
+  411          471.99991    137.28648   0.00243309 
+  448          486.24955    137.26848   0.002232143 
+  479          524.19863    137.25057   0.002087683 
+  533          598.10722    137.23274   0.001876173 
+  640          720.11944    137.21499   0.0015625 
+  904          913.55588    137.19733   0.001106195 
+  1143         1227.27367   137.17976   0.000874891 
+  1780         1791.67644   137.16227   0.000561798 
+  2966         2960.38039   137.14487   0.000337154 
+  5341         5389.41449   137.12755   0.000187231 
+  7909         8734.46849   137.11031   0.000126438 
+  7600         8163.52253   137.09316   0.000131579 
+  5005         4864.19337   137.0761    0.0001998 
+  3068         2896.31071   137.05911   0.000325945 
+  2220         2123.02723   137.04221   0.00045045 
+  2109         2075.24971   137.0254    0.000474158 
+  2669         2731.53938   137.00867   0.000374672 
+  3685         4198.88646   136.99202   0.00027137 
+  4090         4876.0004    136.97545   0.000244499 
+  3107         3277.59493   136.95897   0.000321854 
+  1928         1879.63549   136.94258   0.000518672 
+  1140         1172.70883   136.92626   0.000877193 
+  820          829.50353    136.91003   0.001219512 
+  613          644.40804    136.89388   0.001631321 
+  502          532.20813    136.87781   0.001992032 
+  447          458.96005    136.86183   0.002237136 
+  409          408.97868    136.84592   0.002444988 
+  334          373.95453    136.8301    0.002994012 
+  312          348.96252    136.81437   0.003205128 
+  276          330.47048    136.79871   0.003623188 
+  290          314.29973    136.78314   0.003448276 
+  307          299.05392    136.76765   0.003257329 
+  286          286.92785    136.75223   0.003496503 
+  288          278.32118    136.73691   0.003472222 
+  318          271.75585    136.72166   0.003144654 
+  260          266.26981    136.70649   0.003846154 
+  289          263.24164    136.69141   0.003460208 
+  279          263.24993    136.6764    0.003584229 
+  265          264.49138    136.66148   0.003773585 
+  259          261.3055     136.64663   0.003861004 
+  260          249.84836    136.63187   0.003846154 
+  244          236.93792    136.61719   0.004098361 
+  238          226.90886    136.60259   0.004201681 
+  236          220.04822    136.58807   0.004237288 
+  235          216.47731    136.57362   0.004255319 
+  252          216.03431    136.55926   0.003968254 
+  251          216.82078    136.54498   0.003984064 
+  234          214.952      136.53078   0.004273504 
+  257          211.57246    136.51665   0.003891051 
+  250          211.40788    136.50261   0.004     
+  252          216.27418    136.48865   0.003968254 
+  250          225.39815    136.47476   0.004     
+  284          236.74898    136.46095   0.003521127 
+  276          243.70657    136.44723   0.003623188 
+  251          236.32065    136.43358   0.003984064 
+  249          223.54963    136.42001   0.004016064 
+  248          216.34525    136.40651   0.004032258 
+  245          216.64841    136.3931    0.004081633 
+  229          223.95798    136.37977   0.004366812 
+  258          236.87639    136.36651   0.003875969 
+  253          250.28778    136.35333   0.003952569 
+  230          251.9513     136.34023   0.004347826 
+  245          242.47172    136.3272    0.004081633 
+  253          234.77105    136.31425   0.003952569 
+  264          233.29259    136.30138   0.003787879 
+  231          237.84543    136.28859   0.004329004 
+  212          247.68057    136.27588   0.004716981 
+  215          257.60292    136.26324   0.004651163 
+  214          256.48772    136.25068   0.004672897 
+  230          246.20231    136.23819   0.004347826 
+  232          236.3719     136.22578   0.004310345 
+  211          226.68716    136.21345   0.004739336 
+  212          217.86659    136.20119   0.004716981 
+  207          212.89629    136.18901   0.004830918 
+  191          211.41738    136.17691   0.005235602 
+  215          209.267      136.16488   0.004651163 
+  209          203.61755    136.15293   0.004784689 
+  232          198.49267    136.14105   0.004310345 
+  185          195.44318    136.12925   0.005405405 
+  195          193.66164    136.11752   0.005128205 
+  192          194.43678    136.10587   0.005208333 
+  191          196.6471     136.09429   0.005235602 
+  190          196.58272    136.08279   0.005263158 
+  206          189.13851    136.07137   0.004854369 
+  209          179.65201    136.06001   0.004784689 
+  190          174.42384    136.04874   0.005263158 
+  187          173.43125    136.03753   0.005347594 
+  168          175.91571    136.0264    0.005952381 
+  160          180.42415    136.01535   0.00625   
+  197          184.09611    136.00437   0.005076142 
+  181          185.66432    135.99346   0.005524862 
+  200          186.29209    135.98262   0.005     
+  202          191.94587    135.97186   0.004950495 
+  199          203.78058    135.96117   0.005025126 
+  201          211.87923    135.95056   0.004975124 
+  180          204.21977    135.94002   0.005555556 
+  186          189.65043    135.92955   0.005376344 
+  153          178.27188    135.91915   0.006535948 
+  161          171.94785    135.90883   0.00621118 
+  157          170.38426    135.89858   0.006369427 
+  184          173.07632    135.8884    0.005434783 
+  186          178.09079    135.87829   0.005376344 
+  158          178.76914    135.86826   0.006329114 
+  161          171.83386    135.85829   0.00621118 
+  175          163.7491     135.8484    0.005714286 
+  154          158.06124    135.83858   0.006493506 
+  181          154.5554     135.82883   0.005524862 
+  164          152.48115    135.81916   0.006097561 
+  157          151.34491    135.80955   0.006369427 
+  195          150.91981    135.80001   0.005128205 
+  156          151.14037    135.79055   0.006410256 
+  157          152.06821    135.78116   0.006369427 
+  136          154.02697    135.77183   0.007352941 
+  137          157.04019    135.76258   0.00729927 
+  177          159.05111    135.7534    0.005649718 
+  155          157.29829    135.74428   0.006451613 
+  142          153.87027    135.73524   0.007042254 
+  172          151.40088    135.72627   0.005813953 
+  163          150.23278    135.71737   0.006134969 
+  163          150.06292    135.70853   0.006134969 
+  165          150.63883    135.69977   0.006060606 
+  147          151.74031    135.69107   0.006802721 
+  139          152.13641    135.68245   0.007194245 
+  143          150.89372    135.67389   0.006993007 
+  137          149.44932    135.6654    0.00729927 
+  137          148.68582    135.65698   0.00729927 
+  160          148.10428    135.64863   0.00625   
+  158          147.1683     135.64035   0.006329114 
+  146          146.20933    135.63213   0.006849315 
+  158          145.5424     135.62398   0.006329114 
+  151          145.20119    135.61591   0.006622517 
+  134          145.14052    135.60789   0.007462687 
+  167          145.32257    135.59995   0.005988024 
+  125          145.64367    135.59207   0.008     
+  146          145.81968    135.58426   0.006849315 
+  153          145.80475    135.57652   0.006535948 
+  140          145.91329    135.56885   0.007142857 
+  157          146.31573    135.56124   0.006369427 
+  179          147.02856    135.5537    0.005586592 
+  169          147.9752     135.54622   0.00591716 
+  144          149.04439    135.53881   0.006944444 
+  171          150.42385    135.53147   0.005847953 
+  166          152.74208    135.52419   0.006024096 
+  175          156.72583    135.51698   0.005714286 
+  168          163.02059    135.50984   0.005952381 
+  173          170.69459    135.50276   0.005780347 
+  201          174.62135    135.49575   0.004975124 
+  166          172.77644    135.4888    0.006024096 
+  177          170.93201    135.48191   0.005649718 
+  180          171.35867    135.4751    0.005555556 
+  212          171.80927    135.46834   0.004716981 
+  167          170.2979     135.46165   0.005988024 
+  164          169.40971    135.45503   0.006097561 
+  159          170.14733    135.44847   0.006289308 
+  186          169.47782    135.44197   0.005376344 
+  169          167.10482    135.43554   0.00591716 
+  181          166.17398    135.42917   0.005524862 
+  187          167.39045    135.42287   0.005347594 
+  186          169.30421    135.41663   0.005376344 
+  171          171.09009    135.41045   0.005847953 
+  162          173.09291    135.40434   0.00617284 
+  176          173.38242    135.39829   0.005681818 
+  168          172.45746    135.3923    0.005952381 
+  184          173.59935    135.38637   0.005434783 
+  194          176.62756    135.38051   0.005154639 
+  171          177.27156    135.37471   0.005847953 
+  184          174.97326    135.36898   0.005434783 
+  142          173.87105    135.3633    0.007042254 
+  168          175.08347    135.35769   0.005952381 
+  177          177.27007    135.35214   0.005649718 
+  177          181.01812    135.34665   0.005649718 
+  186          188.40251    135.34122   0.005376344 
+  207          201.30442    135.33585   0.004830918 
+  200          221.02387    135.33055   0.005     
+  234          254.53137    135.3253    0.004273504 
+  307          315.82661    135.32012   0.003257329 
+  342          396.3091     135.315     0.002923977 
+  398          400.44658    135.30994   0.002512563 
+  369          324.39149    135.30494   0.002710027 
+  284          267.48688    135.29999   0.003521127 
+  305          244.63597    135.29511   0.003278689 
+  255          246.8931     135.29029   0.003921569 
+  247          269.15076    135.28553   0.004048583 
+  282          305.42429    135.28083   0.003546099 
+  287          338.09123    135.27619   0.003484321 
+  274          325.64582    135.27161   0.003649635 
+  270          277.14529    135.26708   0.003703704 
+  266          244.2858     135.26262   0.003759398 
+  215          233.83488    135.25821   0.004651163 
+  246          239.84064    135.25387   0.004065041 
+  248          254.00129    135.24958   0.004032258 
+  246          263.64305    135.24535   0.004065041 
+  257          267.03319    135.24118   0.003891051 
+  268          279.80289    135.23707   0.003731343 
+  308          322.36958    135.23301   0.003246753 
+  375          408.14891    135.22901   0.002666667 
+  395          487.45485    135.22508   0.002531646 
+  387          444.09577    135.22119   0.002583979 
+  339          357.70059    135.21737   0.002949853 
+  283          307.32782    135.2136    0.003533569 
+  267          292.88523    135.20989   0.003745318 
+  296          311.75268    135.20624   0.003378378 
+  316          371.24669    135.20264   0.003164557 
+  367          471.75061    135.1991    0.002724796 
+  355          530.4714     135.19561   0.002816901 
+  367          448.21944    135.19218   0.002724796 
+  293          337.50393    135.18881   0.003412969 
+  266          270.65797    135.1855    0.003759398 
+  216          239.52508    135.18223   0.00462963 
+  241          231.20535    135.17903   0.004149378 
+  234          240.99091    135.17588   0.004273504 
+  240          264.96403    135.17278   0.004166667 
+  217          274.49685    135.16975   0.004608295 
+  244          243.44703    135.16676   0.004098361 
+  206          208.83818    135.16383   0.004854369 
+  180          187.56956    135.16095   0.005555556 
+  194          175.9314     135.15813   0.005154639 
+  190          169.43198    135.15537   0.005263158 
+  194          165.21702    135.15265   0.005154639 
+  184          162.18837    135.15      0.005434783 
+  163          160.27152    135.14739   0.006134969 
+  167          159.40874    135.14484   0.005988024 
+  223          159.51699    135.14234   0.004484305 
+  172          160.62607    135.1399    0.005813953 
+  177          162.6861     135.1375    0.005649718 
+  190          165.02079    135.13516   0.005263158 
+  176          167.32879    135.13288   0.005681818 
+  192          171.05575    135.13064   0.005208333 
+  188          177.3502     135.12846   0.005319149 
+  185          185.89005    135.12633   0.005405405 
+  198          195.33396    135.12426   0.005050505 
+  228          200.21163    135.12223   0.004385965 
+  204          199.70247    135.12026   0.004901961 
+  203          203.71108    135.11834   0.004926108 
+  171          219.5765     135.11647   0.005847953 
+  206          244.099      135.11465   0.004854369 
+  203          246.94167    135.11288   0.004926108 
+  178          224.53978    135.11117   0.005617978 
+  198          207.51019    135.1095    0.005050505 
+  179          198.83227    135.10788   0.005586592 
+  193          193.33882    135.10632   0.005181347 
+  179          192.89881    135.10481   0.005586592 
+  173          200.2801     135.10334   0.005780347 
+  186          213.19572    135.10193   0.005376344 
+  193          217.14463    135.10056   0.005181347 
+  199          205.45131    135.09925   0.005025126 
+  184          195.19841    135.09798   0.005434783 
+  219          192.62254    135.09677   0.00456621 
+  212          198.13649    135.0956    0.004716981 
+  227          214.56761    135.09448   0.004405286 
+  275          251.29689    135.09341   0.003636364 
+  378          325.69417    135.09239   0.002645503 
+  497          432.81209    135.09142   0.002012072 
+  438          439.39039    135.09049   0.002283105 
+  391          337.97081    135.08962   0.002557545 
+  279          267.53445    135.08879   0.003584229 
+  253          235.1274     135.08801   0.003952569 
+  251          224.50094    135.08728   0.003984064 
+  273          231.5922     135.08659   0.003663004 
+  295          261.98338    135.08596   0.003389831 
+  339          321.18961    135.08536   0.002949853 
+  361          361.27629    135.08482   0.002770083 
+  311          329.10952    135.08432   0.003215434 
+  262          284.45389    135.08387   0.003816794 
+  255          249.52353    135.08347   0.003921569 
+  227          228.26227    135.08311   0.004405286 
+  195          218.51898    135.0828    0.005128205 
+  225          218.65002    135.08254   0.004444444 
+  237          229.43309    135.08232   0.004219409 
+  218          246.28222    135.08214   0.004587156 
+  197          254.20041    135.08202   0.005076142 
+  181          246.64171    135.08193   0.005524862 
+  196          235.78942    135.0819    0.005102041 
+  210          233.29901    135.0819    0.004761905 
+  190          230.96312    135.08195   0.005263158 
+  161          217.00838    135.08205   0.00621118 
+  169          205.91556    135.08219   0.00591716 
+  192          203.06042    135.08238   0.005208333 
+  212          201.46317    135.08261   0.004716981 
+  204          196.37638    135.08288   0.004901961 
+  180          193.37442    135.0832    0.005555556 
+  203          197.40212    135.08356   0.004926108 
+  192          206.93521    135.08396   0.005208333 
+  202          214.81074    135.08441   0.004950495 
+  213          222.84894    135.0849    0.004694836 
+  165          225.55695    135.08544   0.006060606 
+  184          213.12219    135.08601   0.005434783 
+  195          196.03697    135.08663   0.005128205 
+  153          183.94457    135.08729   0.006535948 
+  179          177.07283    135.088     0.005586592 
+  196          174.04346    135.08874   0.005102041 
+  190          174.8986     135.08953   0.005263158 
+  166          179.48623    135.09036   0.006024096 
+  156          184.02134    135.09123   0.006410256 
+  150          181.18522    135.09214   0.006666667 
+  168          172.50633    135.0931    0.005952381 
+  162          164.7141     135.09409   0.00617284 
+  159          159.37549    135.09513   0.006289308 
+  169          155.63025    135.09621   0.00591716 
+  148          152.89132    135.09732   0.006756757 
+  151          150.74039    135.09848   0.006622517 
+  176          149.46266    135.09968   0.005681818 
+  152          148.62476    135.10092   0.006578947 
+  173          148.10326    135.1022    0.005780347 
+  161          147.82894    135.10351   0.00621118 
+  191          147.77721    135.10487   0.005235602 
+  157          147.95312    135.10627   0.006369427 
+  154          148.26974    135.1077    0.006493506 
+  155          149.03937    135.10918   0.006451613 
+  149          150.15545    135.11069   0.006711409 
+  180          151.37143    135.11225   0.005555556 
+  166          152.34615    135.11384   0.006024096 
+  160          153.38987    135.11547   0.00625   
+  178          155.02952    135.11714   0.005617978 
+  144          156.56978    135.11884   0.006944444 
+  169          156.70943    135.12059   0.00591716 
+  151          156.40004    135.12237   0.006622517 
+  178          157.22901    135.12419   0.005617978 
+  146          159.73621    135.12605   0.006849315 
+  196          163.76735    135.12794   0.005102041 
+  152          167.90795    135.12987   0.006578947 
+  165          169.20732    135.13184   0.006060606 
+  177          167.89957    135.13384   0.005649718 
+  159          166.62482    135.13589   0.006289308 
+  163          166.46458    135.13796   0.006134969 
+  174          168.10429    135.14008   0.005747126 
+  170          171.79016    135.14223   0.005882353 
+  183          178.2347     135.14441   0.005464481 
+  177          187.96343    135.14664   0.005649718 
+  174          199.75465    135.14889   0.005747126 
+  196          212.4535     135.15119   0.005102041 
+  192          221.93247    135.15351   0.005208333 
+  194          218.75139    135.15588   0.005154639 
+  158          207.20969    135.15827   0.006329114 
+  181          197.65008    135.16071   0.005524862 
+  199          192.70677    135.16317   0.005025126 
+  181          191.71619    135.16567   0.005524862 
+  199          193.63893    135.16821   0.005025126 
+  182          197.81313    135.17078   0.005494505 
+  200          203.44812    135.17338   0.005     
+  191          205.87805    135.17602   0.005235602 
+  201          201.81012    135.17869   0.004975124 
+  201          196.11746    135.1814    0.004975124 
+  171          192.58904    135.18413   0.005847953 
+  188          191.51171    135.1869    0.005319149 
+  203          192.35289    135.18971   0.004926108 
+  215          194.78082    135.19254   0.004651163 
+  180          198.64501    135.19541   0.005555556 
+  217          203.32025    135.19831   0.004608295 
+  210          206.76268    135.20125   0.004761905 
+  206          207.92654    135.20421   0.004854369 
+  211          209.01492    135.20721   0.004739336 
+  222          211.89472    135.21024   0.004504505 
+  218          216.79028    135.2133    0.004587156 
+  199          221.66265    135.21639   0.005025126 
+  191          223.36619    135.21951   0.005235602 
+  188          223.31012    135.22267   0.005319149 
+  225          224.33748    135.22585   0.004444444 
+  206          224.87293    135.22907   0.004854369 
+  214          224.82499    135.23231   0.004672897 
+  194          226.86054    135.23559   0.005154639 
+  230          232.07575    135.23889   0.004347826 
+  226          239.92759    135.24223   0.004424779 
+  222          247.89028    135.2456    0.004504505 
+  216          252.51582    135.24899   0.00462963 
+  200          254.78374    135.25242   0.005     
+  232          257.40854    135.25587   0.004310345 
+  226          261.07032    135.25936   0.004424779 
+  223          271.34412    135.26287   0.004484305 
+  258          299.62994    135.26641   0.003875969 
+  314          365.03288    135.26998   0.003184713 
+  383          489.33535    135.27358   0.002610966 
+  411          603.88397    135.27721   0.00243309 
+  414          522.18345    135.28087   0.002415459 
+  326          384.31003    135.28455   0.003067485 
+  261          303.26295    135.28826   0.003831418 
+  247          264.02794    135.292     0.004048583 
+  228          248.73636    135.29577   0.004385965 
+  242          252.77186    135.29957   0.004132231 
+  240          282.33648    135.30339   0.004166667 
+  311          343.01202    135.30724   0.003215434 
+  292          375.55048    135.31111   0.003424658 
+  276          312.12016    135.31501   0.003623188 
+  228          246.04575    135.31894   0.004385965 
+  228          209.18119    135.3229    0.004385965 
+  183          190.16428    135.32688   0.005464481 
+  173          179.70849    135.33089   0.005780347 
+  178          173.3844     135.33492   0.005617978 
+  168          169.22448    135.33898   0.005952381 
+  185          166.11743    135.34307   0.005405405 
+  174          163.65141    135.34718   0.005747126 
+  183          161.93337    135.35131   0.005464481 
+  172          161.01245    135.35547   0.005813953 
+  183          160.92641    135.35966   0.005464481 
+  168          161.82984    135.36387   0.005952381 
+  179          163.84862    135.36811   0.005586592 
+  176          166.26813    135.37237   0.005681818 
+  162          166.35541    135.37665   0.00617284 
+  175          163.4041     135.38096   0.005714286 
+  151          160.21214    135.38529   0.006622517 
+  185          158.52373    135.38965   0.005405405 
+  222          158.32162    135.39403   0.004504505 
+  173          158.01362    135.39843   0.005780347 
+  164          156.78173    135.40286   0.006097561 
+  166          156.21914    135.4073    0.006024096 
+  177          156.33484    135.41178   0.005649718 
+  169          155.67127    135.41627   0.00591716 
+  180          154.13982    135.42079   0.005555556 
+  172          152.98975    135.42533   0.005813953 
+  187          152.71346    135.42989   0.005347594 
+  160          153.06832    135.43448   0.00625   
+  161          153.51737    135.43909   0.00621118 
+  156          154.21329    135.44371   0.006410256 
+  160          155.73502    135.44837   0.00625   
+  173          156.62269    135.45304   0.005780347 
+  137          155.26808    135.45773   0.00729927 
+  155          152.79562    135.46245   0.006451613 
+  154          150.73706    135.46718   0.006493506 
+  161          149.45711    135.47194   0.00621118 
+  156          148.77744    135.47672   0.006410256 
+  154          148.68302    135.48152   0.006493506 
+  140          149.21808    135.48633   0.007142857 
+  158          150.15223    135.49117   0.006329114 
+  129          150.57394    135.49603   0.007751938 
+  162          149.79732    135.50091   0.00617284 
+  150          148.49527    135.50581   0.006666667 
+  133          147.43247    135.51073   0.007518797 
+  157          146.82663    135.51567   0.006369427 
+  141          146.63106    135.52062   0.007092199 
+  148          146.77327    135.5256    0.006756757 
+  140          147.10797    135.5306    0.007142857 
+  148          147.23024    135.53561   0.006756757 
+  147          146.876      135.54064   0.006802721 
+  148          146.41106    135.5457    0.006756757 
+  160          146.14399    135.55077   0.00625   
+  167          146.12526    135.55586   0.005988024 
+  148          146.34802    135.56096   0.006756757 
+  148          146.82631    135.56609   0.006756757 
+  116          147.59412    135.57123   0.00862069 
+  153          148.60407    135.57639   0.006535948 
+  159          149.51368    135.58157   0.006289308 
+  155          149.97384    135.58676   0.006451613 
+  150          150.30678    135.59197   0.006666667 
+  172          150.88746    135.5972    0.005813953 
+  145          151.78047    135.60245   0.006896552 
+  159          152.93045    135.60771   0.006289308 
+  164          154.21879    135.61299   0.006097561 
+  177          155.67205    135.61829   0.005649718 
+  160          157.44716    135.6236    0.00625   
+  152          159.66792    135.62893   0.006578947 
+  165          162.56128    135.63427   0.006060606 
+  169          166.85216    135.63963   0.00591716 
+  166          173.96362    135.64501   0.006024096 
+  181          186.40685    135.6504    0.005524862 
+  176          207.90808    135.6558    0.005681818 
+  210          239.34018    135.66123   0.004761905 
+  219          258.79988    135.66666   0.00456621 
+  190          237.98987    135.67211   0.005263158 
+  177          207.93812    135.67758   0.005649718 
+  179          189.33223    135.68306   0.005586592 
+  182          180.53637    135.68856   0.005494505 
+  172          178.22509    135.69407   0.005813953 
+  182          181.28906    135.69959   0.005494505 
+  198          190.5864     135.70513   0.005050505 
+  197          206.75612    135.71068   0.005076142 
+  205          220.66653    135.71625   0.004878049 
+  202          216.81897    135.72183   0.004950495 
+  182          208.16557    135.72742   0.005494505 
+  176          202.78205    135.73302   0.005681818 
+  179          195.91511    135.73864   0.005586592 
+  195          188.42309    135.74428   0.005128205 
+  195          182.95402    135.74992   0.005128205 
+  195          178.62361    135.75558   0.005128205 
+  180          175.24194    135.76125   0.005555556 
+  163          174.03363    135.76693   0.006134969 
+  169          175.52574    135.77263   0.00591716 
+  169          179.43182    135.77833   0.00591716 
+  182          183.59558    135.78405   0.005494505 
+  186          184.82654    135.78978   0.005376344 
+  146          184.53706    135.79553   0.006849315 
+  154          186.49788    135.80128   0.006493506 
+  210          191.5145     135.80705   0.004761905 
+  174          197.41584    135.81282   0.005747126 
+  190          199.26381    135.81861   0.005263158 
+  192          197.01374    135.82441   0.005208333 
+  180          195.91156    135.83022   0.005555556 
+  188          197.48772    135.83604   0.005319149 
+  176          203.55641    135.84187   0.005681818 
+  208          220.08576    135.84771   0.004807692 
+  266          257.67466    135.85356   0.003759398 
+  267          328.07462    135.85943   0.003745318 
+  341          400.02408    135.8653    0.002932551 
+  308          367.44683    135.87118   0.003246753 
+  257          287.90583    135.87707   0.003891051 
+  226          237.91606    135.88297   0.004424779 
+  204          214.38761    135.88889   0.004901961 
+  210          206.05009    135.89481   0.004761905 
+  190          207.87979    135.90073   0.005263158 
+  212          219.85407    135.90667   0.004716981 
+  225          246.46197    135.91262   0.004444444 
+  239          280.37082    135.91858   0.0041841 
+  211          271.68915    135.92454   0.004739336 
+  210          227.27469    135.93051   0.004761905 
+  173          195.63874    135.9365    0.005780347 
+  199          179.50738    135.94249   0.005025126 
+  193          172.07254    135.94848   0.005181347 
+  161          168.73608    135.95449   0.00621118 
+  160          166.68321    135.9605    0.00625   
+  170          165.1109     135.96653   0.005882353 
+  156          163.51231    135.97256   0.006410256 
+  157          161.79801    135.97859   0.006369427 
+  137          161.14379    135.98464   0.00729927 
+  155          162.19651    135.99069   0.006451613 
+  168          164.66476    135.99675   0.005952381 
+  169          167.34819    136.00281   0.00591716 
+  153          168.40677    136.00888   0.006535948 
+  170          168.22226    136.01496   0.005882353 
+  158          169.48819    136.02105   0.006329114 
+  182          174.14886    136.02714   0.005494505 
+  194          183.45415    136.03324   0.005154639 
+  182          197.37914    136.03934   0.005494505 
+  199          211.91537    136.04545   0.005025126 
+  188          220.83359    136.05157   0.005319149 
+  193          219.80742    136.05769   0.005181347 
+  183          207.70057    136.06382   0.005464481 
+  169          192.36656    136.06995   0.00591716 
+  152          181.00077    136.07609   0.006578947 
+  171          175.10308    136.08223   0.005847953 
+  158          174.09111    136.08838   0.006329114 
+  190          177.18697    136.09454   0.005263158 
+  163          182.47003    136.1007    0.006134969 
+  159          186.24618    136.10686   0.006289308 
+  162          185.75358    136.11303   0.00617284 
+  174          179.76911    136.1192    0.005747126 
+  142          171.09314    136.12538   0.007042254 
+  142          163.82719    136.13156   0.007042254 
+  157          158.975      136.13775   0.006369427 
+  132          155.98178    136.14394   0.007575758 
+  158          154.18751    136.15013   0.006329114 
+  174          153.19791    136.15633   0.005747126 
+  155          152.70857    136.16253   0.006451613 
+  159          152.3812     136.16873   0.006289308 
+  147          152.04519    136.17494   0.006802721 
+  156          151.84099    136.18116   0.006410256 
+  167          151.97374    136.18737   0.005988024 
+  151          152.54706    136.19359   0.006622517 
+  157          153.65026    136.19981   0.006369427 
+  176          155.44988    136.20604   0.005681818 
+  157          158.2066     136.21226   0.006369427 
+  153          162.09557    136.21849   0.006535948 
+  162          166.33742    136.22472   0.00617284 
+  139          168.91822    136.23096   0.007194245 
+  172          169.47201    136.2372    0.005813953 
+  166          169.79935    136.24344   0.006024096 
+  149          170.08749    136.24968   0.006711409 
+  144          169.20687    136.25592   0.006944444 
+  159          168.39431    136.26217   0.006289308 
+  150          169.38782    136.26841   0.006666667 
+  174          172.97132    136.27466   0.005747126 
+  164          179.73599    136.28091   0.006097561 
+  203          190.56539    136.28717   0.004926108 
+  211          208.10861    136.29342   0.004739336 
+  216          238.0282     136.29967   0.00462963 
+  264          279.66301    136.30593   0.003787879 
+  247          298.32344    136.31219   0.004048583 
+  256          271.5057     136.31845   0.00390625 
+  211          239.46999    136.3247    0.004739336 
+  219          216.21851    136.33096   0.00456621 
+  188          199.65208    136.33722   0.005319149 
+  202          190.16154    136.34348   0.004950495 
+  168          187.98359    136.34974   0.005952381 
+  190          193.79874    136.35601   0.005263158 
+  211          208.71054    136.36227   0.004739336 
+  231          225.58213    136.36853   0.004329004 
+  220          222.48035    136.37479   0.004545455 
+  207          205.11566    136.38105   0.004830918 
+  168          190.44881    136.38731   0.005952381 
+  194          179.33102    136.39358   0.005154639 
+  169          171.12075    136.39984   0.00591716 
+  173          165.72874    136.4061    0.005780347 
+  177          162.44416    136.41236   0.005649718 
+  162          160.55641    136.41862   0.00617284 
+  168          159.5958     136.42487   0.005952381 
+  173          159.27814    136.43113   0.005780347 
+  137          159.40424    136.43739   0.00729927 
+  177          159.78691    136.44364   0.005649718 
+  160          160.34023    136.4499    0.00625   
+  189          161.09593    136.45615   0.005291005 
+  169          162.07992    136.4624    0.00591716 
+  189          163.31111    136.46865   0.005291005 
+  185          164.84504    136.4749    0.005405405 
+  179          166.79437    136.48115   0.005586592 
+  159          169.33513    136.48739   0.006289308 
+  172          172.67002    136.49364   0.005813953 
+  175          176.80279    136.49988   0.005714286 
+  168          180.99709    136.50612   0.005952381 
+  218          184.3832     136.51236   0.004587156 
+  187          187.86033    136.51859   0.005347594 
+  190          192.70919    136.52483   0.005263158 
+  202          199.15999    136.53106   0.004950495 
+  198          207.44028    136.53729   0.005050505 
+  201          218.8365     136.54351   0.004975124 
+  237          235.23981    136.54974   0.004219409 
+  230          259.23179    136.55596   0.004347826 
+  265          294.67802    136.56218   0.003773585 
+  341          346.95351    136.5684    0.002932551 
+  447          428.91173    136.57461   0.002237136 
+  555          579.14373    136.58082   0.001801802 
+  892          872.72308    136.58703   0.001121076 
+  1325         1391.59807   136.59323   0.000754717 
+  1598         1892.10543   136.59943   0.000625782 
+  1242         1637.14125   136.60563   0.000805153 
+  979          1064.3909    136.61182   0.00102145 
+  676          702.29029    136.61801   0.00147929 
+  477          525.4928     136.6242    0.002096436 
+  445          451.33384    136.63039   0.002247191 
+  443          439.91848    136.63657   0.002257336 
+  506          492.5923     136.64274   0.001976285 
+  654          641.07756    136.64892   0.001529052 
+  830          908.13042    136.65508   0.001204819 
+  807          1082.02163   136.66125   0.001239157 
+  717          862.46975    136.66741   0.0013947 
+  482          583.55029    136.67357   0.002074689 
+  378          419.15898    136.67972   0.002645503 
+  308          332.24658    136.68587   0.003246753 
+  279          282.41273    136.69201   0.003584229 
+  267          250.98992    136.69816   0.003745318 
+  185          229.54984    136.70429   0.005405405 
+  211          214.47366    136.71042   0.004739336 
+  198          203.99273    136.71655   0.005050505 
+  195          196.19291    136.72267   0.005128205 
+  186          190.43112    136.72879   0.005376344 
+  199          186.94339    136.7349    0.005025126 
+  194          184.69756    136.74101   0.005154639 
+  189          181.47759    136.74712   0.005291005 
+  183          176.92021    136.75321   0.005464481 
+  132          172.40251    136.75931   0.007575758 
+  153          168.25903    136.7654    0.006535948 
+  163          164.73614    136.77148   0.006134969 
+  161          162.08639    136.77756   0.00621118 
+  148          160.21022    136.78363   0.006756757 
+  155          158.95488    136.7897    0.006451613 
+  162          158.19381    136.79576   0.00617284 
+  172          157.67816    136.80182   0.005813953 
+  173          157.08855    136.80788   0.005780347 
+  177          156.50617    136.81392   0.005649718 
+  185          156.22891    136.81996   0.005405405 
+  155          156.34916    136.826     0.006451613 
+  161          156.74276    136.83203   0.00621118 
+  168          157.18949    136.83806   0.005952381 
+  162          157.56662    136.84407   0.00617284 
+  179          157.91537    136.85009   0.005586592 
+  178          158.17116    136.8561    0.005617978 
+  166          158.24774    136.8621    0.006024096 
+  179          158.47608    136.86809   0.005586592 
+  169          159.19897    136.87409   0.00591716 
+  186          160.62389    136.88007   0.005376344 
+  162          162.98461    136.88605   0.00617284 
+  205          166.6199     136.89202   0.004878049 
+  164          172.08554    136.89799   0.006097561 
+  182          180.30219    136.90395   0.005494505 
+  195          192.97629    136.9099    0.005128205 
+  191          213.12345    136.91585   0.005235602 
+  182          241.16219    136.92179   0.005494505 
+  213          260.70231    136.92773   0.004694836 
+  213          249.27029    136.93366   0.004694836 
+  186          223.98959    136.93958   0.005376344 
+  181          202.81855    136.9455    0.005524862 
+  164          189.24553    136.95141   0.006097561 
+  151          182.44731    136.95731   0.006622517 
+  204          180.8808     136.96321   0.004901961 
+  151          183.93425    136.9691    0.006622517 
+  167          192.45129    136.97498   0.005988024 
+  173          206.47393    136.98086   0.005780347 
+  188          217.90965    136.98673   0.005319149 
+  182          215.83219    136.9926    0.005494505 
+  167          209.29649    136.99846   0.005988024 
+  174          206.97517    137.00431   0.005747126 
+  204          206.32061    137.01016   0.004901961 
+  202          199.90193    137.01599   0.004950495 
+  174          188.58746    137.02183   0.005747126 
+  194          178.64935    137.02765   0.005154639 
+  175          172.29723    137.03347   0.005714286 
+  186          169.0685     137.03928   0.005376344 
+  197          168.16771    137.04509   0.005076142 
+  191          169.2738     137.05089   0.005235602 
+  198          172.71687    137.05668   0.005050505 
+  179          178.59114    137.06246   0.005586592 
+  189          185.08804    137.06824   0.005291005 
+  178          188.89998    137.07401   0.005617978 
+  175          190.47231    137.07977   0.005714286 
+  197          192.04236    137.08553   0.005076142 
+  196          192.2009     137.09128   0.005102041 
+  194          187.85368    137.09703   0.005154639 
+  177          181.25091    137.10276   0.005649718 
+  205          176.6108     137.10849   0.004878049 
+  199          175.06553    137.11422   0.005025126 
+  180          175.32991    137.11993   0.005555556 
+  165          175.03366    137.12564   0.006060606 
+  158          174.06754    137.13134   0.006329114 
+  176          174.10753    137.13704   0.005681818 
+  183          175.25513    137.14273   0.005464481 
+  176          176.09132    137.14841   0.005681818 
+  171          174.74885    137.15409   0.005847953 
+  176          171.97089    137.15975   0.005681818 
+  166          170.03291    137.16541   0.006024096 
+  181          169.683      137.17107   0.005524862 
+  187          170.36574    137.17672   0.005347594 
+  207          170.86978    137.18236   0.004830918 
+  219          170.85329    137.18799   0.00456621 
+  195          171.1632     137.19362   0.005128205 
+  206          172.29821    137.19924   0.004854369 
+  201          174.31625    137.20485   0.004975124 
+  233          177.22841    137.21045   0.004291845 
+  216          181.12786    137.21605   0.00462963 
+  216          186.20346    137.22165   0.00462963 
+  194          192.7383     137.22723   0.005154639 
+  215          200.93558    137.23281   0.004651163 
+  246          210.58747    137.23838   0.004065041 
+  246          221.66028    137.24395   0.004065041 
+  257          235.74431    137.24951   0.003891051 
+  269          255.35984    137.25506   0.003717472 
+  305          283.53802    137.2606    0.003278689 
+  388          325.05811    137.26614   0.00257732 
+  438          388.65321    137.27168   0.002283105 
+  554          491.58485    137.2772    0.001805054 
+  831          669.52517    137.28272   0.001203369 
+  1332         993.71482    137.28823   0.000750751 
+  1943         1564.96519   137.29374   0.000514668 
+  2380         2226.97025   137.29924   0.000420168 
+  2195         2126.13467   137.30473   0.000455581 
+  1533         1434.88025   137.31022   0.000652316 
+  1097         927.41565    137.31569   0.000911577 
+  797          662.14032    137.32117   0.001254705 
+  647          538.95058    137.32664   0.001545595 
+  600          496.42809    137.3321    0.001666667 
+  662          516.39425    137.33755   0.001510574 
+  731          613.50344    137.343     0.001367989 
+  1033         830.58012    137.34844   0.000968054 
+  1229         1159.78115   137.35388   0.00081367 
+  1219         1251.61272   137.35931   0.000820345 
+  913          927.44702    137.36473   0.00109529 
+  685          618.23053    137.37015   0.001459854 
+  497          440.44321    137.37556   0.002012072 
+  368          345.80716    137.38096   0.002717391 
+  318          292.90666    137.38636   0.003144654 
+  302          260.18529    137.39176   0.003311258 
+  234          237.53633    137.39714   0.004273504 
+  241          220.82137    137.40253   0.004149378 
+  220          208.45372    137.4079    0.004545455 
+  240          199.29951    137.41327   0.004166667 
+  227          192.46932    137.41864   0.004405286 
+  194          187.36017    137.424     0.005154639 
+  190          183.62283    137.42935   0.005263158 
+  190          181.10212    137.4347    0.005263158 
+  178          179.76285    137.44004   0.005617978 
+  198          179.51411    137.44538   0.005050505 
+  192          180.09396    137.45072   0.005208333 
+  207          181.38584    137.45604   0.004830918 
+  171          182.65736    137.46136   0.005847953 
+  173          181.66123    137.46668   0.005780347 
+  205          178.23336    137.47199   0.004878049 
+  190          174.88372    137.4773    0.005263158 
+  190          172.83424    137.4826    0.005263158 
+  179          171.63914    137.4879    0.005586592 
+  184          170.63325    137.49319   0.005434783 
+  164          170.15507    137.49848   0.006097561 
+  194          170.87189    137.50376   0.005154639 
+  174          173.16495    137.50904   0.005747126 
+  174          177.07323    137.51432   0.005747126 
+  222          181.77336    137.51959   0.004504505 
+  193          185.89285    137.52485   0.005181347 
+  192          190.3468     137.53012   0.005208333 
+  212          199.65038    137.53537   0.004716981 
+  220          218.5719     137.54063   0.004545455 
+  244          250.25171    137.54588   0.004098361 
+  249          284.65674    137.55112   0.004016064 
+  259          284.35346    137.55636   0.003861004 
+  258          251.02989    137.5616    0.003875969 
+  218          222.69186    137.56683   0.004587156 
+  214          208.65075    137.57207   0.004672897 
+  191          205.52596    137.57729   0.005235602 
+  197          210.27186    137.58252   0.005076142 
+  222          221.88876    137.58774   0.004504505 
+  202          234.1709     137.59295   0.004950495 
+  220          238.29627    137.59817   0.004545455 
+  233          242.75068    137.60338   0.004291845 
+  231          244.72106    137.60859   0.004329004 
+  233          228.94428    137.61379   0.004291845 
+  224          207.89524    137.619     0.004464286 
+  198          192.93921    137.6242    0.005050505 
+  188          184.54079    137.62939   0.005319149 
+  195          181.31549    137.63459   0.005128205 
+  156          182.33087    137.63978   0.006410256 
+  170          185.67662    137.64497   0.005882353 
+  181          185.18021    137.65016   0.005524862 
+  161          178.90466    137.65535   0.00621118 
+  161          173.09828    137.66054   0.00621118 
+  165          170.2483     137.66572   0.006060606 
+  154          169.72032    137.6709    0.006493506 
+  173          170.28515    137.67608   0.005780347 
+  161          171.27609    137.68126   0.00621118 
+  200          172.61617    137.68644   0.005     
+  174          173.48154    137.69161   0.005747126 
+  196          173.39301    137.69679   0.005102041 
+  158          173.40775    137.70196   0.006329114 
+  176          173.07461    137.70714   0.005681818 
+  174          170.88193    137.71231   0.005747126 
+  163          167.79574    137.71748   0.006134969 
+  174          165.54934    137.72265   0.005747126 
+  160          164.63554    137.72783   0.00625   
+  183          164.82101    137.733     0.005464481 
+  181          165.7131     137.73817   0.005524862 
+  171          166.90334    137.74334   0.005847953 
+  195          167.77385    137.74851   0.005128205 
+  176          168.41443    137.75369   0.005681818 
+  169          169.33734    137.75886   0.00591716 
+  175          169.99376    137.76403   0.005714286 
+  192          169.94474    137.76921   0.005208333 
+  183          169.79785    137.77438   0.005464481 
+  173          169.7082     137.77956   0.005780347 
+  196          169.50539    137.78474   0.005102041 
+  199          169.49062    137.78992   0.005025126 
+  190          169.95192    137.7951    0.005263158 
+  197          170.94154    137.80028   0.005076142 
+  204          172.41758    137.80546   0.004901961 
+  206          174.35036    137.81065   0.004854369 
+  210          176.75117    137.81584   0.004761905 
+  215          179.66885    137.82103   0.004651163 
+  229          183.15686    137.82622   0.004366812 
+  215          187.17083    137.83142   0.004651163 
+  214          191.45331    137.83661   0.004672897 
+  204          196.3402     137.84182   0.004901961 
+  211          202.16446    137.84702   0.004739336 
+  237          209.36739    137.85223   0.004219409 
+  240          218.38651    137.85744   0.004166667 
+  257          229.81521    137.86265   0.003891051 
+  259          244.5992     137.86787   0.003861004 
+  267          264.4128     137.87309   0.003745318 
+  294          291.90929    137.87832   0.003401361 
+  349          331.76764    137.88355   0.00286533 
+  382          390.09242    137.88879   0.002617801 
+  419          467.19484    137.89403   0.002386635 
+  531          542.02505    137.89927   0.001883239 
+  626          618.07146    137.90452   0.001597444 
+  857          758.9407     137.90978   0.001166861 
+  1172         1045.19044   137.91504   0.000853242 
+  1956         1597.75409   137.9203    0.000511247 
+  2769         2527.47695   137.92557   0.000361141 
+  3219         3374.28897   137.93085   0.000310655 
+  2697         2958.87093   137.93613   0.000370782 
+  1901         1963.17426   137.94142   0.000526039 
+  1329         1296.26634   137.94672   0.000752445 
+  1022         955.19725    137.95202   0.000978474 
+  838          789.81454    137.95733   0.001193317 
+  779          720.81282    137.96265   0.001283697 
+  834          742.48473    137.96797   0.001199041 
+  929          876.29158    137.9733    0.001076426 
+  1262         1152.84792   137.97864   0.000792393 
+  1629         1585.021     137.98399   0.000613874 
+  1720         1908.49803   137.98934   0.000581395 
+  1459         1591.44086   137.99471   0.000685401 
+  990          1064.98444   138.00008   0.001010101 
+  759          719.11545    138.00546   0.001317523 
+  545          529.37352    138.01085   0.001834862 
+  458          426.43454    138.01625   0.002183406 
+  394          369.50601    138.02166   0.002538071 
+  366          340.14358    138.02707   0.00273224 
+  337          328.65152    138.0325    0.002967359 
+  302          318.25425    138.03794   0.003311258 
+  272          293.70044    138.04338   0.003676471 
+  274          267.82991    138.04884   0.003649635 
+  261          250.9369     138.05431   0.003831418 
+  263          242.70126    138.05979   0.003802281 
+  246          240.6119     138.06528   0.004065041 
+  210          240.4524     138.07078   0.004761905 
+  200          236.26676    138.07629   0.005     
+  204          227.61915    138.08182   0.004901961 
+  207          219.28886    138.08736   0.004830918 
+  183          212.72646    138.09291   0.005464481 
+  172          206.60259    138.09847   0.005813953 
+  200          201.09934    138.10404   0.005     
+  207          197.36009    138.10963   0.004830918 
+  185          195.84687    138.11523   0.005405405 
+  172          196.63298    138.12085   0.005813953 
+  181          199.54196    138.12647   0.005524862 
+  195          203.21715    138.13212   0.005128205 
+  194          204.75242    138.13777   0.005154639 
+  196          202.9964     138.14344   0.005102041 
+  194          199.68465    138.14913   0.005154639 
+  154          196.79183    138.15483   0.006493506 
+  166          195.00878    138.16054   0.006024096 
+  179          194.15372    138.16628   0.005586592 
+  190          193.13559    138.17202   0.005263158 
+  198          191.69204    138.17779   0.005050505 
+  184          191.63462    138.18357   0.005434783 
+  195          194.26302    138.18936   0.005128205 
+  172          199.58485    138.19517   0.005813953 
+  184          205.98272    138.201     0.005434783 
+  192          209.2131     138.20685   0.005208333 
+  201          204.95557    138.21272   0.004975124 
+  197          196.09193    138.2186    0.005076142 
+  178          189.18919    138.2245    0.005617978 
+  195          185.6253     138.23042   0.005128205 
+  157          183.89467    138.23636   0.006369427 
+  197          182.89545    138.24232   0.005076142 
+  180          183.07555    138.24829   0.005555556 
+  162          185.06476    138.25429   0.00617284 
+  195          189.03966    138.2603    0.005128205 
+  187          194.58043    138.26634   0.005347594 
+  182          199.72703    138.2724    0.005494505 
+  194          200.61207    138.27848   0.005154639 
+  183          195.1328     138.28457   0.005464481 
+  186          186.90273    138.29069   0.005376344 
+  180          179.82628    138.29684   0.005555556 
+  182          174.95485    138.303     0.005494505 
+  171          171.94173    138.30919   0.005847953 
+  189          170.30481    138.31539   0.005291005 
+  176          169.74891    138.32163   0.005681818 
+  191          170.20889    138.32788   0.005235602 
+  176          171.79936    138.33416   0.005681818 
+  172          174.61475    138.34046   0.005813953 
+  169          178.14274    138.34679   0.00591716 
+  171          180.9106     138.35314   0.005847953 
+  193          181.67072    138.35951   0.005181347 
+  173          180.04011    138.36591   0.005780347 
+  175          177.29914    138.37234   0.005714286 
+  160          175.8067     138.37879   0.00625   
+  197          176.8279     138.38527   0.005076142 
+  163          180.59445    138.39177   0.006134969 
+  176          186.01243    138.3983    0.005681818 
+  206          189.36252    138.40486   0.004854369 
+  155          187.30347    138.41144   0.006451613 
+  155          182.16882    138.41806   0.006451613 
+  167          177.87586    138.4247    0.005988024 
+  144          175.47459    138.43137   0.006944444 
+  157          173.94277    138.43807   0.006369427 
+  169          172.66633    138.44479   0.00591716 
+  187          172.41782    138.45155   0.005347594 
+  197          173.99487    138.45834   0.005076142 
+  208          177.77426    138.46515   0.004807692 
+  184          183.57034    138.472     0.005434783 
+  196          189.52389    138.47888   0.005102041 
+  202          192.44223    138.48579   0.004950495 
+  196          192.1143     138.49273   0.005102041 
+  172          190.3304     138.4997    0.005813953 
+  237          187.10187    138.5067    0.004219409 
+  198          183.28924    138.51374   0.005050505 
+  180          180.55007    138.52081   0.005555556 
+  185          179.41423    138.52791   0.005405405 
+  176          179.70607    138.53505   0.005681818 
+  186          181.35005    138.54222   0.005376344 
+  195          184.34803    138.54943   0.005128205 
+  200          188.12661    138.55667   0.005     
+  225          191.8176     138.56394   0.004444444 
+  232          195.31713    138.57126   0.004310345 
+  231          199.25867    138.5786    0.004329004 
+  199          203.75452    138.58599   0.005025126 
+  215          209.16303    138.59341   0.004651163 
+  229          216.84576    138.60087   0.004366812 
+  263          227.91248    138.60836   0.003802281 
+  278          243.16039    138.61589   0.003597122 
+  304          263.22233    138.62347   0.003289474 
+  349          288.86689    138.63108   0.00286533 
+  362          323.52207    138.63873   0.002762431 
+  448          377.98578    138.64642   0.002232143 
+  593          472.83428    138.65414   0.001686341 
+  829          646.41597    138.66191   0.001206273 
+  1164         959.88981    138.66972   0.000859107 
+  1636         1431.76283   138.67757   0.000611247 
+  1695         1719.78358   138.68547   0.000589971 
+  1407         1403.02116   138.6934    0.000710732 
+  1064         948.59013    138.70138   0.00093985 
+  773          659.41681    138.7094    0.001293661 
+  623          506.8966     138.71746   0.001605136 
+  480          432.75503    138.72557   0.002083333 
+  478          405.88446    138.73372   0.00209205 
+  486          418.1891     138.74191   0.002057613 
+  565          476.62757    138.75015   0.001769912 
+  655          595.26363    138.75844   0.001526718 
+  820          780.50777    138.76677   0.001219512 
+  983          980.63406    138.77515   0.001017294 
+  887          949.70062    138.78357   0.001127396 
+  735          700.14512    138.79204   0.001360544 
+  523          493.23466    138.80056   0.001912046 
+  428          372.29243    138.80913   0.002336449 
+  331          305.44323    138.81775   0.003021148 
+  315          267.91331    138.82641   0.003174603 
+  247          247.17125    138.83512   0.004048583 
+  275          237.90293    138.84389   0.003636364 
+  279          236.78904    138.8527    0.003584229 
+  260          235.15331    138.86156   0.003846154 
+  269          222.82284    138.87048   0.003717472 
+  231          206.57493    138.87945   0.004329004 
+  179          194.30926    138.88847   0.005586592 
+  193          186.5729     138.89754   0.005181347 
+  212          182.25293    138.90666   0.004716981 
+  186          180.49924    138.91584   0.005376344 
+  206          180.31884    138.92507   0.004854369 
+  193          179.07458    138.93436   0.005181347 
+  167          174.79211    138.9437    0.005988024 
+  178          169.98147    138.9531    0.005617978 
+  176          166.42978    138.96255   0.005681818 
+  152          164.0617     138.97206   0.006578947 
+  162          162.53522    138.98163   0.00617284 
+  167          161.71632    138.99125   0.005988024 
+  157          161.62476    139.00093   0.006369427 
+  163          162.33531    139.01067   0.006134969 
+  166          163.80977    139.02047   0.006024096 
+  150          165.59194    139.03033   0.006666667 
+  154          166.82933    139.04024   0.006493506 
+  183          166.41616    139.05022   0.005464481 
+  178          164.62455    139.06026   0.005617978 
+  172          163.21377    139.07036   0.005813953 
+  155          163.01656    139.08052   0.006451613 
+  194          164.008      139.09075   0.005154639 
+  164          165.69735    139.10104   0.006097561 
+  187          166.73088    139.11139   0.005347594 
+  173          165.74922    139.1218    0.005780347 
+  150          163.59267    139.13228   0.006666667 
+  205          161.7296     139.14282   0.004878049 
+  150          160.43584    139.15343   0.006666667 
+  158          159.55309    139.16411   0.006329114 
+  162          159.18628    139.17485   0.00617284 
+  167          159.47941    139.18566   0.005988024 
+  167          160.61445    139.19654   0.005988024 
+  165          162.87617    139.20748   0.006060606 
+  157          166.52453    139.2185    0.006369427 
+  179          171.6156     139.22958   0.005586592 
+  159          177.45782    139.24073   0.006289308 
+  165          182.12483    139.25196   0.006060606 
+  173          182.60681    139.26325   0.005780347 
+  153          178.13714    139.27462   0.006535948 
+  161          172.25431    139.28605   0.00621118 
+  172          167.90493    139.29756   0.005813953 
+  171          165.80341    139.30915   0.005847953 
+  180          165.89631    139.3208    0.005555556 
+  179          168.05006    139.33254   0.005586592 
+  170          171.61573    139.34434   0.005882353 
+  188          174.2881     139.35622   0.005319149 
+  166          174.2212     139.36818   0.006024096 
+  168          173.98706    139.38022   0.005952381 
+  148          174.93774    139.39233   0.006756757 
+  163          175.18148    139.40452   0.006134969 
+  183          173.33364    139.41678   0.005464481 
+  163          170.14742    139.42913   0.006134969 
+  182          167.01656    139.44156   0.005494505 
+  169          164.80502    139.45406   0.00591716 
+  171          163.66056    139.46665   0.005847953 
+  172          163.4609     139.47932   0.005813953 
+  158          163.70821    139.49207   0.006329114 
+  165          163.21695    139.5049    0.006060606 
+  182          161.34155    139.51781   0.005494505 
+  166          159.53199    139.53081   0.006024096 
+  163          158.77549    139.5439    0.006134969 
+  168          159.01342    139.55706   0.005952381 
+  172          159.79195    139.57032   0.005813953 
+  177          160.76172    139.58366   0.005649718 
+  165          162.2452     139.59708   0.006060606 
+  200          164.8318     139.6106    0.005     
+  157          168.67174    139.6242    0.006369427 
+  163          172.77095    139.63789   0.006134969 
+  160          174.80322    139.65167   0.00625   
+  161          173.71089    139.66554   0.00621118 
+  172          170.2972     139.6795    0.005813953 
+  164          165.64534    139.69355   0.006097561 
+  183          161.2918     139.70769   0.005464481 
+  153          158.13655    139.72193   0.006535948 
+  178          156.21934    139.73626   0.005617978 
+  163          155.34643    139.75068   0.006134969 
+  163          155.4        139.7652    0.006134969 
+  143          156.36987    139.77981   0.006993007 
+  162          158.20297    139.79452   0.00617284 
+  139          160.38636    139.80932   0.007194245 
+  155          161.76676    139.82422   0.006451613 
+  163          161.75464    139.83922   0.006134969 
+  166          160.73846    139.85432   0.006024096 
+  147          159.26903    139.86952   0.006802721 
+  159          158.16164    139.88481   0.006289308 
+  167          157.86247    139.90021   0.005988024 
+  177          158.2167     139.91571   0.005649718 
+  158          158.60187    139.93131   0.006329114 
+  180          158.48805    139.94701   0.005555556 
+  168          158.26331    139.96281   0.005952381 
+  170          158.42305    139.97872   0.005882353 
+  152          159.02423    139.99473   0.006578947 
+  170          160.13217    140.01085   0.005882353 
+  161          161.65519    140.02708   0.00621118 
+  155          163.48422    140.04341   0.006451613 
+  170          165.17536    140.05985   0.005882353 
+  152          165.2177     140.07639   0.006578947 
+  160          163.16563    140.09305   0.00625   
+  156          160.59383    140.10981   0.006410256 
+  171          158.52676    140.12669   0.005847953 
+  185          156.72605    140.14367   0.005405405 
+  155          155.56583    140.16077   0.006451613 
+  166          154.96727    140.17798   0.006024096 
+  149          154.85335    140.1953    0.006711409 
+  152          155.1811     140.21273   0.006578947 
+  151          155.87919    140.23029   0.006622517 
+  180          156.8772     140.24795   0.005555556 
+  159          158.05045    140.26573   0.006289308 
+  168          158.74682    140.28363   0.005952381 
+  184          158.60116    140.30165   0.005434783 
+  174          158.40646    140.31978   0.005747126 
+  188          158.73908    140.33803   0.005319149 
+  147          159.39444    140.35641   0.006802721 
+  152          159.30617    140.3749    0.006578947 
+  169          158.25279    140.39351   0.00591716 
+  129          156.78252    140.41225   0.007751938 
+  144          155.41351    140.43111   0.006944444 
+  164          154.49243    140.45009   0.006097561 
+  148          154.14307    140.4692    0.006756757 
+  167          154.37042    140.48843   0.005988024 
+  156          155.16124    140.50779   0.006410256 
+  161          156.47545    140.52727   0.00621118 
+  163          158.13642    140.54688   0.006134969 
+  151          159.90186    140.56662   0.006622517 
+  121          161.42658    140.58649   0.008264463 
+  166          162.45329    140.60649   0.006024096 
+  155          163.14061    140.62662   0.006451613 
+  170          163.41637    140.64688   0.005882353 
+  154          162.57052    140.66727   0.006493506 
+  170          160.6309     140.6878    0.005882353 
+  149          158.57655    140.70846   0.006711409 
+  167          157.07011    140.72925   0.005988024 
+  174          156.30444    140.75018   0.005747126 
+  163          156.23223    140.77124   0.006134969 
+  162          156.69202    140.79245   0.00617284 
+  149          157.48077    140.81378   0.006711409 
+  169          158.47937    140.83526   0.00591716 
+  146          159.76991    140.85688   0.006849315 
+  156          161.52881    140.87864   0.006410256 
+  146          163.14883    140.90054   0.006849315 
+  171          163.16878    140.92258   0.005847953 
+  144          161.26071    140.94476   0.006944444 
+  167          158.74505    140.96709   0.005988024 
+  153          156.64252    140.98956   0.006535948 
+  172          155.19342    141.01218   0.005813953 
+  151          154.32715    141.03494   0.006622517 
+  164          153.92461    141.05785   0.006097561 
+  151          153.89288    141.08091   0.006622517 
+  142          154.16337    141.10412   0.007042254 
+  150          154.71754    141.12747   0.006666667 
+  154          155.49686    141.15098   0.006493506 
+  159          156.27504    141.17464   0.006289308 
+  153          156.61469    141.19845   0.006535948 
+  136          156.30118    141.22241   0.007352941 
+  141          155.76144    141.24653   0.007092199 
+  143          155.46184    141.2708    0.006993007 
+  152          155.45281    141.29523   0.006578947 
+  145          155.49237    141.31981   0.006896552 
+  127          155.58595    141.34456   0.007874016 
+  158          156.01066    141.36946   0.006329114 
+  159          156.93454    141.39452   0.006289308 
+  162          158.47541    141.41973   0.00617284 
+  145          160.71632    141.44512   0.006896552 
+  175          163.47572    141.47066   0.005714286 
+  174          165.86867    141.49636   0.005747126 
+  196          166.58058    141.52223   0.005102041 
+  151          165.62279    141.54827   0.006622517 
+  189          164.44664    141.57447   0.005291005 
+  175          164.11692    141.60083   0.005714286 
+  154          164.84505    141.62737   0.006493506 
+  162          166.41473    141.65407   0.00617284 
+  152          168.3538     141.68094   0.006578947 
+  185          170.08539    141.70798   0.005405405 
+  173          172.05873    141.73519   0.005780347 
+  168          175.51448    141.76258   0.005952381 
+  165          180.65123    141.79014   0.006060606 
+  189          185.03834    141.81787   0.005291005 
+  163          184.79689    141.84577   0.006134969 
+  163          180.11338    141.87386   0.006134969 
+  194          174.96453    141.90212   0.005154639 
+  172          171.41591    141.93055   0.005813953 
+  195          169.5245     141.95917   0.005128205 
+  171          168.94109    141.98797   0.005847953 
+  164          169.59729    142.01694   0.006097561 
+  178          170.53448    142.0461    0.005617978 
+  156          171.70294    142.07544   0.006410256 
+  165          173.33615    142.10497   0.006060606 
+  187          175.54963    142.13468   0.005347594 
+  185          177.78957    142.16457   0.005405405 
+  174          178.85286    142.19466   0.005747126 
+  213          177.93852    142.22493   0.004694836 
+  200          176.41228    142.25538   0.005     
+  220          175.96893    142.28603   0.004545455 
+  206          177.01378    142.31687   0.004854369 
+  212          179.41256    142.3479    0.004716981 
+  213          182.69368    142.37912   0.004694836 
+  189          185.53475    142.41054   0.005291005 
+  186          186.50604    142.44215   0.005376344 
+  200          186.14425    142.47396   0.005     
+  195          186.1154     142.50596   0.005128205 
+  189          186.76592    142.53816   0.005291005 
+  215          188.27665    142.57056   0.004651163 
+  216          190.83997    142.60316   0.00462963 
+  181          194.72146    142.63596   0.005524862 
+  216          200.12065    142.66896   0.00462963 
+  242          206.96973    142.70217   0.004132231 
+  232          214.49229    142.73558   0.004310345 
+  229          221.54606    142.76919   0.004366812 
+  246          228.19749    142.80301   0.004065041 
+  260          235.28178    142.83704   0.003846154 
+  284          243.51469    142.87128   0.003521127 
+  277          254.2489     142.90572   0.003610108 
+  313          269.13118    142.94038   0.003194888 
+  337          289.78503    142.97525   0.002967359 
+  348          318.45617    143.01033   0.002873563 
+  356          358.92295    143.04562   0.002808989 
+  460          418.11233    143.08113   0.002173913 
+  596          509.3309     143.11685   0.001677852 
+  799          658.73217    143.15279   0.001251564 
+  1134         914.74294    143.18895   0.000881834 
+  1569         1349.8844    143.22533   0.000637349 
+  2143         1977.91572   143.26192   0.000466636 
+  2341         2398.26883   143.29874   0.000427168 
+  1963         2053.34365   143.33578   0.000509424 
+  1468         1425.67272   143.37305   0.000681199 
+  1050         978.65824    143.41053   0.000952381 
+  858          721.77084    143.44825   0.001165501 
+  669          582.35333    143.48619   0.001494768 
+  629          510.74301    143.52436   0.001589825 
+  578          482.27496    143.56276   0.001730104 
+  612          489.43307    143.60139   0.001633987 
+  618          538.16525    143.64025   0.001618123 
+  727          648.97038    143.67934   0.001375516 
+  982          855.72047    143.71866   0.00101833 
+  1228         1159.11435   143.75822   0.000814332 
+  1191         1344.16548   143.79802   0.000839631 
+  1132         1147.10128   143.83805   0.000883392 
+  832          826.86792    143.87833   0.001201923 
+  687          600.7532     143.91884   0.001455604 
+  479          467.53606    143.95959   0.002087683 
+  480          390.22214    144.00058   0.002083333 
+  360          343.3493     144.04182   0.002777778 
+  326          313.11946    144.0833    0.003067485 
+  308          292.47451    144.12502   0.003246753 
+  302          277.65748    144.16699   0.003311258 
+  287          266.35416    144.20921   0.003484321 
+  254          257.08311    144.25168   0.003937008 
+  240          249.35737    144.2944    0.004166667 
+  213          242.96708    144.33737   0.004694836 
+  221          237.70927    144.38059   0.004524887 
+  242          233.34438    144.42406   0.004132231 
+  236          229.58694    144.46779   0.004237288 
+  236          225.81981    144.51178   0.004237288 
+  224          221.50448    144.55602   0.004464286 
+  192          217.00286    144.60052   0.005208333 
+  229          212.93188    144.64529   0.004366812 
+  219          209.50519    144.69031   0.00456621 
+  188          206.66322    144.73559   0.005319149 
+  194          204.28009    144.78114   0.005154639 
+  209          202.25388    144.82695   0.004784689 
+  200          200.5374     144.87303   0.005     
+  187          199.1281     144.91937   0.005347594 
+  217          198.02482    144.96599   0.004608295 
+  214          197.2233     145.01287   0.004672897 
+  190          196.69426    145.06002   0.005263158 
+  195          196.23293    145.10745   0.005128205 
+  186          195.58779    145.15515   0.005376344 
+  201          194.92624    145.20312   0.004975124 
+  202          194.59488    145.25137   0.004950495 
+  222          194.71021    145.2999    0.004504505 
+  219          195.19408    145.3487    0.00456621 
+  172          195.88632    145.39779   0.005813953 
+  189          196.57931    145.44715   0.005291005 
+  219          197.08367    145.4968    0.00456621 
+  195          197.30378    145.54673   0.005128205 
+  202          197.27384    145.59695   0.004950495 
+  198          197.08837    145.64745   0.005050505 
+  179          196.88936    145.69824   0.005586592 
+  193          196.8526     145.74932   0.005181347 
+  177          197.15609    145.80069   0.005649718 
+  187          197.97819    145.85235   0.005347594 
+  205          199.51644    145.90431   0.004878049 
+  210          202.02962    145.95655   0.004761905 
+  211          205.90937    146.0091    0.004739336 
+  213          211.72778    146.06194   0.004694836 
+  231          220.11571    146.11508   0.004329004 
+  212          230.57781    146.16851   0.004716981 
+  202          238.70953    146.22225   0.004950495 
+  230          239.64794    146.27629   0.004347826 
+  212          236.55799    146.33064   0.004716981 
+  219          232.42283    146.38529   0.00456621 
+  205          226.55861    146.44024   0.004878049 
+  225          219.30732    146.4955    0.004444444 
+  236          212.29412    146.55108   0.004237288 
+  189          206.56428    146.60696   0.005291005 
+  190          202.33904    146.66315   0.005263158 
+  216          199.59978    146.71966   0.00462963 
+  191          198.4128     146.77648   0.005235602 
+  220          198.98812    146.83362   0.004545455 
+  190          201.35512    146.89107   0.005263158 
+  190          204.11259    146.94885   0.005263158 
+  218          204.23369    147.00694   0.004587156 
+  203          201.81214    147.06535   0.004926108 
+  205          198.9757     147.12409   0.004878049 
+  203          195.71138    147.18315   0.004926108 
+  188          191.68665    147.24254   0.005319149 
+  205          187.43585    147.30226   0.004878049 
+  197          183.6132     147.3623    0.005076142 
+  196          180.51337    147.42267   0.005102041 
+  187          178.15291    147.48338   0.005347594 
+  176          176.42097    147.54442   0.005681818 
+  193          175.09651    147.60579   0.005181347 
+  188          173.89196    147.6675    0.005319149 
+  177          172.75984    147.72954   0.005649718 
+  180          171.96151    147.79193   0.005555556 
+  184          171.76111    147.85465   0.005434783 
+  184          172.32853    147.91772   0.005434783 
+  180          173.74394    147.98113   0.005555556 
+  169          175.76321    148.04488   0.00591716 
+  177          177.32657    148.10898   0.005649718 
+  181          176.93368    148.17343   0.005524862 
+  175          174.61452    148.23822   0.005714286 
+  166          171.88039    148.30337   0.006024096 
+  157          169.75269    148.36887   0.006369427 
+  151          168.40546    148.43472   0.006622517 
+  174          167.64117    148.50093   0.005747126 
+  169          167.23473    148.56749   0.00591716 
+  176          167.10043    148.63441   0.005681818 
+  192          167.18376    148.70169   0.005208333 
+  155          167.44484    148.76933   0.006451613 
+  162          168.00144    148.83734   0.00617284 
+  170          168.99061    148.90571   0.005882353 
+  170          170.24273    148.97444   0.005882353 
+  168          171.10154    149.04354   0.005952381 
+  166          171.03486    149.11301   0.006024096 
+  171          170.46671    149.18285   0.005847953 
+  149          170.14467    149.25306   0.006711409 
+  179          170.42815    149.32365   0.005586592 
+  155          171.41513    149.39461   0.006451613 
+  176          173.1743     149.46594   0.005681818 
+  171          175.84383    149.53766   0.005847953 
+  194          179.66586    149.60975   0.005154639 
+  178          185.0893     149.68223   0.005617978 
+  208          193.06253    149.75509   0.004807692 
+  190          205.59941    149.82833   0.005263158 
+  217          226.49726    149.90196   0.004608295 
+  283          261.60777    149.97597   0.003533569 
+  266          314.59829    150.05038   0.003759398 
+  286          364.05692    150.12517   0.003496503 
+  268          357.46034    150.20036   0.003731343 
+  269          309.63176    150.27594   0.003717472 
+  219          267.12253    150.35192   0.00456621 
+  231          238.97655    150.4283    0.004329004 
+  222          223.1254     150.50507   0.004504505 
+  230          216.68443    150.58224   0.004347826 
+  226          217.63841    150.65982   0.004424779 
+  221          225.59019    150.7378    0.004524887 
+  233          241.63718    150.81618   0.004291845 
+  241          268.18538    150.89497   0.004149378 
+  282          306.94509    150.97417   0.003546099 
+  278          348.30231    151.05378   0.003597122 
+  297          368.78362    151.13381   0.003367003 
+  265          358.67951    151.21424   0.003773585 
+  231          318.94226    151.29509   0.004329004 
+  234          273.87352    151.37636   0.004273504 
+  253          241.10033    151.45805   0.003952569 
+  234          219.99953    151.54016   0.004273504 
+  196          207.47157    151.62268   0.005102041 
+  196          200.96966    151.70564   0.005102041 
+  224          198.94182    151.78901   0.004464286 
+  194          200.81823    151.87282   0.005154639 
+  183          206.65179    151.95705   0.005464481 
+  218          216.80637    152.04172   0.004587156 
+  189          230.42269    152.12681   0.005291005 
+  225          239.67554    152.21234   0.004444444 
+  194          233.40171    152.29831   0.005154639 
+  180          217.46775    152.38471   0.005555556 
+  184          203.13164    152.47155   0.005434783 
+  185          192.86299    152.55884   0.005405405 
+  178          185.72797    152.64656   0.005617978 
+  186          180.86181    152.73473   0.005376344 
+  189          177.63258    152.82335   0.005291005 
+  175          175.55171    152.91241   0.005714286 
+  184          174.28416    153.00192   0.005434783 
+  168          173.60278    153.09189   0.005952381 
+  181          173.31961    153.1823    0.005524862 
+  189          173.26362    153.27317   0.005291005 
+  161          173.3089     153.3645    0.00621118 
+  163          173.37447    153.45629   0.006134969 
+  154          173.46881    153.54854   0.006493506 
+  164          173.67646    153.64125   0.006097561 
+  174          173.9792     153.73442   0.005747126 
+  162          174.26218    153.82806   0.00617284 
+  168          174.58789    153.92216   0.005952381 
+  160          175.16182    154.01674   0.00625   
+  153          176.02855    154.11178   0.006535948 
+  138          176.76004    154.2073    0.007246377 
+  176          176.64536    154.3033    0.005681818 
+  162          175.65266    154.39977   0.00617284 
+  170          174.45324    154.49671   0.005882353 
+  162          173.49035    154.59414   0.00617284 
+  183          172.72447    154.69205   0.005464481 
+  165          172.00157    154.79045   0.006060606 
+  157          171.36271    154.88932   0.006369427 
+  163          170.93808    154.98869   0.006134969 
+  157          170.80365    155.08855   0.006369427 
+  145          170.99047    155.1889    0.006896552 
+  168          171.51258    155.28974   0.005952381 
+  158          172.37268    155.39107   0.006329114 
+  169          173.4737     155.4929    0.00591716 
+  168          174.38014    155.59524   0.005952381 
+  150          174.41136    155.69807   0.006666667 
+  146          173.43476    155.8014    0.006849315 
+  183          172.0864     155.90524   0.005464481 
+  169          170.92738    156.00959   0.00591716 
+  160          170.0651     156.11444   0.00625   
+  171          169.40233    156.2198    0.005847953 
+  165          168.88601    156.32568   0.006060606 
+  154          168.49209    156.43207   0.006493506 
+  162          168.19674    156.53898   0.00617284 
+  184          168.02209    156.6464    0.005434783 
+  143          168.00673    156.75434   0.006993007 
+  170          168.16427    156.86281   0.005882353 
+  164          168.4631     156.9718    0.006097561 
+  161          168.79518    157.08131   0.00621118 
+  167          168.99031    157.19135   0.005988024 
+  173          168.96737    157.30193   0.005780347 
+  196          168.85292    157.41303   0.005102041 
+  188          168.82093    157.52467   0.005319149 
+  170          168.9478     157.63684   0.005882353 
+  167          169.23071    157.74955   0.005988024 
+  160          169.60901    157.8628    0.00625   
+  168          169.97632    157.97659   0.005952381 
+  154          170.26558    158.09092   0.006493506 
+  171          170.53753    158.2058    0.005847953 
+  164          170.88173    158.32123   0.006097561 
+  166          171.33699    158.43721   0.006024096 
+  171          171.90082    158.55373   0.005847953 
+  162          172.55341    158.67082   0.00617284 
+  185          173.27786    158.78845   0.005405405 
+  172          174.05414    158.90665   0.005813953 
+  218          174.83162    159.0254    0.004587156 
+  183          175.59197    159.14472   0.005464481 
+  158          176.43059    159.2646    0.006329114 
+  196          177.49237    159.38504   0.005102041 
+  173          178.89768    159.50606   0.005780347 
+  172          180.74655    159.62764   0.005813953 
+  206          183.12868    159.7498    0.004854369 
+  174          186.0281     159.87252   0.005747126 
+  173          188.97902    159.99583   0.005780347 
+  186          190.87557    160.11971   0.005376344 
+  189          190.94887    160.24418   0.005291005 
+  174          189.88722    160.36922   0.005747126 
+  168          188.89432    160.49485   0.005952381 
+  166          188.56463    160.62107   0.006024096 
+  187          188.99856    160.74788   0.005347594 
+  205          190.17524    160.87527   0.004878049 
+  209          192.05262    161.00326   0.004784689 
+  197          194.37752    161.13185   0.005076142 
+  196          196.62111    161.26103   0.005102041 
+  191          198.53752    161.39081   0.005235602 
+  196          200.38996    161.52119   0.005102041 
+  174          202.41727    161.65218   0.005747126 
+  210          204.84154    161.78377   0.004761905 
+  209          207.83295    161.91597   0.004784689 
+  212          211.24126    162.04878   0.004716981 
+  194          215.06387    162.1822    0.005154639 
+  223          219.91589    162.31624   0.004484305 
+  195          226.34141    162.45089   0.005128205 
+  203          232.37261    162.58617   0.004926108 
+  208          234.78657    162.72206   0.004807692 
+  187          236.26393    162.85858   0.005347594 
+  224          242.07776    162.99572   0.004464286 
+  237          255.58871    163.13349   0.004219409 
+  282          280.6528     163.27188   0.003546099 
+  296          323.66901    163.41092   0.003378378 
+  370          389.54424    163.55058   0.002702703 
+  363          457.15222    163.69088   0.002754821 
+  361          459.69984    163.83182   0.002770083 
+  328          394.65303    163.9734    0.00304878 
+  295          329.34936    164.11563   0.003389831 
+  289          287.11642    164.2585    0.003460208 
+  287          263.49419    164.40201   0.003484321 
+  236          251.39551    164.54618   0.004237288 
+  244          244.55894    164.691     0.004098361 
+  217          239.22731    164.83647   0.004608295 
+  222          235.74173    164.9826    0.004504505 
+  239          235.47327    165.12939   0.0041841 
+  245          240.11469    165.27684   0.004081633 
+  254          252.23029    165.42495   0.003937008 
+  238          275.21302    165.57373   0.004201681 
+  301          309.47956    165.72318   0.003322259 
+  275          336.33693    165.8733    0.003636364 
+  272          324.07936    166.02409   0.003676471 
+  262          288.7507     166.17556   0.003816794 
+  222          259.40884    166.3277    0.004504505 
+  249          240.22089    166.48052   0.004016064 
+  220          227.40105    166.63403   0.004545455 
+  217          218.4272     166.78822   0.004608295 
+  205          212.24555    166.94309   0.004878049 
+  205          207.99772    167.09866   0.004878049 
+  202          204.83453    167.25491   0.004950495 
+  209          202.28733    167.41186   0.004784689 
+  185          200.21812    167.56951   0.005405405 
+  209          198.5433     167.72785   0.004784689 
+  202          197.29825    167.8869    0.004950495 
+  205          196.63276    168.04665   0.004878049 
+  192          196.61248    168.2071    0.005208333 
+  194          196.99095    168.36827   0.005154639 
+  207          197.6764     168.53014   0.004830918 
+  206          198.10096    168.69273   0.004854369 
+  222          197.94894    168.85603   0.004504505 
+  208          197.26279    169.02005   0.004807692 
+  166          196.42226    169.18479   0.006024096 
+  175          195.64636    169.35025   0.005714286 
+  201          194.84889    169.51643   0.004975124 
+  155          194.08336    169.68335   0.006451613 
+  218          193.52688    169.85099   0.004587156 
+  191          193.18201    170.01937   0.005235602 
+  196          192.9893     170.18848   0.005102041 
+  203          193.01835    170.35833   0.004926108 
+  172          193.30438    170.52891   0.005813953 
+  183          193.91654    170.70024   0.005464481 
+  194          194.53022    170.87232   0.005154639 
+  176          194.83084    171.04514   0.005681818 
+  172          194.83794    171.21871   0.005813953 
+  200          194.88353    171.39303   0.005     
+  177          195.23661    171.56811   0.005649718 
+  203          195.95814    171.74395   0.004926108 
+  203          196.943      171.92054   0.004926108 
+  223          198.02528    172.0979    0.004484305 
+  189          199.04452    172.27602   0.005291005 
+  230          199.73475    172.45491   0.004347826 
+  203          199.92292    172.63456   0.004926108 
+  193          199.86051    172.815     0.005181347 
+  189          199.93778    172.9962    0.005291005 
+  204          200.34721    173.17818   0.004901961 
+  186          201.08045    173.36094   0.005376344 
+  207          202.00764    173.54449   0.004830918 
+  187          203.00077    173.72882   0.005347594 
+  209          204.09089    173.91394   0.004784689 
+  204          205.42255    174.09984   0.004901961 
+  206          207.12074    174.28655   0.004854369 
+  181          209.27939    174.47404   0.005524862 
+  239          211.99571    174.66233   0.0041841 
+  179          215.36643    174.85143   0.005586592 
+  208          219.40293    175.04133   0.004807692 
+  205          223.861      175.23203   0.004878049 
+  243          228.10265    175.42354   0.004115226 
+  229          231.24886    175.61586   0.004366812 
+  221          233.03482    175.809     0.004524887 
+  218          234.2948     176.00295   0.004587156 
+  232          235.75052    176.19772   0.004310345 
+  213          237.08298    176.39332   0.004694836 
+  227          237.58587    176.58974   0.004405286 
+  214          237.2891     176.78698   0.004672897 
+  216          236.79779    176.98505   0.00462963 
+  243          236.58636    177.18396   0.004115226 
+  217          236.8804     177.3837    0.004608295 
+  240          237.79193    177.58428   0.004166667 
+  232          239.36955    177.7857    0.004310345 
+  235          241.61533    177.98796   0.004255319 
+  234          244.45452    178.19107   0.004273504 
+  258          247.60719    178.39503   0.003875969 
+  213          250.52776    178.59983   0.004694836 
+  227          252.87304    178.8055    0.004405286 
+  230          255.01154    179.01201   0.004347826 
+  278          257.51343    179.21939   0.003597122 
+  243          260.46975    179.42763   0.004115226 
+  284          263.57806    179.63674   0.003521127 
+  292          266.72351    179.84671   0.003424658 
+  293          270.2392     180.05755   0.003412969 
+  329          274.94093    180.26927   0.003039514 
+  330          282.13883    180.48186   0.003030303 
+  316          293.32366    180.69533   0.003164557 
+  331          309.24042    180.90968   0.003021148 
+  345          326.61603    181.12491   0.002898551 
+  345          335.00109    181.34104   0.002898551 
+  356          329.19918    181.55805   0.002808989 
+  358          318.75864    181.77595   0.002793296 
+  313          311.50806    181.99476   0.003194888 
+  327          308.45914    182.21445   0.003058104 
+  352          308.67725    182.43505   0.002840909 
+  341          311.44358    182.65656   0.002932551 
+  376          316.31687    182.87897   0.002659574 
+  341          322.96786    183.10229   0.002932551 
+  352          331.18598    183.32652   0.002840909 
+  342          341.02807    183.55167   0.002923977 
+  386          352.96804    183.77774   0.002590674 
+  401          367.78826    184.00472   0.002493766 
+  389          386.26715    184.23264   0.002570694 
+  417          408.21325    184.46147   0.002398082 
+  403          430.21748    184.69124   0.00248139 
+  470          447.6346     184.92194   0.00212766 
+  468          463.07474    185.15358   0.002136752 
+  497          482.61463    185.38615   0.002012072 
+  568          508.95289    185.61967   0.001760563 
+  589          542.94363    185.85413   0.001697793 
+  638          586.0775     186.08954   0.001567398 
+  722          641.77078    186.32589   0.001385042 
+  736          715.31912    186.5632    0.001358696 
+  910          812.95668    186.80147   0.001098901 
+  1038         940.29947    187.04069   0.000963391 
+  1277         1105.27728   187.28088   0.000783085 
+  1628         1334.28043   187.52203   0.000614251 
+  2021         1680.61436   187.76415   0.000494805 
+  2750         2229.49248   188.00724   0.000363636 
+  3989         3115.62122   188.25131   0.000250689 
+  5741         4518.73625   188.49635   0.000174186 
+  7669         6468.65858   188.74237   0.000130395 
+  8485         8085.59613   188.98937   0.000117855 
+  7618         7685.64237   189.23736   0.000131268 
+  5883         5771.5179    189.48634   0.000169981 
+  4284         3997.37356   189.73631   0.000233427 
+  3307         2817.48743   189.98728   0.000302389 
+  2583         2099.96818   190.23924   0.000387147 
+  2056         1672.92077   190.4922    0.000486381 
+  1744         1423.08743   190.74617   0.000573394 
+  1586         1285.70544   191.00114   0.000630517 
+  1603         1229.21266   191.25713   0.00062383 
+  1519         1249.66153   191.51413   0.000658328 
+  1740         1364.94098   191.77214   0.000574713 
+  2123         1615.684     192.03117   0.000471032 
+  2662         2072.141     192.29123   0.000375657 
+  3399         2818.59686   192.55231   0.000294204 
+  4017         3791.52101   192.81442   0.000248942 
+  4195         4356.43989   193.07756   0.000238379 
+  3650         3827.34533   193.34174   0.000273973 
+  2866         2801.34648   193.60695   0.000348918 
+  2192         1969.87936   193.8732    0.000456204 
+  1630         1429.13866   194.1405    0.000613497 
+  1296         1092.35357   194.40885   0.000771605 
+  1084         879.10174    194.67825   0.000922509 
+  922          738.27114    194.9487    0.001084599 
+  751          640.26291    195.2202    0.001331558 
+  670          568.31763    195.49277   0.001492537 
+  587          513.07759    195.7664    0.001703578 
+  537          469.60931    196.0411    0.001862197 
+  462          435.25928    196.31686   0.002164502 
+  439          408.14139    196.5937    0.002277904 
+  429          386.77613    196.87161   0.002331002 
+  418          370.01701    197.15061   0.002392344 
+  377          356.88443    197.43068   0.00265252 
+  360          346.29655    197.71184   0.002777778 
+  353          337.09357    197.99409   0.002832861 
+  359          328.72398    198.27743   0.002785515 
+  365          321.55616    198.56187   0.002739726 
+  326          316.32671    198.84741   0.003067485 
+  318          313.60051    199.13404   0.003144654 
+  300          313.15277    199.42178   0.003333333 
+  320          312.89071    199.71063   0.003125  
+  281          309.03829    200.00059   0.003558719 
+  278          300.8396     200.29167   0.003597122 
+  296          291.69106    200.58386   0.003378378 
+  301          284.07967    200.87718   0.003322259 
+  280          278.48679    201.17162   0.003571429 
+  258          274.57622    201.46718   0.003875969 
+  275          271.98653    201.76388   0.003636364 
+  254          270.54919    202.06172   0.003937008 
+  271          270.04615    202.36069   0.003690037 
+  252          270.08124    202.6608    0.003968254 
+  262          270.42179    202.96206   0.003816794 
+  275          271.34771    203.26446   0.003636364 
+  257          273.67017    203.56802   0.003891051 
+  264          278.4517     203.87273   0.003787879 
+  268          286.62502    204.17859   0.003731343 
+  251          298.46778    204.48562   0.003984064 
+  259          312.68168    204.79382   0.003861004 
+  285          324.82758    205.10318   0.003508772 
+  274          325.60487    205.41371   0.003649635 
+  265          311.87814    205.72542   0.003773585 
+  278          293.8984     206.03831   0.003597122 
+  268          279.56662    206.35238   0.003731343 
+  273          270.06137    206.66763   0.003663004 
+  236          264.42225    206.98407   0.004237288 
+  231          261.70083    207.30171   0.004329004 
+  262          261.28204    207.62053   0.003816794 
+  274          262.8361     207.94056   0.003649635 
+  237          266.31651    208.26179   0.004219409 
+  241          272.0835     208.58423   0.004149378 
+  220          281.01142    208.90788   0.004545455 
+  231          294.71862    209.23273   0.004329004 
+#--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--#
+
+# start Validation Reply Form
+_vrf_PLAT741_NEW3minmill_phase_1 # for all atoms in 1_quartz
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT741_NEW3minmill_phase_3 # for all atoms in 3_pyrrhotite
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT741_NEW3minmill_phase_4 # for all atoms in 4_rutile
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT741_NEW3minmill_phase_2 # for all atoms in 2_albite
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT155_NEW3minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT141_NEW3minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT142_NEW3minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT143_NEW3minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT144_NEW3minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT145_NEW3minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT146_NEW3minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT151_NEW3minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+# end Validation Reply Form

--- a/data/hamish/fixed/vb5042sup8.cif
+++ b/data/hamish/fixed/vb5042sup8.cif
@@ -1,0 +1,6669 @@
+
+data_NEW5minmill_publ
+_audit_creation_method  "created in GSAS-II"
+_audit_creation_date  2021-08-04T18:39
+_audit_author_name  "McDougall, Hamish"
+_audit_update_record
+   "2021-08-04T18:39  Initial software-generated CIF"
+_pd_block_id  2021-08-04T18:39|NEW5minmill|McDougallHamish|Overall
+# GSAS-II edited template follows Publication_Template
+#=============================================================================
+# this information describes the project, paper etc. for the CIF             #
+# Acta Cryst. Section C papers and editorial correspondence is generated     #
+# from the information in this section                                       #
+#                                                                            #
+#   (from)   CIF submission form for Rietveld refinements (Acta Cryst. C)    #
+#                                                 Version 14 December 1998   #
+#=============================================================================
+# 1. SUBMISSION DETAILS
+
+_publ_contact_author_name            "Suzanne Neville; Vanessa Peterson; Christophe Didier"   # Name of author for correspondence
+_publ_contact_author_address             # Address of author for correspondence
+; ?
+;
+_publ_contact_author_email           "s.neville@unsw.edu.au; vanessa.peterson@ansto.gov.au; drchristophedidier@gmail.com"
+_publ_contact_author_fax             ?
+_publ_contact_author_phone           ?
+
+_publ_contact_letter
+; ?
+;
+   
+_publ_requested_journal              ?
+_publ_requested_coeditor_name        ?
+_publ_requested_category             ?   # Acta C: one of CI/CM/CO/FI/FM/FO
+
+#==============================================================================
+
+# 2. PROCESSING SUMMARY (IUCr Office Use Only)
+
+_journal_data_validation_number      ?
+
+_journal_date_recd_electronic        ?
+_journal_date_to_coeditor            ?
+_journal_date_from_coeditor          ?
+_journal_date_accepted               ?
+_journal_date_printers_first         ?
+_journal_date_printers_final         ?
+_journal_date_proofs_out             ?
+_journal_date_proofs_in              ?
+_journal_coeditor_name               ?
+_journal_coeditor_code               ?
+_journal_coeditor_notes
+; ?
+;
+_journal_techeditor_code             ?
+_journal_techeditor_notes
+; ?
+;
+_journal_coden_ASTM                  ?
+_journal_name_full                   ?
+_journal_year                        ?
+_journal_volume                      ?
+_journal_issue                       ?
+_journal_page_first                  ?
+_journal_page_last                   ?
+_journal_paper_category              ?
+_journal_suppl_publ_number           ?
+_journal_suppl_publ_pages            ?
+
+#==============================================================================
+
+# 3. TITLE AND AUTHOR LIST
+
+_publ_section_title
+; ?
+;
+_publ_section_title_footnote
+; ?
+;         
+ 
+# The loop structure below should contain the names and addresses of all 
+# authors, in the required order of publication. Repeat as necessary.
+
+loop_
+	_publ_author_name
+        _publ_author_footnote
+	_publ_author_address
+ ?                                   #<--'Last name, first name' 
+; ?
+;
+; ?
+;
+
+#==============================================================================
+
+# 4. TEXT
+
+_publ_section_synopsis
+;  ?
+;
+_publ_section_abstract                         
+; ?
+;          
+_publ_section_comment                          
+; ?
+;
+_publ_section_exptl_prep      # Details of the preparation of the sample(s)
+                              # should be given here. 
+; ?
+;
+_publ_section_exptl_refinement                  
+; ?
+;
+_publ_section_references
+; ?
+;
+_publ_section_figure_captions
+; ?
+;
+_publ_section_acknowledgements
+; ?
+;
+
+#=============================================================================
+# 5. OVERALL REFINEMENT & COMPUTING DETAILS
+
+_refine_special_details
+; ?
+;
+_pd_proc_ls_special_details
+; ?
+;
+
+# The following items are used to identify the programs used.
+_computing_molecular_graphics     ?
+_computing_publication_material   ?
+
+_refine_ls_weighting_scheme       ?        
+_refine_ls_weighting_details      ?
+_refine_ls_hydrogen_treatment     ?        
+_refine_ls_extinction_method      ?        
+_refine_ls_extinction_coef        ?         
+_refine_ls_number_constraints     ?        
+
+_refine_ls_restrained_S_all       ?        
+_refine_ls_restrained_S_obs       ?
+
+#==============================================================================
+# 6. SAMPLE PREPARATION DATA
+
+# (In the unusual case where multiple samples are used in a single
+#  Rietveld study, this information should be moved into the phase
+#  blocks)
+
+# The following three fields describe the preparation of the material.
+# The cooling rate is in K/min.  The pressure at which the sample was  
+# prepared is in kPa.  The temperature of preparation is in K.
+               
+_pd_prep_cool_rate                N/A        
+_pd_prep_pressure                 101.3        
+_pd_prep_temperature              298         
+
+_pd_char_colour                   ?       # use ICDD colour descriptions
+
+data_NEW5minmill_overall
+_pd_proc_info_datetime  2021-08-04T18:39
+_pd_calc_method  "Rietveld Refinement"
+_computing_structure_refinement
+   "GSAS-II (Toby & Von Dreele, J. Appl. Cryst. 46, 544-549, 2013)"
+_refine_ls_number_parameters  30
+_refine_ls_goodness_of_fit_all  2.319
+_refine_ls_shift/su_max  0.1113
+
+# OVERALL WEIGHTED R-FACTOR
+_refine_ls_wR_factor_obs  0.09317
+_refine_ls_matrix_type  full
+# POINTERS TO PHASE AND HISTOGRAM BLOCKS
+loop_   _pd_phase_block_id
+  2021-08-04T18:39|NEW5minmill|phase_0|McDougallHamish
+  2021-08-04T18:39|NEW5minmill|phase_2|McDougallHamish
+  2021-08-04T18:39|NEW5minmill|phase_4|McDougallHamish
+  2021-08-04T18:39|NEW5minmill|phase_1|McDougallHamish
+  2021-08-04T18:39|NEW5minmill|phase_3|McDougallHamish
+_pd_block_diffractogram_id
+;
+2021-08-04T18:39|NEW5minmill|McDougallHamish|PANalytical,Co-EmpyreanII_hist_0
+;
+
+data_NEW5minmill_phase_0
+# Information for phase 0
+_pd_block_id  2021-08-04T18:39|NEW5minmill|phase_0|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for FeS2 follows
+_pd_phase_name  FeS2
+_cell_length_a  5.419730(29)
+_cell_length_b  5.419730(29)
+_cell_length_c  5.419730(29)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  90
+_cell_volume  159.1963(26)
+_exptl_crystal_density_diffrn  5.0054
+_symmetry_cell_setting  cubic
+_symmetry_space_group_name_H-M  "P a -3"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  z,x,y
+     3  y,z,x
+     4  1/2+x,y,1/2-z
+     5  1/2-z,1/2+x,y
+     6  y,1/2-z,1/2+x
+     7  -z,1/2+x,1/2-y
+     8  1/2-y,-z,1/2+x
+     9  1/2+y,1/2-z,-x
+    10  -x,1/2+y,1/2-z
+    11  1/2-z,-x,1/2+y
+    12  1/2+x,1/2-y,-z
+    13  -x,-y,-z
+    14  -z,-x,-y
+    15  -y,-z,-x
+    16  1/2-x,-y,1/2+z
+    17  1/2+z,1/2-x,-y
+    18  -y,1/2+z,1/2-x
+    19  z,1/2-x,1/2+y
+    20  1/2+y,z,1/2-x
+    21  1/2-y,1/2+z,x
+    22  x,1/2-y,1/2+z
+    23  1/2+z,x,1/2-y
+    24  1/2-x,1/2+y,z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Fe1    Fe   0.00000     0.00000     0.00000     1.000      Uiso 0.0079(3)  4   
+S2     S    0.38533(11) 0.38533     0.38533     1.000      Uiso 0.0097(3)  8   
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Fe   4      11.7695    7.3573     3.5222     2.3045     4.7611     0.3072     15.3535    76.8805    1.0369     0.945
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S    8      6.9053     5.2034     1.4379     1.5863     1.4679     22.2151    0.2536     56.172     0.8669     0.2847
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Fe S2"
+_chemical_formula_weight  119.97
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Fe1    S2     2.26580(16)   1_555    4_455 yes
+  Fe1    S2     2.26580(16)   1_555    5_545 yes
+  Fe1    S2     2.26580(16)   1_555    6_554 yes
+  Fe1    S2     2.26580(16)   1_555    7_545 yes
+  Fe1    S2     2.26580(16)   1_555    8_554 yes
+  Fe1    S2     2.2658(5)    1_555    9_455 yes
+  S2     Fe1    2.26580(16)   1_555    4_555 yes
+  S2     Fe1    2.26580(16)   1_555    5_555 yes
+  S2     Fe1    2.2658(5)    1_555    6_555 yes
+  S2     S2     2.1528(7)    1_555   13_666 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.2144(14), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW5minmill_phase_2
+# Information for phase 2
+_pd_block_id  2021-08-04T18:39|NEW5minmill|phase_2|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for NaAlSi3O8 follows
+_pd_phase_name  NaAlSi3O8
+_cell_length_a  8.137
+_cell_length_b  12.785
+_cell_length_c  7.1583
+_cell_angle_alpha  94.26
+_cell_angle_beta   116.6
+_cell_angle_gamma  87.71
+_cell_volume  664.008
+_exptl_crystal_density_diffrn  2.6230
+_symmetry_cell_setting  triclinic
+_symmetry_space_group_name_H-M  "C -1"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -x,-y,-z
+     3  1/2+x,1/2+y,z
+     4  1/2-x,1/2-y,-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Al1    Al3+ 0.00887     0.16846     0.20805     1.000      Uani 0.007      4   
+Si1    Si4+ 0.00375     0.82051     0.23737     1.000      Uani 0.006      4   
+Si2    Si4+ 0.69162     0.11021     0.31466     1.000      Uani 0.006      4   
+Si3    Si4+ 0.68129     0.88190     0.36076     1.000      Uani 0.006      4   
+Na1    Na1+ 0.26799     0.98865     0.14650     1.000      Uani 0.031      4   
+O1     O2-  0.00490     0.13103     0.96660     1.000      Uani 0.012      4   
+O2     O2-  0.59176     0.99756     0.28040     1.000      Uani 0.008      4   
+O3     O2-  0.81230     0.10966     0.19010     1.000      Uani 0.014      4   
+O4     O2-  0.82000     0.85101     0.25870     1.000      Uani 0.018      4   
+O5     O2-  0.01288     0.30238     0.27060     1.000      Uani 0.011      4   
+O6     O2-  0.02329     0.69368     0.22910     1.000      Uani 0.011      4   
+O7     O2-  0.20780     0.10896     0.38900     1.000      Uani 0.011      4   
+O8     O2-  0.18400     0.86817     0.43620     1.000      Uani 0.012      4   
+
+loop_
+   _atom_site_aniso_label
+   _atom_site_aniso_U_11
+   _atom_site_aniso_U_22
+   _atom_site_aniso_U_33
+   _atom_site_aniso_U_12
+   _atom_site_aniso_U_13
+   _atom_site_aniso_U_23
+Al1    0.0074      0.0068      0.0061      -0.0009     0.0031      0.0004      
+Si1    0.0068      0.0065      0.0055      0.0011      0.0030      0.0008      
+Si2    0.0061      0.0055      0.0073      -0.0002     0.0025      0.0004      
+Si3    0.0060      0.0055      0.0074      0.0006      0.0028      0.0009      
+Na1    0.0136      0.0471      0.0315      -0.0050     0.0084      -0.0219     
+O1     0.0164      0.0122      0.0074      -0.0002     0.0067      0.0014      
+O2     0.0074      0.0056      0.0119      0.0003      0.0033      0.0020      
+O3     0.0117      0.0130      0.0162      -0.0040     0.0093      -0.0017     
+O4     0.0134      0.0179      0.0216      0.0046      0.0129      0.0020      
+O5     0.0103      0.0076      0.0150      -0.0020     0.0052      -0.0009     
+O6     0.0101      0.0071      0.0145      0.0022      0.0034      0.0012      
+O7     0.0120      0.0129      0.0080      0.0024      0.0013      0.0015      
+O8     0.0140      0.0140      0.0084      -0.0026     -0.0002     -0.0006     
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Al   4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Na   4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  O    32     ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si   12     ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Al Na O8 Si3"
+_chemical_formula_weight  262.22
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Al1    O1     1.74519      1_555    1_554 yes
+  Al1    O3     1.7429       1_555    1_455 yes
+  Al1    O5     1.73509      1_555    1_555 yes
+  Al1    O7     1.74556      1_555    1_555 yes
+  Si1    O1     1.59985      1_555    2_566 yes
+  Si1    O4     1.59997      1_555    1_455 yes
+  Si1    O6     1.62225      1_555    1_555 yes
+  Si1    O8     1.61907      1_555    1_555 yes
+  Si2    O2     1.63011      1_555    1_545 yes
+  Si2    O3     1.59435      1_555    1_555 yes
+  Si2    O6     1.61836      1_555    3_545 yes
+  Si2    O8     1.6168       1_555    2_666 yes
+  Si3    O2     1.64718      1_555    1_555 yes
+  Si3    O4     1.61975      1_555    1_555 yes
+  Si3    O5     1.59682      1_555    3_555 yes
+  Si3    O7     1.60203      1_555    2_666 yes
+  Na1    O1     2.66887      1_555    1_564 yes
+  Na1    O1     2.53079      1_555    2_566 yes
+  Na1    O2     2.3704       1_555    1_555 yes
+  Na1    O3     2.45321      1_555    2_665 yes
+  Na1    O7     2.43384      1_555    1_565 yes
+  O1     Al1    1.74519      1_555    1_556 yes
+  O1     Si1    1.59985      1_555    2_566 yes
+  O1     Na1    2.66887      1_555    1_546 yes
+  O1     Na1    2.53079      1_555    2_566 yes
+  O2     Si2    1.63011      1_555    1_565 yes
+  O2     Si3    1.64718      1_555    1_555 yes
+  O2     Na1    2.3704       1_555    1_555 yes
+  O3     Al1    1.7429       1_555    1_655 yes
+  O3     Si2    1.59435      1_555    1_555 yes
+  O3     Na1    2.45321      1_555    2_665 yes
+  O4     Si1    1.59997      1_555    1_655 yes
+  O4     Si3    1.61975      1_555    1_555 yes
+  O5     Al1    1.73509      1_555    1_555 yes
+  O5     Si3    1.59682      1_555    3_445 yes
+  O6     Si1    1.62225      1_555    1_555 yes
+  O6     Si2    1.61836      1_555    3_455 yes
+  O7     Al1    1.74556      1_555    1_555 yes
+  O7     Si3    1.60203      1_555    2_666 yes
+  O7     Na1    2.43384      1_555    1_545 yes
+  O8     Si1    1.61907      1_555    1_555 yes
+  O8     Si2    1.6168       1_555    2_666 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Al1    O3     102.836       1_554  1_555    1_455 yes
+  O1     Al1    O5     116.047       1_554  1_555    1_555 yes
+  O3     Al1    O5     112.215       1_455  1_555    1_555 yes
+  O1     Al1    O7     104.004       1_554  1_555    1_555 yes
+  O3     Al1    O7     111.151       1_455  1_555    1_555 yes
+  O5     Al1    O7     110.14        1_555  1_555    1_555 yes
+  O1     Si1    O4     109.433       2_566  1_555    1_455 yes
+  O1     Si1    O6     112.47        2_566  1_555    1_555 yes
+  O4     Si1    O6     108.187       1_455  1_555    1_555 yes
+  O1     Si1    O8     107.176       2_566  1_555    1_555 yes
+  O4     Si1    O8     111.446       1_455  1_555    1_555 yes
+  O6     Si1    O8     108.16        1_555  1_555    1_555 yes
+  O2     Si2    O3     111.144       1_545  1_555    1_555 yes
+  O2     Si2    O6     104.24        1_545  1_555    3_545 yes
+  O3     Si2    O6     112.114       1_555  1_555    3_545 yes
+  O2     Si2    O8     106.97        1_545  1_555    2_666 yes
+  O3     Si2    O8     111.591       1_555  1_555    2_666 yes
+  O6     Si2    O8     110.422       3_545  1_555    2_666 yes
+  O2     Si3    O4     107.269       1_555  1_555    1_555 yes
+  O2     Si3    O5     105.914       1_555  1_555    3_555 yes
+  O4     Si3    O5     110.224       1_555  1_555    3_555 yes
+  O2     Si3    O7     108.565       1_555  1_555    2_666 yes
+  O4     Si3    O7     110.208       1_555  1_555    2_666 yes
+  O5     Si3    O7     114.328       3_555  1_555    2_666 yes
+  Al1    O1     Si1    141.397       1_556  1_555    2_566 yes
+  Si2    O2     Si3    130.019       1_565  1_555    1_555 yes
+  Si2    O2     Na1    120.351       1_565  1_555    1_555 yes
+  Si3    O2     Na1    108.811       1_555  1_555    1_555 yes
+  Al1    O3     Si2    139.461       1_655  1_555    1_555 yes
+  Si1    O4     Si3    161.151       1_655  1_555    1_555 yes
+  Al1    O5     Si3    129.689       1_555  1_555    3_445 yes
+  Si1    O6     Si2    135.676       1_555  1_555    3_455 yes
+  Al1    O7     Si3    133.943       1_555  1_555    2_666 yes
+  Si1    O8     Si2    151.747       1_555  1_555    2_666 yes
+_pd_proc_ls_pref_orient_corr  none
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.129(9), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW5minmill_phase_4
+# Information for phase 4
+_pd_block_id  2021-08-04T18:39|NEW5minmill|phase_4|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Pyrrhotite 4M follows
+_pd_phase_name  "Pyrrhotite 4M"
+_cell_length_a  11.941(30)
+_cell_length_b  6.860(4)
+_cell_length_c  12.83(3)
+_cell_angle_alpha  90
+_cell_angle_beta   117.28(6)
+_cell_angle_gamma  90
+_cell_volume  934.2(4)
+_exptl_crystal_density_diffrn  4.6032
+_symmetry_cell_setting  monoclinic
+_symmetry_space_group_name_H-M  "C 2/c"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -x,y,1/2-z
+     3  -x,-y,-z
+     4  x,-y,1/2+z
+     5  1/2+x,1/2+y,z
+     6  1/2-x,1/2+y,1/2-z
+     7  1/2-x,1/2-y,-z
+     8  1/2+x,1/2-y,1/2+z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+S1     S    0.01800     0.38330     0.11960     1.000      Uiso 0.010      8   
+S2     S    0.02910     0.11420     0.63900     1.000      Uiso 0.010      8   
+Fe3    Fe   0.10860     0.10250     0.49980     1.000      Uiso 0.010      8   
+S4     S    0.23410     0.13550     0.38260     1.000      Uiso 0.010      8   
+Fe5    Fe   0.24180     0.36600     0.24680     1.000      Uiso 0.010      8   
+S6     S    0.26790     0.13400     0.12360     1.000      Uiso 0.010      8   
+Fe7    Fe   0.38720     0.15000     0.01260     1.000      Uiso 0.010      8   
+Fe8    Fe   0.00000     0.14720     0.25000     1.000      Uiso 0.010      4   
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Fe   28     11.7695    7.3573     3.5222     2.3045     4.7611     0.3072     15.3535    76.8805    1.0369     0.945
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S    32     6.9053     5.2034     1.4379     1.5863     1.4679     22.2151    0.2536     56.172     0.8669     0.2847
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Fe7 S8"
+_chemical_formula_weight  647.41
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  S1     Fe3    2.49405      1_555    2_555 yes
+  S1     Fe5    2.41283      1_555    1_555 yes
+  S1     Fe7    2.38878      1_555    5_455 yes
+  S1     Fe7    2.44353      1_555    7_555 yes
+  S1     Fe8    2.40803      1_555    1_555 yes
+  S2     Fe3    2.37734      1_555    1_555 yes
+  S2     Fe3    2.32405      1_555    3_556 yes
+  S2     Fe5    2.44444      1_555    7_556 yes
+  S2     Fe7    2.36627      1_555    8_456 yes
+  S2     Fe8    2.41215      1_555    3_556 yes
+  Fe3    S1     2.49405      1_555    2_555 yes
+  Fe3    S2     2.37734      1_555    1_555 yes
+  Fe3    S2     2.32405      1_555    3_556 yes
+  Fe3    S6     2.45036      1_555    4_556 yes
+  S4     Fe5    2.38574      1_555    1_555 yes
+  Fe5    S1     2.41283      1_555    1_555 yes
+  Fe5    S2     2.44444      1_555    7_556 yes
+  Fe5    S4     2.38574      1_555    1_555 yes
+  Fe5    S6     2.36232      1_555    1_555 yes
+  S6     Fe3    2.45036      1_555    4_555 yes
+  S6     Fe5    2.36232      1_555    1_555 yes
+  S6     Fe7    2.43506      1_555    1_555 yes
+  S6     Fe7    2.39022      1_555    7_555 yes
+  Fe7    S1     2.38878      1_555    5_545 yes
+  Fe7    S1     2.44353      1_555    7_555 yes
+  Fe7    S2     2.36627      1_555    8_555 yes
+  Fe7    S6     2.43506      1_555    1_555 yes
+  Fe7    S6     2.39022      1_555    7_555 yes
+  Fe8    S1     2.40803      1_555    1_555 yes
+  Fe8    S1     2.40803      1_555    2_555 yes
+  Fe8    S2     2.41215      1_555    3_556 yes
+  Fe8    S2     2.41215      1_555    4_555 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.0309(25), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW5minmill_phase_1
+# Information for phase 1
+_pd_block_id  2021-08-04T18:39|NEW5minmill|phase_1|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for SiO2 follows
+_pd_phase_name  SiO2
+_cell_length_a  4.9154(4)
+_cell_length_b  4.9154(4)
+_cell_length_c  5.4060(4)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  120
+_cell_volume  113.117(9)
+_exptl_crystal_density_diffrn  2.6461
+_symmetry_cell_setting  trigonal
+_symmetry_space_group_name_H-M  "P 32 2 1"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -y,x-y,2/3+z
+     3  y-x,-x,1/3+z
+     4  y,x,-z
+     5  -x,y-x,2/3-z
+     6  x-y,-y,1/3-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Si1    Si4+ 0.47000     0.00000     0.66670     1.000      Uani 0.006      3   
+O1     O2-  0.41460     0.26780     0.78543     1.000      Uani 0.011      6   
+
+loop_
+   _atom_site_aniso_label
+   _atom_site_aniso_U_11
+   _atom_site_aniso_U_22
+   _atom_site_aniso_U_33
+   _atom_site_aniso_U_12
+   _atom_site_aniso_U_13
+   _atom_site_aniso_U_23
+Si1    0.0073      0.0059      0.0053      0.0029      0.0003      0.0006      
+O1     0.0120      0.0105      0.0118      0.0065      -0.0029     -0.0040     
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  O    6      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si   3      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  3
+_chemical_formula_sum  "O2 Si"
+_chemical_formula_weight  60.08
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Si1    O1     1.60542      1_555    1_555 yes
+  Si1    O1     1.61173      1_555    2_654 yes
+  Si1    O1     1.61147      1_555    5_656 yes
+  Si1    O1     1.60556      1_555    6_556 yes
+  O1     Si1    1.60542      1_555    1_555 yes
+  O1     Si1    1.61173      1_555    3_665 yes
+  O1     Si1    1.61147      1_555    5_666 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Si1    O1     110.255       1_555  1_555    2_654 yes
+  O1     Si1    O1     108.748       1_555  1_555    5_656 yes
+  O1     Si1    O1     109.683       2_654  1_555    5_656 yes
+  O1     Si1    O1     109.16        1_555  1_555    6_556 yes
+  O1     Si1    O1     108.728       2_654  1_555    6_556 yes
+  O1     Si1    O1     110.26        5_656  1_555    6_556 yes
+  Si1    O1     Si1    143.832       1_555  1_555    3_665 yes
+  Si1    O1     Si1    143.835       1_555  1_555    5_666 yes
+  Si1    O1     Si1    0.009         3_665  1_555    5_666 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.183(9), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW5minmill_phase_3
+# Information for phase 3
+_pd_block_id  2021-08-04T18:39|NEW5minmill|phase_3|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for TiO2 follows
+_pd_phase_name  TiO2
+_cell_length_a  4.5996(11)
+_cell_length_b  4.5996(11)
+_cell_length_c  2.9608(10)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  90
+_cell_volume  62.639(25)
+_exptl_crystal_density_diffrn  4.2361
+_symmetry_cell_setting  tetragonal
+_symmetry_space_group_name_H-M  "P 42/m n m"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  1/2-y,1/2+x,1/2+z
+     3  -x,-y,z
+     4  1/2+y,1/2-x,1/2+z
+     5  1/2-x,1/2+y,1/2+z
+     6  -y,-x,z
+     7  1/2+x,1/2-y,1/2+z
+     8  y,x,z
+     9  -x,-y,-z
+    10  1/2+y,1/2-x,1/2-z
+    11  x,y,-z
+    12  1/2-y,1/2+x,1/2-z
+    13  1/2+x,1/2-y,1/2-z
+    14  y,x,-z
+    15  1/2-x,1/2+y,1/2-z
+    16  -y,-x,-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Ti1    Ti4+ 0.00000     0.00000     0.00000     1.000      Uani 0.006      2   
+O1     O2-  0.30493     0.30493     0.00000     1.000      Uani 0.006      4   
+
+loop_
+   _atom_site_aniso_label
+   _atom_site_aniso_U_11
+   _atom_site_aniso_U_22
+   _atom_site_aniso_U_33
+   _atom_site_aniso_U_12
+   _atom_site_aniso_U_13
+   _atom_site_aniso_U_23
+Ti1    0.0070      0.0070      0.0047      -0.0002     0.0000      0.0000      
+O1     0.0060      0.0060      0.0045      -0.0019     0.0000      0.0000      
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  O    4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Ti   2      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  2
+_chemical_formula_sum  "O2 Ti"
+_chemical_formula_weight  79.9
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Ti1    O1     1.98351      1_555    1_555 yes
+  Ti1    O1     1.94979      1_555    2_544 yes
+  Ti1    O1     1.94979      1_555    2_545 yes
+  Ti1    O1     1.98351      1_555    3_555 yes
+  Ti1    O1     1.94979      1_555    4_454 yes
+  Ti1    O1     1.94979      1_555    4_455 yes
+  O1     Ti1    1.98351      1_555    1_555 yes
+  O1     Ti1    1.94979      1_555    2_554 yes
+  O1     Ti1    1.94979      1_555    2_555 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Ti1    O1     90            1_555  1_555    2_544 yes
+  O1     Ti1    O1     90            1_555  1_555    2_545 yes
+  O1     Ti1    O1     98.799        2_544  1_555    2_545 yes
+  O1     Ti1    O1     180           1_555  1_555    3_555 yes
+  O1     Ti1    O1     90            2_544  1_555    3_555 yes
+  O1     Ti1    O1     90            2_545  1_555    3_555 yes
+  O1     Ti1    O1     90            1_555  1_555    4_454 yes
+  O1     Ti1    O1     81.201        2_544  1_555    4_454 yes
+  O1     Ti1    O1     180           2_545  1_555    4_454 yes
+  O1     Ti1    O1     90            3_555  1_555    4_454 yes
+  O1     Ti1    O1     90            1_555  1_555    4_455 yes
+  O1     Ti1    O1     180           2_544  1_555    4_455 yes
+  O1     Ti1    O1     81.201        2_545  1_555    4_455 yes
+  O1     Ti1    O1     90            3_555  1_555    4_455 yes
+  O1     Ti1    O1     98.799        4_454  1_555    4_455 yes
+  Ti1    O1     Ti1    130.601       1_555  1_555    2_554 yes
+  Ti1    O1     Ti1    130.601       1_555  1_555    2_555 yes
+  Ti1    O1     Ti1    98.799        2_554  1_555    2_555 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.150, 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW5minmill_pwd_0
+_pd_proc_ls_profile_function
+;
+Finger-Cox-Jephcoat function parameters U, V, W, X, Y, SH/L:
+  peak variance(Gauss) = Utan(Th)^2^+Vtan(Th)+W:
+  peak HW(Lorentz) = X/cos(Th)+Ytan(Th); SH/L = S/L+H/L
+  U, V, W in (centideg)^2^, X & Y in centideg
+    0.000, 0.000, 1.089, 0.882, 1.689, 0.058, 
+;
+# Information for histogram 0: PWDR BAT3_5min_milla_30mm_MonicaHamish_Ruoming_step size 0_5_min_mill_a.xrdml Scan 1
+_pd_block_id
+;
+2021-08-04T18:39|NEW5minmill|McDougallHamish|PANalytical,Co-EmpyreanII_hist_0
+;
+# GSAS-II edited template follows Instrument_Template
+#==============================================================================
+# 9. INSTRUMENT CHARACTERIZATION
+
+_exptl_special_details
+; ?
+;
+
+# if regions of the data are excluded, the reason(s) are supplied here:
+_pd_proc_info_excluded_regions
+; ?
+;
+
+# The following item is used to identify the equipment used to record 
+# the powder pattern when the diffractogram was measured at a laboratory 
+# other than the authors' home institution, e.g. when neutron or synchrotron
+# radiation is used.
+
+_pd_instr_location
+; ?
+;
+_pd_calibration_special_details           # description of the method used
+                                          # to calibrate the instrument
+; ?
+;
+
+_diffrn_source                    Co-Ka       
+_diffrn_source_target             Co
+_diffrn_source_type               Graded_Flat
+_diffrn_measurement_device_type   Panalytical_Reflection_Transmission       
+_diffrn_detector                  PIXcel1D       
+_diffrn_detector_type             Empyrean_II       # make or model of detector
+
+_pd_meas_scan_method              ?       # options are 'step', 'cont',
+                                          # 'tof', 'fixed' or
+                                          # 'disp' (= dispersive)
+_pd_meas_special_details
+;  ?
+;
+
+# The following two items identify the program(s) used (if appropriate).
+_computing_data_collection        ?        
+_computing_data_reduction         ?                   
+
+# Describe any processing performed on the data, prior to refinement.
+# For example: a manual Lp correction or a precomputed absorption correction
+_pd_proc_info_data_reduction      ?
+
+# The following item is used for angular dispersive measurements only.
+
+_diffrn_radiation_monochromator   ?        
+
+# The following items are used to define the size of the instrument.
+# Not all distances are appropriate for all instrument types.
+
+_pd_instr_dist_src/mono           ?
+_pd_instr_dist_mono/spec          ?
+_pd_instr_dist_src/spec           ?
+_pd_instr_dist_spec/anal          ?
+_pd_instr_dist_anal/detc          ?
+_pd_instr_dist_spec/detc          ?
+
+# 10. Specimen size and mounting information
+
+# The next three fields give the specimen dimensions in mm.  The equatorial 
+# plane contains the incident and diffracted beam.
+
+_pd_spec_size_axial               ?       # perpendicular to 
+                                          # equatorial plane
+
+_pd_spec_size_equat               ?       # parallel to 
+                                          # scattering vector 
+                                          # in transmission
+
+_pd_spec_size_thick               ?       # parallel to 
+                                          # scattering vector 
+                                          # in reflection
+
+_pd_spec_mounting                         # This field should be
+                                          # used to give details of the 
+                                          # container.
+; ?
+;
+
+_pd_spec_mount_mode               ?       # options are 'reflection' 
+                                          # or 'transmission'
+    
+_pd_spec_shape                    ?       # options are 'cylinder' 
+                                          # 'flat_sheet' or 'irregular'
+
+
+loop_
+     _atom_type_symbol
+     _atom_type_scat_dispersion_real
+     _atom_type_scat_dispersion_imag
+     _atom_type_scat_dispersion_source
+  Al        0.255   0.328   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Fe       -3.332   0.490   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Na        0.167   0.167   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  O         0.063   0.044   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S         0.371   0.733   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si        0.298   0.438   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Ti       -0.063   2.321   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+_diffrn_radiation_type  K\a~1,2~
+loop_
+   _diffrn_radiation_wavelength
+   _diffrn_radiation_wavelength_wt
+   _diffrn_radiation_wavelength_id
+  1.78892         1.0             1     
+  1.79278         0.5000          2     
+
+# PHASE TABLE
+loop_
+   _pd_phase_id
+   _pd_phase_block_id
+   _pd_phase_mass_%
+  0  2021-08-04T18:39|NEW5minmill|phase_0|McDougallHamish  0.8029(27)
+  2  2021-08-04T18:39|NEW5minmill|phase_2|McDougallHamish  0.0912(23)
+  4  2021-08-04T18:39|NEW5minmill|phase_4|McDougallHamish  0.0413(14)
+  1  2021-08-04T18:39|NEW5minmill|phase_1|McDougallHamish  0.0580(9)
+  3  2021-08-04T18:39|NEW5minmill|phase_3|McDougallHamish  0.0065(5)
+loop_
+   _gsas_proc_phase_R_F_factor
+   _gsas_proc_phase_R_Fsqd_factor
+   _gsas_proc_phase_id
+   _gsas_proc_phase_block_id
+    0.02912  0.06495  0  2021-08-04T18:39|NEW5minmill|phase_0|McDougallHamish
+    0.06917  0.15075  2  2021-08-04T18:39|NEW5minmill|phase_2|McDougallHamish
+    0.05582  0.09704  4  2021-08-04T18:39|NEW5minmill|phase_4|McDougallHamish
+    0.05993  0.14633  1  2021-08-04T18:39|NEW5minmill|phase_1|McDougallHamish
+    0.04930  0.09668  3  2021-08-04T18:39|NEW5minmill|phase_3|McDougallHamish
+_pd_proc_ls_prof_R_factor     0.07083
+_pd_proc_ls_prof_wR_factor    0.09317
+_gsas_proc_ls_prof_R_B_factor   0.08891
+_gsas_proc_ls_prof_wR_B_factor  0.11185
+_pd_proc_ls_prof_wR_expected  0.04032
+_diffrn_radiation_probe  x-ray
+_diffrn_radiation_polarisn_ratio  0.7000
+_pd_proc_ls_background_function
+;
+Background function: "chebyschev-1" function with 7 terms:
+    442.2(14), -516.5(22), 392.6(21), -195.8(19), 105.9(18), 
+    -33.3(13), 12.8(12), 
+;
+_diffrn_ambient_temperature  300
+_diffrn_ambient_pressure  100
+
+# STRUCTURE FACTOR TABLE
+loop_
+   _pd_refln_phase_id
+   _refln_index_h
+   _refln_index_k
+   _refln_index_l
+   _refln_F_squared_meas
+   _refln_F_squared_calc
+   _refln_phase_calc
+   _refln_d_spacing
+   _gsas_i100_meas
+  0  1    1    1    970.6116   857.3528   0.0     3.12908  25.86  
+  0  2    0    0    6738.2609  6339.6750  -0.0    2.70987  99.52  
+  0  2    1    0    3439.5149  3299.2276  0.0     2.42378  80.24  
+  0  2    1    1    1726.7036  1684.8090  -180.0  2.21260  66.40  
+  0  2    2    0    3200.4430  3314.7358  -0.0    1.91616  45.42  
+  0  2    2    1    37.8137    39.3552    -0.0    1.80658  0.95   
+  0  3    1    1    4873.9326  5161.4979  -0.0    1.63411  100.00 
+  0  2    2    2    2168.5371  2329.4918  0.0     1.56454  13.64  
+  0  3    0    2    2772.3874  2959.0267  -0.0    1.50316  24.30  
+  0  3    1    2    532.5664   552.2034   0.0     1.44848  8.75   
+  0  3    2    1    1536.9834  1593.6556  180.0   1.44848  25.26  
+  0  4    0    0    384.2169   325.7156   -180.0  1.35493  1.42   
+  0  3    2    2    39.8474    41.6412    -0.0    1.31448  0.57   
+  0  4    1    0    100.5664   105.0935   -0.0    1.31448  0.71   
+  0  4    1    1    61.1449    57.0935    180.0   1.27744  0.84   
+  0  3    3    1    560.7789   589.9787   -0.0    1.24337  7.51   
+  0  4    0    2    882.8590   871.7121   0.0     1.21189  5.80   
+  0  4    2    0    882.8590   871.7121   0.0     1.21189  5.80   
+  0  4    1    2    1.5173     1.5200     -0.0    1.18268  0.02   
+  0  4    2    1    1261.0621  1263.3276  -180.0  1.18268  16.36  
+  0  3    3    2    667.2141   642.3643   0.0     1.15549  8.61   
+  0  4    2    2    1046.2901  1002.5247  0.0     1.10630  13.62  
+  0  4    3    0    124.0373   125.7646   -0.0    1.08395  0.82   
+  0  4    1    3    60.6366    68.7836    -180.0  1.06290  0.82   
+  0  4    3    1    21.0107    23.8336    0.0     1.06290  0.28   
+  0  3    3    3    1686.1221  1496.5925  -0.0    1.04303  7.83   
+  0  5    1    1    3488.8974  3096.7257  -0.0    1.04303  48.62  
+  1  1    0    0    245.2690   242.5123   180.0   4.25687  0.48   
+  1  1    0    1    726.6254   634.4637   120.0   3.34446  0.87   
+  1  1    0    -1   1728.6013  1509.3536  -120.0  3.34446  2.07   
+  1  1    1    0    369.7698   343.8218   -155.6  2.45771  0.23   
+  1  1    0    2    272.5890   298.8477   -120.0  2.28185  0.15   
+  1  1    0    -2   78.5977    86.1691    -60.0   2.28185  0.04   
+  1  1    1    1    92.4053    96.0493    82.9    2.23735  0.09   
+  1  2    0    0    307.7820   308.9250   -0.0    2.12844  0.14   
+  1  2    0    -1   86.2873    77.2128    60.0    1.98046  0.03   
+  1  2    0    1    206.7454   185.0027   -60.0   1.98046  0.08   
+  1  1    1    2    535.1577   602.8170   9.8     1.81841  0.35   
+  1  0    0    3    89.0095    94.4583    0.0     1.80200  0.01   
+  1  2    0    2    90.2323    82.0787    60.0    1.67223  0.03   
+  1  2    0    -2   400.3722   364.1936   120.0   1.67223  0.11   
+  1  1    0    -3   204.2412   203.8424   180.0   1.65944  0.06   
+  1  1    0    3    2.5890     2.5840     0.0     1.65944  0.00   
+  1  2    1    0    15.8292    14.6393    -38.9   1.60895  0.01   
+  1  2    1    -1   292.0889   356.3201   95.9    1.54210  0.14   
+  1  2    1    1    251.4256   306.7148   -109.6  1.54210  0.12   
+  1  1    1    3    138.8989   142.5670   117.5   1.45323  0.06   
+  1  3    0    0    76.2653    76.3507    -180.0  1.41896  0.02   
+  1  2    1    -2   368.0958   413.7822   -123.3  1.38255  0.15   
+  1  2    1    2    114.2824   128.4666   143.4   1.38255  0.05   
+  1  2    0    -3   240.5906   292.6563   -0.0    1.37530  0.05   
+  1  2    0    3    847.0399   1030.3459  0.0     1.37530  0.17   
+  1  3    0    -1   678.9740   815.7970   -120.0  1.37247  0.13   
+  1  3    0    1    0.8444     1.0146     -60.0   1.37247  0.00   
+  1  1    0    -4   109.2835   120.2809   -120.0  1.28814  0.02   
+  1  1    0    4    360.1800   396.4255   120.0   1.28814  0.07   
+  1  3    0    -2   174.6427   208.2996   120.0   1.25636  0.03   
+  1  3    0    2    398.1686   474.9032   -120.0  1.25636  0.07   
+  1  2    2    0    304.9756   371.0385   -16.5   1.22885  0.05   
+  1  2    1    -3   61.4417    71.0028    179.1   1.20017  0.02   
+  1  2    1    3    260.8000   301.3836   -134.8  1.20017  0.09   
+  1  2    2    1    97.4452    105.5817   88.6    1.19828  0.03   
+  1  1    1    4    346.2970   334.1523   -14.4   1.18425  0.12   
+  1  3    1    0    360.2727   361.5244   121.4   1.18064  0.12   
+  1  3    1    -1   202.8465   189.9002   -18.5   1.15346  0.07   
+  1  3    1    1    67.7214    63.3992    16.4    1.15346  0.02   
+  1  2    0    4    61.7525    70.6740    120.0   1.14093  0.01   
+  1  2    0    -4   1.2870     1.4729     -120.0  1.14093  0.00   
+  1  2    2    2    3.7956     3.3501     -9.8    1.11867  0.00   
+  1  3    0    3    64.2389    62.7207    -180.0  1.11482  0.01   
+  1  3    0    -3   6.8473     6.6855     -0.0    1.11482  0.00   
+  1  3    1    -2   277.2696   304.3259   -8.9    1.08194  0.10   
+  1  3    1    2    113.2849   124.3393   59.1    1.08194  0.04   
+  1  4    0    0    135.0593   168.1758   0.0     1.06422  0.02   
+  1  1    0    -5   388.5114   346.2573   120.0   1.04793  0.07   
+  1  1    0    5    145.7621   129.9092   -120.0  1.04793  0.03   
+  1  4    0    -1   36.1789    31.4040    60.0    1.04418  0.01   
+  1  4    0    1    333.7129   289.6701   120.0   1.04418  0.06   
+  1  2    1    4    170.4079   240.8736   -129.5  1.03485  0.06   
+  1  2    1    -4   7.6843     10.8619    51.2    1.03485  0.00   
+  2  0    0    1    1597.7964  685.7541   180.0   6.38786  0.05   
+  2  0    2    0    895.0359   396.3962   180.0   6.37466  0.01   
+  2  1    1    0    559.3383   238.2363   -0.0    6.33955  0.01   
+  2  1    -1   0    801.0726   287.4879   -0.0    6.29869  0.01   
+  2  1    1    -1   871.0644   406.2352   180.0   5.91009  0.01   
+  2  1    -1   -1   746.8181   415.6378   -180.0  5.58552  0.01   
+  2  0    2    -1   10.1648    16.5792    0.0     4.66174  0.00   
+  2  0    2    1    3.1163     1.8371     180.0   4.37623  0.00   
+  2  2    0    -1   22042.8296 21037.4763 -0.0    4.02732  0.13   
+  2  1    -1   1    3934.2336  3767.3897  -0.0    3.85265  0.03   
+  2  1    1    1    9734.5902  10390.3834 0.0     3.77565  0.08   
+  2  1    3    0    8567.7243  5886.9121  180.0   3.68167  0.05   
+  2  1    3    -1   5939.0294  4505.3267  0.0     3.66562  0.03   
+  2  1    -3   0    12710.1208 11675.3013 180.0   3.65766  0.06   
+  2  2    0    0    1.8511     2.5781     0.0     3.63776  0.00   
+  2  1    1    -2   4491.9300  4328.5159  0.0     3.50520  0.03   
+  2  2    2    -1   2533.8585  1650.0035  180.0   3.48122  0.01   
+  2  1    -3   -1   59.2346    12.1276    0.0     3.43616  0.00   
+  2  1    -1   -2   5647.2138  5251.4578  0.0     3.37264  0.04   
+  2  2    -2   -1   358.2004   364.8637   0.0     3.33313  0.00   
+  2  2    0    -2   26107.3593 26655.4799 -180.0  3.21484  0.12   
+  2  0    0    2    39753.4496 37071.8044 -180.0  3.19393  0.28   
+  2  0    4    0    26944.3301 25362.8195 180.0   3.18733  0.10   
+  2  2    2    0    13674.2896 13873.6743 180.0   3.16977  0.06   
+  2  2    -2   0    15448.0036 14946.6082 -180.0  3.14934  0.06   
+  2  1    -3   1    13672.2651 11175.2497 -180.0  2.96418  0.05   
+  2  2    2    -2   7976.3293  7187.5067  0.0     2.95504  0.03   
+  2  0    2    -2   6065.1206  5310.5610  0.0     2.93060  0.03   
+  2  0    4    -1   8721.4832  8585.7945  0.0     2.92677  0.03   
+  2  1    3    1    5970.7697  6897.0276  180.0   2.86133  0.02   
+  2  1    3    -2   1543.5287  1923.0466  -0.0    2.83885  0.01   
+  2  2    -2   -2   167.8510   183.4547   -0.0    2.79276  0.00   
+  2  0    2    2    191.2460   191.6414   0.0     2.78600  0.00   
+  2  0    4    1    401.1000   387.5360   -0.0    2.78271  0.00   
+  2  2    0    1    110.4720   109.5836   -0.0    2.68712  0.00   
+  2  3    1    -1   422.5997   431.0071   -180.0  2.66293  0.00   
+  2  1    -3   -2   6878.1104  6171.6319  -0.0    2.63839  0.02   
+  2  3    -1   -1   37.5870    33.5476    -180.0  2.62530  0.00   
+  2  2    4    -1   15397.7878 12550.4891 -180.0  2.55995  0.03   
+  2  3    1    -2   2009.2877  1812.0722  180.0   2.53704  0.00   
+  2  1    -1   2    1034.4311  667.2869   180.0   2.51139  0.00   
+  2  2    -2   1    2137.3388  1686.7859  -180.0  2.49495  0.01   
+  2  3    -1   -2   550.7996   451.5613   180.0   2.48043  0.00   
+  2  1    1    2    131.5783   110.2849   180.0   2.46610  0.00   
+  2  2    2    1    1484.9621  1367.0046  -180.0  2.45771  0.00   
+  2  2    -4   -1   10970.6946 10453.7459 -180.0  2.44277  0.02   
+  2  1    5    -1   4294.2472  4093.1663  -0.0    2.42941  0.01   
+  2  1    5    0    56.3669    64.0884    180.0   2.41202  0.00   
+  2  2    4    0    3446.7410  3944.1458  -0.0    2.40628  0.01   
+  2  1    -5   0    1965.7117  2230.8323  180.0   2.40074  0.00   
+  2  2    -4   0    1819.7527  2079.3222  -0.0    2.38844  0.00   
+  2  3    1    0    1364.0717  1565.2946  -0.0    2.38575  0.00   
+  2  3    -1   0    1781.0580  2090.0863  -0.0    2.37918  0.00   
+  2  2    0    -3   6.2504     7.3701     180.0   2.35133  0.00   
+  2  2    4    -2   2.4401     2.9331     0.0     2.34729  0.00   
+  2  1    1    -3   111.1183   110.8373   -0.0    2.33656  0.00   
+  2  0    4    -2   1027.7615  884.3144   -180.0  2.33087  0.00   
+  2  3    3    -1   18524.9186 9809.7794  180.0   2.31766  0.03   
+  2  1    -5   -1   2148.1657  1044.9800  0.0     2.31526  0.00   
+  2  1    -1   -3   2105.7826  2291.2470  -0.0    2.27750  0.01   
+  2  2    2    -3   168.8133   155.6865   -0.0    2.26146  0.00   
+  2  3    3    -2   17.1848    15.9172    0.0     2.25070  0.00   
+  2  3    -3   -1   2699.0979  2703.2457  -180.0  2.24518  0.00   
+  2  1    -3   2    841.7306   824.7896   -0.0    2.22556  0.00   
+  2  0    4    2    1729.1576  2085.0250  0.0     2.18812  0.00   
+  2  2    -4   -2   1189.0247  1431.8638  0.0     2.18799  0.00   
+  2  1    -5   1    3656.6450  4194.8986  180.0   2.18493  0.01   
+  2  2    -2   -3   1314.7405  1851.4932  0.0     2.15451  0.00   
+  2  1    5    -2   211.8399   312.7232   -180.0  2.15169  0.00   
+  2  3    1    -3   158.1236   204.6119   0.0     2.13824  0.00   
+  2  3    -3   -2   415.2992   512.1941   180.0   2.13724  0.00   
+  2  1    3    2    167.2028   174.4523   -180.0  2.13433  0.00   
+  2  0    0    3    454.9181   454.6548   -0.0    2.12929  0.00   
+  2  0    6    0    10181.4597 11042.6256 -0.0    2.12489  0.02   
+  2  1    3    -3   564.4860   674.2906   -180.0  2.11876  0.00   
+  2  1    5    1    4082.7726  4734.7647  180.0   2.11595  0.01   
+  2  3    3    0    1319.6009  1496.6439  -180.0  2.11318  0.00   
+  2  3    -3   0    125.0057   182.7827   -180.0  2.09956  0.00   
+  2  3    -1   -3   1805.7056  2416.5634  0.0     2.08973  0.00   
+  2  2    -4   1    7263.9089  8370.0925  180.0   2.07604  0.01   
+  2  0    2    -3   266.4130   286.8930   -180.0  2.05903  0.00   
+  2  0    6    -1   75.8425    83.9001    -0.0    2.05549  0.00   
+  2  2    4    1    2654.5427  2723.1302  180.0   2.03350  0.00   
+  2  4    0    -2   1331.8976  1673.8545  -0.0    2.01366  0.00   
+  2  1    -5   -2   918.9591   976.2191   -0.0    2.00557  0.00   
+  2  4    0    -1   2982.4013  3207.5402  -0.0    2.00025  0.00   
+  2  2    0    2    828.4968   914.6787   0.0     1.99827  0.00   
+  2  1    -3   -3   2086.2833  2006.9284  -0.0    1.99351  0.00   
+  2  0    2    3    1565.1975  1320.4879  0.0     1.98235  0.00   
+  2  0    6    1    5408.0754  4760.1395  0.0     1.97919  0.01   
+  2  3    -1   1    2138.6768  1778.1424  0.0     1.97162  0.00   
+  2  3    3    -3   914.0840   747.2487   -180.0  1.97003  0.00   
+  2  3    1    1    1105.8271  1049.8991  0.0     1.96352  0.00   
+  2  2    4    -3   220.4512   210.6125   -180.0  1.96339  0.00   
+  2  4    2    -2   1513.2806  1505.1300  0.0     1.94723  0.00   
+  2  2    -2   2    4259.4731  4434.5615  -0.0    1.92633  0.01   
+  2  4    2    -1   184.9416   195.3738   0.0     1.92397  0.00   
+  2  2    6    -1   24.3870    25.7092    -0.0    1.91781  0.00   
+  2  4    -2   -2   14507.5481 14612.2943 -0.0    1.89414  0.02   
+  2  4    -2   -1   81.7718    83.9894    180.0   1.89341  0.00   
+  2  3    5    -1   3196.5905  3253.1319  -180.0  1.88804  0.00   
+  2  2    2    2    10945.2698 11147.4650 -0.0    1.88782  0.02   
+  2  3    -3   -3   374.3102   242.1347   -0.0    1.86184  0.00   
+  2  3    5    -2   225.1295   151.7748   -180.0  1.86122  0.00   
+  2  4    0    -3   15784.0021 17227.6438 -180.0  1.84958  0.02   
+  2  2    -6   -1   641.2491   630.1904   -180.0  1.84310  0.00   
+  2  1    -5   2    33.9473    32.7906    -180.0  1.84286  0.00   
+  2  2    6    0    7066.1929  5973.8074  -0.0    1.84084  0.01   
+  2  2    6    -2   2722.0729  2234.4122  -180.0  1.83281  0.00   
+  2  1    -1   3    2640.1051  2403.8627  -180.0  1.82957  0.01   
+  2  2    -6   0    11732.7341 11170.3478 0.0     1.82883  0.01   
+  2  2    -4   -3   360.5082   351.5785   -0.0    1.82817  0.00   
+  2  0    4    -3   6221.2363  6600.1943  180.0   1.82454  0.01   
+  2  3    -5   -1   503.8540   547.0575   -180.0  1.82305  0.00   
+  2  0    6    -2   8632.6142  9376.7847  -180.0  1.82300  0.01   
+  2  4    0    0    14813.5249 16544.7345 -0.0    1.81888  0.02   
+  2  3    -3   1    1287.3929  1388.1619  -0.0    1.81269  0.00   
+  2  4    2    -3   1627.9184  1698.2109  -0.0    1.80678  0.00   
+  2  1    1    3    12531.4100 13204.6231 -180.0  1.80269  0.03   
+  2  3    3    1    632.2133   659.8672   -0.0    1.79396  0.00   
+  2  1    5    -3   37.5158    36.9138    180.0   1.79152  0.00   
+  2  1    7    -1   312.3863   370.2527   -180.0  1.78554  0.00   
+  2  2    0    -4   24381.2246 29304.7955 0.0     1.78457  0.04   
+  2  1    7    0    1449.0925  1186.7943  -0.0    1.76994  0.00   
+  2  3    5    0    503.1200   192.4714   -180.0  1.76391  0.00   
+  2  1    -7   0    5030.3152  1861.7091  0.0     1.76369  0.01   
+  2  1    5    2    5362.9062  1478.1411  -180.0  1.75728  0.01   
+  2  3    -5   -2   874.8326   292.8600   -180.0  1.75539  0.00   
+  2  2    2    -4   10872.7556 5374.4235  180.0   1.75260  0.02   
+  2  4    2    0    6511.4096  3240.2714  180.0   1.75255  0.01   
+  2  3    -5   0    1.1423     0.6787     -180.0  1.75073  0.00   
+  2  4    -2   -3   1909.7609  1498.9920  -180.0  1.74735  0.00   
+  2  4    -2   0    1840.8683  1478.3757  -180.0  1.74562  0.00   
+  2  4    4    -2   13900.5312 11156.5991 -180.0  1.74061  0.01   
+  2  3    1    -4   16.1024    11.6942    0.0     1.73791  0.00   
+  2  1    1    -4   1184.4524  931.5858   180.0   1.73044  0.00   
+  2  0    4    3    1693.1688  1649.4123  180.0   1.72108  0.00   
+  2  1    -7   -1   557.9828   544.5769   -0.0    1.72100  0.00   
+  2  2    -4   2    5200.6264  5111.9528  -180.0  1.72066  0.01   
+  2  0    6    2    4062.6808  4043.0244  180.0   1.71979  0.01   
+  2  2    -6   -2   5818.7011  5843.5104  180.0   1.71808  0.01   
+  2  1    -3   3    3850.8954  3889.7621  0.0     1.71755  0.01   
+  2  4    4    -1   3335.7556  3425.3612  -0.0    1.71605  0.00   
+  2  3    -1   -4   34.5668    26.3196    -0.0    1.70384  0.00   
+  2  3    5    -3   2291.2396  1781.5059  180.0   1.70048  0.00   
+  2  1    -1   -4   1474.4199  1087.2281  180.0   1.69839  0.00   
+  2  2    -2   -4   7452.0304  6607.2640  -0.0    1.68632  0.01   
+  2  2    -6   1    131.3221   111.8094   180.0   1.68403  0.00   
+  2  1    -7   1    1321.6617  1037.6002  0.0     1.67991  0.00   
+  2  1    7    -2   3544.1680  3014.1863  0.0     1.67337  0.00   
+  2  4    -4   -1   3642.0513  3113.5342  -0.0    1.67328  0.00   
+  2  1    -5   -3   354.1888   322.6770   -180.0  1.66739  0.00   
+  2  2    4    2    7698.4031  6980.1241  -180.0  1.66673  0.01   
+  2  4    -4   -2   3301.3094  2996.9232  -180.0  1.66656  0.00   
+  2  1    3    3    625.2856   605.4945   0.0     1.65314  0.00   
+  2  3    3    -4   499.9937   474.5918   180.0   1.65084  0.00   
+  2  2    6    1    15.7241    15.0623    180.0   1.64996  0.00   
+  2  4    4    -3   85.9167    81.5092    0.0     1.64497  0.00   
+  2  1    3    -4   1331.7327  1267.0308  -180.0  1.64299  0.00   
+  2  2    6    -3   410.7566   438.3802   0.0     1.63845  0.00   
+  2  1    7    1    908.3293   959.6711   0.0     1.63566  0.00   
+  2  5    1    -2   59.0243    62.3555    -180.0  1.62122  0.00   
+  2  2    4    -4   7.1994     6.6299     0.0     1.60885  0.00   
+  2  3    -1   2    261.5094   237.1891   -180.0  1.60779  0.00   
+  2  4    0    -4   28.4739    25.5451    0.0     1.60742  0.00   
+  2  5    -1   -2   124.4599   104.4782   -0.0    1.60481  0.00   
+  2  3    1    2    5.2445     3.3755     -180.0  1.59704  0.00   
+  2  0    0    4    2677.9775  1719.5025  -0.0    1.59697  0.00   
+  2  0    8    0    6622.1561  4104.7411  -0.0    1.59366  0.01   
+  2  3    -5   -3   7621.6485  7048.0684  -180.0  1.58673  0.01   
+  2  4    2    -4   5906.1466  5767.4424  -180.0  1.58523  0.01   
+  2  4    4    0    82.5661    80.5872    180.0   1.58489  0.00   
+  2  3    -5   1    3529.6163  3541.7994  0.0     1.57987  0.00   
+  2  1    -7   -2   98.1449    106.0592   180.0   1.57566  0.00   
+  2  4    -4   0    908.1788   972.7791   180.0   1.57467  0.00   
+  2  4    0    1    1228.3147  1313.3627  0.0     1.57405  0.00   
+  2  0    2    -4   6446.9555  6835.8768  -180.0  1.57267  0.01   
+  2  5    1    -1   1742.2836  1838.8969  0.0     1.57223  0.00   
+  2  5    1    -3   4.3625     4.5305     0.0     1.57056  0.00   
+  2  0    8    -1   4793.8420  5105.5113  -180.0  1.56971  0.00   
+  2  3    -3   -4   206.5644   222.0271   -180.0  1.56739  0.00   
+  2  1    -3   -4   1103.3413  1168.3240  -180.0  1.56437  0.00   
+  2  5    -1   -1   3402.8447  3532.8589  -0.0    1.56314  0.00   
+  2  3    5    1    6291.8262  6630.5027  -0.0    1.55930  0.01   
+  2  2    0    3    1671.7128  1763.6711  -180.0  1.55911  0.00   
+  2  4    -4   -3   632.9302   668.2938   0.0     1.55805  0.00   
+  2  0    6    -3   50.7263    50.4752    180.0   1.55391  0.00   
+  2  5    -1   -3   3081.4358  3177.9812  180.0   1.54983  0.00   
+  2  5    3    -2   1777.6431  1684.3120  0.0     1.53962  0.00   
+  2  3    7    -1   378.1945   255.3064   -0.0    1.53554  0.00   
+  2  4    -2   -4   6708.9038  4566.3850  180.0   1.53333  0.01   
+  2  4    -2   1    482.7903   360.2122   -0.0    1.53138  0.00   
+  2  2    -2   3    5192.2185  3884.5431  0.0     1.52972  0.01   
+  2  1    -5   3    148.1925   114.2358   180.0   1.52775  0.00   
+  2  0    2    4    2661.1339  1999.2534  180.0   1.52655  0.00   
+  2  3    7    -2   1887.6700  1417.6951  180.0   1.52649  0.00   
+  2  4    2    1    68.5714    55.0425    -0.0    1.52494  0.00   
+  2  0    8    1    67.1347    53.4117    0.0     1.52385  0.00   
+  2  3    -3   2    921.4088   713.5252   0.0     1.52351  0.00   
+  2  2    -6   -3   1360.2585  972.3599   180.0   1.52111  0.00   
+  2  1    -7   2    2568.6620  2092.8268  180.0   1.51406  0.00   
+  2  2    -4   -4   3957.8519  3475.0688  -180.0  1.51008  0.00   
+  2  2    8    -1   8901.8321  8932.7653  0.0     1.50687  0.01   
+  2  5    3    -3   10648.7285 11216.4371 -0.0    1.50125  0.01   
+  2  2    2    3    245.5853   261.4234   0.0     1.49966  0.00   
+  2  5    -3   -2   1221.9096  1283.3165  0.0     1.49852  0.00   
+  2  4    6    -2   1568.6419  1643.4734  -180.0  1.49804  0.00   
+  2  3    3    2    2769.7578  2828.3266  0.0     1.49651  0.00   
+  2  5    3    -1   1476.8988  1375.8687  180.0   1.49230  0.00   
+  2  1    7    -3   1048.4549  963.7100   -0.0    1.49138  0.00   
+  2  3    5    -4   1155.5674  976.7543   0.0     1.48741  0.00   
+  2  3    -7   -1   5.0215     4.1505     -180.0  1.48641  0.00   
+  2  2    -6   2    2696.7849  2225.9899  -180.0  1.48209  0.00   
+  2  1    5    -4   630.9222   569.2303   -0.0    1.48061  0.00   
+  2  4    4    -4   1019.0278  936.8644   -0.0    1.47752  0.00   
+  2  4    6    -1   2651.3158  2425.3077  -0.0    1.47727  0.00   
+  2  2    8    -2   2288.8795  2036.6290  -0.0    1.46947  0.00   
+  2  5    -3   -1   2505.7412  2250.7625  180.0   1.46932  0.00   
+  2  0    4    -4   1774.8652  1799.2981  0.0     1.46530  0.00   
+  2  2    8    0    16940.7581 17372.8918 180.0   1.46378  0.01   
+  2  0    8    -2   2621.4480  2670.5014  0.0     1.46338  0.00   
+  2  3    7    0    1372.4271  1344.4772  -0.0    1.46164  0.00   
+  2  0    6    3    10318.0929 9727.2084  -180.0  1.45874  0.01   
+  2  2    -8   -1   297.0693   277.6153   0.0     1.45806  0.00   
+  2  2    -8   0    15333.1748 14971.6548 -180.0  1.45572  0.01   
+  2  1    5    3    82.9564    84.4701    0.0     1.45352  0.00   
+  2  3    -7   0    1823.3370  1874.7884  -0.0    1.45113  0.00   
+  2  5    -3   -3   3864.8165  3973.0050  -0.0    1.44873  0.00   
+  2  1    7    2    335.5408   339.6716   180.0   1.44736  0.00   
+  2  5    1    0    462.1422   468.7582   0.0     1.44694  0.00   
+  2  5    -1   0    272.4316   282.6566   0.0     1.44450  0.00   
+  2  3    -7   -2   393.6317   407.5222   -180.0  1.44435  0.00   
+  2  5    1    -4   363.2903   376.0669   -0.0    1.44434  0.00   
+  2  4    6    -3   4725.9166  4799.2632  180.0   1.44037  0.00   
+  2  3    7    -3   2131.1267  2066.9126  0.0     1.43858  0.00   
+  2  4    -6   -1   13914.9030 13974.0377 -0.0    1.43651  0.01   
+  2  1    -1   4    1976.6007  1747.7612  -0.0    1.43156  0.00   
+  2  2    6    2    15300.3645 14127.5120 -180.0  1.43067  0.02   
+  2  4    -6   -2   10712.5984 11494.7453 -180.0  1.42772  0.01   
+  2  3    1    -5   46.7032    54.5453    0.0     1.42498  0.00   
+  2  2    -4   3    7935.7127  9304.7725  -0.0    1.42492  0.01   
+  2  5    -1   -4   5276.1773  6191.0063  0.0     1.42367  0.00   
+  2  2    0    -5   534.4107   530.6717   -0.0    1.41970  0.00   
+  2  2    6    -4   4124.7651  4109.1661  -0.0    1.41942  0.00   
+  2  4    -4   1    2207.6228  2328.2327  -180.0  1.41643  0.00   
+  2  1    1    4    9389.8539  9765.5200  -0.0    1.41417  0.01   
+  2  2    2    -5   139.0749   102.1798   180.0   1.40774  0.00   
+  2  4    4    1    6472.9699  4251.1055  -180.0  1.40628  0.01   
+  2  1    9    -1   489.3369   313.3806   180.0   1.40427  0.00   
+  2  3    -1   -5   875.8501   559.2035   180.0   1.40173  0.00   
+  2  5    5    -2   178.3543   121.8591   180.0   1.39689  0.00   
+  2  4    -4   -4   475.3106   333.7965   -180.0  1.39638  0.00   
+  2  5    3    -4   12768.6905 10290.7248 -180.0  1.39407  0.01   
+  2  0    4    4    693.5445   603.2489   180.0   1.39300  0.00   
+  2  1    9    0    6820.4401  6061.3448  -180.0  1.39244  0.00   
+  2  0    8    2    899.6342   841.8614   -0.0    1.39135  0.00   
+  2  1    -7   -3   9.0418     8.6161     0.0     1.39082  0.00   
+  2  2    -8   -2   414.3314   389.1003   0.0     1.38958  0.00   
+  2  1    -9   0    5226.4859  5032.6219  -180.0  1.38852  0.00   
+  2  3    -5   -4   736.2155   712.8918   180.0   1.38828  0.00   
+  2  1    -5   -4   12.3911    12.2841    -0.0    1.38705  0.00   
+  2  4    6    0    6930.4531  6881.9956  0.0     1.38694  0.01   
+  2  2    -8   1    2490.1733  2583.5813  -0.0    1.38353  0.00   
+  2  3    -5   2    100.6397   107.7060   180.0   1.38139  0.00   
+  2  1    -3   4    10187.7155 11498.8556 180.0   1.38001  0.01   
+  2  3    3    -5   528.8669   601.2645   -0.0    1.37984  0.00   
+  2  5    3    0    1814.3591  2064.1961  180.0   1.37983  0.00   
+  2  2    4    3    6700.6223  7682.9819  -0.0    1.37735  0.01   
+  2  4    -6   0    2511.5779  2929.6322  0.0     1.37669  0.00   
+  2  5    -3   0    1599.7832  1846.9850  -180.0  1.37349  0.00   
+  2  4    0    -5   8428.9149  9852.1453  -0.0    1.37263  0.01   
+  2  5    5    -3   894.4178   1000.1841  -0.0    1.37203  0.00   
+  2  1    1    -5   65.5562    51.8333    180.0   1.36876  0.00   
+  2  2    8    -3   1302.0139  897.0709   0.0     1.36740  0.00   
+  2  2    -2   -5   1285.2891  890.9937   -180.0  1.36475  0.00   
+  2  1    -9   -1   3180.3265  2521.2414  180.0   1.36346  0.00   
+  2  4    2    -5   13035.6905 11335.5971 180.0   1.36264  0.01   
+  2  2    8    1    3944.6498  3611.9875  -180.0  1.35827  0.00   
+  2  5    5    -1   1013.3201  870.4892   -180.0  1.35737  0.00   
+  2  4    -6   -3   4646.5489  4126.3352  180.0   1.35385  0.00   
+  2  3    -7   1    648.0771   576.4772   0.0     1.35312  0.00   
+  2  1    9    -2   15494.4387 16147.0686 0.0     1.35152  0.01   
+  2  6    0    -2   16034.0835 16981.3924 180.0   1.35133  0.01   
+  2  1    -9   1    3418.2052  3741.5161  -0.0    1.35032  0.00   
+  2  1    -1   -5   9576.9952  10683.9602 -0.0    1.34891  0.01   
+  2  3    5    2    192.5920   209.3398   0.0     1.34817  0.00   
+  2  5    -5   -2   512.5815   568.7530   180.0   1.34647  0.00   
+  2  4    0    2    18183.3936 20266.7951 180.0   1.34356  0.02   
+  2  6    0    -3   405.4791   424.9852   0.0     1.34244  0.00   
+  2  3    -7   -3   956.0205   987.1236   180.0   1.34218  0.00   
+  2  5    -3   -4   20.3995    19.4544    -0.0    1.34037  0.00   
+  2  3    7    1    730.6433   545.2034   0.0     1.33504  0.00   
+  2  1    3    4    400.2831   303.9072   180.0   1.33473  0.00   
+  2  2    4    -5   2648.7976  2138.1647  -0.0    1.33359  0.00   
+  2  6    2    -2   7207.5607  7470.5514  0.0     1.33146  0.00   
+  2  3    -1   3    527.5130   551.6386   -0.0    1.32984  0.00   
+  2  5    -5   -1   3081.5634  3077.6343  -180.0  1.32879  0.00   
+  2  1    -7   3    866.0421   845.5145   -180.0  1.32789  0.00   
+  2  1    3    -5   13271.5609 12956.3684 180.0   1.32785  0.01   
+  2  4    6    -4   1246.5253  1219.1637  0.0     1.32754  0.00   
+  2  6    2    -3   6.1860     6.0091     -0.0    1.32656  0.00   
+  2  4    -2   -5   3329.0988  3146.4347  0.0     1.32203  0.00   
+  2  1    9    1    1070.6918  1105.1306  -0.0    1.32057  0.00   
+  2  4    -2   2    2149.8971  2255.4357  0.0     1.32028  0.00   
+  2  3    1    3    3073.4479  3237.6008  0.0     1.32015  0.00   
+  2  2    -6   -4   109.0008   114.0134   0.0     1.31919  0.00   
+  2  3    -3   -5   2084.5538  2179.7868  180.0   1.31918  0.00   
+  2  0    6    -4   3255.5650  3685.3963  0.0     1.31717  0.00   
+  2  0    8    -3   4222.2892  4546.6333  -0.0    1.31636  0.00   
+  2  6    -2   -2   348.6221   330.6363   180.0   1.31265  0.00   
+  2  4    2    2    594.2908   505.4413   0.0     1.30914  0.00   
+  2  5    -5   -3   7408.7013  6208.9517  0.0     1.30653  0.00   
+  2  3    7    -4   13.8019    11.5530    -180.0  1.30602  0.00   
+  2  6    0    -1   882.4968   635.2341   -0.0    1.30261  0.00   
+  2  6    -2   -3   6558.3528  4797.6968  0.0     1.30107  0.00   
+  2  1    7    -4   1118.7640  816.7390   180.0   1.30069  0.00   
+  2  4    4    -5   1042.1917  839.8412   -180.0  1.29576  0.00   
+  2  5    -1   1    760.5766   560.8179   -180.0  1.29287  0.00   
+  2  5    5    -4   133.1859   102.0732   -0.0    1.29210  0.00   
+  2  5    1    1    269.2952   213.0414   180.0   1.29128  0.00   
+  2  5    1    -5   1276.4191  1297.0866  -180.0  1.28850  0.00   
+  2  1    -9   -2   6669.3289  7594.2794  0.0     1.28440  0.00   
+  2  3    -3   3    3354.7257  3821.2749  180.0   1.28422  0.00   
+  2  2    -6   3    87.8502    97.9036    -0.0    1.28363  0.00   
+  2  3    5    -5   2764.6180  3037.5557  -0.0    1.28334  0.00   
+  2  6    2    -1   2369.5143  2446.8719  180.0   1.28151  0.00   
+  2  4    8    -2   15911.4940 16043.2073 -0.0    1.27998  0.01   
+  2  6    0    -4   4882.7836  4642.8182  0.0     1.27913  0.00   
+  2  1    -5   4    0.2979     0.2762     -0.0    1.27885  0.00   
+  2  0    0    5    1629.1216  1504.7953  0.0     1.27757  0.00   
+  2  2    -8   -3   1133.9531  969.8153   0.0     1.27578  0.00   
+  2  1    -3   -5   1892.1475  1649.0848  -180.0  1.27554  0.00   
+  2  0    10   0    5991.4710  5612.4673  -0.0    1.27493  0.00   
+  2  3    9    -1   629.8932   567.6734   180.0   1.27318  0.00   
+  2  3    9    -2   207.7059   209.3409   0.0     1.27118  0.00   
+  2  6    -2   -1   598.0334   604.9530   -180.0  1.27102  0.00   
+  2  5    -1   -5   3180.4708  3287.3648  -0.0    1.27057  0.00   
+  2  4    -6   1    2067.9792  2157.0193  180.0   1.27033  0.00   
+  2  2    0    4    4633.7886  5970.9564  -0.0    1.26862  0.00   
+  2  6    2    -4   2020.0899  2642.8907  -180.0  1.26852  0.00   
+  2  0    2    -5   3035.5866  4140.6925  180.0   1.26818  0.00   
+  2  2    -8   2    11358.0706 15669.9235 0.0     1.26800  0.01   
+  2  5    5    0    1114.6329  1539.1640  -0.0    1.26791  0.00   
+  2  0    10   -1   654.5441   722.1628   -180.0  1.26570  0.00   
+  2  4    8    -1   134.4447   116.1733   180.0   1.26381  0.00   
+  2  2    -4   -5   38.4523    34.2839    180.0   1.26302  0.00   
+  2  1    -9   2    449.0978   407.6104   0.0     1.26267  0.00   
+  2  6    4    -2   3812.8613  4060.9393  -0.0    1.26012  0.00   
+  2  1    7    3    1313.0168  1423.0605  -180.0  1.25993  0.00   
+  2  5    -5   0    1133.1217  1251.7915  -0.0    1.25974  0.00   
+  2  4    6    1    31.0378    35.4122    180.0   1.25938  0.00   
+  2  6    4    -3   4996.8805  5742.7030  -180.0  1.25904  0.00   
+  2  3    3    3    30.6044    34.1056    0.0     1.25855  0.00   
+  2  2    -2   4    2258.1496  2630.4316  180.0   1.25569  0.00   
+  2  5    3    -5   6826.3807  7849.9862  180.0   1.25548  0.00   
+  2  1    9    -3   416.8733   446.4585   -180.0  1.25310  0.00   
+  2  4    -4   2    3152.5684  2913.1494  0.0     1.24747  0.00   
+  2  4    8    -3   1649.5998  1591.0184  -180.0  1.24643  0.00   
+  2  5    -3   1    152.5103   154.1169   -180.0  1.24419  0.00   
+  2  4    -6   -4   4711.4030  4649.8078  0.0     1.24074  0.00   
+  2  1    5    -5   21.1501    20.8490    -0.0    1.24058  0.00   
+  2  6    -2   -4   117.9710   116.0421   -0.0    1.24022  0.00   
+  2  5    3    1    880.4836   865.0651   -180.0  1.23993  0.00   
+  2  0    6    4    4501.3470  4402.8269  -0.0    1.23960  0.00   
+  2  0    8    3    2674.8433  2523.8232  0.0     1.23892  0.00   
+  2  5    7    -2   54.0563    48.4702    -180.0  1.23815  0.00   
+  2  0    2    5    6.9290     6.1649     -0.0    1.23770  0.00   
+  2  3    -9   -1   2185.7524  1878.7146  -180.0  1.23697  0.00   
+  2  0    10   1    88.5088    69.0195    180.0   1.23540  0.00   
+  2  2    8    -4   0.8474     0.6712     -0.0    1.23509  0.00   
+  2  2    2    4    277.5528   202.3679   180.0   1.23305  0.00   
+  2  2    10   -1   893.4662   674.5837   -0.0    1.23266  0.00   
+  2  2    6    3    699.5127   591.5126   -0.0    1.23202  0.00   
+  2  4    -8   -1   1608.2340  1660.8265  180.0   1.22975  0.00   
+  2  4    4    2    6166.3624  7216.8110  -0.0    1.22886  0.01   
+  2  6    -4   -2   6350.7874  7429.0559  0.0     1.22874  0.00   
+  2  4    -4   -5   5150.1538  5935.8119  180.0   1.22833  0.00   
+  2  3    9    0    193.3937   207.1256   180.0   1.22722  0.00   
+  2  2    8    2    15449.2933 16367.8700 -0.0    1.22501  0.01   
+  2  3    -7   2    4.1820     4.4310     -180.0  1.22493  0.00   
+  2  5    7    -3   695.0245   701.3947   180.0   1.22357  0.00   
+  2  5    -5   -4   547.5227   527.2945   -180.0  1.22255  0.00   
+  2  2    6    -5   96.6780    93.3157    -0.0    1.22244  0.00   
+  2  3    9    -3   4079.9632  3989.5508  -0.0    1.22187  0.00   
+  2  4    -8   -2   15991.0804 15576.6760 0.0     1.22139  0.01   
+  2  1    5    4    3266.0203  2923.6151  -180.0  1.22003  0.00   
+  2  3    -9   0    74.8341    63.1939    -0.0    1.21922  0.00   
+  2  6    -4   -3   1.9816     1.6171     -180.0  1.21643  0.00   
+  2  6    4    -1   11.1753    10.2523    180.0   1.21473  0.00   
+  2  2    10   -2   3480.3886  3195.8904  -180.0  1.21471  0.00   
+  2  3    -7   -4   10.3126    9.5153     0.0     1.21279  0.00   
+  2  6    0    0    14066.2091 13100.2263 0.0     1.21259  0.01   
+  2  1    9    2    1878.5295  1749.7864  0.0     1.21259  0.00   
+  2  0    4    -5   55.1788    51.4047    -180.0  1.21258  0.00   
+  2  1    -7   -4   721.7062   673.8718   0.0     1.21254  0.00   
+  2  6    4    -4   205.8398   199.9465   0.0     1.21185  0.00   
+  2  0    10   -2   2515.7857  2393.1814  180.0   1.21068  0.00   
+  2  3    -9   -2   2.5158     2.4088     0.0     1.20966  0.00   
+  2  5    7    -1   979.0799   919.5910   -0.0    1.20764  0.00   
+  2  5    -3   -5   1784.1120  1669.4106  -180.0  1.20756  0.00   
+  2  2    10   0    13.2599    11.8619    180.0   1.20601  0.00   
+  2  3    -5   -5   5811.3143  5223.5291  -0.0    1.20426  0.01   
+  2  4    8    0    2169.9643  2036.1638  -180.0  1.20314  0.00   
+  2  2    -10  0    1095.6617  1234.3417  180.0   1.20037  0.00   
+  2  2    -10  -1   1790.6892  1881.5821  0.0     1.19900  0.00   
+  2  2    -4   4    0.0040     0.0043     180.0   1.19841  0.00   
+  2  3    -5   3    4836.8901  5149.8089  -180.0  1.19827  0.00   
+  2  6    -4   -1   4121.3065  4013.4094  180.0   1.19705  0.00   
+  2  4    -8   0    2143.3521  1701.7086  -180.0  1.19422  0.00   
+  2  4    6    -5   6565.9412  5356.2972  -0.0    1.19366  0.00   
+  2  6    2    0    8198.8599  6359.8747  -180.0  1.19287  0.01   
+  2  3    1    -6   224.3193   172.0799   180.0   1.19278  0.00   
+  2  3    7    2    280.1634   210.6961   180.0   1.19262  0.00   
+  2  6    -2   0    2676.8775  1825.4606  -180.0  1.18959  0.00   
+  2  5    -7   -2   349.0978   235.2689   -180.0  1.18926  0.00   
+  2  5    5    -5   656.0314   652.0282   -0.0    1.18202  0.00   
+  2  6    0    -5   1880.9696  1859.8386  -0.0    1.18139  0.00   
+  2  5    -7   -1   1143.7345  1170.6276  -0.0    1.17956  0.00   
+  2  3    -1   -6   9896.5585  10651.6340 0.0     1.17652  0.01   
+  2  1    -9   -3   3266.5328  3479.3329  -0.0    1.17569  0.00   
+  2  4    0    -6   652.9998   694.8770   -180.0  1.17567  0.00   
+  2  6    2    -5   650.8973   690.4314   180.0   1.17553  0.00   
+  2  4    8    -4   4718.0642  5262.2410  180.0   1.17365  0.00   
+  2  1    -1   5    40.1511    44.3347    0.0     1.17349  0.00   
+  2  2    0    -6   3059.0572  3262.2227  -180.0  1.17258  0.00   
+  2  4    2    -6   699.7026   785.7923   0.0     1.17185  0.00   
+  2  4    -8   -3   448.1193   512.5086   -0.0    1.17167  0.00   
+  2  1    -5   -5   4667.5795  5414.4867  -180.0  1.17131  0.00   
+  2  3    3    -6   2793.2633  3178.6335  180.0   1.16840  0.00   
+  2  5    7    -4   5205.6997  5932.4007  0.0     1.16833  0.00   
+  2  2    2    -6   389.8015   444.4424   0.0     1.16828  0.00   
+  2  0    8    -4   6747.9899  6734.2463  -180.0  1.16544  0.00   
+  2  3    5    3    9586.7936  9033.3981  -180.0  1.16397  0.01   
+  2  6    -4   -4   1416.9505  1331.0105  -180.0  1.16381  0.00   
+  2  3    7    -5   1259.4391  1180.8749  180.0   1.16377  0.00   
+  2  3    -9   1    29.4704    24.5109    -0.0    1.16177  0.00   
+  2  1    1    5    2374.5187  1984.2370  0.0     1.16142  0.00   
+  2  2    -10  1    489.8657   408.7012   -180.0  1.16134  0.00   
+  2  0    4    5    4516.0332  3674.6390  -180.0  1.16082  0.00   
+  2  6    6    -3   713.1311   572.9928   0.0     1.16041  0.00   
+  2  5    -5   1    10.2433    8.2052     180.0   1.16017  0.00   
+  2  7    1    -3   409.0354   326.8856   180.0   1.15995  0.00   
+  2  2    4    4    418.9544   334.7388   180.0   1.15990  0.00   
+  2  0    10   2    2342.0836  1953.1670  -180.0  1.15916  0.00   
+  2  5    -7   -3   16.5682    13.9221    0.0     1.15905  0.00   
+  2  6    6    -2   1256.5097  1062.5954  180.0   1.15883  0.00   
+  2  2    -10  -2   1062.0485  927.1428   -180.0  1.15763  0.00   
+  2  2    10   -3   521.9804   456.9863   180.0   1.15752  0.00   
+  2  1    -7   4    8962.8695  7894.1741  -0.0    1.15699  0.01   
+  2  1    11   -1   185.0294   172.4013   -0.0    1.15488  0.00   
+  2  5    5    1    15.8832    14.5872    180.0   1.15443  0.00   
+  2  4    0    3    419.6892   372.8509   -0.0    1.15214  0.00   
+  2  7    -1   -3   226.9447   190.7937   -0.0    1.15103  0.00   
+  2  1    -9   3    462.5081   390.2848   -180.0  1.15086  0.00   
+  2  7    1    -2   498.2203   417.6649   180.0   1.14957  0.00   
+  2  6    -2   -5   4.1049     3.3422     180.0   1.14818  0.00   
+  2  2    -8   -4   1323.3114  1241.1393  -0.0    1.14713  0.00   
+  2  3    9    1    894.8281   840.9132   -180.0  1.14703  0.00   
+  2  1    -3   5    140.1332   131.0137   -0.0    1.14691  0.00   
+  2  4    -6   2    983.9974   884.2580   -180.0  1.14653  0.00   
+  2  1    11   0    734.3507   673.8595   0.0     1.14593  0.00   
+  2  3    -9   -3   6873.2793  6842.7549  -0.0    1.14539  0.00   
+  2  1    -11  0    52.2751    56.5171    180.0   1.14326  0.00   
+  2  7    -1   -2   236.8211   258.5173   180.0   1.14319  0.00   
+  2  2    10   1    2003.1122  2221.3310  -180.0  1.14260  0.00   
+  2  2    -6   -5   7512.8369  8280.7099  -0.0    1.14253  0.01   
+  2  5    -1   2    0.2320     0.2523     -180.0  1.14237  0.00   
+  2  4    -2   -6   145.5558   159.9954   -0.0    1.14109  0.00   
+  2  5    7    0    1433.7688  1584.2307  0.0     1.14103  0.00   
+  2  3    9    -4   3287.1387  3452.1120  -180.0  1.13977  0.00   
+  2  4    -2   3    643.9415   675.3480   180.0   1.13965  0.00   
+  2  2    -8   3    920.0440   940.5804   180.0   1.13923  0.00   
+  2  5    1    2    150.5002   151.0052   180.0   1.13897  0.00   
+  2  2    -2   -6   456.3159   457.5743   180.0   1.13875  0.00   
+  2  5    1    -6   102.5472   92.8501    180.0   1.13644  0.00   
+  2  6    4    0    11126.4919 9886.1889  -180.0  1.13618  0.01   
+  2  1    9    -4   7590.5865  6387.1239  180.0   1.13575  0.00   
+  2  7    1    -4   113.1499   104.3489   0.0     1.13318  0.00   
+  2  5    -7   0    629.8327   561.3250   0.0     1.13270  0.00   
+  2  6    4    -5   3947.2538  3560.8356  -0.0    1.13225  0.00   
+  2  7    3    -3   1998.6521  1752.7599  180.0   1.13164  0.00   
+  2  1    7    -5   2150.1861  1876.4532  -0.0    1.13113  0.00   
+  2  4    4    -6   85.4478    74.0198    180.0   1.13073  0.00   
+  2  6    -4   0    10358.6460 8996.3605  -180.0  1.13052  0.01   
+  2  1    1    -6   14.6203    12.7255    180.0   1.13041  0.00   
+  2  4    2    3    37.8355    26.9687    0.0     1.12798  0.00   
+  2  1    11   -2   5333.3722  4054.5939  -180.0  1.12721  0.00   
+  2  2    4    -6   810.1471   617.9103   -180.0  1.12706  0.00   
+  2  1    -11  -1   105.7789   80.5660    180.0   1.12692  0.00   
+  2  0    6    -5   1086.8977  825.3110   -0.0    1.12677  0.00   
+  2  0    10   -3   30.9734    25.1309    180.0   1.12560  0.00   
+  2  6    6    -4   1334.9548  1116.6065  -0.0    1.12535  0.00   
+  2  4    -8   1    1557.6102  1428.0735  -0.0    1.12500  0.00   
+  2  4    6    2    532.9234   491.6513   180.0   1.12497  0.00   
+  2  3    -3   -6   2525.1900  2679.1058  0.0     1.12421  0.00   
+  2  1    -11  1    479.5915   520.4388   180.0   1.12385  0.00   
+  2  3    -1   4    57.9482    62.3074    180.0   1.12290  0.00   
+  2  7    -1   -4   322.8438   340.7362   180.0   1.12266  0.00   
+  2  6    -6   -2   5.5620     5.8815     -0.0    1.12259  0.00   
+  2  5    -1   -6   3186.6707  3679.1020  -180.0  1.12188  0.00   
+  2  6    6    -1   17.0780    18.5196    -180.0  1.12105  0.00   
+  2  7    3    -2   573.8522   466.2613   -180.0  1.11981  0.00   
+  2  5    -5   -5   3218.6294  3254.1700  180.0   1.11710  0.00   
+  2  1    -1   -6   1548.1293  1573.1101  -180.0  1.11699  0.00   
+  2  4    -6   -5   13.2413    12.1624    -180.0  1.11621  0.00   
+  2  5    3    -6   4020.2813  3572.8767  0.0     1.11574  0.00   
+  2  3    1    4    580.4218   557.2568   180.0   1.11489  0.00   
+  2  4    8    1    3161.2955  3030.2470  -0.0    1.11486  0.00   
+  2  1    3    5    235.6873   208.8946   -180.0  1.11404  0.00   
+  2  2    -6   4    1942.3187  1626.0861  -0.0    1.11278  0.00   
+  2  6    -6   -3   10549.4680 9170.8262  180.0   1.11104  0.01   
+  2  5    -3   2    27.2018    23.9804    -180.0  1.11049  0.00   
+  2  3    5    -6   85.0816    75.3696    -0.0    1.11017  0.00   
+  2  1    3    -6   4096.5235  3749.4968  0.0     1.10915  0.00   
+  2  7    3    -4   918.9486   851.8273   -0.0    1.10885  0.00   
+  2  7    -3   -3   8.8751     8.0510     -0.0    1.10731  0.00   
+  2  7    1    -1   599.0543   540.2195   -180.0  1.10485  0.00   
+  2  6    0    1    3110.5933  2851.2916  180.0   1.10441  0.00   
+  2  1    11   1    378.3620   353.4958   0.0     1.10278  0.00   
+  2  7    -3   -2   8.2740     7.6618     -0.0    1.10240  0.00   
+  2  4    10   -2   306.3559   293.9448   -180.0  1.10139  0.00   
+  2  7    -1   -1   582.5976   560.8360   -180.0  1.10125  0.00   
+  2  5    3    2    95.9879    92.4856    -180.0  1.10119  0.00   
+  2  2    8    -5   3896.1608  3728.5603  180.0   1.10077  0.00   
+  2  6    -6   -1   6.6221     6.2337     0.0     1.10033  0.00   
+  2  5    -7   -4   129.6086   136.6182   0.0     1.09716  0.00   
+  2  3    -3   4    136.1787   143.6453   -0.0    1.09706  0.00   
+  2  1    7    4    54.4690    57.0295    -0.0    1.09661  0.00   
+  2  0    8    4    3292.7438  2959.2417  180.0   1.09406  0.00   
+  2  4    -8   -4   4110.7938  3685.4545  -180.0  1.09399  0.00   
+  2  4    -4   3    2458.6154  2186.7268  180.0   1.09385  0.00   
+  2  3    -7   3    2040.8119  1814.2931  0.0     1.09384  0.00   
+  2  1    9    3    347.0460   308.2223   180.0   1.09383  0.00   
+  2  2    -10  2    4.6648     3.3265     -0.0    1.09247  0.00   
+  2  2    8    3    539.3952   379.8198   0.0     1.09126  0.00   
+  2  5    9    -2   2505.9766  1582.6840  -0.0    1.09021  0.00   
+  2  4    10   -1   2.5152     1.7369     -180.0  1.08903  0.00   
+  2  6    -2   1    2.2278     1.5406     -180.0  1.08894  0.00   
+  2  1    -5   5    8181.3215  5646.2565  0.0     1.08884  0.01   
+  2  6    2    1    352.4606   245.3481   -0.0    1.08745  0.00   
+  2  2    -10  -3   861.7093   617.4947   180.0   1.08733  0.00   
+  2  5    7    -5   121.3846   91.0318    -180.0  1.08704  0.00   
+  2  6    -4   -5   460.2220   422.0173   180.0   1.08477  0.00   
+  2  3    -7   -5   3043.3851  3180.2930  0.0     1.08232  0.00   
+  2  5    9    -3   34.8607    37.0056    -180.0  1.08217  0.00   
+  2  4    10   -3   458.5478   496.5346   180.0   1.08176  0.00   
+  2  4    8    -5   356.4862   416.8216   0.0     1.08002  0.00   
+  2  7    -3   -4   406.9688   475.9937   -180.0  1.08002  0.00   
+  2  3    11   -2   991.3995   1209.7235  180.0   1.07973  0.00   
+  2  3    -9   2    924.8909   1162.0253  -0.0    1.07952  0.00   
+  2  1    -11  -2   395.8522   505.5742   -0.0    1.07909  0.00   
+  2  3    11   -1   1981.5297  2531.9784  -180.0  1.07901  0.00   
+  2  4    -4   -6   40.2526    79.4879    0.0     1.07725  0.00   
+  2  7    3    -1   250.6002   517.9063   0.0     1.07642  0.00   
+  2  7    1    -5   12.3344    25.2106    -0.0    1.07626  0.00   
+  2  5    -3   -6   717.5836   1371.1187  180.0   1.07586  0.00   
+  2  2    10   -4   1491.5120  2842.5457  0.0     1.07584  0.00   
+  2  2    -4   -6   101.0975   186.5753   0.0     1.07568  0.00   
+  2  3    3    4    300.9064   560.4316   180.0   1.07511  0.00   
+  2  1    -11  2    324.5856   558.2780   -180.0  1.07370  0.00   
+  2  7    5    -3   548.2242   928.6481   180.0   1.07351  0.00   
+  2  4    4    3    484.3101   818.8776   180.0   1.07348  0.00   
+  2  1    -3   -6   107.4029   135.6225   180.0   1.07233  0.00   
+  2  6    0    -6   3.6445     4.1780     -180.0  1.07161  0.00   
+  2  1    11   -3   408.3705   540.3856   180.0   1.07008  0.00   
+  2  6    2    -6   60.4788    107.8329   0.0     1.06912  0.00   
+  2  6    -6   -4   306.1462   552.9788   0.0     1.06862  0.00   
+  2  5    9    -1   652.5194   1026.4794  0.0     1.06732  0.00   
+  2  2    6    4    2682.7839  4143.5979  0.0     1.06716  0.00   
+  2  7    -3   -1   126.1189   173.9010   0.0     1.06652  0.00   
+  2  2    0    5    1440.4261  1937.9253  0.0     1.06580  0.00   
+  2  0    6    5    262.2085   358.8678   0.0     1.06561  0.00   
+  2  7    -1   -5   2354.2672  3288.8085  0.0     1.06535  0.00   
+  2  5    5    -6   319.7441   447.2840   -180.0  1.06509  0.00   
+  2  0    0    6    40.5392    53.4823    180.0   1.06464  0.00   
+  2  0    10   3    2488.9128  3276.3246  0.0     1.06463  0.00   
+  2  4    6    -6   27.3220    31.3322    -180.0  1.06282  0.00   
+  2  6    6    -5   376.1086   434.3157   -0.0    1.06260  0.00   
+  2  0    12   0    97.4211    112.6819   180.0   1.06244  0.00   
+  2  4    -10  -1   968.5252   1132.6677  180.0   1.06171  0.00   
+  2  7    5    -2   3873.8382  4496.3914  -180.0  1.06153  0.00   
+  2  0    2    -6   663.5824   748.1993   0.0     1.06104  0.00   
+  2  5    -7   1    816.8899   969.1237   180.0   1.06052  0.00   
+  2  1    -9   -4   1411.9185  1706.8793  -180.0  1.06015  0.00   
+  2  2    -2   5    2747.2209  3313.4198  -180.0  1.05994  0.00   
+  2  3    -9   -4   11.3370    13.6703    -180.0  1.05993  0.00   
+  2  2    6    -6   233.0996   288.6216   -180.0  1.05938  0.00   
+  2  0    12   -1   1079.1947  1340.4500  -0.0    1.05892  0.00   
+  2  1    -7   -5   6.2047     7.5059     -180.0  1.05860  0.00   
+  2  1    5    -6   39.2107    47.4061    -180.0  1.05858  0.00   
+  2  2    10   2    1042.0503  1237.1699  -0.0    1.05797  0.00   
+  2  3    7    3    11.2102    12.9031    -180.0  1.05758  0.00   
+  2  7    3    -5   1953.3475  2239.1302  -180.0  1.05718  0.00   
+  2  6    6    0    400.0425   461.7745   -0.0    1.05659  0.00   
+  2  7    5    -4   1953.1987  2051.4003  0.0     1.05581  0.00   
+  2  4    -10  -2   2596.8179  3145.7849  0.0     1.05450  0.00   
+  2  5    7    1    30.8993    37.2884    180.0   1.05440  0.00   
+  2  6    8    -3   7485.8403  8866.7538  -0.0    1.05196  0.00   
+  2  3    -11  -1   221.2417   261.5320   -0.0    1.05193  0.00   
+  2  5    -5   2    4654.0358  5387.0808  -180.0  1.05131  0.00   
+  2  3    9    2    749.6681   862.2832   -0.0    1.05108  0.00   
+  2  3    11   -3   591.9482   673.7850   180.0   1.05082  0.00   
+  2  6    -6   0    469.9349   488.9045   -0.0    1.04978  0.00   
+  2  6    8    -2   346.8765   331.3808   0.0     1.04899  0.00   
+  2  3    11   0    431.8583   407.0557   -0.0    1.04881  0.00   
+  2  3    -5   -6   1318.5442  1235.7557  -180.0  1.04872  0.00   
+  2  4    10   0    69.0136    61.4161    -0.0    1.04771  0.00   
+  2  5    -9   -2   2521.1608  2208.3085  -0.0    1.04729  0.00   
+  2  5    9    -4   251.8560   228.7958   -180.0  1.04516  0.00   
+  2  6    -2   -6   1441.9475  1293.5044  -0.0    1.04487  0.00   
+  2  6    -4   1    3525.3901  3160.5795  -0.0    1.04485  0.00   
+  2  3    -5   4    2653.2204  2301.6767  -0.0    1.04377  0.00   
+  2  3    9    -5   2075.5694  1817.7670  180.0   1.04328  0.00   
+  2  1    5    5    1846.0354  1623.2967  -0.0    1.04294  0.00   
+  2  3    -11  0    1594.4220  1387.3612  0.0     1.04270  0.00   
+  2  2    2    5    303.9499   264.3036   0.0     1.04269  0.00   
+  2  5    -9   -1   73.5383    62.5557    0.0     1.04240  0.00   
+  2  6    4    1    1214.6439  1021.8291  -0.0    1.04223  0.00   
+  2  4    -10  0    622.2127   554.7785   -0.0    1.04034  0.00   
+  2  2    12   -1   4330.6990  3828.0670  -180.0  1.03971  0.00   
+  2  0    2    6    1683.5239  1492.8101  0.0     1.03949  0.00   
+  2  7    -5   -3   3960.6847  3517.5593  180.0   1.03943  0.00   
+  2  5    5    2    4388.3358  4324.4718  -180.0  1.03825  0.00   
+  2  4    -8   2    293.8053   298.1823   -0.0    1.03802  0.00   
+  2  6    4    -6   1227.6578  1251.2761  -180.0  1.03798  0.00   
+  2  0    12   1    313.9048   335.8693   -0.0    1.03750  0.00   
+  2  7    -5   -2   1372.7763  1492.9651  -180.0  1.03709  0.00   
+  2  7    1    0    1136.0255  1264.8986  -0.0    1.03656  0.00   
+  2  1    -9   4    2.3073     2.8086     180.0   1.03594  0.00   
+  2  1    11   2    1361.1730  1702.3367  180.0   1.03580  0.00   
+  2  7    -1   0    1330.4339  1823.6465  -0.0    1.03529  0.00   
+  2  4    10   -4   6.5366     9.1218     0.0     1.03486  0.00   
+  2  3    -11  -2   1016.2031  1522.0493  -180.0  1.03326  0.00   
+  3  1    1    0    1398.6835  1272.1960  -0.0    3.25240  0.03   
+  3  1    0    1    571.8130   492.3261   -0.0    2.48960  0.01   
+  3  2    0    0    176.9896   149.2681   -0.0    2.29979  0.00   
+  3  1    1    1    308.3231   375.0754   180.0   2.18945  0.01   
+  3  2    1    0    138.5574   152.8791   0.0     2.05700  0.00   
+  3  2    1    1    982.2782   880.5338   -0.0    1.68932  0.02   
+  3  2    2    0    1011.1246  1143.6505  -0.0    1.62620  0.01   
+  3  0    0    2    1552.1771  1418.4422  -0.0    1.48041  0.00   
+  3  3    1    0    354.8654   356.9070   -0.0    1.45452  0.00   
+  3  2    2    1    24.6789    28.2573    180.0   1.42536  0.00   
+  3  3    0    1    1045.9935  1055.8168  -0.0    1.36148  0.01   
+  3  1    1    2    494.7908   541.7767   -0.0    1.34739  0.00   
+  3  3    1    1    41.0006    32.7751    0.0     1.30549  0.00   
+  3  3    2    0    17.6911    15.0361    180.0   1.27569  0.00   
+  3  2    0    2    143.8955   145.3634   -0.0    1.24480  0.00   
+  3  2    1    2    39.1723    42.1898    0.0     1.20157  0.00   
+  3  3    2    1    132.7810   154.5513   -0.0    1.17158  0.00   
+  3  4    0    0    498.4845   422.4216   -0.0    1.14990  0.00   
+  3  4    1    0    87.5090    78.7516    180.0   1.11556  0.00   
+  3  2    2    2    628.7071   562.9323   -0.0    1.09473  0.00   
+  3  3    3    0    598.2465   592.6880   -0.0    1.08413  0.00   
+  3  4    1    1    313.9758   271.8807   -0.0    1.04392  0.00   
+  3  3    1    2    206.0552   220.9289   -0.0    1.03753  0.00   
+  4  1    1    0    10161.0593 5229.6750  0.0     5.76131  0.01   
+  4  1    1    -1   2716.3131  1404.4379  0.0     5.75024  0.00   
+  4  0    0    2    13792.9390 6634.7144  0.0     5.70210  0.00   
+  4  2    0    0    1225.4327  777.7431   180.0   5.30658  0.00   
+  4  2    0    -2   18323.0717 11511.0018 0.0     5.27220  0.01   
+  4  1    1    1    5691.8746  5910.3865  -180.0  4.69381  0.00   
+  4  1    1    -2   424.3736   470.8478   -180.0  4.67589  0.00   
+  4  1    1    2    1777.0674  1807.1380  -180.0  3.62670  0.00   
+  4  1    1    -3   6502.3186  6211.6446  180.0   3.61292  0.00   
+  4  0    2    0    5737.3448  1737.1571  180.0   3.43004  0.00   
+  4  3    1    -1   2264.4085  1015.7401  -0.0    3.40758  0.00   
+  4  3    1    -2   6265.3398  3189.8450  180.0   3.40071  0.00   
+  4  0    2    1    5290.7372  5004.2608  -0.0    3.28468  0.00   
+  4  2    0    2    12124.6508 11585.2987 -0.0    3.21813  0.00   
+  4  2    0    -4   5237.1652  4999.3745  180.0   3.19515  0.00   
+  4  3    1    0    2321.8052  2137.9524  0.0     3.14425  0.00   
+  4  3    1    -3   2977.5078  2676.9934  180.0   3.12812  0.00   
+  4  4    0    -2   103112.3281 80975.7674 180.0   2.98514  0.01   
+  4  2    2    -1   97178.0296 75021.6217 -0.0    2.97414  0.02   
+  4  0    2    2    888.0953   792.4753   0.0     2.93924  0.00   
+  4  2    2    0    1642.7631  1808.6435  0.0     2.88066  0.00   
+  4  2    2    -2   479.3830   529.2778   -0.0    2.87512  0.00   
+  4  1    1    3    2200.4317  2483.8849  -0.0    2.86245  0.00   
+  4  1    1    -4   4989.8260  5798.6291  -0.0    2.85296  0.00   
+  4  0    0    4    8839.0016  10329.5453 -0.0    2.85105  0.00   
+  4  3    1    1    3529.3489  3753.1651  -180.0  2.75703  0.00   
+  4  3    1    -4   2977.1950  3264.5994  -0.0    2.73895  0.00   
+  4  4    0    0    75399.0416 71082.4735 0.0     2.65329  0.01   
+  4  2    2    1    146036.7218 132924.3238 0.0     2.64126  0.02   
+  4  2    2    -3   73375.4705 66256.8188 -180.0  2.63274  0.01   
+  4  4    0    -4   155469.1747 140708.2869 180.0   2.63610  0.01   
+  4  0    2    3    16772.0645 14172.9119 180.0   2.54660  0.00   
+  4  3    1    2    8574.8719  9771.0786  -180.0  2.37461  0.00   
+  4  3    1    -5   5065.7517  5863.2949  -0.0    2.35845  0.00   
+  4  2    2    2    132.4601   143.7186   -180.0  2.34690  0.00   
+  4  2    2    -4   911.6827   881.3280   180.0   2.33794  0.00   
+  4  1    1    4    3276.9810  2963.0551  -0.0    2.33480  0.00   
+  4  1    1    -5   387.6634   299.6422   -0.0    2.32818  0.00   
+  4  4    2    -2   1474.9584  1408.2385  -0.0    2.25179  0.00   
+  4  5    1    -2   2173.3716  2125.2391  180.0   2.24606  0.00   
+  4  5    1    -3   543.9069   539.7611   180.0   2.24278  0.00   
+  4  1    3    0    51.9214    52.4285    0.0     2.23539  0.00   
+  4  1    3    -1   4138.5890  4180.6260  -0.0    2.23475  0.00   
+  4  4    2    -1   887.1011   918.4883   0.0     2.21165  0.00   
+  4  4    2    -3   12230.3999 13302.5266 -0.0    2.20664  0.00   
+  4  0    2    4    829.2837   966.4675   180.0   2.19254  0.00   
+  4  5    1    -1   9843.7886  11528.3975 -0.0    2.16665  0.00   
+  4  1    3    1    786.4328   1030.9651  -0.0    2.15474  0.00   
+  4  1    3    -2   8290.5113  10961.7549 0.0     2.15300  0.00   
+  4  5    1    -4   552.1304   710.7068   -180.0  2.15784  0.00   
+  4  2    0    4    1390.8997  1630.6538  0.0     2.13629  0.00   
+  4  2    0    -6   6457.9704  7206.8043  0.0     2.12506  0.00   
+  4  4    2    0    553.3538   728.3764   -180.0  2.09868  0.00   
+  4  4    2    -4   429.1237   548.8985   -180.0  2.09014  0.00   
+  4  4    0    2    264681.7694 285788.8251 180.0   2.06997  0.01   
+  4  2    2    3    274228.0064 292603.8723 0.0     2.06220  0.02   
+  4  2    2    -5   271118.7453 297029.3238 0.0     2.05410  0.02   
+  4  4    0    -6   275838.4974 302463.3977 -180.0  2.05368  0.01   
+  4  3    1    3    988.5080   1080.9561  -180.0  2.04762  0.00   
+  4  3    1    -6   144.7722   154.7557   -0.0    2.03429  0.00   
+  4  5    1    0    707.6942   771.3638   180.0   2.02778  0.00   
+  4  1    3    2    12383.8018 14009.0017 -0.0    2.01610  0.00   
+  4  1    3    -3   1097.9996  1237.9441  -0.0    2.01373  0.00   
+  4  5    1    -5   12526.3244 14172.6029 -0.0    2.01578  0.00   
+  4  3    3    -1   8021.1242  7021.6149  -0.0    1.97598  0.00   
+  4  3    3    -2   215.1942   188.1236   0.0     1.97464  0.00   
+  4  1    1    5    4695.7447  4611.6517  180.0   1.96035  0.00   
+  4  6    0    -2   1029.9243  972.0328   180.0   1.96310  0.00   
+  4  1    1    -6   1550.1709  1560.8783  -0.0    1.95555  0.00   
+  4  6    0    -4   17239.2500 17289.1164 -180.0  1.95785  0.00   
+  4  4    2    1    20722.4417 20959.5475 -0.0    1.94249  0.00   
+  4  4    2    -5   70.9535    70.9719    180.0   1.93235  0.00   
+  4  3    3    0    9635.1539  9832.9281  180.0   1.92044  0.00   
+  4  3    3    -3   2750.1068  2769.1433  -0.0    1.91675  0.00   
+  4  0    0    6    1794.9120  1705.5770  -0.0    1.90070  0.00   
+  4  0    2    5    95.2273    90.1136    -180.0  1.89927  0.00   
+  4  5    1    1    3372.3313  2501.8974  -180.0  1.86097  0.00   
+  4  1    3    3    3743.9677  3420.8545  0.0     1.85046  0.00   
+  4  1    3    -4   541.7963   508.5661   -180.0  1.84789  0.00   
+  4  5    1    -6   3093.2000  2901.7349  -180.0  1.84800  0.00   
+  4  3    3    1    3239.3641  3294.5080  -0.0    1.82104  0.00   
+  4  3    3    -4   14605.0790 15075.0579 -180.0  1.81580  0.00   
+  4  2    2    4    1941.7987  2003.6984  180.0   1.81335  0.00   
+  4  2    2    -6   108.5120   110.8678   -0.0    1.80646  0.00   
+  4  3    1    4    1190.9602  1170.6904  -0.0    1.78161  0.00   
+  4  4    2    2    772.8460   569.7667   -0.0    1.77225  0.00   
+  4  3    1    -7   1044.3244  721.4003   -180.0  1.77086  0.00   
+  4  6    0    0    53796.1101 33144.7445 180.0   1.76886  0.00   
+  4  4    2    -6   3008.0688  1199.1369  -0.0    1.76200  0.00   
+  4  6    0    -6   5.3524     2.0494     0.0     1.75740  0.00   
+  4  6    2    -3   413369.1211 370342.6891 -180.0  1.72135  0.02   
+  4  0    4    0    379015.4442 348520.2203 -180.0  1.71502  0.01   
+  4  6    2    -2   490.2048   389.8445   -0.0    1.70379  0.00   
+  4  6    2    -4   2002.1968  1561.3298  180.0   1.70035  0.00   
+  4  0    4    1    4255.0563  3255.5368  -0.0    1.69595  0.00   
+  4  3    3    2    4699.8153  3597.9604  -0.0    1.69678  0.00   
+  4  3    3    -5   13038.4715 10533.0605 0.0     1.69085  0.00   
+  4  5    1    2    3188.9942  2567.5159  -180.0  1.69108  0.00   
+  4  1    1    6    890.5728   741.7087   -0.0    1.68462  0.00   
+  4  1    3    4    54.7200    44.8806    -0.0    1.68207  0.00   
+  4  1    1    -7   15254.4314 12425.2148 -180.0  1.68102  0.00   
+  4  1    3    -5   5788.0725  4677.9319  0.0     1.67959  0.00   
+  4  5    1    -7   330.3244   266.1178   -180.0  1.67858  0.00   
+  4  0    2    6    1083.2289  1003.3066  0.0     1.66251  0.00   
+  4  2    4    -1   2983.6471  2840.4331  180.0   1.64836  0.00   
+  4  6    2    -1   910.2792   866.2894   -180.0  1.65103  0.00   
+  4  7    1    -3   37.3349    35.5473    180.0   1.65196  0.00   
+  4  5    3    -2   353.7115   336.8182   -180.0  1.64796  0.00   
+  4  7    1    -4   587.0479   558.6115   -0.0    1.65013  0.00   
+  4  5    3    -3   1293.1472  1233.3662  -180.0  1.64667  0.00   
+  4  0    4    2    627.8563   610.8347   -180.0  1.64234  0.00   
+  4  6    2    -5   527.6174   505.9910   -180.0  1.64479  0.00   
+  4  2    4    0    728.4302   752.6524   -0.0    1.63191  0.00   
+  4  2    4    -2   4296.6452  4457.3392  180.0   1.63090  0.00   
+  4  7    1    -2   3583.3456  3576.7634  180.0   1.62008  0.00   
+  4  5    3    -1   1009.4543  966.7480   0.0     1.61582  0.00   
+  4  7    1    -5   965.7087   918.8077   -0.0    1.61492  0.00   
+  4  5    3    -4   4116.5734  3837.2028  -180.0  1.61215  0.00   
+  4  4    0    4    71498.3185 64363.4327 180.0   1.60907  0.00   
+  4  4    2    3    31.3016    27.4571    180.0   1.60723  0.00   
+  4  2    2    5    44180.1997 37113.4833 -180.0  1.60445  0.00   
+  4  2    2    -7   89232.3696 66526.2849 0.0     1.59872  0.00   
+  4  4    2    -7   3539.6985  2583.5958  -0.0    1.59767  0.00   
+  4  4    0    -8   50736.6981 36968.8690 0.0     1.59758  0.00   
+  4  2    4    1    2129.6286  1922.5667  0.0     1.58444  0.00   
+  4  2    4    -3   2025.8226  1874.8256  0.0     1.58260  0.00   
+  4  2    0    6    28376.1295 28884.2226 -0.0    1.57487  0.00   
+  4  6    2    0    309.6709   317.4820   -0.0    1.57212  0.00   
+  4  2    0    -8   4811.5358  4976.1849  -180.0  1.56856  0.00   
+  4  3    1    5    1678.7006  1737.5450  180.0   1.56754  0.00   
+  4  3    3    3    469.4194   484.1567   0.0     1.56460  0.00   
+  4  0    4    3    2830.7697  2912.7742  -0.0    1.56329  0.00   
+  4  6    2    -6   1211.9175  1248.6891  -180.0  1.56406  0.00   
+  4  3    3    -6   1465.8725  1492.6482  -180.0  1.55863  0.00   
+  4  3    1    -8   1824.2375  1859.5355  0.0     1.55889  0.00   
+  4  7    1    -1   1998.7490  2044.5361  -0.0    1.55994  0.00   
+  4  5    3    0    3754.7091  3762.4243  180.0   1.55570  0.00   
+  4  7    1    -6   3825.2341  3794.0712  -180.0  1.55228  0.00   
+  4  5    3    -5   1409.9730  1408.0138  0.0     1.55026  0.00   
+  4  5    1    3    1035.4118  786.9396   0.0     1.53215  0.00   
+  4  1    3    5    9.5090     7.4040     -180.0  1.52461  0.00   
+  4  1    3    -6   1497.2294  1154.7668  0.0     1.52235  0.00   
+  4  5    1    -8   6.9483     5.3528     0.0     1.52078  0.00   
+  4  2    4    2    5103.5108  4249.5793  180.0   1.51351  0.00   
+  4  2    4    -4   2880.7641  2485.6081  -0.0    1.51110  0.00   
+  4  6    0    2    9294.2357  8932.9238  -180.0  1.50545  0.00   
+  4  6    0    -8   4685.7213  4394.0447  -180.0  1.49370  0.00   
+  4  8    0    -4   21842.2696 20160.8586 0.0     1.49257  0.00   
+  4  4    4    -2   23779.1963 20480.1013 -0.0    1.48707  0.00   
+  4  7    1    0    604.2144   522.7716   0.0     1.48044  0.00   
+  4  6    2    1    585.2389   505.6757   180.0   1.47808  0.00   
+  4  5    3    1    1728.1722  1469.6671  180.0   1.47644  0.00   
+  4  4    4    -1   215.3184   180.4672   180.0   1.47533  0.00   
+  4  1    1    7    10913.6147 9073.7476  -0.0    1.47458  0.00   
+  4  4    4    -3   2017.4966  1669.1331  180.0   1.47384  0.00   
+  4  1    1    -8   8866.0177  7394.9747  0.0     1.47180  0.00   
+  4  0    2    7    2988.1627  2498.9699  180.0   1.47161  0.00   
+  4  0    4    4    663.7715   580.4637   180.0   1.46962  0.00   
+  4  5    3    -6   0.2067     0.1792     -180.0  1.46994  0.00   
+  4  7    1    -7   276.6434   232.5805   -180.0  1.47129  0.00   
+  4  6    2    -7   1226.8209  1086.2533  180.0   1.46915  0.00   
+  4  4    2    4    320.6998   308.8901   -180.0  1.45674  0.00   
+  4  4    2    -8   301.6949   302.8403   -180.0  1.44820  0.00   
+  4  8    0    -2   52083.0829 52363.8924 0.0     1.44673  0.00   
+  4  4    4    0    40843.8244 40392.3461 -180.0  1.44033  0.00   
+  4  8    0    -6   39821.0784 39567.5729 -180.0  1.44114  0.00   
+  4  4    4    -4   55708.2851 54113.8315 0.0     1.43756  0.00   
+  4  3    3    4    4820.4118  4615.5819  -180.0  1.43585  0.00   
+  4  2    2    6    0.8525     0.8040     -180.0  1.43122  0.00   
+  4  3    3    -7   1516.9921  1448.7554  0.0     1.43021  0.00   
+  4  2    4    3    2724.0225  2695.6766  180.0   1.42837  0.00   
+  4  2    2    -8   1772.2539  1820.4729  -0.0    1.42648  0.00   
+  4  2    4    -5   1609.3681  1670.8630  180.0   1.42567  0.00   
+  4  0    0    8    256429.0699 266624.8860 -0.0    1.42553  0.01   
+  4  3    1    6    1201.6634  937.5789   180.0   1.39446  0.00   
+  4  5    1    4    845.7377   766.3808   0.0     1.38986  0.00   
+  4  7    1    1    56.6412    50.2194    -180.0  1.39081  0.00   
+  4  3    1    -9   747.2248   708.4063   -0.0    1.38743  0.00   
+  4  4    4    1    3776.2768  3621.8553  -0.0    1.38673  0.00   
+  4  5    3    2    464.8886   442.5561   -180.0  1.38718  0.00   
+  4  1    3    6    3129.5576  3145.4290  0.0     1.38361  0.00   
+  4  4    4    -5   1207.8227  1224.0544  0.0     1.38303  0.00   
+  4  1    3    -7   470.7554   485.6557   -180.0  1.38162  0.00   
+  4  5    3    -7   1027.8538  1076.1332  180.0   1.38026  0.00   
+  4  7    1    -8   223.2558   231.7311   0.0     1.38107  0.00   
+  4  5    1    -9   3013.3707  3167.9679  -0.0    1.37983  0.00   
+  4  6    2    2    240.7691   255.5256   -180.0  1.37852  0.00   
+  4  0    4    5    389.9833   361.1834   -180.0  1.37075  0.00   
+  4  6    2    -8   3.2746     2.8431     0.0     1.36948  0.00   
+  4  8    2    -4   888.2208   740.2662   180.0   1.36861  0.00   
+  4  7    3    -3   4083.3492  3200.8854  -180.0  1.36535  0.00   
+  4  7    3    -4   577.0898   462.9328   -180.0  1.36431  0.00   
+  4  1    5    0    4901.2773  4364.7672  -180.0  1.36069  0.00   
+  4  1    5    -1   64.2333    57.2889    -0.0    1.36055  0.00   
+  4  8    2    -3   2151.7622  1925.6545  180.0   1.36003  0.00   
+  4  8    2    -5   15966.3431 14179.0382 180.0   1.35770  0.00   
+  4  7    3    -2   6823.3382  6976.5819  0.0     1.34718  0.00   
+  4  1    5    1    7680.2821  7425.4301  0.0     1.34187  0.00   
+  4  7    3    -5   2382.8045  2393.8480  180.0   1.34421  0.00   
+  4  1    5    -2   2925.7948  2797.4080  180.0   1.34145  0.00   
+  4  2    4    4    242.3340   204.6053   -180.0  1.33738  0.00   
+  4  2    4    -6   5029.3420  4273.0755  180.0   1.33461  0.00   
+  4  8    2    -2   215.7546   192.4880   0.0     1.33301  0.00   
+  4  8    2    -6   120.6620   116.9523   0.0     1.32863  0.00   
+  4  8    0    0    130793.8018 126800.3949 0.0     1.32665  0.00   
+  4  4    2    5    13190.5556 12801.5839 0.0     1.32369  0.00   
+  4  4    4    2    114896.5378 113771.8246 0.0     1.32063  0.00   
+  4  0    2    8    367.0640   368.1735   180.0   1.31637  0.00   
+  4  4    4    -6   120287.9779 120657.2769 0.0     1.31637  0.00   
+  4  3    3    5    1238.1794  1244.0810  -0.0    1.31652  0.00   
+  4  4    2    -9   5522.6755  5528.4059  180.0   1.31621  0.00   
+  4  8    0    -8   137948.1035 139513.1700 -0.0    1.31805  0.00   
+  4  3    3    -8   7888.5551  7099.8097  180.0   1.31138  0.00   
+  4  7    3    -1   1128.6862  1032.7529  180.0   1.31200  0.00   
+  4  1    1    8    181.0324   157.0017   180.0   1.30990  0.00   
+  4  1    1    -9   863.7340   715.2980   180.0   1.30769  0.00   
+  4  1    5    2    2137.5033  1735.0835  180.0   1.30631  0.00   
+  4  1    5    -3   9109.1290  7311.1267  -0.0    1.30567  0.00   
+  4  7    3    -6   9154.4025  7552.3208  -0.0    1.30744  0.00   
+  4  6    4    -3   2860.7915  2357.8645  -0.0    1.29916  0.00   
+  4  9    1    -4   1067.8198  842.7244   0.0     1.30105  0.00   
+  4  9    1    -5   318.3318   257.4524   0.0     1.29990  0.00   
+  4  7    1    2    4753.2969  3973.0463  -180.0  1.29855  0.00   
+  4  3    5    -1   758.5173   622.2524   0.0     1.29521  0.00   
+  4  3    5    -2   2684.3221  2189.8756  -0.0    1.29483  0.00   
+  4  5    3    3    408.0462   335.4555   180.0   1.29534  0.00   
+  4  6    4    -2   30.5354    25.6064    0.0     1.29156  0.00   
+  4  4    0    6    21102.8806 18442.5072 180.0   1.29035  0.00   
+  4  6    4    -4   8082.2950  7144.9543  -0.0    1.29006  0.00   
+  4  8    2    -1   10346.8016 8929.7467  180.0   1.29068  0.00   
+  4  5    3    -8   3685.6079  3487.9205  180.0   1.28845  0.00   
+  4  7    1    -9   143.2387   133.2598   180.0   1.28886  0.00   
+  4  2    2    7    16457.8495 16111.0142 -0.0    1.28747  0.00   
+  4  2    2    -9   19257.9613 19763.8670 0.0     1.28352  0.00   
+  4  8    2    -7   419.8460   430.4622   -180.0  1.28473  0.00   
+  4  9    1    -3   5427.5902  5518.4835  180.0   1.28555  0.00   
+  4  4    0    -10  20334.9619 20679.5221 -180.0  1.28244  0.00   
+  4  3    5    0    746.4336   721.1362   -0.0    1.27918  0.00   
+  4  9    1    -6   184.3724   187.0371   -0.0    1.28223  0.00   
+  4  6    2    3    0.3858     0.3799     180.0   1.28025  0.00   
+  4  3    5    -3   6362.3325  6042.5647  -0.0    1.27809  0.00   
+  4  0    4    6    122.9495   118.5712   180.0   1.27330  0.00   
+  4  6    2    -9   463.9838   465.9159   180.0   1.27156  0.00   
+  4  6    4    -1   440.9875   481.8034   -180.0  1.26812  0.00   
+  4  6    4    -5   568.2734   582.0359   -180.0  1.26528  0.00   
+  4  5    1    5    4517.6624  4608.3387  180.0   1.26517  0.00   
+  4  6    0    4    7021.8739  7258.6407  180.0   1.26554  0.00   
+  4  7    3    0    823.8732   802.9350   180.0   1.26364  0.00   
+  4  1    3    7    8266.9422  8415.8665  -0.0    1.25999  0.00   
+  4  1    5    3    33.2990    35.1951    180.0   1.25786  0.00   
+  4  1    3    -8   2939.8431  3095.2520  180.0   1.25825  0.00   
+  4  1    5    -4   2918.3365  3100.6595  180.0   1.25705  0.00   
+  4  7    3    -7   2297.1554  2426.3364  180.0   1.25793  0.00   
+  4  5    1    -10  6633.7744  7054.3026  -180.0  1.25644  0.00   
+  4  6    0    -10  111.0904   117.7386   180.0   1.25577  0.00   
+  4  3    1    7    1597.5722  1611.7435  -0.0    1.25300  0.00   
+  4  9    1    -2   344.5615   362.3661   0.0     1.25511  0.00   
+  4  3    5    1    8875.2529  8342.7401  0.0     1.24850  0.00   
+  4  4    4    3    17.4666    16.4758    0.0     1.24795  0.00   
+  4  9    1    -7   9263.7517  8756.2353  -180.0  1.24997  0.00   
+  4  3    5    -4   1144.4562  1092.6264  -0.0    1.24681  0.00   
+  4  3    1    -10  3145.4404  2988.6873  180.0   1.24721  0.00   
+  4  2    4    5    1202.5092  1150.4100  0.0     1.24664  0.00   
+  4  2    4    -7   806.6475   790.8449   0.0     1.24395  0.00   
+  4  4    4    -7   6670.1774  6544.6644  -0.0    1.24346  0.00   
+  4  2    0    8    28.5508    27.6700    -0.0    1.24152  0.00   
+  4  2    0    -10  2252.7656  2005.3801  180.0   1.23754  0.00   
+  4  8    2    0    828.4509   733.0590   180.0   1.23732  0.00   
+  4  6    4    0    15652.7425 14150.5162 -0.0    1.23130  0.00   
+  4  8    2    -8   666.8229   629.1269   180.0   1.23034  0.00   
+  4  6    4    -6   127.3967   129.7572   -180.0  1.22741  0.00   
+  4  9    1    -1   2961.2497  2740.8756  -0.0    1.21277  0.00   
+  4  3    3    6    902.9926   848.1601   0.0     1.20890  0.00   
+  4  4    2    6    441.2857   411.4999   -0.0    1.20772  0.00   
+  4  7    1    3    78.0874    73.2829    180.0   1.20869  0.00   
+  4  3    5    2    4046.4967  3743.5564  0.0     1.20620  0.00   
+  4  5    3    4    8136.0574  7528.8432  -180.0  1.20590  0.00   
+  4  7    3    1    2957.6236  2737.5316  180.0   1.20652  0.00   
+  4  3    5    -5   52.1531    48.8777    180.0   1.20407  0.00   
+  4  3    3    -9   1011.9324  945.5909   -0.0    1.20431  0.00   
+  4  9    1    -8   2515.6071  2327.4244  0.0     1.20630  0.00   
+  4  1    5    4    3947.0351  3936.6827  180.0   1.20088  0.00   
+  4  4    2    -10  166.8596   165.7584   -0.0    1.20122  0.00   
+  4  1    5    -5   656.8798   656.4639   0.0     1.19998  0.00   
+  4  7    3    -8   5.4520     5.4517     0.0     1.20014  0.00   
+  4  5    3    -9   302.8783   300.8910   180.0   1.19933  0.00   
+  4  7    1    -10  8354.5860  8313.3744  -180.0  1.19946  0.00   
+  4  0    2    9    359.6482   269.4603   -0.0    1.18862  0.00   
+  4  5    5    -2   4010.1566  3026.7927  -0.0    1.18828  0.00   
+  4  5    5    -3   0.1308     0.1003     -0.0    1.18780  0.00   
+  4  6    2    4    342.2807   267.8752   180.0   1.18731  0.00   
+  4  10   0    -4   9074.1219  6809.0115  0.0     1.18854  0.00   
+  4  10   0    -6   13704.7010 11123.4673 0.0     1.18659  0.00   
+  4  6    4    1    1470.2460  1319.9528  0.0     1.18452  0.00   
+  4  0    4    7    294.7408   286.2811   180.0   1.18118  0.00   
+  4  6    4    -7   1807.3287  1788.2732  0.0     1.17991  0.00   
+  4  6    2    -10  2.2199     2.2157     -0.0    1.17922  0.00   
+  4  1    1    9    120.5790   122.6216   -0.0    1.17762  0.00   
+  4  8    0    2    30992.8375 31222.7748 180.0   1.17842  0.00   
+  4  5    5    -1   7070.1500  7318.5371  -180.0  1.17606  0.00   
+  4  1    1    -10  735.4264   763.0185   180.0   1.17582  0.00   
+  4  8    2    1    5714.9750  5832.5257  -180.0  1.17732  0.00   
+  4  5    5    -4   5308.0393  5562.6575  -0.0    1.17465  0.00   
+  4  4    4    4    32011.4836 33768.6937 0.0     1.17345  0.00   
+  4  4    4    -8   27305.0420 28608.1528 -180.0  1.16897  0.00   
+  4  8    2    -9   8017.6019  8433.5515  180.0   1.16981  0.00   
+  4  8    0    -10  36506.9257 38318.7221 0.0     1.16940  0.00   
+  4  2    2    8    97.3650    100.3659   0.0     1.16740  0.00   
+  4  2    2    -10  597.0314   559.6903   -0.0    1.16409  0.00   
+  4  2    4    6    15991.4856 13773.5602 180.0   1.15999  0.00   
+  4  9    1    0    198.8338   175.9916   180.0   1.16219  0.00   
+  4  2    4    -8   2736.9279  2416.2326  0.0     1.15746  0.00   
+  4  3    5    3    3476.3748  3131.8290  0.0     1.15587  0.00   
+  4  5    1    6    56.6873    50.4438    0.0     1.15687  0.00   
+  4  3    5    -6   57.2533    51.7225    -0.0    1.15345  0.00   
+  4  9    1    -9   625.0191   566.6209   180.0   1.15488  0.00   
+  4  1    3    8    3085.5013  2760.3092  0.0     1.15255  0.00   
+  4  5    5    0    7481.1427  6664.3182  -0.0    1.15226  0.00   
+  4  1    3    -9   1.5182     1.3292     -0.0    1.15104  0.00   
+  4  5    5    -5   9806.0630  8512.5139  -180.0  1.15005  0.00   
+  4  5    1    -11  1748.7232  1515.0727  0.0     1.14930  0.00   
+  4  9    3    -4   462.9012   427.5713   0.0     1.14651  0.00   
+  4  0    6    0    2592.0627  2607.2585  -0.0    1.14335  0.00   
+  4  9    3    -5   68.5806    64.9887    -0.0    1.14572  0.00   
+  4  7    3    2    5020.5261  4898.3011  -0.0    1.14479  0.00   
+  4  0    0    10   419.9997   423.9774   -0.0    1.14042  0.00   
+  4  1    5    5    5077.4998  5040.6794  -0.0    1.13946  0.00   
+  4  10   0    -2   15727.7268 16012.7283 0.0     1.14177  0.00   
+  4  1    5    -6   5462.6834  5306.9420  180.0   1.13852  0.00   
+  4  0    6    1    1734.8693  1646.7726  180.0   1.13764  0.00   
+  4  7    3    -9   4852.9692  4669.6471  180.0   1.13814  0.00   
+  4  3    1    8    75.6532    68.5267    180.0   1.13593  0.00   
+  4  10   0    -8   1575.9502  1452.6450  0.0     1.13661  0.00   
+  4  9    3    -3   1578.2628  1427.5891  -180.0  1.13586  0.00   
+  4  9    3    -6   2069.7480  1858.5777  -0.0    1.13357  0.00   
+  4  3    1    -11  35.8201    30.9624    0.0     1.13111  0.00   
+  4  6    4    2    3247.8384  2825.7667  0.0     1.13139  0.00   
+  4  6    4    -8   2501.5534  2099.7238  -0.0    1.12638  0.00   
+  4  10   2    -5   7770.0919  6286.6782  0.0     1.12768  0.00   
+  4  8    4    -4   4854.9734  4165.8140  -180.0  1.12590  0.00   
+  4  2    6    -1   3615.7779  3553.5119  180.0   1.12294  0.00   
+  4  7    1    4    5199.2406  4924.4150  -0.0    1.12414  0.00   
+  4  0    6    2    1432.4573  1374.7221  -180.0  1.12103  0.00   
+  4  5    3    5    2008.0482  1968.1837  -180.0  1.12173  0.00   
+  4  10   2    -4   9.2192     9.0481     180.0   1.12303  0.00   
+  4  8    4    -3   3452.5094  3322.1983  -180.0  1.12110  0.00   
+  4  10   2    -6   177.5370   172.5017   180.0   1.12139  0.00   
+  4  5    5    1    772.5602   710.7095   0.0     1.11892  0.00   
+  4  8    4    -5   1119.6182  1032.2344  180.0   1.11980  0.00   
+  4  2    6    0    5688.7351  5313.5186  180.0   1.11770  0.00   
+  4  2    6    -2   1060.1420  992.1704   180.0   1.11737  0.00   
+  4  5    5    -6   2702.6929  2504.3983  0.0     1.11609  0.00   
+  4  5    3    -10  1734.2921  1596.9973  -0.0    1.11563  0.00   
+  4  7    1    -11  2267.4792  2086.4076  180.0   1.11558  0.00   
+  4  3    3    7    8107.6030  7157.0451  0.0     1.11322  0.00   
+  4  9    3    -2   2226.6826  2020.9809  0.0     1.11470  0.00   
+  4  8    2    2    133.5257   120.6943   0.0     1.11448  0.00   
+  4  9    3    -7   1981.9637  1753.9793  -180.0  1.11109  0.00   
+  4  3    3    -10  291.5190   264.2352   -0.0    1.10916  0.00   
+  4  4    2    7    10076.0737 9258.4011  0.0     1.10712  0.00   
+  4  8    2    -10  39.7986    36.6125    0.0     1.10685  0.00   
+  4  10   2    -3   38397.3076 35175.3194 -180.0  1.10783  0.00   
+  4  9    1    1    4140.5653  3808.5155  -180.0  1.10688  0.00   
+  4  8    4    -2   31816.0280 29365.9440 -180.0  1.10582  0.00   
+  4  2    6    1    29389.7952 27603.3788 -180.0  1.10209  0.00   
+  4  10   2    -7   37811.9626 35007.4599 0.0     1.10469  0.00   
+  4  8    4    -6   32313.2129 30157.9471 0.0     1.10332  0.00   
+  4  2    6    -3   31675.8569 29876.5059 0.0     1.10147  0.00   
+  4  4    2    -11  2305.6237  2174.2563  -0.0    1.10149  0.00   
+  4  3    5    4    74.2073    70.2503    0.0     1.10094  0.00   
+  4  6    2    5    140193.1855 132083.1961 -180.0  1.10162  0.00   
+  4  4    4    5    2837.6823  2695.5379  180.0   1.10049  0.00   
+  4  3    5    -7   3043.3871  2935.8897  0.0     1.09840  0.00   
+  4  9    1    -10  292.0263   280.6925   0.0     1.09916  0.00   
+  4  0    4    8    142072.5409 133810.4963 -180.0  1.09627  0.00   
+  4  4    4    -9   142.7539   134.0615   0.0     1.09618  0.00   
+  4  0    6    3    3805.7058  3394.6812  -0.0    1.09489  0.00   
+  4  6    2    -11  173308.4284 149954.2083 -180.0  1.09424  0.01   
+  4  9    3    -1   1237.5389  1114.9345  0.0     1.08472  0.00   
+  4  0    2    10   129.5720   133.7463   0.0     1.08217  0.00   
+  4  10   2    -2   901.4906   880.0363   -0.0    1.08332  0.00   
+  4  7    3    3    5702.4030  5992.6594  180.0   1.08180  0.00   
+  4  8    4    -1   6.0602     6.5257     0.0     1.08130  0.00   
+  4  2    4    7    117.5697   143.3075   180.0   1.07941  0.00   
+  4  9    3    -8   14.6512    16.9764    180.0   1.08008  0.00   
+  4  5    5    2    4041.5849  5303.2273  0.0     1.07854  0.00   
+  4  2    6    2    327.0398   478.4922   0.0     1.07737  0.00   
+  4  2    4    -9   870.4928   1302.6387  -180.0  1.07708  0.00   
+  4  1    5    6    4933.2676  7487.6933  180.0   1.07686  0.00   
+  4  2    6    -4   2044.1713  3157.1192  -0.0    1.07650  0.00   
+  4  10   2    -8   238.2231   302.2474   0.0     1.07892  0.00   
+  4  8    4    -7   628.9331   885.9347   -0.0    1.07779  0.00   
+  4  1    5    -7   7135.1893  11179.0961 0.0     1.07592  0.00   
+  4  5    5    -7   10.5082    16.4924    0.0     1.07528  0.00   
+  4  6    4    3    968.0858   1517.8392  -180.0  1.07514  0.00   
+  4  7    3    -10  7831.9758  12282.4680 0.0     1.07517  0.00   
+  4  6    0    6    624.5227   878.8629   180.0   1.07271  0.00   
+  4  6    4    -9   588.3110   818.1178   -180.0  1.06998  0.00   
+  4  1    1    10   1818.1429  2599.2609  -180.0  1.06919  0.00   
+  4  11   1    -5   116.7797   157.2990   180.0   1.07138  0.00   
+  4  11   1    -6   4.1780     5.7019     -180.0  1.07059  0.00   
+  4  4    6    -2   1743.7980  2486.6852  -180.0  1.06771  0.00   
+  4  1    1    -11  29.5496    42.1348    0.0     1.06771  0.00   
+  4  7    5    -3   923.4307   1330.6239  -180.0  1.06818  0.00   
+  4  4    0    8    16336.2359 23528.0251 -0.0    1.06815  0.00   
+  4  7    5    -4   118.2972   168.5700   180.0   1.06768  0.00   
+  4  2    2    9    18091.0749 24375.6868 -0.0    1.06623  0.00   
+  4  6    0    -12  2276.5103  2937.0054  -180.0  1.06505  0.00   
+  4  4    6    -1   1.6727     2.0175     -0.0    1.06334  0.00   
+  4  2    2    -11  17379.6391 21012.4971 -180.0  1.06342  0.00   
+  4  4    6    -3   2369.6453  2823.1169  180.0   1.06278  0.00   
+  4  4    0    -12  23836.1011 28292.0837 -180.0  1.06253  0.00   
+  4  5    1    7    2728.5531  3262.8752  0.0     1.06298  0.00   
+  4  0    6    4    1418.3046  1669.4504  0.0     1.06119  0.00   
+  4  11   1    -4   4298.8474  5124.0743  0.0     1.06281  0.00   
+  4  1    3    9    1362.0070  1610.0884  0.0     1.05935  0.00   
+  4  10   0    0    697.3963   820.9631   0.0     1.06132  0.00   
+  4  7    5    -2   1.3851     1.6376     -0.0    1.05941  0.00   
+  4  11   1    -7   56.2778    66.3589    -180.0  1.06052  0.00   
+  4  1    3    -10  2022.3025  2357.2538  0.0     1.05804  0.00   
+  4  7    5    -5   3337.0061  3884.8061  -180.0  1.05797  0.00   
+  4  5    1    -12  1847.6239  2096.7871  -180.0  1.05642  0.00   
+  4  10   0    -10  4117.4741  4668.9149  0.0     1.05444  0.00   
+  4  4    6    0    1529.6660  1589.3411  0.0     1.05001  0.00   
+  4  8    2    3    20354.9023 22554.2584 180.0   1.05168  0.00   
+  4  10   2    -1   52875.4219 57998.0764 0.0     1.05132  0.00   
+  4  4    6    -4   1185.8457  1169.3238  0.0     1.04893  0.00   
+  4  8    4    0    61815.8255 62135.0799 -180.0  1.04934  0.00   
+  4  9    1    2    129.1196   132.5963   -0.0    1.04977  0.00   
+  4  9    3    0    2471.6869  2357.4816  0.0     1.04808  0.00   
+  4  2    6    3    60794.4302 55791.9290 -180.0  1.04535  0.00   
+  4  7    1    5    1107.1857  1023.6228  0.0     1.04625  0.00   
+  4  2    6    -5   61906.5674 56117.4536 -180.0  1.04429  0.00   
+  4  3    5    5    4014.6009  3639.8966  -0.0    1.04431  0.00   
+  4  10   2    -9   73068.8925 67415.9583 0.0     1.04597  0.00   
+  4  8    4    -8   73901.6887 67615.2048 -180.0  1.04507  0.00   
+  4  5    3    6    1545.4143  1399.1370  -180.0  1.04417  0.00   
+  4  8    2    -11  5.3763     4.8686     0.0     1.04420  0.00   
+  4  11   1    -3   29.9118    27.5035    180.0   1.04555  0.00   
+  4  3    5    -8   426.5411   381.8895   -0.0    1.04174  0.00   
+  4  7    5    -1   5203.4874  4651.8504  -180.0  1.04205  0.00   
+  4  9    3    -9   551.4426   493.6091   -180.0  1.04271  0.00   
+  4  9    1    -11  5541.8624  4955.0317  180.0   1.04200  0.00   
+  4  11   1    -8   5981.4500  5349.6895  0.0     1.04191  0.00   
+  4  7    5    -6   22.1617    20.5772    180.0   1.03976  0.00   
+  4  5    3    -11  171.6355   166.7886   -0.0    1.03860  0.00   
+  4  7    1    -12  576.0771   564.9314   -180.0  1.03842  0.00   
+  4  3    1    9    969.8708   983.5490   -180.0  1.03783  0.00   
+_reflns_number_total  1184
+_reflns_d_resolution_low    6.388
+_reflns_d_resolution_high   1.033
+
+# POWDER DATA TABLE
+_pd_meas_2theta_range_min  10.01313
+_pd_meas_2theta_range_max  119.99238
+_pd_meas_2theta_range_inc  0.02626
+_pd_proc_2theta_range_min  9.98829
+_pd_proc_2theta_range_max  119.96754
+_pd_proc_2theta_range_inc  0.02626
+_pd_proc_number_of_points  4189
+
+loop_
+   _pd_meas_intensity_total
+   _pd_calc_intensity_total
+   _pd_proc_intensity_bkg_calc
+   _pd_proc_ls_weight
+  2695         0            0           0         
+  2699         0            0           0         
+  2711         0            0           0         
+  2682         0            0           0         
+  2674         0            0           0         
+  2701         0            0           0         
+  2743         0            0           0         
+  2521         0            0           0         
+  2698         0            0           0         
+  2664         0            0           0         
+  2681         0            0           0         
+  2637         0            0           0         
+  2644         0            0           0         
+  2597         0            0           0         
+  2569         0            0           0         
+  2594         0            0           0         
+  2562         0            0           0         
+  2609         0            0           0         
+  2529         0            0           0         
+  2557         0            0           0         
+  2570         0            0           0         
+  2564         0            0           0         
+  2571         0            0           0         
+  2460         0            0           0         
+  2519         0            0           0         
+  2612         0            0           0         
+  2602         0            0           0         
+  2501         0            0           0         
+  2460         0            0           0         
+  2492         0            0           0         
+  2457         0            0           0         
+  2537         0            0           0         
+  2505         0            0           0         
+  2401         0            0           0         
+  2499         0            0           0         
+  2500         0            0           0         
+  2462         0            0           0         
+  2426         0            0           0         
+  2387         0            0           0         
+  2484         0            0           0         
+  2421         0            0           0         
+  2512         0            0           0         
+  2451         0            0           0         
+  2385         0            0           0         
+  2478         0            0           0         
+  2377         0            0           0         
+  2404         0            0           0         
+  2352         0            0           0         
+  2341         0            0           0         
+  2372         0            0           0         
+  2440         0            0           0         
+  2312         0            0           0         
+  2375         0            0           0         
+  2425         0            0           0         
+  2366         0            0           0         
+  2426         0            0           0         
+  2294         0            0           0         
+  2322         0            0           0         
+  2355         0            0           0         
+  2304         0            0           0         
+  2261         0            0           0         
+  2289         0            0           0         
+  2214         0            0           0         
+  2248         0            0           0         
+  2296         0            0           0         
+  2295         0            0           0         
+  2211         0            0           0         
+  2198         0            0           0         
+  2298         0            0           0         
+  2197         0            0           0         
+  2215         0            0           0         
+  2272         0            0           0         
+  2296         0            0           0         
+  2289         0            0           0         
+  2192         0            0           0         
+  2241         0            0           0         
+  2260         0            0           0         
+  2331         0            0           0         
+  2267         0            0           0         
+  2197         0            0           0         
+  2217         0            0           0         
+  2279         0            0           0         
+  2136         0            0           0         
+  2216         0            0           0         
+  2186         0            0           0         
+  2145         0            0           0         
+  2211         0            0           0         
+  2205         0            0           0         
+  2156         0            0           0         
+  2167         0            0           0         
+  2163         0            0           0         
+  2147         0            0           0         
+  2142         0            0           0         
+  2166         0            0           0         
+  2139         0            0           0         
+  2145         0            0           0         
+  2103         0            0           0         
+  2091         0            0           0         
+  2017         0            0           0         
+  2095         0            0           0         
+  2104         0            0           0         
+  2138         0            0           0         
+  2105         0            0           0         
+  2103         0            0           0         
+  2090         0            0           0         
+  2137         0            0           0         
+  2112         0            0           0         
+  1972         0            0           0         
+  2172         0            0           0         
+  2011         0            0           0         
+  2005         0            0           0         
+  2054         0            0           0         
+  2035         0            0           0         
+  1969         0            0           0         
+  1948         0            0           0         
+  2041         0            0           0         
+  1992         0            0           0         
+  2055         0            0           0         
+  2016         0            0           0         
+  1965         0            0           0         
+  2056         0            0           0         
+  1997         0            0           0         
+  1899         0            0           0         
+  1972         0            0           0         
+  1990         0            0           0         
+  1978         0            0           0         
+  1975         0            0           0         
+  1964         0            0           0         
+  1912         0            0           0         
+  1954         0            0           0         
+  1960         0            0           0         
+  1833         0            0           0         
+  1896         0            0           0         
+  1931         0            0           0         
+  1965         0            0           0         
+  1933         0            0           0         
+  1964         0            0           0         
+  1950         0            0           0         
+  1901         0            0           0         
+  1952         0            0           0         
+  1846         0            0           0         
+  1927         0            0           0         
+  1900         0            0           0         
+  1883         0            0           0         
+  1880         0            0           0         
+  1926         0            0           0         
+  1932         0            0           0         
+  1895         0            0           0         
+  1869         0            0           0         
+  1840         0            0           0         
+  1851         0            0           0         
+  1818         0            0           0         
+  1789         0            0           0         
+  1834         0            0           0         
+  1871         0            0           0         
+  1840         0            0           0         
+  1813         0            0           0         
+  1811         0            0           0         
+  1786         0            0           0         
+  1876         0            0           0         
+  1742         0            0           0         
+  1761         0            0           0         
+  1796         0            0           0         
+  1880         0            0           0         
+  1741         0            0           0         
+  1790         0            0           0         
+  1718         0            0           0         
+  1815         0            0           0         
+  1783         0            0           0         
+  1780         0            0           0         
+  1711         0            0           0         
+  1784         0            0           0         
+  1784         0            0           0         
+  1875         0            0           0         
+  1759         0            0           0         
+  1763         0            0           0         
+  1684         0            0           0         
+  1735         0            0           0         
+  1777         0            0           0         
+  1755         0            0           0         
+  1764         0            0           0         
+  1710         1699.64338   1699.08492  0.000584795 
+  1703         1696.25017   1695.67625  0.000587199 
+  1731         1692.86407   1692.27424  0.000577701 
+  1675         1689.48567   1688.87887  0.000597015 
+  1681         1686.1148    1685.49015  0.000594884 
+  1690         1682.75139   1682.10804  0.000591716 
+  1721         1679.39568   1678.73255  0.000581058 
+  1745         1676.04777   1675.36367  0.000573066 
+  1694         1672.70774   1672.00137  0.000590319 
+  1773         1669.37571   1668.64566  0.000564016 
+  1682         1666.05182   1665.29652  0.00059453 
+  1606         1662.73619   1661.95394  0.000622665 
+  1630         1659.42901   1658.61791  0.000613497 
+  1651         1656.13047   1655.28842  0.000605694 
+  1680         1652.84078   1651.96546  0.000595238 
+  1691         1649.56021   1648.64901  0.000591366 
+  1669         1646.28906   1645.33907  0.000599161 
+  1713         1643.02767   1642.03563  0.000583771 
+  1668         1639.77646   1638.73867  0.00059952 
+  1668         1636.53591   1635.44819  0.00059952 
+  1735         1633.3066    1632.16417  0.000576369 
+  1603         1630.08921   1628.88661  0.00062383 
+  1654         1626.88457   1625.61549  0.000604595 
+  1609         1623.69368   1622.3508   0.000621504 
+  1560         1620.51777   1619.09253  0.000641026 
+  1652         1617.35834   1615.84068  0.000605327 
+  1659         1614.21728   1612.59522  0.000602773 
+  1588         1611.09698   1609.35616  0.000629723 
+  1661         1608.00049   1606.12348  0.000602047 
+  1578         1604.9318    1602.89716  0.000633714 
+  1659         1601.89622   1599.67721  0.000602773 
+  1657         1598.90097   1596.4636   0.0006035 
+  1622         1595.95616   1593.25633  0.000616523 
+  1628         1593.07653   1590.05539  0.000614251 
+  1560         1590.28461   1586.86076  0.000641026 
+  1583         1587.61759   1583.67245  0.000631712 
+  1554         1585.14207   1580.49043  0.000643501 
+  1645         1582.98063   1577.31469  0.000607903 
+  1630         1581.33474   1574.14523  0.000613497 
+  1552         1580.34818   1570.98204  0.00064433 
+  1685         1579.81428   1567.8251   0.000593472 
+  1640         1580.04446   1564.6744   0.000609756 
+  1552         1581.27033   1561.52994  0.00064433 
+  1594         1582.97993   1558.3917   0.000627353 
+  1646         1586.51106   1555.25968  0.000607533 
+  1630         1592.04594   1552.13386  0.000613497 
+  1554         1596.84405   1549.01423  0.000643501 
+  1569         1606.19627   1545.90078  0.000637349 
+  1680         1618.93519   1542.79351  0.000595238 
+  1599         1630.53913   1539.6924   0.000625391 
+  1679         1638.99683   1536.59744  0.000595593 
+  1717         1631.7816    1533.50863  0.000582411 
+  1610         1611.68353   1530.42594  0.000621118 
+  1582         1589.44511   1527.34938  0.000632111 
+  1591         1573.31218   1524.27893  0.000628536 
+  1608         1562.67856   1521.21458  0.000621891 
+  1561         1553.44458   1518.15632  0.000640615 
+  1639         1545.77853   1515.10414  0.000610128 
+  1517         1539.89104   1512.05803  0.000659196 
+  1559         1534.1303    1509.01798  0.000641437 
+  1605         1526.37839   1505.98398  0.000623053 
+  1463         1518.02242   1502.95603  0.000683527 
+  1519         1510.75402   1499.9341   0.000658328 
+  1501         1505.08251   1496.91819  0.000666223 
+  1500         1500.47829   1493.9083   0.000666667 
+  1598         1496.46445   1490.9044   0.000625782 
+  1551         1492.78311   1487.90649  0.000644745 
+  1518         1489.30542   1484.91457  0.000658762 
+  1525         1485.96385   1481.92861  0.000655738 
+  1532         1482.71957   1478.94862  0.000652742 
+  1466         1479.54854   1475.97457  0.000682128 
+  1484         1476.43505   1473.00647  0.000673854 
+  1467         1473.36851   1470.0443   0.000681663 
+  1463         1470.34162   1467.08804  0.000683527 
+  1496         1467.34928   1464.1377   0.000668449 
+  1505         1464.38795   1461.19326  0.000664452 
+  1396         1461.45524   1458.25471  0.000716332 
+  1481         1458.54965   1455.32204  0.000675219 
+  1510         1455.67045   1452.39524  0.000662252 
+  1534         1452.81755   1449.4743   0.00065189 
+  1515         1449.99155   1446.55921  0.000660066 
+  1463         1447.20952   1443.64997  0.000683527 
+  1396         1444.44223   1440.74655  0.000716332 
+  1420         1441.71652   1437.84896  0.000704225 
+  1477         1439.02168   1434.95718  0.000677048 
+  1507         1436.37317   1432.0712   0.00066357 
+  1494         1433.78352   1429.19102  0.000669344 
+  1522         1431.27496   1426.31661  0.00065703 
+  1452         1428.88805   1423.44799  0.000688705 
+  1437         1426.68807   1420.58512  0.000695894 
+  1414         1424.72971   1417.72801  0.000707214 
+  1493         1422.85608   1414.87664  0.000669792 
+  1406         1421.18256   1412.03101  0.000711238 
+  1395         1420.02061   1409.1911   0.000716846 
+  1376         1419.19378   1406.3569   0.000726744 
+  1475         1418.40078   1403.52841  0.000677966 
+  1451         1418.39895   1400.70562  0.00068918 
+  1462         1419.04747   1397.88851  0.000683995 
+  1417         1420.17466   1395.07708  0.000705716 
+  1455         1421.70819   1392.27131  0.000687285 
+  1447         1421.36095   1389.47121  0.000691085 
+  1383         1417.0314    1386.67675  0.000723066 
+  1397         1410.42431   1383.88793  0.00071582 
+  1415         1404.40371   1381.10473  0.000706714 
+  1382         1400.45553   1378.32716  0.000723589 
+  1458         1398.29466   1375.55519  0.000685871 
+  1473         1397.34522   1372.78883  0.000678887 
+  1413         1397.28665   1370.02805  0.000707714 
+  1339         1397.96577   1367.27286  0.000746826 
+  1324         1399.25378   1364.52324  0.000755287 
+  1358         1400.94356   1361.77918  0.000736377 
+  1421         1402.69119   1359.04067  0.00070373 
+  1411         1404.01725   1356.30771  0.000708717 
+  1372         1404.38088   1353.58027  0.000728863 
+  1316         1403.41086   1350.85837  0.000759878 
+  1379         1401.04      1348.14198  0.000725163 
+  1441         1397.50972   1345.43109  0.000693963 
+  1395         1393.2225    1342.7257   0.000716846 
+  1399         1388.52002   1340.0258   0.000714796 
+  1323         1383.56102   1337.33137  0.000755858 
+  1414         1378.31308   1334.64241  0.000707214 
+  1378         1372.69752   1331.95891  0.000725689 
+  1375         1366.71046   1329.28086  0.000727273 
+  1395         1360.48732   1326.60825  0.000716846 
+  1396         1354.24703   1323.94107  0.000716332 
+  1386         1348.20819   1321.27931  0.000721501 
+  1437         1342.53281   1318.62297  0.000695894 
+  1371         1337.32033   1315.97202  0.000729395 
+  1354         1332.6348    1313.32647  0.000738552 
+  1301         1328.52038   1310.68631  0.00076864 
+  1296         1324.89379   1308.05152  0.000771605 
+  1338         1321.64626   1305.4221   0.000747384 
+  1366         1319.05266   1302.79803  0.000732064 
+  1284         1317.07945   1300.17931  0.000778816 
+  1369         1315.30049   1297.56593  0.00073046 
+  1321         1314.35589   1294.95788  0.000757002 
+  1338         1314.13389   1292.35514  0.000747384 
+  1374         1314.42697   1289.75772  0.000727802 
+  1319         1314.94325   1287.16561  0.00075815 
+  1298         1312.96045   1284.57878  0.000770416 
+  1292         1306.74181   1281.99724  0.000773994 
+  1251         1298.461     1279.42097  0.000799361 
+  1318         1290.68749   1276.84997  0.000758725 
+  1271         1284.74291   1274.28422  0.000786782 
+  1313         1280.22951   1271.72372  0.000761615 
+  1189         1276.50666   1269.16846  0.000841043 
+  1355         1273.20648   1266.61843  0.000738007 
+  1258         1270.14959   1264.07362  0.000794913 
+  1284         1267.24819   1261.53402  0.000778816 
+  1223         1264.45574   1258.99963  0.000817661 
+  1277         1261.74559   1256.47042  0.000783085 
+  1253         1259.10174   1253.9464   0.000798085 
+  1278         1256.5144    1251.42756  0.000782473 
+  1313         1253.97783   1248.91388  0.000761615 
+  1289         1251.48897   1246.40536  0.000775795 
+  1228         1249.0468    1243.90199  0.000814332 
+  1284         1246.66256   1241.40376  0.000778816 
+  1258         1244.31739   1238.91066  0.000794913 
+  1274         1242.02547   1236.42268  0.000784929 
+  1241         1239.79749   1233.93981  0.000805802 
+  1212         1237.63003   1231.46205  0.000825083 
+  1246         1235.53766   1228.98938  0.000802568 
+  1229         1233.53231   1226.5218   0.00081367 
+  1230         1231.62881   1224.0593   0.000813008 
+  1217         1229.84554   1221.60187  0.000821693 
+  1244         1228.20486   1219.14949  0.000803859 
+  1261         1226.73315   1216.70217  0.000793021 
+  1213         1225.46026   1214.25989  0.000824402 
+  1131         1224.41803   1211.82264  0.000884173 
+  1171         1223.63702   1209.39042  0.000853971 
+  1193         1223.13792   1206.96321  0.000838223 
+  1176         1222.92768   1204.54102  0.00085034 
+  1258         1222.98496   1202.12382  0.000794913 
+  1184         1223.24385   1199.71161  0.000844595 
+  1141         1223.56472   1197.30438  0.000876424 
+  1186         1223.7062    1194.90212  0.00084317 
+  1206         1223.32534   1192.50483  0.000829187 
+  1204         1222.05139   1190.11249  0.000830565 
+  1193         1219.62636   1187.7251   0.000838223 
+  1139         1216.02944   1185.34265  0.000877963 
+  1145         1211.48977   1182.96512  0.000873362 
+  1141         1206.38176   1180.59252  0.000876424 
+  1162         1201.08252   1178.22483  0.000860585 
+  1271         1195.87614   1175.86204  0.000786782 
+  1188         1190.9315    1173.50415  0.000841751 
+  1134         1186.30833   1171.15114  0.000881834 
+  1181         1182.01801   1168.80301  0.00084674 
+  1142         1178.03062   1166.45975  0.000875657 
+  1197         1174.30933   1164.12136  0.000835422 
+  1175         1170.81664   1161.78781  0.000851064 
+  1189         1167.51029   1159.45911  0.000841043 
+  1124         1164.36884   1157.13524  0.00088968 
+  1204         1161.34948   1154.8162   0.000830565 
+  1140         1158.44156   1152.50197  0.000877193 
+  1106         1155.62038   1150.19256  0.000904159 
+  1161         1152.87474   1147.88795  0.000861326 
+  1134         1150.19286   1145.58812  0.000881834 
+  1128         1147.56514   1143.29309  0.000886525 
+  1233         1144.98383   1141.00283  0.00081103 
+  1134         1142.44257   1138.71734  0.000881834 
+  1114         1139.93614   1136.4366   0.000897666 
+  1167         1137.46025   1134.16062  0.000856898 
+  1130         1135.01135   1131.88938  0.000884956 
+  1166         1132.58646   1129.62287  0.000857633 
+  1184         1130.1831    1127.36109  0.000844595 
+  1151         1127.79918   1125.10403  0.00086881 
+  1123         1125.43293   1122.85167  0.000890472 
+  1119         1123.08285   1120.60402  0.000893655 
+  1162         1120.74766   1118.36106  0.000860585 
+  1116         1118.42627   1116.12278  0.000896057 
+  1122         1116.11775   1113.88917  0.000891266 
+  1079         1113.82127   1111.66024  0.000926784 
+  1131         1111.53614   1109.43596  0.000884173 
+  1144         1109.26177   1107.21634  0.000874126 
+  1092         1106.99763   1105.00135  0.000915751 
+  1120         1104.74327   1102.791    0.000892857 
+  1084         1102.49831   1100.58528  0.000922509 
+  1123         1100.26241   1098.38418  0.000890472 
+  1083         1098.03528   1096.18768  0.000923361 
+  1134         1095.81668   1093.99579  0.000881834 
+  1006         1093.6064    1091.80849  0.000994036 
+  1123         1091.40426   1089.62577  0.000890472 
+  1023         1089.21013   1087.44763  0.000977517 
+  1119         1087.0239    1085.27406  0.000893655 
+  1103         1084.84547   1083.10506  0.000906618 
+  1068         1082.67479   1080.9406   0.00093633 
+  1079         1080.51184   1078.78069  0.000926784 
+  1087         1078.3566    1076.62531  0.000919963 
+  1050         1076.20909   1074.47447  0.000952381 
+  1000         1074.06937   1072.32814  0.001     
+  1098         1071.9375    1070.18633  0.000910747 
+  1066         1069.81358   1068.04901  0.000938086 
+  1054         1067.69776   1065.9162   0.000948767 
+  1023         1065.5902    1063.78787  0.000977517 
+  998          1063.4911    1061.66403  0.001002004 
+  1106         1061.40072   1059.54465  0.000904159 
+  1013         1059.31936   1057.42974  0.000987167 
+  1017         1057.24735   1055.31929  0.000983284 
+  1028         1055.18513   1053.21328  0.000972763 
+  1070         1053.13667   1051.11172  0.000934579 
+  1013         1051.09554   1049.01458  0.000987167 
+  1036         1049.06591   1046.92187  0.000965251 
+  1071         1047.05031   1044.83358  0.000933707 
+  968          1045.04613   1042.74969  0.001033058 
+  1084         1043.05622   1040.67021  0.000922509 
+  1023         1041.08182   1038.59511  0.000977517 
+  1030         1039.12446   1036.5244   0.000970874 
+  1046         1037.18678   1034.45807  0.000956023 
+  949          1035.26918   1032.39611  0.001053741 
+  1039         1033.37509   1030.33851  0.000962464 
+  977          1031.50802   1028.28526  0.001023541 
+  1013         1029.67082   1026.23636  0.000987167 
+  961          1027.86845   1024.19179  0.001040583 
+  1012         1026.10648   1022.15155  0.000988142 
+  1033         1024.39169   1020.11564  0.000968054 
+  1032         1022.73243   1018.08404  0.000968992 
+  983          1021.13906   1016.05674  0.001017294 
+  991          1019.62432   1014.03375  0.001009082 
+  1002         1018.20386   1012.01504  0.000998004 
+  997          1016.89692   1010.00062  0.001003009 
+  1024         1015.72674   1007.99047  0.000976562 
+  1051         1014.72069   1005.98459  0.000951475 
+  989          1013.91004   1003.98297  0.001011122 
+  996          1013.3276    1001.9856   0.001004016 
+  1027         1013.00221   999.99248   0.00097371 
+  1023         1012.94836   998.00359   0.000977517 
+  924          1013.14678   996.01893   0.001082251 
+  1007         1013.51694   994.0385    0.000993049 
+  993          1013.88996   992.06227   0.001007049 
+  973          1014.00161   990.09026   0.001027749 
+  951          1013.53716   988.12244   0.001051525 
+  1000         1012.23211   986.15881   0.001     
+  980          1009.97691   984.19937   0.001020408 
+  945          1006.85306   982.2441    0.001058201 
+  972          1003.09854   980.293     0.001028807 
+  946          999.01579    978.34605   0.001057082 
+  990          994.85265    976.40327   0.001010101 
+  934          990.79548    974.46462   0.001070664 
+  981          986.96738    972.53012   0.001019368 
+  917          983.35431    970.59974   0.001090513 
+  965          979.91276    968.67349   0.001036269 
+  988          976.59768    966.75135   0.001012146 
+  976          973.46309    964.83332   0.00102459 
+  960          970.51541    962.91939   0.001041667 
+  903          967.76047    961.00956   0.00110742 
+  930          965.16865    959.1038    0.001075269 
+  937          962.69492    957.20213   0.001067236 
+  949          960.31733    955.30453   0.001053741 
+  974          958.01975    953.41098   0.001026694 
+  893          955.78353    951.5215    0.001119821 
+  898          953.60059    949.63606   0.001113586 
+  896          951.4627     947.75466   0.001116071 
+  970          949.36326    945.8773    0.001030928 
+  936          947.29694    944.00396   0.001068376 
+  897          945.25946    942.13464   0.001114827 
+  890          943.24727    940.26933   0.001123596 
+  876          941.25773    938.40802   0.001141553 
+  887          939.28794    936.55071   0.001127396 
+  907          937.33615    934.69739   0.001102536 
+  903          935.40085    932.84805   0.00110742 
+  888          933.48043    931.00269   0.001126126 
+  907          931.57363    929.16129   0.001102536 
+  883          929.67966    927.32385   0.001132503 
+  912          927.79752    925.49036   0.001096491 
+  917          925.92658    923.66082   0.001090513 
+  910          924.06624    921.83522   0.001098901 
+  917          922.21601    920.01355   0.001090513 
+  885          920.37545    918.1958    0.001129944 
+  938          918.54424    916.38196   0.001066098 
+  884          916.72208    914.57204   0.001131222 
+  884          914.90875    912.76601   0.001131222 
+  897          913.10411    910.96389   0.001114827 
+  914          911.30798    909.16564   0.001094092 
+  913          909.52044    907.37128   0.00109529 
+  895          907.7412     905.58079   0.001117318 
+  933          905.97041    903.79417   0.001071811 
+  883          904.2081     902.01141   0.001132503 
+  963          902.45445    900.23249   0.001038422 
+  881          900.70949    898.45743   0.001135074 
+  843          898.97344    896.68619   0.00118624 
+  877          897.24658    894.91879   0.001140251 
+  860          895.52921    893.15521   0.001162791 
+  901          893.82172    891.39545   0.001109878 
+  916          892.12455    889.6395    0.001091703 
+  846          890.43828    887.88734   0.001182033 
+  866          888.76359    886.13898   0.001154734 
+  848          887.10137    884.39441   0.001179245 
+  859          885.45277    882.65362   0.001164144 
+  848          883.81915    880.91661   0.001179245 
+  888          882.20153    879.18336   0.001126126 
+  794          880.60136    877.45387   0.001259446 
+  821          879.02214    875.72813   0.001218027 
+  866          877.46448    874.00614   0.001154734 
+  936          875.93075    872.28788   0.001068376 
+  863          874.42495    870.57336   0.001158749 
+  847          872.94123    868.86256   0.001180638 
+  834          871.47725    867.15548   0.001199041 
+  865          870.03963    865.45211   0.001156069 
+  858          868.64326    863.75244   0.001165501 
+  854          867.29964    862.05647   0.00117096 
+  806          866.02224    860.36419   0.001240695 
+  828          864.91038    858.67559   0.001207729 
+  818          863.80252    856.99067   0.001222494 
+  833          862.80666    855.30942   0.00120048 
+  829          862.01024    853.63183   0.001206273 
+  847          861.33433    851.95789   0.001180638 
+  776          860.89333    850.28761   0.00128866 
+  842          860.77516    848.62096   0.001187648 
+  839          861.08628    846.95796   0.001191895 
+  833          862.02636    845.29857   0.00120048 
+  858          863.92059    843.64281   0.001165501 
+  895          867.39887    841.99067   0.001117318 
+  884          873.7969     840.34213   0.001131222 
+  887          885.9611     838.69719   0.001127396 
+  950          907.12481    837.05585   0.001052632 
+  904          934.48414    835.41809   0.001106195 
+  929          980.33724    833.78392   0.001076426 
+  1027         1039.92284   832.15332   0.00097371 
+  1144         1116.80968   830.52628   0.000874126 
+  1207         1230.35856   828.90281   0.0008285 
+  1377         1351.26969   827.28289   0.000726216 
+  1497         1414.82936   825.66651   0.000668003 
+  1343         1315.32352   824.05368   0.000744602 
+  1154         1188.82992   822.44438   0.000866551 
+  985          1049.10107   820.83861   0.001015228 
+  898          947.38793    819.23635   0.001113586 
+  868          895.69922    817.63762   0.001152074 
+  843          869.06793    816.04238   0.00118624 
+  827          853.40436    814.45065   0.00120919 
+  835          843.00025    812.86241   0.001197605 
+  842          835.4966     811.27766   0.001187648 
+  849          829.75613    809.69639   0.001177856 
+  819          825.13971    808.11859   0.001221001 
+  825          821.28692    806.54426   0.001212121 
+  843          817.9737     804.97339   0.00118624 
+  807          815.04601    803.40598   0.001239157 
+  808          812.40875    801.84201   0.001237624 
+  841          809.99407    800.28148   0.001189061 
+  762          807.75376    798.72439   0.001312336 
+  838          805.65334    797.17072   0.001193317 
+  847          803.66761    795.62048   0.001180638 
+  829          801.77787    794.07365   0.001206273 
+  806          799.96812    792.53023   0.001240695 
+  725          798.23255    790.99021   0.00137931 
+  827          796.55978    789.45359   0.00120919 
+  807          794.94785    787.92035   0.001239157 
+  775          793.39243    786.3905    0.001290323 
+  822          791.89096    784.86402   0.001216545 
+  748          790.44419    783.34092   0.001336898 
+  805          789.05285    781.82117   0.001242236 
+  812          787.72013    780.30479   0.001231527 
+  833          786.45014    778.79175   0.00120048 
+  812          785.25012    777.28206   0.001231527 
+  722          784.12854    775.7757    0.001385042 
+  790          783.09798    774.27268   0.001265823 
+  770          782.17447    772.77298   0.001298701 
+  712          781.37946    771.27659   0.001404494 
+  723          780.74196    769.78352   0.001383126 
+  728          780.30156    768.29376   0.001373626 
+  764          780.11309    766.80729   0.001308901 
+  772          780.25396    765.32412   0.001295337 
+  750          780.83718    763.84424   0.001333333 
+  766          782.0328     762.36763   0.001305483 
+  732          784.10808    760.8943    0.00136612 
+  764          787.5133     759.42423   0.001308901 
+  808          793.06912    757.95743   0.001237624 
+  812          802.33732    756.49388   0.001231527 
+  800          818.14234    755.03359   0.00125   
+  836          844.1744     753.57653   0.001196172 
+  920          878.5325     752.12271   0.001086957 
+  898          917.01301    750.67212   0.001113586 
+  1088         980.71866    749.22475   0.000919118 
+  1206         1069.59093   747.7806    0.000829187 
+  1341         1147.81589   746.33967   0.000745712 
+  1275         1216.86856   744.90193   0.000784314 
+  1125         1196.29008   743.4674    0.000888889 
+  1083         1107.21363   742.03606   0.000923361 
+  879          1012.72751   740.60791   0.001137656 
+  852          916.05683    739.18293   0.001173709 
+  804          850.48785    737.76113   0.001243781 
+  849          812.37877    736.3425    0.001177856 
+  752          789.74436    734.92703   0.001329787 
+  749          775.24688    733.51472   0.001335113 
+  751          765.19187    732.10556   0.001331558 
+  754          757.75855    730.69954   0.00132626 
+  712          751.98546    729.29666   0.001404494 
+  796          747.32045    727.8969    0.001256281 
+  722          743.42568    726.50028   0.001385042 
+  725          740.08363    725.10677   0.00137931 
+  744          737.14969    723.71638   0.001344086 
+  700          734.5251     722.3291    0.001428571 
+  715          732.13999    720.94491   0.001398601 
+  690          729.94432    719.56382   0.001449275 
+  700          727.90114    718.18582   0.001428571 
+  723          725.9847     716.8109    0.001383126 
+  740          724.17397    715.43906   0.001351351 
+  719          722.45483    714.07029   0.001390821 
+  716          720.81599    712.70459   0.001396648 
+  759          719.24974    711.34194   0.001317523 
+  757          717.75115    709.98235   0.001321004 
+  650          716.31758    708.62581   0.001538462 
+  719          714.94886    707.2723    0.001390821 
+  676          713.80132    705.92183   0.00147929 
+  767          712.57366    704.5744    0.001303781 
+  708          711.42778    703.22998   0.001412429 
+  708          710.45524    701.88858   0.001412429 
+  745          709.52455    700.55019   0.001342282 
+  680          708.74589    699.21481   0.001470588 
+  636          708.17274    697.88243   0.001572327 
+  699          707.8915     696.55304   0.001430615 
+  714          708.05611    695.22664   0.00140056 
+  727          708.95558    693.90322   0.001375516 
+  702          711.13598    692.58278   0.001424501 
+  714          715.46174    691.26531   0.00140056 
+  695          722.44084    689.9508    0.001438849 
+  741          730.71868    688.63926   0.001349528 
+  795          743.12813    687.33066   0.001257862 
+  800          762.99951    686.02501   0.00125   
+  848          782.03899    684.72231   0.001179245 
+  775          797.86322    683.42253   0.001290323 
+  817          797.16814    682.12569   0.00122399 
+  754          776.82231    680.83178   0.00132626 
+  721          755.69294    679.54078   0.001386963 
+  676          732.55473    678.25269   0.00147929 
+  687          715.31839    676.96751   0.001455604 
+  696          705.16982    675.68523   0.001436782 
+  704          699.36899    674.40584   0.001420455 
+  729          696.02926    673.12935   0.001371742 
+  672          694.23411    671.85574   0.001488095 
+  689          693.61923    670.585     0.001451379 
+  687          694.15705    669.31714   0.001455604 
+  689          696.07769    668.05215   0.001451379 
+  692          699.99905    666.79001   0.001445087 
+  749          707.19103    665.53073   0.001335113 
+  699          719.95646    664.27431   0.001430615 
+  748          740.98842    663.02072   0.001336898 
+  787          768.21156    661.76997   0.001270648 
+  789          802.70419    660.52206   0.001267427 
+  826          860.15242    659.27697   0.001210654 
+  874          925.39471    658.03471   0.001144165 
+  995          978.13578    656.79526   0.001005025 
+  991          998.6616     655.55862   0.001009082 
+  946          946.97354    654.32478   0.001057082 
+  858          885.25177    653.09375   0.001165501 
+  816          816.56123    651.86551   0.00122549 
+  718          757.48763    650.64005   0.001392758 
+  743          721.04141    649.41738   0.001345895 
+  624          699.82914    648.19748   0.001602564 
+  662          686.85813    646.98036   0.001510574 
+  613          678.30346    645.766     0.001631321 
+  629          672.27298    644.5544    0.001589825 
+  651          667.81772    643.34556   0.001536098 
+  691          664.42726    642.13946   0.001447178 
+  668          661.80964    640.93611   0.001497006 
+  648          659.79743    639.7355    0.00154321 
+  670          658.30305    638.53762   0.001492537 
+  644          657.29806    637.34246   0.001552795 
+  650          656.81009    636.15003   0.001538462 
+  622          656.93625    634.96032   0.001607717 
+  679          657.88568    633.77331   0.001472754 
+  677          660.07272    632.58901   0.001477105 
+  633          664.26489    631.40741   0.001579779 
+  688          671.61563    630.22851   0.001453488 
+  662          682.4608     629.05229   0.001510574 
+  719          696.10951    627.87876   0.001390821 
+  736          718.02212    626.70791   0.001358696 
+  827          748.04434    625.53973   0.00120919 
+  918          777.11947    624.37422   0.001089325 
+  963          802.19467    623.21136   0.001038422 
+  922          807.83119    622.05117   0.001084599 
+  895          816.88245    620.89363   0.001117318 
+  950          830.55891    619.73873   0.001052632 
+  1055         851.2677     618.58647   0.000947867 
+  1009         884.78362    617.43685   0.00099108 
+  1023         901.40115    616.28986   0.000977517 
+  886          906.97501    615.1455    0.001128668 
+  797          870.41836    614.00375   0.001254705 
+  765          815.3274     612.86462   0.00130719 
+  712          765.67435    611.7281    0.001404494 
+  709          718.26851    610.59418   0.001410437 
+  634          686.21773    609.46286   0.001577287 
+  624          667.52821    608.33413   0.001602564 
+  635          656.48057    607.20799   0.001574803 
+  617          649.49204    606.08443   0.001620746 
+  667          644.66016    604.96345   0.00149925 
+  601          640.94661    603.84504   0.001663894 
+  627          637.73325    602.7292    0.001594896 
+  631          634.63646    601.61592   0.001584786 
+  617          631.45429    600.50519   0.001620746 
+  613          628.13506    599.39702   0.001631321 
+  658          624.73124    598.2914    0.001519757 
+  654          621.3453     597.18831   0.001529052 
+  617          618.08218    596.08776   0.001620746 
+  604          615.01853    594.98974   0.001655629 
+  626          612.19327    593.89425   0.001597444 
+  627          609.61333    592.80127   0.001594896 
+  604          607.26519    591.71082   0.001655629 
+  594          605.13039    590.62287   0.001683502 
+  636          603.17375    589.53742   0.001572327 
+  548          601.37534    588.45448   0.001824818 
+  585          599.71395    587.37403   0.001709402 
+  609          598.17201    586.29607   0.001642036 
+  576          596.73822    585.2206    0.001736111 
+  565          595.39718    584.1476    0.001769912 
+  613          594.15427    583.07708   0.001631321 
+  567          592.9862     582.00903   0.001763668 
+  583          591.90222    580.94344   0.001715266 
+  590          590.90573    579.88031   0.001694915 
+  585          590.00436    578.81963   0.001709402 
+  598          589.21658    577.76141   0.001672241 
+  566          588.55464    576.70562   0.001766784 
+  566          588.05778    575.65228   0.001766784 
+  628          587.7901     574.60137   0.001592357 
+  562          587.82647    573.55289   0.001779359 
+  606          588.32251    572.50684   0.001650165 
+  604          589.57191    571.4632    0.001655629 
+  598          592.11767    570.42197   0.001672241 
+  576          596.89728    569.38316   0.001736111 
+  571          604.79324    568.34675   0.001751313 
+  627          615.07942    567.31274   0.001594896 
+  667          630.00413    566.28112   0.00149925 
+  625          652.4772     565.25189   0.0016    
+  664          672.46535    564.22505   0.001506024 
+  697          684.38121    563.20058   0.00143472 
+  650          675.30461    562.17849   0.001538462 
+  641          656.68098    561.15877   0.001560062 
+  610          638.66864    560.14142   0.001639344 
+  593          619.37805    559.12642   0.001686341 
+  589          607.42736    558.11378   0.001697793 
+  636          603.58493    557.10349   0.001572327 
+  584          602.69354    556.09554   0.001712329 
+  645          601.57601    555.08994   0.001550388 
+  615          596.26441    554.08667   0.001626016 
+  581          589.48367    553.08573   0.00172117 
+  607          583.04117    552.08711   0.001647446 
+  592          576.49819    551.09082   0.001689189 
+  600          571.72683    550.09684   0.001666667 
+  599          568.64825    549.10518   0.001669449 
+  651          566.60022    548.11582   0.001536098 
+  622          565.15623    547.12876   0.001607717 
+  637          564.09679    546.144     0.001569859 
+  649          563.31369    545.16153   0.001540832 
+  637          562.74788    544.18135   0.001569859 
+  692          562.36482    543.20345   0.001445087 
+  668          562.14719    542.22783   0.001497006 
+  709          562.05747    541.25448   0.001410437 
+  707          562.0637     540.2834    0.001414427 
+  653          562.13798    539.31458   0.001531394 
+  638          562.30202    538.34803   0.001567398 
+  631          562.60723    537.38372   0.001584786 
+  612          563.0784     536.42167   0.001633987 
+  592          563.75764    535.46186   0.001689189 
+  599          564.66634    534.50429   0.001669449 
+  593          565.79746    533.54896   0.001686341 
+  631          567.12753    532.59585   0.001584786 
+  614          568.63057    531.64497   0.001628664 
+  564          570.2996     530.69632   0.00177305 
+  635          572.18086    529.74988   0.001574803 
+  576          574.40625    528.80565   0.001736111 
+  608          577.22541    527.86363   0.001644737 
+  623          581.05223    526.92381   0.001605136 
+  589          586.56935    525.98619   0.001697793 
+  554          594.90798    525.05077   0.001805054 
+  607          607.71239    524.11753   0.001647446 
+  612          625.82036    523.18648   0.001633987 
+  633          649.23969    522.25761   0.001579779 
+  675          683.93049    521.33091   0.001481481 
+  767          725.34703    520.40638   0.001303781 
+  721          761.5576     519.48402   0.001386963 
+  768          782.6818     518.56382   0.001302083 
+  792          793.41134    517.64577   0.001262626 
+  832          822.40179    516.72988   0.001201923 
+  892          884.34169    515.81614   0.001121076 
+  1040         1023.68237   514.90454   0.000961538 
+  1239         1277.16285   513.99508   0.000807103 
+  1644         1574.21679   513.08775   0.000608273 
+  2279         2119.48931   512.18255   0.000438789 
+  3344         2919.67212   511.27948   0.000299043 
+  4497         3479.23391   510.37852   0.00022237 
+  4327         3557.34752   509.47969   0.000231107 
+  3250         2909.33341   508.58296   0.000307692 
+  2753         2445.73912   507.68834   0.00036324 
+  1927         1843.30141   506.79583   0.000518941 
+  1175         1272.13437   505.90541   0.000851064 
+  840          967.49086    505.01709   0.001190476 
+  729          815.22288    504.13085   0.001371742 
+  626          730.60051    503.2467    0.001597444 
+  633          677.9053     502.36463   0.001579779 
+  579          642.71932    501.48464   0.001727116 
+  590          618.06316    500.60672   0.001694915 
+  582          600.14409    499.73087   0.001718213 
+  559          586.76765    498.85707   0.001788909 
+  579          576.581      497.98534   0.001727116 
+  577          568.76245    497.11566   0.001733102 
+  548          562.71171    496.24803   0.001824818 
+  579          558.03342    495.38245   0.001727116 
+  569          554.39839    494.5189    0.001757469 
+  535          551.53673    493.6574    0.001869159 
+  581          549.22143    492.79792   0.00172117 
+  537          547.28514    491.94047   0.001862197 
+  529          545.64763    491.08505   0.001890359 
+  554          544.33007    490.23165   0.001805054 
+  542          543.45381    489.38026   0.001845018 
+  526          543.24236    488.53088   0.001901141 
+  558          544.05125    487.6835    0.001792115 
+  555          546.47987    486.83813   0.001801802 
+  524          551.65941    485.99476   0.001908397 
+  544          561.73559    485.15338   0.001838235 
+  614          580.41626    484.31399   0.001628664 
+  559          605.80339    483.47658   0.001788909 
+  672          641.27052    482.64115   0.001488095 
+  757          698.68764    481.8077    0.001321004 
+  743          749.59413    480.97622   0.001345895 
+  805          771.96576    480.14671   0.001242236 
+  828          741.99721    479.31917   0.001207729 
+  748          704.7978     478.49358   0.001336898 
+  689          670.07601    477.66995   0.001451379 
+  614          628.03991    476.84827   0.001628664 
+  597          603.13872    476.02853   0.001675042 
+  605          595.83095    475.21074   0.001652893 
+  637          601.03379    474.39488   0.001569859 
+  628          617.9912     473.58096   0.001592357 
+  631          650.63691    472.76897   0.001584786 
+  658          705.38207    471.95891   0.001519757 
+  755          776.01984    471.15076   0.001324503 
+  911          848.88238    470.34454   0.001097695 
+  1022         960.25712    469.54023   0.000978474 
+  1095         1068.90321   468.73782   0.000913242 
+  994          1054.09484   467.93732   0.001006036 
+  943          1019.81629   467.13873   0.001060445 
+  943          1025.69239   466.34202   0.001060445 
+  916          1042.68045   465.54722   0.001091703 
+  954          1118.48829   464.7543    0.001048218 
+  1141         1235.76939   463.96326   0.000876424 
+  1426         1438.47498   463.1741    0.000701262 
+  1980         1711.58443   462.38682   0.000505051 
+  2119         1752.33949   461.60142   0.000471921 
+  1962         1658.25358   460.81788   0.000509684 
+  1836         1605.42409   460.0362    0.000544662 
+  1505         1399.24841   459.25639   0.000664452 
+  1194         1173.78606   458.47843   0.000837521 
+  965          1033.77687   457.70232   0.001036269 
+  786          928.78003    456.92806   0.001272265 
+  792          864.55811    456.15564   0.001262626 
+  797          855.26819    455.38507   0.001254705 
+  878          867.84586    454.61633   0.001138952 
+  808          835.01849    453.84942   0.001237624 
+  807          797.9847     453.08434   0.001239157 
+  776          780.31663    452.32108   0.00128866 
+  797          761.37603    451.55964   0.001254705 
+  838          761.64821    450.80002   0.001193317 
+  820          783.44519    450.04221   0.001219512 
+  843          831.19727    449.28621   0.00118624 
+  830          907.27487    448.53201   0.001204819 
+  936          957.99917    447.77961   0.001068376 
+  1032         1003.99336   447.029     0.000968992 
+  1159         1128.24841   446.28019   0.000862813 
+  1441         1388.60758   445.53317   0.000693963 
+  1798         1871.43932   444.78793   0.000556174 
+  2761         2451.04509   444.04447   0.000362188 
+  4022         3630.64634   443.30279   0.000248633 
+  6130         5195.13163   442.56288   0.000163132 
+  7729         6130.59149   441.82474   0.000129383 
+  6273         5399.11645   441.08836   0.000159413 
+  4712         4278.79918   440.35374   0.000212224 
+  4124         3674.66139   439.62088   0.000242483 
+  2559         2489.5092    438.88978   0.000390778 
+  1357         1543.4987    438.16042   0.00073692 
+  953          1095.99825   437.43281   0.001049318 
+  827          882.34213    436.70694   0.00120919 
+  733          763.26048    435.9828    0.001364256 
+  662          688.17521    435.2604    0.001510574 
+  647          637.22437    434.53973   0.001545595 
+  581          600.8312     433.82079   0.00172117 
+  588          573.79147    433.10357   0.00170068 
+  576          553.05797    432.38806   0.001736111 
+  507          536.74269    431.67427   0.001972387 
+  544          523.62569    430.96219   0.001838235 
+  578          512.88497    430.25182   0.001730104 
+  522          503.95064    429.54316   0.001915709 
+  522          496.41778    428.83619   0.001915709 
+  496          489.99054    428.13091   0.002016129 
+  488          484.44914    427.42733   0.00204918 
+  523          479.62805    426.72544   0.001912046 
+  505          475.39962    426.02523   0.001980198 
+  499          471.66524    425.3267    0.002004008 
+  513          468.34727    424.62985   0.001949318 
+  481          465.38403    423.93467   0.002079002 
+  499          462.7262     423.24116   0.002004008 
+  500          460.33443    422.54932   0.002     
+  494          458.17667    421.85914   0.002024291 
+  505          456.22737    421.17062   0.001980198 
+  497          454.46572    420.48375   0.002012072 
+  511          452.8751     419.79853   0.001956947 
+  464          451.44262    419.11496   0.002155172 
+  451          450.15819    418.43303   0.002217295 
+  523          449.01453    417.75275   0.001912046 
+  454          448.00691    417.0741    0.002202643 
+  476          447.13259    416.39708   0.00210084 
+  467          446.39137    415.72169   0.002141328 
+  491          445.78527    415.04793   0.00203666 
+  440          445.31862    414.37578   0.002272727 
+  456          444.99828    413.70526   0.002192982 
+  441          444.83819    413.03635   0.002267574 
+  430          444.84322    412.36905   0.002325581 
+  427          445.0343     411.70336   0.00234192 
+  442          445.43288    411.03927   0.002262443 
+  454          446.06778    410.37678   0.002202643 
+  403          446.96833    409.71588   0.00248139 
+  433          448.1781     409.05658   0.002309469 
+  456          449.74814    408.39887   0.002192982 
+  432          451.74131    407.74275   0.002314815 
+  478          454.23465    407.0882    0.00209205 
+  438          457.32399    406.43524   0.002283105 
+  470          461.11421    405.78385   0.00212766 
+  462          465.7236     405.13403   0.002164502 
+  476          471.32032    404.48577   0.00210084 
+  467          478.02888    403.83909   0.002141328 
+  508          485.98003    403.19396   0.001968504 
+  568          495.22237    402.55039   0.001760563 
+  536          505.68562    401.90837   0.001865672 
+  568          517.12193    401.26791   0.001760563 
+  537          529.09213    400.62899   0.001862197 
+  563          541.0458     399.99161   0.001776199 
+  604          552.45106    399.35578   0.001655629 
+  587          562.88143    398.72147   0.001703578 
+  637          571.99945    398.08871   0.001569859 
+  707          579.55423    397.45747   0.001414427 
+  697          585.62097    396.82775   0.00143472 
+  753          591.16493    396.19956   0.001328021 
+  763          598.59228    395.57289   0.001310616 
+  703          610.64613    394.94773   0.001422475 
+  782          624.73799    394.32409   0.001278772 
+  780          642.68624    393.70195   0.001282051 
+  731          670.96621    393.08132   0.001367989 
+  648          674.75641    392.46219   0.00154321 
+  664          652.23992    391.84456   0.001506024 
+  660          640.74836    391.22842   0.001515152 
+  651          633.61113    390.61377   0.001536098 
+  632          609.76532    390.00061   0.001582278 
+  587          569.8615     389.38894   0.001703578 
+  545          540.85929    388.77875   0.001834862 
+  530          520.41483    388.17003   0.001886792 
+  493          497.58322    387.56279   0.002028398 
+  472          481.0574     386.95702   0.002118644 
+  502          474.17877    386.35272   0.001992032 
+  531          476.55253    385.74988   0.001883239 
+  474          488.37516    385.14851   0.002109705 
+  559          507.5535     384.54859   0.001788909 
+  634          535.34793    383.95012   0.001577287 
+  660          568.05258    383.35311   0.001515152 
+  638          584.12019    382.75754   0.001567398 
+  618          585.88689    382.16342   0.001618123 
+  522          567.61467    381.57074   0.001915709 
+  545          535.46758    380.97949   0.001834862 
+  425          506.85968    380.38968   0.002352941 
+  459          477.71312    379.80131   0.002178649 
+  424          451.58669    379.21436   0.002358491 
+  428          434.42479    378.62883   0.002336449 
+  421          423.8746     378.04473   0.002375297 
+  404          417.10203    377.46204   0.002475248 
+  388          412.44457    376.88077   0.00257732 
+  391          409.0502     376.30091   0.002557545 
+  400          406.47004    375.72245   0.0025    
+  395          404.46319    375.14541   0.002531646 
+  370          402.88375    374.56976   0.002702703 
+  362          401.64422    373.99551   0.002762431 
+  382          400.69041    373.42266   0.002617801 
+  399          399.98867    372.8512    0.002506266 
+  375          399.51787    372.28113   0.002666667 
+  412          399.26382    371.71244   0.002427184 
+  418          399.21645    371.14514   0.002392344 
+  424          399.37096    370.57921   0.002358491 
+  405          399.7361     370.01466   0.002469136 
+  378          400.34881    369.45149   0.002645503 
+  407          401.2946     368.88968   0.002457002 
+  357          402.73708    368.32924   0.00280112 
+  419          404.97823    367.77016   0.002386635 
+  418          408.58601    367.21245   0.002392344 
+  386          414.61928    366.65609   0.002590674 
+  434          424.84096    366.10108   0.002304147 
+  438          440.60414    365.54742   0.002283105 
+  435          458.86511    364.99512   0.002298851 
+  478          480.50269    364.44415   0.00209205 
+  490          503.74526    363.89453   0.002040816 
+  477          500.75642    363.34624   0.002096436 
+  480          482.668      362.79929   0.002083333 
+  442          472.20941    362.25368   0.002262443 
+  443          457.29925    361.70939   0.002257336 
+  428          437.74832    361.16642   0.002336449 
+  398          423.95363    360.62478   0.002512563 
+  380          416.25278    360.08446   0.002631579 
+  408          413.4263     359.54546   0.00245098 
+  423          412.71717    359.00776   0.002364066 
+  409          413.36898    358.47138   0.002444988 
+  400          415.89825    357.93631   0.0025    
+  402          415.7462     357.40254   0.002487562 
+  381          409.81647    356.87007   0.002624672 
+  402          404.98607    356.3389    0.002487562 
+  394          401.03413    355.80902   0.002538071 
+  411          395.51102    355.28043   0.00243309 
+  387          390.80436    354.75314   0.002583979 
+  347          387.72137    354.22713   0.002881844 
+  346          385.74452    353.7024    0.002890173 
+  363          384.421      353.17895   0.002754821 
+  356          383.49473    352.65678   0.002808989 
+  362          382.83343    352.13589   0.002762431 
+  356          382.36963    351.61626   0.002808989 
+  404          382.05877    351.0979    0.002475248 
+  383          381.88041    350.58081   0.002610966 
+  353          381.82081    350.06498   0.002832861 
+  407          381.87099    349.55041   0.002457002 
+  431          382.03983    349.03709   0.002320186 
+  389          382.32904    348.52503   0.002570694 
+  371          382.76445    348.01421   0.002695418 
+  384          383.38593    347.50465   0.002604167 
+  401          384.25033    346.99632   0.002493766 
+  391          385.37382    346.48924   0.002557545 
+  357          386.74106    345.9834    0.00280112 
+  379          388.52365    345.47879   0.002638522 
+  376          390.3576     344.97542   0.002659574 
+  393          392.06897    344.47327   0.002544529 
+  388          394.35471    343.97235   0.00257732 
+  413          396.89664    343.47265   0.002421308 
+  388          398.68916    342.97418   0.00257732 
+  393          399.96948    342.47692   0.002544529 
+  388          400.5296     341.98088   0.00257732 
+  426          401.03267    341.48605   0.002347418 
+  444          401.97505    340.99243   0.002252252 
+  411          403.04913    340.50001   0.00243309 
+  397          404.53287    340.0088    0.002518892 
+  432          406.73747    339.51879   0.002314815 
+  386          409.58316    339.02998   0.002590674 
+  425          412.97195    338.54236   0.002352941 
+  422          416.85582    338.05593   0.002369668 
+  426          421.21594    337.5707    0.002347418 
+  387          426.04944    337.08665   0.002583979 
+  451          431.36793    336.60378   0.002217295 
+  433          437.20899    336.12209   0.002309469 
+  394          443.65125    335.64158   0.002538071 
+  447          450.82008    335.16225   0.002237136 
+  420          458.87622    334.68409   0.002380952 
+  475          468.02505    334.2071    0.002105263 
+  454          478.50656    333.73127   0.002202643 
+  456          490.59923    333.25661   0.002192982 
+  474          504.62447    332.78311   0.002109705 
+  531          520.97366    332.31077   0.001883239 
+  472          540.14007    331.83958   0.002118644 
+  498          562.78558    331.36955   0.002008032 
+  569          589.8123     330.90067   0.001757469 
+  567          622.46117    330.43293   0.001763668 
+  561          662.44759    329.96634   0.001782531 
+  645          712.19674    329.50089   0.001550388 
+  668          775.20761    329.03658   0.001497006 
+  778          856.67559    328.5734    0.001285347 
+  915          964.66128    328.11136   0.001092896 
+  997          1112.16517   327.65045   0.001003009 
+  1359         1321.91115   327.19067   0.000735835 
+  1748         1636.50853   326.73201   0.000572082 
+  2327         2150.24935   326.27448   0.000429738 
+  3344         3092.70552   325.81807   0.000299043 
+  5028         4944.93858   325.36277   0.000198886 
+  8441         8007.48415   324.90859   0.000118469 
+  14217        12555.37508  324.45552   0.000070338 
+  22630        19457.33547  324.00356   0.000044189 
+  28130        23366.22754  323.5527    0.000035549 
+  20940        18911.80334  323.10295   0.000047755 
+  14846        15012.65473  322.6543    0.000067358 
+  14615        13876.65265  322.20675   0.000068423 
+  10894        10623.95542  321.76029   0.000091794 
+  5034         5997.35857   321.31493   0.000198649 
+  2650         3502.47472   320.87066   0.000377358 
+  1691         2348.10756   320.42748   0.000591366 
+  1353         1751.27752   319.98538   0.000739098 
+  1228         1394.79458   319.54436   0.000814332 
+  1068         1161.77201   319.10443   0.00093633 
+  966          1000.49517   318.66557   0.001035197 
+  896          884.16987    318.22778   0.001116071 
+  817          797.37324    317.79107   0.00122399 
+  767          730.71521    317.35543   0.001303781 
+  723          678.72901    316.92086   0.001383126 
+  658          637.67694    316.48735   0.001519757 
+  606          604.76493    316.0549    0.001650165 
+  595          578.27329    315.62351   0.001680672 
+  581          557.03832    315.19317   0.00172117 
+  548          540.12266    314.7639    0.001824818 
+  536          526.87807    314.33567   0.001865672 
+  573          516.87375    313.90849   0.001745201 
+  468          509.85806    313.48236   0.002136752 
+  516          505.65657    313.05727   0.001937984 
+  492          504.00739    312.63322   0.00203252 
+  457          504.85911    312.21021   0.002188184 
+  484          507.61164    311.78824   0.002066116 
+  502          511.62486    311.3673    0.001992032 
+  557          517.68824    310.9474    0.001795332 
+  511          525.88828    310.52852   0.001956947 
+  524          535.53881    310.11067   0.001908397 
+  554          546.80821    309.69384   0.001805054 
+  595          560.12002    309.27803   0.001680672 
+  586          575.65218    308.86324   0.001706485 
+  666          593.5064     308.44946   0.001501502 
+  600          613.74279    308.0367    0.001666667 
+  701          636.53084    307.62496   0.001426534 
+  754          661.9616     307.21422   0.00132626 
+  750          687.53244    306.80448   0.001333333 
+  787          710.10886    306.39575   0.001270648 
+  748          726.7447     305.98802   0.001336898 
+  758          718.86144    305.58129   0.001319261 
+  753          693.7036     305.17556   0.001328021 
+  688          669.22486    304.77082   0.001453488 
+  662          640.52925    304.36707   0.001510574 
+  653          603.17227    303.96431   0.001531394 
+  602          567.22997    303.56253   0.00166113 
+  560          536.05548    303.16174   0.001785714 
+  545          508.9827     302.76193   0.001834862 
+  512          485.2793     302.3631    0.001953125 
+  450          464.42968    301.96525   0.002222222 
+  513          446.52723    301.56837   0.001949318 
+  432          431.09273    301.17247   0.002314815 
+  430          417.72587    300.77753   0.002325581 
+  428          406.31316    300.38356   0.002336449 
+  392          396.49312    299.99056   0.00255102 
+  370          388.01041    299.59852   0.002702703 
+  386          380.64011    299.20743   0.002590674 
+  345          374.20475    298.81731   0.002898551 
+  376          368.55365    298.42814   0.002659574 
+  379          363.56688    298.03992   0.002638522 
+  368          359.13293    297.65266   0.002717391 
+  361          355.18502    297.26634   0.002770083 
+  363          351.64882    296.88097   0.002754821 
+  358          348.46574    296.49654   0.002793296 
+  366          345.5968     296.11305   0.00273224 
+  370          343.00151    295.7305    0.002702703 
+  352          340.64914    295.34889   0.002840909 
+  375          338.51481    294.96821   0.002666667 
+  341          336.57874    294.58846   0.002932551 
+  375          334.82545    294.20965   0.002666667 
+  332          333.24343    293.83176   0.003012048 
+  351          331.8256     293.45479   0.002849003 
+  327          330.57101    293.07875   0.003058104 
+  317          329.47719    292.70362   0.003154574 
+  325          328.55422    292.32942   0.003076923 
+  307          327.81789    291.95613   0.003257329 
+  355          327.29605    291.58375   0.002816901 
+  383          327.03041    291.21229   0.002610966 
+  311          327.09279    290.84173   0.003215434 
+  289          327.59948    290.47208   0.003460208 
+  369          328.75224    290.10334   0.002710027 
+  326          330.92456    289.7355    0.003067485 
+  355          334.83345    289.36855   0.002816901 
+  348          341.83359    289.00251   0.002873563 
+  403          354.02521    288.63735   0.00248139 
+  388          372.16666    288.2731    0.00257732 
+  403          392.84413    287.90973   0.00248139 
+  517          414.84378    287.54725   0.001934236 
+  445          420.23217    287.18566   0.002247191 
+  417          404.47186    286.82495   0.002398082 
+  445          392.09258    286.46512   0.002247191 
+  372          385.3305     286.10617   0.002688172 
+  375          370.56662    285.7481    0.002666667 
+  329          354.12729    285.39091   0.003039514 
+  312          343.85958    285.03459   0.003205128 
+  354          337.5829     284.67914   0.002824859 
+  376          333.77032    284.32455   0.002659574 
+  348          331.29991    283.97084   0.002873563 
+  333          330.05828    283.61798   0.003003003 
+  303          329.62298    283.26599   0.00330033 
+  359          330.11626    282.91486   0.002785515 
+  356          331.0462     282.56459   0.002808989 
+  323          331.91668    282.21517   0.003095975 
+  329          329.64442    281.86661   0.003039514 
+  319          325.49323    281.5189    0.003134796 
+  307          322.56837    281.17203   0.003257329 
+  314          320.1221     280.82602   0.003184713 
+  326          316.5742     280.48085   0.003067485 
+  319          313.36177    280.13652   0.003134796 
+  322          311.19047    279.79303   0.00310559 
+  341          309.77644    279.45038   0.002932551 
+  342          308.846      279.10856   0.002923977 
+  349          308.26821    278.76758   0.00286533 
+  314          307.99146    278.42743   0.003184713 
+  329          308.05225    278.08812   0.003039514 
+  364          308.57005    277.74962   0.002747253 
+  342          309.68378    277.41196   0.002923977 
+  309          311.35074    277.07512   0.003236246 
+  354          313.28158    276.7391    0.002824859 
+  341          314.89675    276.4039    0.002932551 
+  337          314.57201    276.06951   0.002967359 
+  334          313.66639    275.73595   0.002994012 
+  336          313.64993    275.40319   0.00297619 
+  322          313.8801     275.07125   0.00310559 
+  338          313.84226    274.74011   0.00295858 
+  310          314.70646    274.40978   0.003225806 
+  319          317.16635    274.08026   0.003134796 
+  333          321.69512    273.75154   0.003003003 
+  359          328.56187    273.42362   0.002785515 
+  408          338.41725    273.0965    0.00245098 
+  364          352.39576    272.77017   0.002747253 
+  382          369.61332    272.44464   0.002617801 
+  404          389.1731     272.11991   0.002475248 
+  408          412.69115    271.79596   0.00245098 
+  412          420.5733     271.4728    0.002427184 
+  427          400.20074    271.15043   0.00234192 
+  405          384.82127    270.82884   0.002469136 
+  412          380.7157     270.50804   0.002427184 
+  358          368.86976    270.18802   0.002793296 
+  397          351.92173    269.86877   0.002518892 
+  347          341.40702    269.5503    0.002881844 
+  334          335.85582    269.23261   0.002994012 
+  376          333.51024    268.91568   0.002659574 
+  351          333.33829    268.59953   0.002849003 
+  368          334.30046    268.28415   0.002717391 
+  319          336.04929    267.96953   0.003134796 
+  359          338.99046    267.65568   0.002785515 
+  342          343.35389    267.34259   0.002923977 
+  375          349.37178    267.03027   0.002666667 
+  385          357.64992    266.7187    0.002597403 
+  411          369.46645    266.40788   0.00243309 
+  421          388.18274    266.09783   0.002375297 
+  483          421.35208    265.78852   0.002070393 
+  459          476.0962     265.47997   0.002178649 
+  522          539.13905    265.17216   0.001915709 
+  650          615.21404    264.8651    0.001538462 
+  594          628.82105    264.55879   0.001683502 
+  587          574.86684    264.25322   0.001703578 
+  603          553.33274    263.94839   0.001658375 
+  580          563.94936    263.6443    0.001724138 
+  556          540.30978    263.34095   0.001798561 
+  570          509.53077    263.03834   0.001754386 
+  561          505.97579    262.73645   0.001782531 
+  599          524.57149    262.4353    0.001669449 
+  613          557.6306     262.13488   0.001631321 
+  589          600.02745    261.83519   0.001697793 
+  621          644.17312    261.53622   0.001610306 
+  652          679.46199    261.23798   0.001533742 
+  746          724.86685    260.94046   0.001340483 
+  815          794.83745    260.64366   0.001226994 
+  871          889.69505    260.34758   0.001148106 
+  1060         1017.95699   260.05222   0.000943396 
+  1336         1211.53474   259.75757   0.000748503 
+  1533         1516.26704   259.46363   0.000652316 
+  2155         2025.48582   259.17041   0.000464037 
+  3084         2980.51196   258.87789   0.000324254 
+  5033         4944.02898   258.58608   0.000198689 
+  8778         8552.2764    258.29498   0.000113921 
+  14362        12639.96244  258.00458   0.000069628 
+  20582        18081.85304  257.71488   0.000048586 
+  19072        17465.79661  257.42589   0.000052433 
+  12416        12396.83899  257.13759   0.000080541 
+  10777        10519.05767  256.84999   0.00009279 
+  11270        11076.83055  256.56308   0.000088731 
+  8154         8104.35777   256.27686   0.000122639 
+  4172         4504.17036   255.99134   0.000239693 
+  2172         2679.04912   255.70651   0.000460405 
+  1545         1830.03056   255.42236   0.000647249 
+  1162         1383.14088   255.1389    0.000860585 
+  945          1115.86836   254.85612   0.001058201 
+  838          944.71245    254.57403   0.001193317 
+  756          825.18966    254.29261   0.001322751 
+  649          730.2604     254.01187   0.001540832 
+  593          658.27864    253.73181   0.001686341 
+  591          607.88465    253.45243   0.001692047 
+  504          566.86665    253.17372   0.001984127 
+  487          525.11621    252.89568   0.002053388 
+  457          489.31732    252.61831   0.002188184 
+  429          462.57125    252.3416    0.002331002 
+  415          441.13804    252.06557   0.002409639 
+  406          421.99206    251.79019   0.002463054 
+  413          406.71525    251.51548   0.002421308 
+  387          396.24927    251.24144   0.002583979 
+  375          390.42216    250.96805   0.002666667 
+  363          386.50144    250.69531   0.002754821 
+  354          380.53822    250.42324   0.002824859 
+  346          373.94439    250.15182   0.002890173 
+  368          366.55551    249.88104   0.002717391 
+  332          360.06856    249.61093   0.003012048 
+  348          355.49432    249.34145   0.002873563 
+  359          353.0656     249.07263   0.002785515 
+  324          348.59544    248.80445   0.00308642 
+  321          340.01203    248.53692   0.003115265 
+  316          332.4479     248.27003   0.003164557 
+  300          327.89642    248.00377   0.003333333 
+  304          323.54923    247.73816   0.003289474 
+  341          317.53958    247.47318   0.002932551 
+  272          311.90338    247.20884   0.003676471 
+  313          307.37655    246.94514   0.003194888 
+  294          303.67656    246.68206   0.003401361 
+  279          300.52171    246.41961   0.003584229 
+  304          297.76318    246.1578    0.003289474 
+  286          295.33645    245.89661   0.003496503 
+  293          293.19115    245.63604   0.003412969 
+  267          291.28202    245.3761    0.003745318 
+  251          289.54481    245.11678   0.003984064 
+  285          287.91233    244.85808   0.003508772 
+  249          286.3303     244.6       0.004016064 
+  299          284.76497    244.34254   0.003344482 
+  286          283.20974    244.08569   0.003496503 
+  269          281.67324    243.82946   0.003717472 
+  268          280.17519    243.57384   0.003731343 
+  265          278.7233     243.31883   0.003773585 
+  281          277.32769    243.06443   0.003558719 
+  253          276.03562    242.81063   0.003952569 
+  265          274.87259    242.55744   0.003773585 
+  307          273.84164    242.30486   0.003257329 
+  274          272.94097    242.05287   0.003649635 
+  256          272.19629    241.80149   0.00390625 
+  244          271.62066    241.55071   0.004098361 
+  257          271.2295     241.30052   0.003891051 
+  233          271.0664     241.05093   0.004291845 
+  269          271.17434    240.80194   0.003717472 
+  287          271.44382    240.55354   0.003484321 
+  273          271.5699     240.30573   0.003663004 
+  273          271.90514    240.05851   0.003663004 
+  255          273.07831    239.81188   0.003921569 
+  275          274.91732    239.56583   0.003636364 
+  284          275.38483    239.32037   0.003521127 
+  281          273.80748    239.07549   0.003558719 
+  291          272.72849    238.8312    0.003436426 
+  251          272.96153    238.58748   0.003984064 
+  291          273.50021    238.34434   0.003436426 
+  275          274.20249    238.10179   0.003636364 
+  326          276.80567    237.8598    0.003067485 
+  340          283.06456    237.61839   0.002941176 
+  342          295.2611     237.37756   0.002923977 
+  334          313.96383    237.13729   0.002994012 
+  394          329.83689    236.8976    0.002538071 
+  402          324.99896    236.65847   0.002487562 
+  400          313.73964    236.41991   0.0025    
+  391          308.35715    236.18191   0.002557545 
+  389          305.35672    235.94448   0.002570694 
+  424          295.06694    235.70761   0.002358491 
+  381          283.08532    235.4713    0.002624672 
+  312          274.02687    235.23555   0.003205128 
+  362          268.17041    235.00035   0.002762431 
+  289          264.7817     234.76572   0.003460208 
+  302          263.01       234.53163   0.003311258 
+  270          262.45019    234.2981    0.003703704 
+  254          263.12322    234.06513   0.003937008 
+  279          265.12813    233.8327    0.003584229 
+  258          267.83952    233.60082   0.003875969 
+  268          270.36216    233.36948   0.003731343 
+  275          269.60429    233.1387    0.003636364 
+  282          267.42867    232.90845   0.003546099 
+  268          266.88156    232.67875   0.003731343 
+  276          267.48981    232.44959   0.003623188 
+  265          267.18224    232.22098   0.003773585 
+  290          266.7527     231.99289   0.003448276 
+  268          267.93306    231.76535   0.003731343 
+  266          271.10714    231.53834   0.003759398 
+  276          276.95528    231.31187   0.003623188 
+  300          287.50414    231.08592   0.003333333 
+  302          307.66676    230.86051   0.003311258 
+  327          346.27498    230.63563   0.003058104 
+  398          403.63082    230.41128   0.002512563 
+  464          467.35562    230.18745   0.002155172 
+  437          499.29404    229.96415   0.00228833 
+  370          450.62148    229.74137   0.002702703 
+  379          421.45381    229.51912   0.002638522 
+  411          417.53111    229.29739   0.00243309 
+  421          406.47441    229.07617   0.002375297 
+  344          359.11822    228.85548   0.002906977 
+  272          322.46819    228.6353    0.003676471 
+  297          300.89887    228.41564   0.003367003 
+  291          286.435      228.19649   0.003436426 
+  282          277.47528    227.97785   0.003546099 
+  266          272.19766    227.75973   0.003759398 
+  292          269.11756    227.54211   0.003424658 
+  275          267.38323    227.32501   0.003636364 
+  272          266.55601    227.10841   0.003676471 
+  291          266.42588    226.89231   0.003436426 
+  289          266.79737    226.67673   0.003460208 
+  281          267.22338    226.46164   0.003558719 
+  226          267.59332    226.24706   0.004424779 
+  272          268.3081     226.03297   0.003676471 
+  278          269.45221    225.81939   0.003597122 
+  253          270.81102    225.6063    0.003952569 
+  277          272.30298    225.39371   0.003610108 
+  266          274.12998    225.18162   0.003759398 
+  320          276.40765    224.97002   0.003125  
+  281          279.20717    224.75891   0.003558719 
+  290          282.66993    224.54829   0.003448276 
+  286          287.14364    224.33816   0.003496503 
+  304          293.25347    224.12852   0.003289474 
+  303          301.54826    223.91936   0.00330033 
+  305          310.27948    223.7107    0.003278689 
+  315          314.84565    223.50251   0.003174603 
+  342          318.14686    223.29481   0.002923977 
+  309          325.74591    223.08759   0.003236246 
+  322          339.49585    222.88085   0.00310559 
+  330          360.49918    222.67459   0.003030303 
+  395          390.5722     222.46881   0.002531646 
+  430          424.95486    222.26351   0.002325581 
+  420          447.23498    222.05868   0.002380952 
+  428          429.88559    221.85432   0.002336449 
+  426          421.2559     221.65043   0.002347418 
+  447          431.23883    221.44702   0.002237136 
+  415          446.22577    221.24408   0.002409639 
+  415          444.83598    221.0416    0.002409639 
+  421          447.70321    220.8396    0.002375297 
+  414          464.52933    220.63806   0.002415459 
+  503          493.18517    220.43698   0.001988072 
+  518          531.77241    220.23637   0.001930502 
+  629          580.44064    220.03622   0.001589825 
+  714          644.92389    219.83653   0.00140056 
+  800          733.4341     219.6373    0.00125   
+  901          856.97296    219.43853   0.001109878 
+  1030         1034.65362   219.24022   0.000970874 
+  1322         1305.65429   219.04236   0.00075643 
+  1868         1755.07067   218.84496   0.000535332 
+  2802         2594.79339   218.64801   0.000356888 
+  4572         4328.87545   218.45151   0.000218723 
+  8169         7635.58494   218.25547   0.000122414 
+  13383        11735.20032  218.05987   0.000074722 
+  17278        15637.94223  217.86472   0.000057877 
+  13923        12889.44733  217.67002   0.000071824 
+  8773         9034.53954   217.47577   0.000113986 
+  8055         8275.48192   217.28196   0.000124146 
+  9083         9036.88805   217.0886    0.000110096 
+  7459         7357.15424   216.89567   0.000134066 
+  3830         4204.85686   216.70319   0.000261097 
+  2082         2456.73393   216.51115   0.000480307 
+  1271         1638.49883   216.31955   0.000786782 
+  943          1217.64845   216.12838   0.001060445 
+  764          967.84991    215.93766   0.001308901 
+  640          804.91477    215.74736   0.0015625 
+  551          692.32343    215.5575    0.001814882 
+  520          611.35472    215.36808   0.001923077 
+  470          551.63744    215.17908   0.00212766 
+  410          507.25479    214.99052   0.002439024 
+  424          475.19735    214.80238   0.002358491 
+  412          454.94225    214.61468   0.002427184 
+  439          448.25564    214.4274    0.002277904 
+  375          454.66476    214.24055   0.002666667 
+  417          454.78114    214.05412   0.002398082 
+  345          434.73854    213.86811   0.002898551 
+  385          413.65907    213.68253   0.002597403 
+  387          405.17893    213.49736   0.002583979 
+  372          398.0105     213.31262   0.002688172 
+  360          375.76854    213.1283    0.002777778 
+  313          350.73962    212.94439   0.003194888 
+  346          332.56673    212.7609    0.002890173 
+  283          319.76357    212.57783   0.003533569 
+  309          307.19625    212.39517   0.003236246 
+  298          296.17796    212.21292   0.003355705 
+  294          287.95354    212.03109   0.003401361 
+  245          281.86574    211.84966   0.004081633 
+  286          277.19601    211.66865   0.003496503 
+  285          273.49433    211.48804   0.003508772 
+  271          270.49852    211.30784   0.003690037 
+  278          268.04563    211.12805   0.003597122 
+  286          266.01232    210.94866   0.003496503 
+  255          264.28886    210.76968   0.003921569 
+  246          262.76875    210.5911    0.004065041 
+  281          261.35831    210.41292   0.003558719 
+  266          259.99409    210.23515   0.003759398 
+  246          258.65564    210.05777   0.004065041 
+  256          257.36214    209.88079   0.00390625 
+  217          256.16114    209.70421   0.004608295 
+  231          255.12293    209.52802   0.004329004 
+  244          254.35202    209.35223   0.004098361 
+  242          254.02034    209.17683   0.004132231 
+  239          254.42467    209.00183   0.0041841 
+  245          256.04703    208.82722   0.004081633 
+  237          259.38146    208.653     0.004219409 
+  265          263.32225    208.47917   0.003773585 
+  235          263.2836     208.30572   0.004255319 
+  260          259.74412    208.13267   0.003846154 
+  245          257.21619    207.96      0.004081633 
+  246          255.99399    207.78772   0.004065041 
+  224          254.05771    207.61582   0.004464286 
+  228          250.68376    207.44431   0.004385965 
+  224          247.09524    207.27317   0.004464286 
+  205          244.27664    207.10242   0.004878049 
+  255          242.06345    206.93205   0.003921569 
+  221          240.46621    206.76206   0.004524887 
+  233          239.60613    206.59245   0.004291845 
+  234          239.03883    206.42321   0.004273504 
+  244          239.00561    206.25435   0.004098361 
+  212          239.63785    206.08586   0.004716981 
+  223          241.02718    205.91775   0.004484305 
+  222          242.75958    205.75001   0.004504505 
+  236          244.0638     205.58265   0.004237288 
+  217          245.50365    205.41565   0.004608295 
+  248          248.37616    205.24902   0.004032258 
+  274          253.01424    205.08277   0.003649635 
+  272          260.53103    204.91688   0.003676471 
+  287          274.56236    204.75135   0.003484321 
+  317          302.05533    204.5862    0.003154574 
+  353          346.28255    204.4214    0.002832861 
+  392          395.18577    204.25697   0.00255102 
+  447          419.69607    204.09291   0.002237136 
+  456          394.47698    203.9292    0.002192982 
+  355          383.90205    203.76586   0.002816901 
+  363          380.44995    203.60288   0.002754821 
+  362          371.42867    203.44025   0.002762431 
+  323          342.43129    203.27798   0.003095975 
+  302          315.56102    203.11607   0.003311258 
+  294          299.7172     202.95452   0.003401361 
+  258          286.23298    202.79331   0.003875969 
+  238          278.74444    202.63247   0.004201681 
+  276          278.85371    202.47197   0.003623188 
+  262          279.20076    202.31183   0.003816794 
+  274          272.80247    202.15204   0.003649635 
+  254          266.67532    201.9926    0.003937008 
+  270          262.94479    201.83351   0.003703704 
+  265          259.561      201.67476   0.003773585 
+  241          253.6357     201.51636   0.004149378 
+  231          247.03383    201.35831   0.004329004 
+  239          242.17854    201.2006    0.0041841 
+  226          237.98444    201.04324   0.004424779 
+  250          234.78589    200.88622   0.004     
+  229          232.2914     200.72954   0.004366812 
+  211          231.19825    200.57321   0.004739336 
+  219          230.69455    200.41721   0.00456621 
+  222          230.61841    200.26156   0.004504505 
+  221          230.64222    200.10624   0.004524887 
+  227          231.21744    199.95126   0.004405286 
+  219          231.8324     199.79661   0.00456621 
+  207          232.33638    199.6423    0.004830918 
+  232          233.04105    199.48833   0.004310345 
+  226          234.12104    199.33469   0.004424779 
+  232          235.57198    199.18138   0.004310345 
+  210          237.36417    199.02841   0.004761905 
+  222          239.83107    198.87576   0.004504505 
+  210          243.56408    198.72345   0.004761905 
+  224          249.07545    198.57146   0.004464286 
+  281          255.26889    198.4198    0.003558719 
+  233          257.6459     198.26847   0.004291845 
+  228          256.66499    198.11747   0.004385965 
+  229          257.17138    197.96679   0.004366812 
+  238          260.17777    197.81644   0.004201681 
+  244          263.66401    197.66641   0.004098361 
+  265          265.61626    197.5167    0.003773585 
+  268          267.9407     197.36732   0.003731343 
+  250          272.09427    197.21825   0.004     
+  263          278.30109    197.06951   0.003802281 
+  308          286.9051     196.92108   0.003246753 
+  293          298.83566    196.77298   0.003412969 
+  314          315.69238    196.62519   0.003184713 
+  301          338.34169    196.47771   0.003322259 
+  312          359.88596    196.33056   0.003205128 
+  350          368.12435    196.18372   0.002857143 
+  341          372.33588    196.03719   0.002932551 
+  408          383.54282    195.89097   0.00245098 
+  355          400.84902    195.74507   0.002816901 
+  358          415.85618    195.59948   0.002793296 
+  385          425.30392    195.4542    0.002597403 
+  420          435.25325    195.30923   0.002380952 
+  469          447.72515    195.16456   0.002132196 
+  499          462.22203    195.02021   0.002004008 
+  502          478.13006    194.87616   0.001992032 
+  529          494.86314    194.73242   0.001890359 
+  526          511.67979    194.58899   0.001901141 
+  541          527.75954    194.44585   0.001848429 
+  546          542.46305    194.30303   0.001831502 
+  561          555.71645    194.1605    0.001782531 
+  534          568.18306    194.01828   0.001872659 
+  549          580.91632    193.87636   0.001821494 
+  567          594.5995     193.73474   0.001763668 
+  580          608.15142    193.59341   0.001724138 
+  568          613.97611    193.45239   0.001760563 
+  604          611.69643    193.31166   0.001655629 
+  596          607.34846    193.17124   0.001677852 
+  567          600.81428    193.0311    0.001763668 
+  456          589.12138    192.89127   0.002192982 
+  513          568.95496    192.75173   0.001949318 
+  513          544.06286    192.61248   0.001949318 
+  465          517.47889    192.47352   0.002150538 
+  452          489.92112    192.33486   0.002212389 
+  410          462.00238    192.19649   0.002439024 
+  384          434.60319    192.0584    0.002604167 
+  378          408.6358     191.92061   0.002645503 
+  340          384.80489    191.78311   0.002941176 
+  386          363.48644    191.64589   0.002590674 
+  372          344.7674     191.50897   0.002688172 
+  319          328.54673    191.37233   0.003134796 
+  313          314.60438    191.23597   0.003194888 
+  287          302.71333    191.0999    0.003484321 
+  273          292.68883    190.96411   0.003663004 
+  269          284.36776    190.82861   0.003717472 
+  273          277.78425    190.69339   0.003663004 
+  257          273.18255    190.55845   0.003891051 
+  260          271.00068    190.42379   0.003846154 
+  295          270.98147    190.28942   0.003389831 
+  267          269.22259    190.15532   0.003745318 
+  283          262.45801    190.0215    0.003533569 
+  244          255.54717    189.88796   0.004098361 
+  253          251.44586    189.7547    0.003952569 
+  243          249.26693    189.62171   0.004115226 
+  239          245.87275    189.489     0.0041841 
+  242          240.90362    189.35656   0.004132231 
+  224          236.67613    189.2244    0.004464286 
+  205          233.67244    189.09251   0.004878049 
+  257          231.58014    188.96089   0.003891051 
+  231          230.12238    188.82955   0.004329004 
+  196          229.14739    188.69847   0.005102041 
+  239          228.57262    188.56767   0.0041841 
+  214          228.3508     188.43713   0.004672897 
+  231          228.44281    188.30687   0.004329004 
+  222          228.80363    188.17687   0.004504505 
+  259          229.37715    188.04714   0.003861004 
+  212          230.12668    187.91768   0.004716981 
+  222          231.0913     187.78848   0.004504505 
+  199          232.42463    187.65955   0.005025126 
+  213          234.10433    187.53089   0.004694836 
+  215          234.66085    187.40248   0.004651163 
+  234          232.43796    187.27434   0.004273504 
+  234          229.47797    187.14646   0.004273504 
+  221          227.44593    187.01885   0.004524887 
+  212          226.27183    186.89149   0.004716981 
+  207          224.82809    186.7644    0.004830918 
+  220          222.8595     186.63756   0.004545455 
+  222          221.69687    186.51098   0.004504505 
+  222          221.61851    186.38466   0.004504505 
+  221          221.09889    186.2586    0.004524887 
+  215          219.50628    186.1328    0.004651163 
+  207          218.8213     186.00725   0.004830918 
+  229          220.26652    185.88195   0.004366812 
+  227          223.9938     185.75692   0.004405286 
+  239          228.18131    185.63213   0.0041841 
+  211          228.90692    185.5076    0.004739336 
+  215          226.79445    185.38332   0.004651163 
+  226          224.8288     185.25929   0.004424779 
+  205          223.72775    185.13551   0.004878049 
+  236          224.42543    185.01198   0.004237288 
+  214          225.71366    184.88871   0.004672897 
+  222          227.83482    184.76568   0.004504505 
+  214          227.97439    184.6429    0.004672897 
+  216          223.29564    184.52037   0.00462963 
+  219          218.66726    184.39808   0.00456621 
+  225          216.91486    184.27604   0.004444444 
+  229          217.34835    184.15425   0.004366812 
+  224          217.24835    184.0327    0.004464286 
+  229          215.72619    183.9114    0.004366812 
+  238          215.06505    183.79033   0.004201681 
+  237          216.30552    183.66952   0.004219409 
+  255          219.8808     183.54894   0.003921569 
+  223          226.84351    183.42861   0.004484305 
+  277          239.54293    183.30852   0.003610108 
+  278          261.6266     183.18866   0.003597122 
+  316          298.13513    183.06905   0.003164557 
+  338          344.22478    182.94968   0.00295858 
+  345          343.56882    182.83054   0.002898551 
+  310          308.85619    182.71164   0.003225806 
+  303          287.03388    182.59298   0.00330033 
+  292          286.12777    182.47456   0.003424658 
+  291          294.54977    182.35637   0.003436426 
+  299          279.3248     182.23842   0.003344482 
+  287          255.61922    182.1207    0.003484321 
+  266          239.61695    182.00321   0.003759398 
+  239          231.91142    181.88596   0.0041841 
+  224          228.91293    181.76894   0.004464286 
+  235          225.7885     181.65216   0.004255319 
+  215          222.03231    181.5356    0.004651163 
+  233          218.88294    181.41927   0.004291845 
+  231          217.24459    181.30318   0.004329004 
+  231          216.74039    181.18731   0.004329004 
+  232          215.91458    181.07168   0.004310345 
+  261          215.2415     180.95627   0.003831418 
+  207          215.42725    180.84109   0.004830918 
+  224          216.3781     180.72614   0.004464286 
+  217          216.15247    180.61141   0.004608295 
+  214          214.6299     180.49691   0.004672897 
+  222          213.7829     180.38263   0.004504505 
+  200          214.07453    180.26858   0.005     
+  211          214.82328    180.15475   0.004739336 
+  199          214.73557    180.04115   0.005025126 
+  229          213.98601    179.92777   0.004366812 
+  189          213.43349    179.81461   0.005291005 
+  199          213.19274    179.70167   0.005025126 
+  212          213.1598     179.58895   0.004716981 
+  217          213.26809    179.47646   0.004608295 
+  207          213.50587    179.36418   0.004830918 
+  218          213.90069    179.25212   0.004587156 
+  183          214.51339    179.14028   0.005464481 
+  232          215.44303    179.02866   0.004310345 
+  228          216.85043    178.91726   0.004385965 
+  240          218.96697    178.80607   0.004166667 
+  228          221.91722    178.6951    0.004385965 
+  211          224.82907    178.58435   0.004739336 
+  235          225.99339    178.47381   0.004255319 
+  231          226.44633    178.36349   0.004329004 
+  221          227.30363    178.25338   0.004524887 
+  222          229.52521    178.14348   0.004504505 
+  218          231.84133    178.03379   0.004587156 
+  236          233.25721    177.92432   0.004237288 
+  257          234.33411    177.81506   0.003891051 
+  196          235.50018    177.70601   0.005102041 
+  236          237.2612     177.59717   0.004237288 
+  253          239.36019    177.48855   0.003952569 
+  233          241.80222    177.38013   0.004291845 
+  217          244.6429     177.27192   0.004608295 
+  247          247.97849    177.16392   0.004048583 
+  265          251.93116    177.05612   0.003773585 
+  267          256.64329    176.94853   0.003745318 
+  262          262.28116    176.84115   0.003816794 
+  246          269.03964    176.73398   0.004065041 
+  275          277.16466    176.62701   0.003636364 
+  318          286.99681    176.52025   0.003144654 
+  319          299.03813    176.41369   0.003134796 
+  326          314.07008    176.30734   0.003067485 
+  321          333.30426    176.20119   0.003115265 
+  358          358.3243     176.09524   0.002793296 
+  370          389.41766    175.98949   0.002702703 
+  400          421.6302     175.88395   0.0025    
+  474          453.93071    175.77861   0.002109705 
+  526          496.98654    175.67346   0.001901141 
+  531          558.99219    175.56852   0.001883239 
+  561          646.54955    175.46378   0.001782531 
+  694          768.61961    175.35924   0.001440922 
+  858          946.69363    175.25489   0.001165501 
+  1094         1230.0321    175.15075   0.000914077 
+  1521         1725.37358   175.0468    0.000657462 
+  2431         2714.57972   174.94305   0.000411353 
+  4201         4877.03373   174.8395    0.000238039 
+  7289         9045.01538   174.73614   0.000137193 
+  10359        12004.1711   174.63298   0.000096534 
+  10041        8490.45675   174.53001   0.000099592 
+  6358         5270.18367   174.42724   0.000157282 
+  4502         4536.06973   174.32466   0.000222124 
+  4823         5777.9129    174.22227   0.00020734 
+  5761         6700.46182   174.12008   0.000173581 
+  5140         4536.69508   174.01808   0.000194553 
+  3158         2556.74275   173.91627   0.000316656 
+  1699         1567.74884   173.81466   0.000588582 
+  1103         1092.53565   173.71323   0.000906618 
+  806          834.80136    173.612     0.001240695 
+  633          676.24517    173.51095   0.001579779 
+  538          570.61209    173.4101    0.001858736 
+  462          496.38647    173.30943   0.002164502 
+  413          442.12908    173.20896   0.002421308 
+  406          401.22341    173.10867   0.002463054 
+  363          369.63786    173.00857   0.002754821 
+  335          344.8048     172.90865   0.002985075 
+  314          325.04461    172.80892   0.003184713 
+  343          309.24153    172.70938   0.002915452 
+  303          296.6833     172.61003   0.00330033 
+  280          287.00226    172.51086   0.003571429 
+  301          280.20289    172.41187   0.003322259 
+  320          276.82197    172.31307   0.003125  
+  323          278.13822    172.21445   0.003095975 
+  309          285.88842    172.11602   0.003236246 
+  299          298.36659    172.01777   0.003344482 
+  277          301.377      171.9197    0.003610108 
+  245          287.88812    171.82181   0.004081633 
+  278          275.11303    171.7241    0.003597122 
+  276          272.23595    171.62658   0.003623188 
+  250          278.97848    171.52924   0.004     
+  297          288.98024    171.43207   0.003367003 
+  296          299.08666    171.33509   0.003378378 
+  309          311.29336    171.23828   0.003236246 
+  298          306.52853    171.14166   0.003355705 
+  257          282.58563    171.04521   0.003891051 
+  245          263.42478    170.94894   0.004081633 
+  305          256.76425    170.85284   0.003278689 
+  217          257.92769    170.75693   0.004608295 
+  236          253.04333    170.66119   0.004237288 
+  239          237.88309    170.56562   0.0041841 
+  214          223.55702    170.47023   0.004672897 
+  227          213.84297    170.37502   0.004405286 
+  189          207.53957    170.27998   0.005291005 
+  232          203.26466    170.18512   0.004310345 
+  225          200.16472    170.09043   0.004444444 
+  212          197.77694    169.99591   0.004716981 
+  203          195.85196    169.90157   0.004926108 
+  203          194.24977    169.80739   0.004926108 
+  200          192.88473    169.7134    0.005     
+  180          191.70154    169.61957   0.005555556 
+  195          190.66106    169.52591   0.005128205 
+  206          189.74039    169.43242   0.004854369 
+  221          188.91965    169.33911   0.004524887 
+  190          188.18548    169.24596   0.005263158 
+  225          187.52732    169.15299   0.004444444 
+  201          186.93994    169.06018   0.004975124 
+  208          186.41857    168.96754   0.004807692 
+  181          185.96075    168.87507   0.005524862 
+  168          185.56638    168.78277   0.005952381 
+  205          185.23771    168.69063   0.004878049 
+  192          184.98154    168.59866   0.005208333 
+  204          184.81067    168.50686   0.004901961 
+  192          184.74997    168.41523   0.005208333 
+  199          184.84173    168.32376   0.005025126 
+  203          185.1303     168.23245   0.004926108 
+  209          185.53042    168.14131   0.004784689 
+  206          185.64937    168.05034   0.004854369 
+  191          185.36684    167.95953   0.005235602 
+  187          185.09989    167.86888   0.005347594 
+  172          185.10708    167.77839   0.005813953 
+  201          185.37469    167.68807   0.004975124 
+  195          185.72138    167.59792   0.005128205 
+  178          186.04455    167.50792   0.005617978 
+  202          186.57779    167.41808   0.004950495 
+  191          187.56528    167.32841   0.005235602 
+  210          189.21448    167.2389    0.004761905 
+  179          191.86332    167.14955   0.005586592 
+  217          196.19645    167.06035   0.004608295 
+  202          203.51263    166.97132   0.004950495 
+  224          215.89645    166.88245   0.004464286 
+  220          234.84513    166.79374   0.004545455 
+  228          252.94162    166.70518   0.004385965 
+  226          250.87313    166.61678   0.004424779 
+  226          234.96886    166.52855   0.004424779 
+  244          224.38501    166.44046   0.004098361 
+  233          223.26763    166.35254   0.004291845 
+  202          227.37154    166.26477   0.004950495 
+  185          225.4444     166.17716   0.005405405 
+  195          215.89338    166.0897    0.005128205 
+  205          208.27974    166.0024    0.004878049 
+  184          205.27046    165.91526   0.005434783 
+  208          206.22143    165.82827   0.004807692 
+  198          210.22716    165.74143   0.005050505 
+  203          211.58879    165.65475   0.004926108 
+  214          206.47184    165.56822   0.004672897 
+  228          200.99631    165.48185   0.004385965 
+  211          198.54088    165.39563   0.004739336 
+  224          199.03871    165.30956   0.004464286 
+  238          199.92406    165.22364   0.004201681 
+  217          197.99972    165.13788   0.004608295 
+  191          195.58376    165.05227   0.005235602 
+  213          195.24751    164.9668    0.004694836 
+  199          197.36114    164.88149   0.005025126 
+  217          201.13506    164.79633   0.004608295 
+  202          204.59686    164.71132   0.004950495 
+  251          208.842      164.62646   0.003984064 
+  244          217.68116    164.54175   0.004098361 
+  246          232.70275    164.45719   0.004065041 
+  261          249.008      164.37277   0.003831418 
+  231          254.06336    164.28851   0.004329004 
+  240          246.53541    164.20439   0.004166667 
+  264          241.61879    164.12042   0.003787879 
+  238          247.37277    164.0366    0.004201681 
+  270          263.29687    163.95292   0.003703704 
+  257          281.60452    163.86939   0.003891051 
+  283          290.79664    163.78601   0.003533569 
+  280          294.15977    163.70277   0.003571429 
+  285          296.69329    163.61968   0.003508772 
+  278          302.64526    163.53674   0.003597122 
+  320          327.66172    163.45394   0.003125  
+  368          385.34467    163.37128   0.002717391 
+  412          495.93533    163.28877   0.002427184 
+  552          662.82197    163.2064    0.001811594 
+  608          730.36696    163.12418   0.001644737 
+  580          583.58386    163.0421    0.001724138 
+  496          453.64925    162.96016   0.002016129 
+  379          414.79699    162.87836   0.002638522 
+  393          449.21408    162.79671   0.002544529 
+  400          492.11484    162.7152    0.0025    
+  393          430.68897    162.63383   0.002544529 
+  344          340.29182    162.5526    0.002906977 
+  271          285.34283    162.47152   0.003690037 
+  263          256.30588    162.39057   0.003802281 
+  250          242.14037    162.30976   0.004     
+  228          237.58748    162.2291    0.004385965 
+  213          241.65492    162.14857   0.004694836 
+  257          257.83307    162.06818   0.003891051 
+  256          297.82759    161.98794   0.00390625 
+  357          378.91352    161.90783   0.00280112 
+  431          449.00462    161.82786   0.002320186 
+  383          388.51828    161.74803   0.002610966 
+  344          322.11312    161.66833   0.002906977 
+  340          310.46763    161.58878   0.002941176 
+  335          347.75836    161.50936   0.002985075 
+  403          407.91034    161.43007   0.00248139 
+  382          393.44168    161.35093   0.002617801 
+  342          322.12039    161.27192   0.002923977 
+  275          273.16297    161.19304   0.003636364 
+  233          253.04008    161.11431   0.004291845 
+  232          249.80909    161.0357    0.004310345 
+  227          246.07313    160.95724   0.004405286 
+  238          230.94658    160.87891   0.004201681 
+  193          213.4686     160.80071   0.005181347 
+  188          201.40148    160.72264   0.005319149 
+  170          194.36768    160.64472   0.005882353 
+  203          190.57675    160.56692   0.004926108 
+  174          188.60109    160.48926   0.005747126 
+  186          186.99143    160.41173   0.005376344 
+  174          185.42383    160.33433   0.005747126 
+  174          184.627      160.25707   0.005747126 
+  187          184.83158    160.17994   0.005347594 
+  207          185.99262    160.10294   0.004830918 
+  209          187.93873    160.02607   0.004784689 
+  203          190.69611    159.94933   0.004926108 
+  171          195.25209    159.87273   0.005847953 
+  204          203.13364    159.79625   0.004901961 
+  234          216.765      159.71991   0.004273504 
+  198          241.31416    159.64369   0.005050505 
+  247          279.64013    159.56761   0.004048583 
+  294          327.28821    159.49165   0.003401361 
+  286          345.12859    159.41583   0.003496503 
+  288          313.47185    159.34013   0.003472222 
+  288          278.0719     159.26457   0.003472222 
+  239          263.78047    159.18913   0.0041841 
+  239          268.21333    159.11382   0.0041841 
+  217          275.57932    159.03864   0.004608295 
+  234          260.9315     158.96358   0.004273504 
+  185          233.63019    158.88865   0.005405405 
+  217          212.34066    158.81385   0.004608295 
+  185          199.04564    158.73918   0.005405405 
+  180          191.00677    158.66464   0.005555556 
+  176          186.02008    158.59022   0.005681818 
+  194          182.80424    158.51592   0.005154639 
+  154          180.68319    158.44176   0.006493506 
+  177          179.29993    158.36771   0.005649718 
+  198          178.46075    158.2938    0.005050505 
+  196          178.06908    158.22001   0.005102041 
+  191          178.09868    158.14634   0.005235602 
+  157          178.58546    158.0728    0.006369427 
+  167          179.58483    157.99938   0.005988024 
+  180          180.86775    157.92609   0.005555556 
+  178          181.36139    157.85292   0.005617978 
+  182          180.64142    157.77987   0.005494505 
+  175          179.83981    157.70695   0.005714286 
+  202          179.52226    157.63415   0.004950495 
+  185          179.71244    157.56147   0.005405405 
+  187          180.13378    157.48892   0.005347594 
+  170          180.36782    157.41649   0.005882353 
+  196          180.86161    157.34418   0.005102041 
+  170          181.85383    157.27199   0.005882353 
+  219          181.8151     157.19993   0.00456621 
+  215          179.97825    157.12798   0.004651163 
+  207          178.16854    157.05616   0.004830918 
+  251          177.36074    156.98446   0.003984064 
+  247          177.55854    156.91287   0.004048583 
+  253          178.2441     156.84141   0.003952569 
+  273          178.55747    156.77007   0.003663004 
+  260          179.01884    156.69885   0.003846154 
+  285          180.53932    156.62775   0.003508772 
+  292          182.27248    156.55676   0.003424658 
+  300          182.49281    156.4859    0.003333333 
+  273          182.49825    156.41516   0.003663004 
+  254          184.18434    156.34453   0.003937008 
+  278          188.4191     156.27402   0.003597122 
+  261          196.24924    156.20363   0.003831418 
+  315          206.93239    156.13336   0.003174603 
+  252          213.67172    156.06321   0.003968254 
+  236          208.58807    155.99318   0.004237288 
+  229          199.25805    155.92326   0.004366812 
+  230          193.96208    155.85346   0.004347826 
+  232          193.88084    155.78377   0.004310345 
+  192          197.12845    155.7142    0.005208333 
+  205          198.23488    155.64475   0.004878049 
+  205          195.03266    155.57542   0.004878049 
+  184          191.34982    155.5062    0.005434783 
+  197          188.5072     155.4371    0.005076142 
+  212          187.07214    155.36811   0.004716981 
+  190          186.06981    155.29924   0.005263158 
+  199          185.45983    155.23048   0.005025126 
+  167          186.27463    155.16184   0.005988024 
+  188          188.42898    155.09331   0.005319149 
+  182          192.52502    155.0249    0.005494505 
+  193          199.69989    154.9566    0.005181347 
+  219          209.07081    154.88841   0.00456621 
+  191          214.06803    154.82034   0.005235602 
+  221          208.59409    154.75239   0.004524887 
+  223          200.81768    154.68454   0.004484305 
+  219          197.11942    154.61681   0.00456621 
+  231          197.88804    154.54919   0.004329004 
+  200          200.96336    154.48169   0.005     
+  221          201.04952    154.41429   0.004524887 
+  237          197.04083    154.34701   0.004219409 
+  220          193.45234    154.27985   0.004545455 
+  204          191.83379    154.21279   0.004901961 
+  180          191.8052     154.14585   0.005555556 
+  215          192.92294    154.07901   0.004651163 
+  226          194.99741    154.01229   0.004424779 
+  202          198.04661    153.94568   0.004950495 
+  227          202.12159    153.87918   0.004405286 
+  228          206.66819    153.81279   0.004385965 
+  234          210.35883    153.74651   0.004273504 
+  219          213.70554    153.68034   0.00456621 
+  191          218.17485    153.61429   0.005235602 
+  244          224.22363    153.54834   0.004098361 
+  279          231.84289    153.4825    0.003584229 
+  259          240.58303    153.41677   0.003861004 
+  277          249.9523     153.35115   0.003610108 
+  254          260.55513    153.28564   0.003937008 
+  289          272.94889    153.22024   0.003460208 
+  319          287.15496    153.15495   0.003134796 
+  314          303.069      153.08976   0.003184713 
+  344          320.71072    153.02468   0.002906977 
+  350          340.3476     152.95972   0.002857143 
+  355          361.6328     152.89486   0.002816901 
+  347          380.20038    152.8301    0.002881844 
+  399          389.77638    152.76546   0.002506266 
+  388          392.12982    152.70092   0.00257732 
+  380          393.87309    152.63649   0.002631579 
+  412          399.2892     152.57217   0.002427184 
+  427          401.71501    152.50795   0.00234192 
+  383          394.9582     152.44384   0.002610966 
+  351          382.60063    152.37984   0.002849003 
+  339          367.70099    152.31594   0.002949853 
+  318          352.93976    152.25215   0.003144654 
+  327          340.57817    152.18847   0.003058104 
+  300          326.94678    152.12489   0.003333333 
+  264          311.43781    152.06142   0.003787879 
+  304          296.82447    151.99805   0.003289474 
+  289          282.65903    151.93478   0.003460208 
+  268          269.63794    151.87163   0.003731343 
+  269          258.1014     151.80857   0.003717472 
+  237          247.91373    151.74562   0.004219409 
+  235          238.82669    151.68278   0.004255319 
+  212          230.56561    151.62004   0.004716981 
+  214          223.38867    151.55741   0.004672897 
+  255          217.10281    151.49487   0.003921569 
+  221          211.65748    151.43245   0.004524887 
+  240          206.98606    151.37012   0.004166667 
+  228          203.02331    151.3079    0.004385965 
+  209          199.70707    151.24578   0.004784689 
+  230          196.98233    151.18377   0.004347826 
+  226          194.80022    151.12186   0.004424779 
+  183          193.1829     151.06005   0.005464481 
+  205          192.26041    150.99834   0.004878049 
+  217          192.20785    150.93674   0.004608295 
+  196          192.9988     150.87524   0.005102041 
+  213          193.64766    150.81384   0.004694836 
+  196          193.38246    150.75254   0.005102041 
+  192          193.23064    150.69135   0.005208333 
+  216          193.65571    150.63025   0.00462963 
+  190          193.16511    150.56926   0.005263158 
+  209          192.15296    150.50837   0.004784689 
+  175          191.43479    150.44758   0.005714286 
+  229          190.9627     150.38689   0.004366812 
+  230          191.38261    150.3263    0.004347826 
+  226          192.38038    150.26582   0.004424779 
+  236          193.34075    150.20543   0.004237288 
+  221          194.91627    150.14514   0.004524887 
+  231          198.17516    150.08496   0.004329004 
+  225          204.10264    150.02487   0.004444444 
+  237          214.57347    149.96488   0.004219409 
+  240          233.33299    149.905     0.004166667 
+  285          266.01147    149.84521   0.003508772 
+  297          311.70902    149.78552   0.003367003 
+  312          333.872      149.72593   0.003205128 
+  353          305.57096    149.66644   0.002832861 
+  292          274.79367    149.60705   0.003424658 
+  291          266.11213    149.54776   0.003436426 
+  284          277.24854    149.48857   0.003521127 
+  267          293.33616    149.42947   0.003745318 
+  250          287.97727    149.37047   0.004     
+  299          259.19554    149.31158   0.003344482 
+  244          234.48531    149.25278   0.004098361 
+  242          221.73086    149.19407   0.004132231 
+  247          216.54145    149.13547   0.004048583 
+  211          211.65759    149.07696   0.004739336 
+  223          204.72549    149.01855   0.004484305 
+  206          199.18629    148.96024   0.004854369 
+  197          196.0628     148.90202   0.005076142 
+  188          194.26804    148.84391   0.005319149 
+  197          192.57539    148.78588   0.005076142 
+  196          191.20184    148.72796   0.005102041 
+  218          190.68713    148.67013   0.004587156 
+  226          191.13784    148.6124    0.004424779 
+  205          192.59209    148.55477   0.004878049 
+  241          195.02495    148.49723   0.004149378 
+  256          198.68504    148.43978   0.00390625 
+  210          205.02596    148.38244   0.004761905 
+  225          216.62192    148.32518   0.004444444 
+  270          237.20729    148.26803   0.003703704 
+  279          270.32238    148.21097   0.003584229 
+  313          314.40163    148.154     0.003194888 
+  295          328.84991    148.09713   0.003389831 
+  299          288.76413    148.04036   0.003344482 
+  307          254.89476    147.98368   0.003257329 
+  252          244.1274     147.92709   0.003968254 
+  298          251.18517    147.8706    0.003355705 
+  245          269.85437    147.81421   0.004081633 
+  287          276.99743    147.75791   0.003484321 
+  248          261.48621    147.7017    0.004032258 
+  275          251.61669    147.64559   0.003636364 
+  282          245.86575    147.58957   0.003546099 
+  234          234.01436    147.53364   0.004273504 
+  229          222.0949     147.47781   0.004366812 
+  203          215.79966    147.42207   0.004926108 
+  229          215.18962    147.36643   0.004366812 
+  215          218.39393    147.31088   0.004651163 
+  236          220.55921    147.25542   0.004237288 
+  217          218.16718    147.20005   0.004608295 
+  216          215.84699    147.14478   0.00462963 
+  249          218.08832    147.0896    0.004016064 
+  219          227.57125    147.03452   0.00456621 
+  248          246.40494    146.97952   0.004032258 
+  254          263.1963     146.92462   0.003937008 
+  246          252.97298    146.86981   0.004065041 
+  253          235.76197    146.8151    0.003952569 
+  245          227.94892    146.76047   0.004081633 
+  230          228.96927    146.70594   0.004347826 
+  228          237.28435    146.6515    0.004385965 
+  221          246.22289    146.59715   0.004524887 
+  231          242.44851    146.54289   0.004329004 
+  222          235.10979    146.48873   0.004504505 
+  274          232.46871    146.43465   0.003649635 
+  219          233.526      146.38067   0.00456621 
+  226          236.09318    146.32678   0.004424779 
+  253          239.08229    146.27298   0.003952569 
+  255          242.9937     146.21927   0.003921569 
+  239          248.06221    146.16565   0.0041841 
+  288          253.87681    146.11212   0.003472222 
+  245          260.20388    146.05868   0.004081633 
+  271          267.12684    146.00533   0.003690037 
+  267          274.7028     145.95207   0.003745318 
+  304          283.41626    145.89891   0.003289474 
+  310          293.55971    145.84583   0.003225806 
+  316          305.10292    145.79284   0.003164557 
+  331          318.15194    145.73994   0.003021148 
+  330          333.20861    145.68714   0.003030303 
+  358          350.7905     145.63442   0.002793296 
+  369          371.42066    145.58179   0.002710027 
+  376          395.81285    145.52925   0.002659574 
+  480          424.81286    145.4768    0.002083333 
+  480          458.64855    145.42444   0.002083333 
+  578          497.51757    145.37217   0.001730104 
+  633          544.18549    145.31999   0.001579779 
+  692          602.43513    145.26789   0.001445087 
+  684          676.21668    145.21589   0.001461988 
+  834          770.95436    145.16397   0.001199041 
+  873          894.53807    145.11214   0.001145475 
+  883          1059.16634   145.0604    0.001132503 
+  1154         1286.12083   145.00875   0.000866551 
+  1328         1612.36001   144.95719   0.000753012 
+  1817         2105.9224    144.90571   0.000550358 
+  2649         2907.32156   144.85433   0.000377501 
+  3993         4355.03792   144.80303   0.000250438 
+  6879         7282.15677   144.75182   0.00014537 
+  12069        13267.03295  144.70069   0.000082857 
+  19165        22345.87211  144.64966   0.000052178 
+  22144        23373.37515  144.59871   0.000045159 
+  16400        14879.03655  144.54785   0.000060976 
+  9751         9180.65335   144.49707   0.000102554 
+  7281         7341.59714   144.44639   0.000137344 
+  7853         8474.42497   144.39579   0.00012734 
+  9876         12065.83395  144.34527   0.000101256 
+  11375        13140.7022   144.29485   0.000087912 
+  8819         8645.69154   144.24451   0.000113392 
+  5201         4942.42183   144.19426   0.000192271 
+  2926         3037.33424   144.14409   0.000341763 
+  1758         2086.59132   144.09401   0.000568828 
+  1342         1563.57898   144.04402   0.000745156 
+  1042         1245.25478   143.99411   0.000959693 
+  890          1036.26437   143.94429   0.001123596 
+  771          879.63924    143.89456   0.001297017 
+  631          753.00392    143.84491   0.001584786 
+  642          656.39582    143.79535   0.001557632 
+  509          584.9137     143.74587   0.001964637 
+  479          531.9423     143.69648   0.002087683 
+  448          492.15402    143.64717   0.002232143 
+  390          456.21057    143.59795   0.002564103 
+  411          419.74978    143.54882   0.00243309 
+  345          388.14541    143.49977   0.002898551 
+  317          362.63027    143.4508    0.003154574 
+  342          341.82757    143.40192   0.002923977 
+  337          324.62395    143.35313   0.002967359 
+  305          309.89578    143.30442   0.003278689 
+  281          297.22176    143.2558    0.003558719 
+  277          286.20114    143.20726   0.003610108 
+  271          276.56263    143.1588    0.003690037 
+  278          268.08274    143.11043   0.003597122 
+  292          260.61441    143.06214   0.003424658 
+  243          254.03545    143.01394   0.004115226 
+  277          248.23786    142.96583   0.003610108 
+  256          243.15212    142.91779   0.00390625 
+  239          238.70794    142.86984   0.0041841 
+  225          234.85424    142.82198   0.004444444 
+  233          231.55181    142.7742    0.004291845 
+  218          228.77093    142.7265    0.004587156 
+  232          226.49539    142.67889   0.004310345 
+  227          224.74261    142.63136   0.004405286 
+  230          223.60498    142.58391   0.004347826 
+  239          223.32539    142.53655   0.0041841 
+  219          224.25725    142.48927   0.00456621 
+  225          225.77292    142.44207   0.004444444 
+  217          224.4714     142.39496   0.004608295 
+  205          221.08805    142.34793   0.004878049 
+  231          218.46524    142.30098   0.004329004 
+  211          216.87988    142.25412   0.004739336 
+  241          216.36345    142.20734   0.004149378 
+  238          216.71427    142.16064   0.004201681 
+  243          216.36294    142.11403   0.004115226 
+  233          214.48167    142.06749   0.004291845 
+  231          212.58894    142.02104   0.004329004 
+  216          211.08398    141.97468   0.00462963 
+  236          209.97244    141.92839   0.004237288 
+  195          209.24239    141.88219   0.005128205 
+  208          208.86436    141.83607   0.004807692 
+  216          208.78266    141.79003   0.00462963 
+  218          208.91367    141.74407   0.004587156 
+  228          209.1989     141.6982    0.004385965 
+  230          209.59887    141.6524    0.004347826 
+  221          210.07306    141.60669   0.004524887 
+  217          210.65695    141.56106   0.004608295 
+  244          211.50778    141.51552   0.004098361 
+  252          212.73415    141.47005   0.003968254 
+  244          213.46892    141.42467   0.004098361 
+  282          211.75834    141.37936   0.003546099 
+  231          208.40441    141.33414   0.004329004 
+  255          205.71935    141.289     0.003921569 
+  273          204.58362    141.24394   0.003663004 
+  279          205.12606    141.19896   0.003584229 
+  247          206.07144    141.15407   0.004048583 
+  241          203.78158    141.10925   0.004149378 
+  231          198.10565    141.06452   0.004329004 
+  235          192.7707     141.01986   0.004255319 
+  240          189.22961    140.97529   0.004166667 
+  222          187.40812    140.93079   0.004504505 
+  216          186.81742    140.88638   0.00462963 
+  212          186.17263    140.84205   0.004716981 
+  224          184.70454    140.7978    0.004464286 
+  201          183.74574    140.75363   0.004975124 
+  214          184.46176    140.70953   0.004672897 
+  188          187.48255    140.66552   0.005319149 
+  179          193.16017    140.62159   0.005586592 
+  195          199.64416    140.57774   0.005128205 
+  217          202.06183    140.53397   0.004608295 
+  182          201.36113    140.49028   0.005494505 
+  173          200.66679    140.44667   0.005780347 
+  189          197.63011    140.40314   0.005291005 
+  181          193.90601    140.35969   0.005524862 
+  209          192.60227    140.31631   0.004784689 
+  207          192.11477    140.27302   0.004830918 
+  199          190.58766    140.22981   0.005025126 
+  218          189.57635    140.18667   0.004587156 
+  186          188.57802    140.14362   0.005376344 
+  190          186.98067    140.10064   0.005263158 
+  191          186.60454    140.05775   0.005235602 
+  168          187.24199    140.01493   0.005952381 
+  224          186.39081    139.97219   0.004464286 
+  162          184.30828    139.92953   0.00617284 
+  184          183.12402    139.88695   0.005434783 
+  193          183.44685    139.84445   0.005181347 
+  178          185.19046    139.80203   0.005617978 
+  181          188.06753    139.75969   0.005524862 
+  168          191.08922    139.71742   0.005952381 
+  188          193.72403    139.67523   0.005319149 
+  196          197.24417    139.63312   0.005102041 
+  195          202.51826    139.59109   0.005128205 
+  196          209.40811    139.54914   0.005102041 
+  205          218.04565    139.50727   0.004878049 
+  212          229.15203    139.46547   0.004716981 
+  239          239.45831    139.42376   0.0041841 
+  248          242.49569    139.38212   0.004032258 
+  251          242.19369    139.34056   0.003984064 
+  229          245.77408    139.29907   0.004366812 
+  275          255.41148    139.25767   0.003636364 
+  296          270.93661    139.21634   0.003378378 
+  269          289.75874    139.17509   0.003717472 
+  271          308.22143    139.13392   0.003690037 
+  263          330.0501     139.09282   0.003802281 
+  336          364.81185    139.05181   0.00297619 
+  406          422.46812    139.01087   0.002463054 
+  519          518.3805     138.97001   0.001926782 
+  596          687.76899    138.92922   0.001677852 
+  973          1018.33492   138.88851   0.001027749 
+  1530         1692.87709   138.84788   0.000653595 
+  2411         2849.67707   138.80733   0.000414766 
+  2991         3476.87328   138.76685   0.000334336 
+  2647         2497.37293   138.72645   0.000377786 
+  1629         1555.76997   138.68613   0.000613874 
+  1141         1137.48478   138.64589   0.000876424 
+  1093         1101.89601   138.60572   0.000914913 
+  1251         1407.05086   138.56563   0.000799361 
+  1620         1907.85675   138.52561   0.000617284 
+  1598         1767.35463   138.48567   0.000625782 
+  1144         1146.56681   138.44581   0.000874126 
+  784          740.8004     138.40603   0.00127551 
+  496          535.87373    138.36632   0.002016129 
+  401          424.07404    138.32668   0.002493766 
+  332          354.21183    138.28713   0.003012048 
+  274          308.57699    138.24765   0.003649635 
+  274          278.78949    138.20824   0.003649635 
+  257          259.18259    138.16892   0.003891051 
+  233          246.32586    138.12966   0.004291845 
+  224          235.24438    138.09049   0.004464286 
+  215          223.16973    138.05139   0.004651163 
+  229          212.20177    138.01237   0.004366812 
+  190          203.4839     137.97342   0.005263158 
+  181          196.74863    137.93454   0.005524862 
+  198          191.76878    137.89575   0.005050505 
+  200          187.8056     137.85703   0.005     
+  206          184.81982    137.81838   0.004854369 
+  169          182.71589    137.77981   0.00591716 
+  201          181.55298    137.74132   0.004975124 
+  194          181.42185    137.7029    0.005154639 
+  183          181.97051    137.66455   0.005464481 
+  165          181.54586    137.62629   0.006060606 
+  169          179.26545    137.58809   0.00591716 
+  173          176.90448    137.54998   0.005780347 
+  181          175.62471    137.51193   0.005524862 
+  158          175.56172    137.47396   0.006329114 
+  181          176.66354    137.43607   0.005524862 
+  176          178.58278    137.39825   0.005681818 
+  189          180.54718    137.36051   0.005291005 
+  175          182.99165    137.32284   0.005714286 
+  202          187.52813    137.28525   0.004950495 
+  192          195.79886    137.24773   0.005208333 
+  203          210.6291     137.21028   0.004926108 
+  200          238.33509    137.17291   0.005     
+  258          291.4069     137.13562   0.003875969 
+  271          384.74382    137.0984    0.003690037 
+  336          483.09101    137.06125   0.00297619 
+  340          453.62015    137.02418   0.002941176 
+  323          351.49798    136.98718   0.003095975 
+  300          286.20084    136.95026   0.003333333 
+  252          263.45226    136.91341   0.003968254 
+  240          274.28058    136.87663   0.004166667 
+  275          313.05722    136.83993   0.003636364 
+  265          340.23693    136.80331   0.003773585 
+  265          298.87499    136.76675   0.003773585 
+  219          243.89382    136.73027   0.00456621 
+  218          210.1185     136.69387   0.004587156 
+  208          192.2432     136.65754   0.004807692 
+  206          182.56876    136.62128   0.004854369 
+  188          176.67574    136.58509   0.005319149 
+  217          173.01138    136.54898   0.004608295 
+  190          171.28791    136.51295   0.005263158 
+  231          171.57333    136.47698   0.004329004 
+  211          173.5439     136.44109   0.004739336 
+  188          174.94793    136.40528   0.005319149 
+  180          173.07509    136.36953   0.005555556 
+  209          169.97291    136.33386   0.004784689 
+  182          168.2752     136.29826   0.005494505 
+  159          168.52597    136.26274   0.006289308 
+  172          170.76415    136.22729   0.005813953 
+  196          174.89249    136.19191   0.005102041 
+  193          178.4916     136.15661   0.005181347 
+  185          177.37918    136.12138   0.005405405 
+  182          172.98118    136.08622   0.005494505 
+  196          169.71054    136.05113   0.005102041 
+  181          168.96594    136.01612   0.005524862 
+  182          170.68539    135.98118   0.005494505 
+  193          174.42429    135.94631   0.005181347 
+  204          177.25208    135.91151   0.004901961 
+  186          175.09557    135.87679   0.005376344 
+  199          170.3885     135.84214   0.005025126 
+  158          167.00398    135.80756   0.006329114 
+  153          165.68124    135.77306   0.006535948 
+  154          166.08944    135.73862   0.006493506 
+  174          167.42966    135.70426   0.005747126 
+  191          167.83349    135.66997   0.005235602 
+  168          166.47297    135.63576   0.005952381 
+  189          165.06461    135.60161   0.005291005 
+  176          164.66397    135.56754   0.005681818 
+  190          164.93624    135.53354   0.005263158 
+  176          164.99958    135.49961   0.005681818 
+  164          164.73744    135.46576   0.006097561 
+  175          164.50123    135.43197   0.005714286 
+  182          164.5776     135.39826   0.005494505 
+  198          165.14727    135.36462   0.005050505 
+  184          166.17265    135.33105   0.005434783 
+  173          167.39571    135.29755   0.005780347 
+  181          168.47149    135.26413   0.005524862 
+  184          169.57088    135.23077   0.005434783 
+  189          171.02533    135.19749   0.005291005 
+  175          172.96099    135.16428   0.005714286 
+  191          175.46278    135.13114   0.005235602 
+  153          178.65446    135.09807   0.006535948 
+  184          182.532      135.06507   0.005434783 
+  216          186.40618    135.03215   0.00462963 
+  184          189.31528    134.99929   0.005434783 
+  233          192.02814    134.96651   0.004291845 
+  219          195.70713    134.9338    0.00456621 
+  209          200.78121    134.90116   0.004784689 
+  227          207.52903    134.86859   0.004405286 
+  248          216.28284    134.83609   0.004032258 
+  276          227.0163     134.80366   0.003623188 
+  249          238.71555    134.7713    0.004016064 
+  262          249.40504    134.73901   0.003816794 
+  305          259.71839    134.70679   0.003278689 
+  276          273.52887    134.67465   0.003623188 
+  328          293.45107    134.64257   0.00304878 
+  362          321.42671    134.61057   0.002762431 
+  364          359.69834    134.57864   0.002747253 
+  379          409.25442    134.54677   0.002638522 
+  424          469.84619    134.51498   0.002358491 
+  492          552.08268    134.48326   0.00203252 
+  658          681.03062    134.4516    0.001519757 
+  884          899.4633     134.42002   0.001131222 
+  1284         1304.05555   134.38851   0.000778816 
+  2127         2113.47095   134.35707   0.000470146 
+  3472         3671.37311   134.32569   0.000288018 
+  4916         5637.48337   134.29439   0.000203417 
+  4764         5313.05187   134.26316   0.000209908 
+  3260         3372.65538   134.232     0.000306748 
+  2058         2147.43907   134.20091   0.000485909 
+  1660         1680.1068    134.16988   0.00060241 
+  1727         1745.02194   134.13893   0.000579039 
+  2088         2330.18876   134.10805   0.000478927 
+  2699         3171.47857   134.07724   0.000370508 
+  2445         2876.06588   134.04649   0.000408998 
+  1741         1822.61496   134.01582   0.000574383 
+  1069         1129.27158   133.98521   0.000935454 
+  689          774.20508    133.95468   0.001451379 
+  542          586.66579    133.92421   0.001845018 
+  419          475.35276    133.89382   0.002386635 
+  375          403.99254    133.86349   0.002666667 
+  322          354.68484    133.83323   0.00310559 
+  323          317.61332    133.80305   0.003095975 
+  292          289.62577    133.77293   0.003424658 
+  260          268.54936    133.74288   0.003846154 
+  252          252.23155    133.7129    0.003968254 
+  236          239.66293    133.68298   0.004237288 
+  246          230.22189    133.65314   0.004065041 
+  224          222.5015     133.62337   0.004464286 
+  217          215.41352    133.59366   0.004608295 
+  209          209.04497    133.56403   0.004784689 
+  197          203.22089    133.53446   0.005076142 
+  205          197.92768    133.50496   0.004878049 
+  191          193.08       133.47553   0.005235602 
+  183          188.97204    133.44617   0.005464481 
+  204          185.84243    133.41688   0.004901961 
+  206          183.58876    133.38765   0.004854369 
+  193          181.8464     133.3585    0.005181347 
+  166          180.25096    133.32941   0.006024096 
+  197          178.81887    133.30039   0.005076142 
+  193          177.42109    133.27144   0.005181347 
+  169          175.70092    133.24256   0.00591716 
+  186          173.6023     133.21374   0.005376344 
+  182          171.61635    133.185     0.005494505 
+  158          170.02574    133.15632   0.006329114 
+  201          168.83848    133.12771   0.004975124 
+  190          168.03298    133.09917   0.005263158 
+  164          167.55144    133.07069   0.006097561 
+  171          167.1853     133.04229   0.005847953 
+  164          166.22952    133.01395   0.006097561 
+  202          166.44901    132.98568   0.004950495 
+  160          167.55134    132.95748   0.00625   
+  181          169.37464    132.92934   0.005524862 
+  190          171.16117    132.90127   0.005263158 
+  195          173.48414    132.87327   0.005128205 
+  178          177.60338    132.84534   0.005617978 
+  177          181.97977    132.81748   0.005649718 
+  176          180.15151    132.78968   0.005681818 
+  189          174.54883    132.76195   0.005291005 
+  191          170.81182    132.73429   0.005235602 
+  174          169.50664    132.70669   0.005747126 
+  180          170.22962    132.67916   0.005555556 
+  157          173.17432    132.6517    0.006369427 
+  159          176.22393    132.62431   0.006289308 
+  175          174.68216    132.59698   0.005714286 
+  165          169.58237    132.56972   0.006060606 
+  162          165.35472    132.54253   0.00617284 
+  175          163.01056    132.5154    0.005714286 
+  172          162.12968    132.48835   0.005813953 
+  168          162.22585    132.46135   0.005952381 
+  167          162.59096    132.43443   0.005988024 
+  166          162.27248    132.40757   0.006024096 
+  172          161.39462    132.38078   0.005813953 
+  172          160.68589    132.35405   0.005813953 
+  181          160.37146    132.32739   0.005524862 
+  176          160.40243    132.3008    0.005681818 
+  190          160.73651    132.27428   0.005263158 
+  185          161.41539    132.24782   0.005405405 
+  174          162.58098    132.22142   0.005747126 
+  196          164.42853    132.1951    0.005102041 
+  159          166.92591    132.16884   0.006289308 
+  156          168.88836    132.14264   0.006410256 
+  186          168.63416    132.11652   0.005376344 
+  179          167.16546    132.09045   0.005586592 
+  151          166.28688    132.06446   0.006622517 
+  169          166.51427    132.03853   0.00591716 
+  175          167.89552    132.01267   0.005714286 
+  171          170.46739    131.98687   0.005847953 
+  168          173.97614    131.96114   0.005952381 
+  186          177.78841    131.93547   0.005376344 
+  164          182.11193    131.90987   0.006097561 
+  193          187.50596    131.88433   0.005181347 
+  188          195.20963    131.85887   0.005319149 
+  192          205.99601    131.83346   0.005208333 
+  209          214.09524    131.80812   0.004784689 
+  208          211.8137     131.78285   0.004807692 
+  203          204.21225    131.75764   0.004926108 
+  198          199.17946    131.7325    0.005050505 
+  215          198.33605    131.70743   0.004651163 
+  186          200.66226    131.68242   0.005376344 
+  200          205.61336    131.65747   0.005     
+  224          211.61178    131.63259   0.004464286 
+  189          214.83202    131.60777   0.005291005 
+  201          216.50544    131.58302   0.004975124 
+  227          221.41531    131.55834   0.004405286 
+  248          229.5408     131.53372   0.004032258 
+  245          234.1726     131.50916   0.004081633 
+  234          232.45074    131.48467   0.004273504 
+  249          231.02977    131.46025   0.004016064 
+  259          234.42923    131.43588   0.003861004 
+  281          243.87416    131.41159   0.003558719 
+  286          259.90215    131.38736   0.003496503 
+  280          280.83675    131.36319   0.003571429 
+  296          298.71596    131.33909   0.003378378 
+  326          309.47535    131.31505   0.003067485 
+  316          321.88558    131.29107   0.003164557 
+  342          339.48425    131.26716   0.002923977 
+  353          365.89269    131.24332   0.002832861 
+  412          404.98501    131.21954   0.002427184 
+  426          438.18286    131.19582   0.002347418 
+  418          461.88759    131.17217   0.002392344 
+  437          499.96392    131.14858   0.00228833 
+  563          565.4816     131.12506   0.001776199 
+  627          667.8553     131.1016    0.001594896 
+  770          824.34153    131.0782    0.001298701 
+  1079         1077.80763   131.05487   0.000926784 
+  1505         1517.36351   131.0316    0.000664452 
+  2270         2352.10966   131.0084    0.000440529 
+  4026         3993.74446   130.98525   0.000248385 
+  6022         6596.0769    130.96218   0.000166058 
+  7011         7667.8855    130.93916   0.000142633 
+  5463         5412.19743   130.91621   0.00018305 
+  3505         3313.73192   130.89333   0.000285307 
+  2423         2289.91961   130.8705    0.000412712 
+  2017         2005.73293   130.84774   0.000495786 
+  2315         2312.01016   130.82505   0.000431965 
+  3027         3259.09945   130.80241   0.00033036 
+  3674         4227.75542   130.77984   0.000272183 
+  3141         3495.33549   130.75734   0.00031837 
+  2162         2166.94927   130.73489   0.000462535 
+  1345         1348.35151   130.71251   0.000743494 
+  927          923.58034    130.6902    0.001078749 
+  687          695.93364    130.66794   0.001455604 
+  514          561.43656    130.64575   0.001945525 
+  426          474.84177    130.62362   0.002347418 
+  378          415.95609    130.60156   0.002645503 
+  361          374.57395    130.57955   0.002770083 
+  325          344.87227    130.55761   0.003076923 
+  312          323.08927    130.53574   0.003205128 
+  292          305.84775    130.51392   0.003424658 
+  306          290.2051     130.49217   0.003267974 
+  265          276.6047     130.47048   0.003773585 
+  307          266.25452    130.44885   0.003257329 
+  274          258.77394    130.42729   0.003649635 
+  264          253.04988    130.40578   0.003787879 
+  267          249.19635    130.38434   0.003745318 
+  238          248.01419    130.36296   0.004201681 
+  222          248.77469    130.34165   0.004504505 
+  227          248.58565    130.32039   0.004405286 
+  221          242.58907    130.2992    0.004524887 
+  211          231.95291    130.27807   0.004739336 
+  231          222.10401    130.257     0.004329004 
+  221          214.76921    130.236     0.004524887 
+  229          210.16048    130.21505   0.004366812 
+  217          208.25637    130.19417   0.004608295 
+  204          208.32571    130.17335   0.004901961 
+  208          207.8162     130.15259   0.004807692 
+  207          204.97503    130.13189   0.004830918 
+  231          202.60135    130.11125   0.004329004 
+  220          203.38115    130.09068   0.004545455 
+  253          207.79216    130.07017   0.003952569 
+  225          214.80934    130.04971   0.004444444 
+  210          221.82556    130.02932   0.004761905 
+  225          221.91152    130.00899   0.004444444 
+  248          213.78856    129.98872   0.004032258 
+  232          205.98938    129.96852   0.004310345 
+  227          203.09775    129.94837   0.004405286 
+  211          205.61521    129.92829   0.004739336 
+  233          212.96795    129.90826   0.004291845 
+  224          223.02697    129.8883    0.004464286 
+  202          228.99853    129.8684    0.004950495 
+  201          224.77145    129.84855   0.004975124 
+  221          216.85352    129.82877   0.004524887 
+  219          212.37174    129.80905   0.00456621 
+  203          213.07147    129.78939   0.004926108 
+  217          218.50725    129.76979   0.004608295 
+  213          226.43287    129.75026   0.004694836 
+  207          230.49632    129.73078   0.004830918 
+  187          226.51379    129.71136   0.005347594 
+  173          219.36664    129.692     0.005780347 
+  181          212.31601    129.67271   0.005524862 
+  193          204.90972    129.65347   0.005181347 
+  186          199.25533    129.63429   0.005376344 
+  184          196.54352    129.61517   0.005434783 
+  200          195.07442    129.59612   0.005     
+  164          192.04457    129.57712   0.006097561 
+  173          188.14188    129.55818   0.005780347 
+  173          185.49552    129.53931   0.005780347 
+  190          183.87057    129.52049   0.005263158 
+  214          183.59613    129.50173   0.004672897 
+  171          185.18927    129.48304   0.005847953 
+  208          186.25137    129.4644    0.004807692 
+  189          182.06674    129.44582   0.005291005 
+  165          173.79706    129.4273    0.006060606 
+  158          167.71943    129.40884   0.006329114 
+  167          165.1075     129.39044   0.005988024 
+  162          165.46356    129.3721    0.00617284 
+  182          168.12719    129.35382   0.005494505 
+  151          171.36301    129.3356    0.006622517 
+  166          172.86722    129.31743   0.006024096 
+  169          172.01888    129.29933   0.00591716 
+  183          172.57469    129.28128   0.005464481 
+  170          177.41575    129.2633    0.005882353 
+  150          183.91967    129.24537   0.006666667 
+  186          184.19178    129.2275    0.005376344 
+  145          176.52533    129.20969   0.006896552 
+  167          167.78919    129.19194   0.005988024 
+  160          161.57527    129.17425   0.00625   
+  175          158.48032    129.15662   0.005714286 
+  172          158.31667    129.13904   0.005813953 
+  151          160.44027    129.12152   0.006622517 
+  158          162.32301    129.10407   0.006329114 
+  156          160.10152    129.08667   0.006410256 
+  148          154.90529    129.06932   0.006756757 
+  162          150.23675    129.05204   0.00617284 
+  161          147.04803    129.03482   0.00621118 
+  156          145.04312    129.01765   0.006410256 
+  161          143.85374    129.00054   0.00621118 
+  136          143.26332    128.98349   0.007352941 
+  154          143.18915    128.9665    0.006493506 
+  125          143.63518    128.94956   0.008     
+  158          144.72734    128.93268   0.006329114 
+  147          146.62856    128.91586   0.006802721 
+  151          148.71763    128.8991    0.006622517 
+  157          148.93888    128.8824    0.006369427 
+  168          146.81779    128.86575   0.005952381 
+  168          144.46014    128.84916   0.005952381 
+  157          142.98949    128.83263   0.006369427 
+  135          142.40625    128.81616   0.007407407 
+  155          142.48344    128.79974   0.006451613 
+  148          143.05559    128.78338   0.006756757 
+  155          143.6589     128.76708   0.006451613 
+  179          143.29029    128.75083   0.005586592 
+  132          142.12198    128.73464   0.007575758 
+  150          141.17091    128.71851   0.006666667 
+  148          140.59829    128.70244   0.006756757 
+  129          139.97427    128.68642   0.007751938 
+  135          139.21227    128.67046   0.007407407 
+  161          138.56033    128.65456   0.00621118 
+  153          138.14482    128.63871   0.006535948 
+  154          137.96078    128.62292   0.006493506 
+  150          137.9773     128.60718   0.006666667 
+  151          138.15325    128.59151   0.006622517 
+  136          138.35873    128.57589   0.007352941 
+  145          138.44565    128.56032   0.006896552 
+  153          138.52509    128.54481   0.006535948 
+  149          138.78107    128.52936   0.006711409 
+  147          139.28177    128.51396   0.006802721 
+  140          140.01622    128.49862   0.007142857 
+  142          140.91205    128.48334   0.007042254 
+  148          142.0237     128.46811   0.006756757 
+  162          143.64287    128.45294   0.00617284 
+  167          146.31958    128.43782   0.005988024 
+  161          150.58061    128.42276   0.00621118 
+  163          156.45367    128.40776   0.006134969 
+  166          161.68962    128.39281   0.006024096 
+  182          162.60579    128.37792   0.005494505 
+  164          160.87661    128.36308   0.006097561 
+  163          160.26098    128.3483    0.006134969 
+  164          160.84441    128.33357   0.006097561 
+  151          160.55376    128.3189    0.006622517 
+  174          159.4334     128.30428   0.005747126 
+  159          159.37131    128.28972   0.006289308 
+  159          159.55309    128.27522   0.006289308 
+  152          158.20238    128.26077   0.006578947 
+  156          156.68885    128.24637   0.006410256 
+  150          156.77437    128.23203   0.006666667 
+  171          158.17015    128.21774   0.005847953 
+  168          159.7243     128.20351   0.005952381 
+  179          161.3354     128.18934   0.005586592 
+  133          162.48897    128.17522   0.007518797 
+  171          162.17436    128.16115   0.005847953 
+  167          162.17021    128.14714   0.005988024 
+  168          163.99272    128.13318   0.005952381 
+  160          165.89929    128.11928   0.00625   
+  164          165.39868    128.10543   0.006097561 
+  168          164.18284    128.09163   0.005952381 
+  142          164.58838    128.07789   0.007042254 
+  192          166.47565    128.06421   0.005208333 
+  180          169.4675     128.05057   0.005555556 
+  157          175.00219    128.037     0.006369427 
+  159          184.98552    128.02347   0.006289308 
+  229          201.1347     128.01      0.004366812 
+  251          227.12501    127.99658   0.003984064 
+  267          271.33882    127.98322   0.003745318 
+  250          333.88836    127.96991   0.004     
+  314          360.16168    127.95666   0.003184713 
+  270          311.42343    127.94346   0.003703704 
+  274          257.86464    127.93031   0.003649635 
+  232          230.08931    127.91721   0.004310345 
+  241          224.18155    127.90417   0.004149378 
+  205          235.65667    127.89118   0.004878049 
+  261          261.79487    127.87825   0.003831418 
+  265          292.66072    127.86537   0.003773585 
+  237          297.31119    127.85254   0.004219409 
+  242          263.58046    127.83976   0.004132231 
+  205          231.18929    127.82704   0.004878049 
+  225          215.67941    127.81437   0.004444444 
+  191          214.2861     127.80175   0.005235602 
+  240          222.53696    127.78919   0.004166667 
+  206          233.74705    127.77668   0.004854369 
+  204          242.56075    127.76422   0.004901961 
+  231          254.76047    127.75181   0.004329004 
+  280          284.94634    127.73946   0.003571429 
+  307          345.67433    127.72716   0.003257329 
+  350          414.62113    127.71491   0.002857143 
+  338          405.93773    127.70271   0.00295858 
+  299          338.49933    127.69057   0.003344482 
+  272          290.02319    127.67848   0.003676471 
+  262          271.42851    127.66644   0.003816794 
+  265          279.93576    127.65445   0.003773585 
+  263          318.86625    127.64251   0.003802281 
+  296          391.82968    127.63063   0.003378378 
+  296          457.12492    127.6188    0.003378378 
+  337          422.36201    127.60702   0.002967359 
+  278          331.79352    127.59529   0.003597122 
+  265          265.4833     127.58361   0.003773585 
+  217          230.3916     127.57198   0.004608295 
+  206          216.79033    127.56041   0.004854369 
+  218          219.07479    127.54889   0.004587156 
+  208          234.46676    127.53742   0.004807692 
+  208          247.92749    127.526     0.004807692 
+  219          232.03623    127.51463   0.00456621 
+  226          202.63368    127.50331   0.004424779 
+  167          181.28174    127.49204   0.005988024 
+  156          168.68313    127.48083   0.006410256 
+  171          161.46662    127.46966   0.005847953 
+  181          157.04696    127.45855   0.005524862 
+  157          153.94066    127.44748   0.006369427 
+  173          151.76747    127.43647   0.005780347 
+  201          150.50391    127.42551   0.004975124 
+  163          150.08541    127.4146    0.006134969 
+  163          150.48487    127.40374   0.006134969 
+  176          151.72577    127.39293   0.005681818 
+  185          153.6427     127.38217   0.005405405 
+  183          155.85735    127.37146   0.005464481 
+  178          158.7747     127.3608    0.005617978 
+  184          163.46483    127.35019   0.005434783 
+  186          170.30299    127.33963   0.005376344 
+  206          178.98792    127.32912   0.004854369 
+  198          187.89091    127.31866   0.005050505 
+  202          194.37094    127.30825   0.004950495 
+  199          201.48743    127.29789   0.005025126 
+  180          209.3361     127.28758   0.005555556 
+  195          206.47493    127.27732   0.005128205 
+  172          193.7733     127.26711   0.005813953 
+  180          183.63198    127.25695   0.005555556 
+  177          179.38256    127.24684   0.005649718 
+  187          179.24921    127.23678   0.005347594 
+  189          180.44735    127.22676   0.005291005 
+  168          183.21572    127.2168    0.005952381 
+  179          188.32405    127.20688   0.005586592 
+  162          189.87332    127.19702   0.00617284 
+  184          184.30769    127.1872    0.005434783 
+  191          177.80402    127.17744   0.005235602 
+  181          174.61182    127.16772   0.005524862 
+  174          175.36664    127.15805   0.005747126 
+  226          180.83864    127.14843   0.004424779 
+  212          193.61374    127.13885   0.004716981 
+  247          219.77128    127.12933   0.004048583 
+  326          270.326      127.11986   0.003067485 
+  405          350.56385    127.11043   0.002469136 
+  469          397.60686    127.10105   0.002132196 
+  370          338.59404    127.09172   0.002702703 
+  290          268.57054    127.08244   0.003448276 
+  250          230.27042    127.07321   0.004     
+  241          214.34627    127.06402   0.004149378 
+  276          214.41939    127.05488   0.003623188 
+  261          231.72628    127.04579   0.003831418 
+  318          270.68594    127.03675   0.003144654 
+  334          313.60281    127.02776   0.002994012 
+  301          307.84423    127.01881   0.003322259 
+  244          274.44636    127.00992   0.004098361 
+  215          243.06923    127.00107   0.004651163 
+  209          219.53324    126.99226   0.004784689 
+  190          205.50305    126.98351   0.005263158 
+  197          199.43336    126.9748    0.005076142 
+  205          201.05871    126.96614   0.004878049 
+  180          209.61052    126.95753   0.005555556 
+  203          218.9544     126.94896   0.004926108 
+  183          219.99041    126.94044   0.005464481 
+  217          212.91149    126.93197   0.004608295 
+  170          205.85584    126.92354   0.005882353 
+  198          202.08562    126.91517   0.005050505 
+  189          195.82913    126.90683   0.005291005 
+  186          187.33656    126.89855   0.005376344 
+  161          182.36426    126.89031   0.00621118 
+  164          180.51868    126.88212   0.006097561 
+  175          177.94279    126.87398   0.005714286 
+  191          174.89692    126.86588   0.005235602 
+  199          174.90799    126.85783   0.005025126 
+  185          179.17302    126.84982   0.005405405 
+  172          185.57772    126.84186   0.005813953 
+  195          192.35878    126.83395   0.005128205 
+  163          198.14638    126.82608   0.006134969 
+  184          195.473      126.81826   0.005434783 
+  145          184.22731    126.81049   0.006896552 
+  193          173.14726    126.80276   0.005181347 
+  152          165.88729    126.79507   0.006578947 
+  182          161.93531    126.78744   0.005494505 
+  151          160.80399    126.77985   0.006622517 
+  151          162.54238    126.7723    0.006622517 
+  161          165.99661    126.7648    0.00621118 
+  149          166.96798    126.75734   0.006711409 
+  163          162.4963     126.74994   0.006134969 
+  161          156.10523    126.74257   0.00621118 
+  143          151.01001    126.73525   0.006993007 
+  140          147.41544    126.72798   0.007142857 
+  143          144.76728    126.72075   0.006993007 
+  142          142.8311     126.71357   0.007042254 
+  153          141.47285    126.70643   0.006535948 
+  152          140.53692    126.69933   0.006578947 
+  148          139.9024     126.69229   0.006756757 
+  148          139.49465    126.68528   0.006756757 
+  125          139.2798     126.67832   0.008     
+  132          139.2531     126.67141   0.007575758 
+  163          139.43315    126.66454   0.006134969 
+  138          139.85915    126.65771   0.007246377 
+  147          140.56857    126.65093   0.006802721 
+  160          141.494      126.64419   0.00625   
+  161          142.39859    126.6375    0.00621118 
+  140          143.23683    126.63085   0.007142857 
+  165          144.34489    126.62425   0.006060606 
+  147          145.73685    126.61769   0.006802721 
+  166          146.61805    126.61117   0.006024096 
+  173          146.74047    126.6047    0.005780347 
+  141          147.16082    126.59827   0.007092199 
+  151          148.68869    126.59189   0.006622517 
+  137          151.49777    126.58554   0.00729927 
+  153          155.09466    126.57925   0.006535948 
+  161          157.70102    126.57299   0.00621118 
+  134          157.75235    126.56678   0.007462687 
+  150          156.66142    126.56062   0.006666667 
+  161          156.04017    126.55449   0.00621118 
+  140          156.3961     126.54841   0.007142857 
+  167          158.53012    126.54237   0.005988024 
+  135          162.50214    126.53638   0.007407407 
+  177          168.76005    126.53043   0.005649718 
+  171          176.86565    126.52452   0.005847953 
+  202          185.46784    126.51865   0.004950495 
+  200          193.28259    126.51283   0.005     
+  225          195.75795    126.50705   0.004444444 
+  177          189.95163    126.50132   0.005649718 
+  180          181.84698    126.49562   0.005555556 
+  173          176.08124    126.48997   0.005780347 
+  192          173.42022    126.48436   0.005208333 
+  172          173.36525    126.47879   0.005813953 
+  180          175.19914    126.47327   0.005555556 
+  149          178.42328    126.46779   0.006711409 
+  185          181.43388    126.46235   0.005405405 
+  167          180.8994     126.45695   0.005988024 
+  178          177.15919    126.45159   0.005617978 
+  182          173.5446     126.44628   0.005494505 
+  164          171.50611    126.44101   0.006097561 
+  183          171.02126    126.43578   0.005464481 
+  177          171.84729    126.43059   0.005649718 
+  159          173.87519    126.42544   0.006289308 
+  183          176.95937    126.42034   0.005464481 
+  180          180.33446    126.41527   0.005555556 
+  226          182.76209    126.41025   0.004424779 
+  187          184.66431    126.40527   0.005347594 
+  197          187.56043    126.40033   0.005076142 
+  189          192.0203     126.39543   0.005291005 
+  201          197.23533    126.39058   0.004975124 
+  183          201.02423    126.38576   0.005464481 
+  216          202.32387    126.38099   0.00462963 
+  189          202.99475    126.37625   0.005291005 
+  201          203.69234    126.37156   0.004975124 
+  212          203.57114    126.36691   0.004716981 
+  215          203.76094    126.3623    0.004651163 
+  211          205.75764    126.35773   0.004739336 
+  165          209.86884    126.3532    0.006060606 
+  186          215.2685     126.34871   0.005376344 
+  181          219.92283    126.34426   0.005524862 
+  201          222.74809    126.33985   0.004975124 
+  202          225.40218    126.33549   0.004950495 
+  220          228.95491    126.33116   0.004545455 
+  250          235.0767     126.32687   0.004     
+  248          250.00359    126.32263   0.004032258 
+  266          283.74496    126.31842   0.003759398 
+  358          348.72228    126.31425   0.002793296 
+  374          430.72211    126.31012   0.002673797 
+  410          428.71824    126.30604   0.002439024 
+  318          344.28756    126.30199   0.003144654 
+  263          277.27105    126.29798   0.003802281 
+  250          240.74974    126.29402   0.004     
+  214          223.75476    126.29009   0.004672897 
+  203          220.83669    126.2862    0.004926108 
+  267          232.84169    126.28235   0.003745318 
+  261          263.30633    126.27854   0.003831418 
+  261          294.66955    126.27477   0.003831418 
+  256          274.60154    126.27104   0.00390625 
+  236          228.59135    126.26735   0.004237288 
+  200          196.67612    126.2637    0.005     
+  168          178.73022    126.26008   0.005952381 
+  194          168.58712    126.25651   0.005154639 
+  174          162.42761    126.25297   0.005747126 
+  152          158.36982    126.24948   0.006578947 
+  160          155.44787    126.24602   0.00625   
+  164          153.12593    126.2426    0.006097561 
+  157          151.33401    126.23922   0.006369427 
+  161          150.16269    126.23588   0.00621118 
+  176          149.66753    126.23257   0.005681818 
+  157          149.94329    126.22931   0.006369427 
+  159          151.12816    126.22608   0.006289308 
+  156          153.07603    126.22289   0.006410256 
+  137          154.53557    126.21974   0.00729927 
+  156          153.79836    126.21663   0.006410256 
+  154          151.62845    126.21356   0.006493506 
+  142          149.6234     126.21052   0.007042254 
+  155          147.76114    126.20753   0.006451613 
+  151          146.01975    126.20457   0.006622517 
+  161          144.96468    126.20164   0.00621118 
+  165          144.78134    126.19876   0.006060606 
+  150          145.24159    126.19591   0.006666667 
+  153          145.55329    126.19311   0.006535948 
+  148          144.98363    126.19033   0.006756757 
+  139          144.10789    126.1876    0.007194245 
+  156          143.52241    126.18491   0.006410256 
+  142          142.97491    126.18225   0.007042254 
+  158          142.56738    126.17963   0.006329114 
+  160          142.86571    126.17704   0.00625   
+  120          144.0245     126.1745    0.008333333 
+  165          145.33987    126.17199   0.006060606 
+  165          145.31596    126.16951   0.006060606 
+  178          143.6916     126.16708   0.005617978 
+  150          141.71153    126.16468   0.006666667 
+  147          140.21543    126.16232   0.006802721 
+  145          139.28581    126.15999   0.006896552 
+  138          138.84779    126.15771   0.007246377 
+  161          138.92404    126.15546   0.00621118 
+  136          139.45914    126.15324   0.007352941 
+  133          140.03093    126.15106   0.007518797 
+  137          139.88476    126.14892   0.00729927 
+  124          138.96957    126.14682   0.008064516 
+  121          137.92646    126.14475   0.008264463 
+  141          137.16913    126.14272   0.007092199 
+  142          136.77169    126.14072   0.007042254 
+  132          136.69222    126.13876   0.007575758 
+  118          136.85892    126.13684   0.008474576 
+  140          137.07764    126.13495   0.007142857 
+  143          137.04227    126.1331    0.006993007 
+  151          136.76394    126.13128   0.006622517 
+  129          136.52418    126.1295    0.007751938 
+  148          136.45019    126.12776   0.006756757 
+  139          136.55959    126.12605   0.007194245 
+  133          136.85579    126.12438   0.007518797 
+  151          137.3565     126.12274   0.006622517 
+  150          138.06591    126.12114   0.006666667 
+  133          138.85939    126.11957   0.007518797 
+  144          139.43426    126.11804   0.006944444 
+  160          139.73995    126.11655   0.00625   
+  145          140.07757    126.11509   0.006896552 
+  134          140.62231    126.11367   0.007462687 
+  151          141.40218    126.11228   0.006622517 
+  152          142.37939    126.11092   0.006578947 
+  164          143.54328    126.1096    0.006097561 
+  151          145.01575    126.10832   0.006622517 
+  145          146.94952    126.10707   0.006896552 
+  163          149.52826    126.10586   0.006134969 
+  172          153.20089    126.10468   0.005813953 
+  165          159.00407    126.10353   0.006060606 
+  159          168.77627    126.10243   0.006289308 
+  194          185.21299    126.10135   0.005154639 
+  206          209.35122    126.10031   0.004854369 
+  198          228.32823    126.09931   0.005050505 
+  201          218.44321    126.09833   0.004975124 
+  162          194.63065    126.0974    0.00617284 
+  160          177.44869    126.0965    0.00625   
+  167          168.49939    126.09563   0.005988024 
+  177          165.38397    126.0948    0.005649718 
+  177          166.88701    126.094     0.005649718 
+  181          173.27978    126.09323   0.005524862 
+  178          184.93389    126.0925    0.005617978 
+  175          196.43007    126.0918    0.005714286 
+  175          195.57688    126.09114   0.005714286 
+  173          187.95821    126.09051   0.005780347 
+  177          183.29437    126.08992   0.005649718 
+  154          179.43561    126.08936   0.006493506 
+  161          174.05337    126.08883   0.00621118 
+  154          169.04035    126.08833   0.006493506 
+  178          165.2637     126.08787   0.005617978 
+  155          162.16941    126.08745   0.006451613 
+  161          160.24863    126.08706   0.00621118 
+  146          160.22444    126.0867    0.006849315 
+  167          162.2374     126.08637   0.005988024 
+  165          165.6231     126.08608   0.006060606 
+  169          168.06539    126.08582   0.00591716 
+  152          168.57289    126.08559   0.006578947 
+  189          169.34928    126.0854    0.005291005 
+  149          172.32321    126.08524   0.006711409 
+  158          177.08176    126.08512   0.006329114 
+  196          180.83759    126.08502   0.005102041 
+  177          180.74939    126.08496   0.005649718 
+  147          179.15543    126.08494   0.006802721 
+  190          179.14858    126.08494   0.005263158 
+  184          181.82697    126.08498   0.005434783 
+  199          190.09198    126.08505   0.005025126 
+  217          209.49613    126.08516   0.004608295 
+  265          247.01896    126.08529   0.003773585 
+  313          296.56779    126.08546   0.003194888 
+  308          304.8478     126.08567   0.003246753 
+  274          259.95116    126.0859    0.003649635 
+  209          219.02962    126.08617   0.004784689 
+  218          196.20679    126.08647   0.004587156 
+  225          185.98781    126.0868    0.004444444 
+  221          184.07066    126.08717   0.004524887 
+  200          189.11563    126.08756   0.005     
+  223          202.40601    126.08799   0.004484305 
+  219          223.11787    126.08846   0.00456621 
+  216          229.91721    126.08895   0.00462963 
+  188          206.59933    126.08948   0.005319149 
+  188          181.46906    126.09003   0.005319149 
+  158          166.38496    126.09063   0.006329114 
+  172          158.66616    126.09125   0.005813953 
+  165          154.97153    126.0919    0.006060606 
+  170          153.01719    126.09259   0.005882353 
+  143          151.64772    126.09331   0.006993007 
+  157          150.53357    126.09406   0.006369427 
+  130          149.38578    126.09484   0.007692308 
+  139          148.54509    126.09565   0.007194245 
+  167          148.74131    126.0965    0.005988024 
+  169          150.13952    126.09737   0.00591716 
+  143          152.24806    126.09828   0.006993007 
+  162          153.9077     126.09922   0.00617284 
+  163          154.29703    126.10019   0.006134969 
+  172          154.55568    126.1012    0.005813953 
+  152          156.53968    126.10223   0.006578947 
+  154          161.43611    126.1033    0.006493506 
+  177          169.77421    126.10439   0.005649718 
+  139          180.51295    126.10552   0.007194245 
+  164          190.02142    126.10668   0.006097561 
+  183          194.37205    126.10787   0.005464481 
+  147          190.59521    126.1091    0.006802721 
+  133          180.30681    126.11035   0.007518797 
+  176          169.74075    126.11163   0.005681818 
+  124          162.5601     126.11295   0.008064516 
+  152          159.25859    126.1143    0.006578947 
+  146          159.38887    126.11567   0.006849315 
+  172          162.12076    126.11708   0.005813953 
+  161          165.53317    126.11852   0.00621118 
+  144          167.14946    126.11999   0.006944444 
+  128          165.26287    126.12149   0.0078125 
+  130          159.83408    126.12302   0.007692308 
+  154          153.60936    126.12459   0.006493506 
+  170          148.7511     126.12618   0.005882353 
+  138          145.51391    126.1278    0.007246377 
+  150          143.48559    126.12946   0.006666667 
+  148          142.2717     126.13114   0.006756757 
+  162          141.60709    126.13286   0.00617284 
+  142          141.25316    126.13461   0.007042254 
+  121          140.97995    126.13638   0.008264463 
+  156          140.75759    126.13819   0.006410256 
+  143          140.73234    126.14003   0.006993007 
+  146          141.03532    126.1419    0.006849315 
+  157          141.74951    126.14379   0.006369427 
+  157          142.97765    126.14572   0.006369427 
+  153          144.88248    126.14768   0.006535948 
+  136          147.64588    126.14967   0.007352941 
+  135          151.11785    126.15169   0.007407407 
+  164          154.22199    126.15374   0.006097561 
+  156          155.80053    126.15582   0.006410256 
+  142          156.4102     126.15793   0.007042254 
+  147          157.02414    126.16007   0.006802721 
+  141          157.14425    126.16224   0.007092199 
+  158          156.67214    126.16444   0.006329114 
+  166          157.01958    126.16667   0.006024096 
+  156          159.33625    126.16893   0.006410256 
+  172          164.33748    126.17123   0.005813953 
+  148          172.86193    126.17355   0.006756757 
+  196          186.46863    126.1759    0.005102041 
+  193          208.39057    126.17828   0.005181347 
+  208          239.63039    126.18069   0.004807692 
+  240          261.61441    126.18313   0.004166667 
+  183          248.75401    126.1856    0.005464481 
+  205          222.58379    126.1881    0.004878049 
+  187          202.67821    126.19062   0.005347594 
+  187          188.43473    126.19318   0.005347594 
+  178          178.99802    126.19577   0.005617978 
+  171          175.20866    126.19839   0.005847953 
+  164          177.7627     126.20104   0.006097561 
+  195          187.34985    126.20372   0.005128205 
+  186          200.52607    126.20642   0.005376344 
+  190          202.60071    126.20916   0.005263158 
+  180          190.33739    126.21193   0.005555556 
+  162          177.77124    126.21472   0.00617284 
+  155          168.44469    126.21755   0.006451613 
+  141          161.1695     126.2204    0.007092199 
+  163          155.85771    126.22329   0.006134969 
+  160          152.36894    126.2262    0.00625   
+  145          150.23159    126.22914   0.006896552 
+  155          149.01494    126.23212   0.006451613 
+  156          148.44845    126.23512   0.006410256 
+  137          148.3389     126.23815   0.00729927 
+  152          148.53904    126.24121   0.006578947 
+  155          148.98028    126.2443    0.006451613 
+  136          149.57013    126.24742   0.007352941 
+  173          150.3957     126.25057   0.005780347 
+  158          151.49012    126.25375   0.006329114 
+  159          152.88573    126.25696   0.006289308 
+  178          154.65205    126.26019   0.005617978 
+  160          156.88728    126.26346   0.00625   
+  147          159.72816    126.26675   0.006802721 
+  177          163.2774     126.27008   0.005649718 
+  163          167.34426    126.27343   0.006134969 
+  178          171.28935    126.27681   0.005617978 
+  210          175.06626    126.28023   0.004761905 
+  183          179.61505    126.28367   0.005464481 
+  175          185.67282    126.28714   0.005714286 
+  190          193.48095    126.29064   0.005263158 
+  225          203.76832    126.29417   0.004444444 
+  225          218.04154    126.29772   0.004444444 
+  238          238.38257    126.30131   0.004201681 
+  240          267.80322    126.30493   0.004166667 
+  295          311.03268    126.30857   0.003389831 
+  388          377.79597    126.31224   0.00257732 
+  514          491.99554    126.31595   0.001945525 
+  684          699.99445    126.31968   0.001461988 
+  1036         1061.12852   126.32344   0.000965251 
+  1357         1508.29881   126.32723   0.00073692 
+  1324         1558.58419   126.33105   0.000755287 
+  981          1141.00958   126.3349    0.001019368 
+  753          768.54772    126.33878   0.001328021 
+  548          558.44318    126.34268   0.001824818 
+  464          457.89375    126.34662   0.002155172 
+  410          425.03565    126.35058   0.002439024 
+  452          448.25743    126.35458   0.002212389 
+  571          540.86704    126.3586    0.001751313 
+  737          722.58713    126.36265   0.001356852 
+  825          912.79156    126.36673   0.001212121 
+  751          850.48828    126.37084   0.001331558 
+  625          618.27053    126.37498   0.0016    
+  410          442.17447    126.37915   0.002439024 
+  346          340.97341    126.38334   0.002890173 
+  255          283.14397    126.38757   0.003921569 
+  241          247.51361    126.39182   0.004149378 
+  204          223.90383    126.39611   0.004901961 
+  220          207.27987    126.40042   0.004545455 
+  188          195.4368     126.40476   0.005319149 
+  211          186.83815    126.40913   0.004739336 
+  183          180.25341    126.41353   0.005464481 
+  184          175.48915    126.41796   0.005434783 
+  181          172.31747    126.42242   0.005524862 
+  156          169.54498    126.42691   0.006410256 
+  171          166.00158    126.43142   0.005847953 
+  169          162.06174    126.43597   0.00591716 
+  171          158.35958    126.44054   0.005847953 
+  159          155.03789    126.44515   0.006289308 
+  157          152.31614    126.44978   0.006369427 
+  167          150.2587     126.45444   0.005988024 
+  149          148.77278    126.45913   0.006711409 
+  139          147.75592    126.46385   0.007194245 
+  145          147.07522    126.4686    0.006896552 
+  149          146.48885    126.47338   0.006711409 
+  166          145.85456    126.47818   0.006024096 
+  158          145.33148    126.48302   0.006329114 
+  146          145.0903     126.48788   0.006849315 
+  181          145.13934    126.49278   0.005524862 
+  142          145.36666    126.4977    0.007042254 
+  162          145.62728    126.50266   0.00617284 
+  169          145.87044    126.50764   0.00591716 
+  153          146.1335     126.51265   0.006535948 
+  141          146.37635    126.51769   0.007092199 
+  151          146.67841    126.52276   0.006622517 
+  162          147.29345    126.52786   0.00617284 
+  147          148.42241    126.53299   0.006802721 
+  143          150.24469    126.53815   0.006993007 
+  182          153.0173     126.54333   0.005494505 
+  169          157.15257    126.54855   0.00591716 
+  177          163.32406    126.5538    0.005649718 
+  161          172.61651    126.55907   0.00621118 
+  149          186.84807    126.56438   0.006711409 
+  167          207.28253    126.56971   0.005988024 
+  189          226.63948    126.57508   0.005291005 
+  217          226.59439    126.58047   0.004608295 
+  181          209.75701    126.58589   0.005524862 
+  171          192.04681    126.59135   0.005847953 
+  171          178.97564    126.59683   0.005847953 
+  162          171.21949    126.60234   0.00617284 
+  174          168.11173    126.60788   0.005747126 
+  178          168.99383    126.61345   0.005617978 
+  179          173.98922    126.61905   0.005586592 
+  159          183.41218    126.62468   0.006289308 
+  161          193.55421    126.63034   0.00621118 
+  171          195.36266    126.63603   0.005847953 
+  189          190.40473    126.64175   0.005291005 
+  182          186.77636    126.6475    0.005494505 
+  187          185.86215    126.65328   0.005347594 
+  167          183.71395    126.65909   0.005988024 
+  149          177.06967    126.66493   0.006711409 
+  190          168.8001     126.6708    0.005263158 
+  169          162.33963    126.6767    0.00591716 
+  143          158.4416     126.68263   0.006993007 
+  152          156.70864    126.68859   0.006578947 
+  150          156.70111    126.69458   0.006666667 
+  178          158.38943    126.7006    0.005617978 
+  178          161.97469    126.70665   0.005617978 
+  166          167.00546    126.71273   0.006024096 
+  167          171.56998    126.71884   0.005988024 
+  173          174.18572    126.72498   0.005780347 
+  169          175.90138    126.73116   0.00591716 
+  155          177.14038    126.73736   0.006451613 
+  184          175.94272    126.74359   0.005434783 
+  171          171.45515    126.74985   0.005847953 
+  153          166.50683    126.75615   0.006535948 
+  170          163.4577     126.76247   0.005882353 
+  157          162.49548    126.76882   0.006369427 
+  156          162.43042    126.77521   0.006410256 
+  167          162.17804    126.78163   0.005988024 
+  182          162.21799    126.78807   0.005494505 
+  164          163.14234    126.79455   0.006097561 
+  168          164.41468    126.80106   0.005952381 
+  182          164.71107    126.8076    0.005494505 
+  156          163.30957    126.81417   0.006410256 
+  150          161.50988    126.82077   0.006666667 
+  202          160.65075    126.8274    0.004950495 
+  155          160.92389    126.83406   0.006451613 
+  172          161.77627    126.84076   0.005813953 
+  164          162.57451    126.84749   0.006097561 
+  199          163.47366    126.85424   0.005025126 
+  173          164.9503     126.86103   0.005780347 
+  211          167.2181     126.86785   0.004739336 
+  171          170.34819    126.8747    0.005847953 
+  178          174.43818    126.88159   0.005617978 
+  182          179.66089    126.8885    0.005494505 
+  191          186.28022    126.89545   0.005235602 
+  202          194.61262    126.90242   0.004950495 
+  217          204.83906    126.90943   0.004608295 
+  210          217.01731    126.91647   0.004761905 
+  225          231.95766    126.92355   0.004444444 
+  279          251.8188     126.93065   0.003584229 
+  317          279.57686    126.93779   0.003154574 
+  357          319.54738    126.94496   0.00280112 
+  412          379.24448    126.95216   0.002427184 
+  516          473.06124    126.95939   0.001937984 
+  681          629.16708    126.96666   0.001468429 
+  1020         899.3255     126.97396   0.000980392 
+  1452         1358.5339    126.98129   0.000688705 
+  1984         1976.46284   126.98865   0.000504032 
+  2024         2206.65684   126.99605   0.000494071 
+  1590         1709.50927   127.00348   0.000628931 
+  1166         1145.98185   127.01094   0.000857633 
+  793          799.838      127.01843   0.001261034 
+  624          621.04029    127.02596   0.001602564 
+  637          543.88226    127.03352   0.001569859 
+  592          537.68177    127.04111   0.001689189 
+  684          603.37762    127.04873   0.001461988 
+  812          766.18673    127.05639   0.001231527 
+  1008         1038.65092   127.06408   0.000992063 
+  1063         1237.30604   127.07181   0.000940734 
+  923          1059.49398   127.07957   0.001083424 
+  699          742.59002    127.08736   0.001430615 
+  515          521.40727    127.09518   0.001941748 
+  431          393.90855    127.10304   0.002320186 
+  301          321.06117    127.11093   0.003322259 
+  289          276.89496    127.11886   0.003460208 
+  250          247.67233    127.12682   0.004     
+  235          226.70782    127.13482   0.004255319 
+  211          211.12784    127.14284   0.004739336 
+  210          199.48138    127.15091   0.004761905 
+  204          190.71409    127.159     0.004901961 
+  202          184.05832    127.16713   0.004950495 
+  178          179.00508    127.1753    0.005617978 
+  168          175.24873    127.1835    0.005952381 
+  174          172.63319    127.19173   0.005747126 
+  181          171.0549     127.2       0.005524862 
+  167          170.3291     127.2083    0.005988024 
+  163          170.23368    127.21664   0.006134969 
+  182          170.55537    127.22502   0.005494505 
+  174          170.34608    127.23342   0.005747126 
+  206          168.47367    127.24187   0.004854369 
+  185          165.71211    127.25035   0.005405405 
+  172          163.48963    127.25886   0.005813953 
+  186          162.13716    127.26741   0.005376344 
+  156          161.21722    127.27599   0.006410256 
+  147          160.56389    127.28461   0.006802721 
+  184          160.61661    127.29327   0.005434783 
+  184          161.81001    127.30196   0.005434783 
+  133          164.33089    127.31069   0.007518797 
+  152          167.91179    127.31945   0.006578947 
+  168          171.73262    127.32825   0.005952381 
+  173          176.09969    127.33709   0.005780347 
+  180          183.73956    127.34596   0.005555556 
+  217          198.12711    127.35487   0.004608295 
+  165          221.82309    127.36382   0.006060606 
+  233          249.7164     127.3728    0.004291845 
+  217          257.41286    127.38182   0.004608295 
+  199          235.55321    127.39088   0.005025126 
+  222          210.63773    127.39997   0.004504505 
+  183          195.86354    127.4091    0.005464481 
+  200          190.52355    127.41827   0.005     
+  190          192.29061    127.42747   0.005263158 
+  192          200.15927    127.43671   0.005208333 
+  202          210.99785    127.44599   0.004950495 
+  187          217.33355    127.45531   0.005347594 
+  211          220.79903    127.46467   0.004739336 
+  184          222.834      127.47406   0.005434783 
+  200          213.01062    127.48349   0.005     
+  177          196.09656    127.49296   0.005649718 
+  192          182.53536    127.50247   0.005208333 
+  168          174.01748    127.51201   0.005952381 
+  166          169.80686    127.5216    0.006024096 
+  177          169.17909    127.53122   0.005649718 
+  168          171.05429    127.54088   0.005952381 
+  175          171.74588    127.55059   0.005714286 
+  140          167.88182    127.56033   0.007142857 
+  170          162.76657    127.5701    0.005882353 
+  166          159.50582    127.57992   0.006024096 
+  164          158.32121    127.58978   0.006097561 
+  189          158.46588    127.59968   0.005291005 
+  156          159.15525    127.60962   0.006410256 
+  192          160.11166    127.61959   0.005208333 
+  157          161.10653    127.62961   0.006369427 
+  133          161.50598    127.63967   0.007518797 
+  171          161.53838    127.64977   0.005847953 
+  160          161.52076    127.65991   0.00625   
+  170          160.69502    127.67009   0.005882353 
+  172          158.64999    127.6803    0.005813953 
+  182          156.51212    127.69057   0.005494505 
+  168          155.22418    127.70087   0.005952381 
+  164          154.93125    127.71121   0.006097561 
+  160          155.39405    127.72159   0.00625   
+  173          156.3135     127.73202   0.005780347 
+  178          157.30581    127.74248   0.005617978 
+  155          158.06199    127.75299   0.006451613 
+  186          158.84116    127.76354   0.005376344 
+  160          159.71466    127.77414   0.00625   
+  179          160.24376    127.78477   0.005586592 
+  178          160.3958     127.79545   0.005617978 
+  154          160.57889    127.80617   0.006493506 
+  181          160.75966    127.81693   0.005524862 
+  174          160.96411    127.82773   0.005747126 
+  180          161.47153    127.83858   0.005555556 
+  218          162.43476    127.84947   0.004587156 
+  204          163.87266    127.86041   0.004901961 
+  209          165.76767    127.87138   0.004784689 
+  196          168.11921    127.8824    0.005102041 
+  208          170.96214    127.89347   0.004807692 
+  216          174.35363    127.90458   0.00462963 
+  231          178.32971    127.91573   0.004329004 
+  223          182.84314    127.92693   0.004484305 
+  195          187.88733    127.93817   0.005128205 
+  213          193.73484    127.94945   0.004694836 
+  229          200.81851    127.96078   0.004366812 
+  233          209.6039     127.97216   0.004291845 
+  213          220.65649    127.98358   0.004694836 
+  258          234.82935    127.99505   0.003875969 
+  234          253.48673    128.00656   0.004273504 
+  296          278.85445    128.01812   0.003378378 
+  324          314.48486    128.02972   0.00308642 
+  352          365.06452    128.04137   0.002840909 
+  417          432.04873    128.05306   0.002398082 
+  506          503.62816    128.0648    0.001976285 
+  572          578.02898    128.07659   0.001748252 
+  732          698.38527    128.08842   0.00136612 
+  952          925.25896    128.10031   0.00105042 
+  1543         1340.55543   128.11223   0.000648088 
+  2181         2034.67344   128.12421   0.000458505 
+  2804         2847.27048   128.13623   0.000356633 
+  2669         2941.63929   128.1483    0.000374672 
+  2046         2196.83411   128.16042   0.000488759 
+  1428         1490.55496   128.17259   0.00070028 
+  1100         1071.36979   128.1848    0.000909091 
+  871          851.11394    128.19706   0.001148106 
+  766          746.5014     128.20938   0.001305483 
+  745          732.40957    128.22174   0.001342282 
+  841          814.35737    128.23415   0.001189061 
+  1014         1010.35381   128.2466    0.000986193 
+  1373         1331.80069   128.25911   0.000728332 
+  1541         1671.26374   128.27167   0.000648929 
+  1404         1613.87739   128.28427   0.000712251 
+  1079         1188.63921   128.29693   0.000926784 
+  817          818.16762    128.30964   0.00122399 
+  592          591.19828    128.3224    0.001689189 
+  467          461.35224    128.3352    0.002141328 
+  394          386.99768    128.34806   0.002538071 
+  353          344.93829    128.36097   0.002832861 
+  317          323.02006    128.37393   0.003154574 
+  304          308.64226    128.38694   0.003289474 
+  294          287.12554    128.40001   0.003401361 
+  244          261.8162     128.41312   0.004098361 
+  253          242.3602     128.42629   0.003952569 
+  222          230.21935    128.43951   0.004504505 
+  231          223.79097    128.45278   0.004329004 
+  221          220.85103    128.46611   0.004524887 
+  185          218.00475    128.47949   0.005405405 
+  202          212.44814    128.49292   0.004950495 
+  191          205.44961    128.5064    0.005235602 
+  200          199.29183    128.51994   0.005     
+  189          193.95904    128.53353   0.005291005 
+  199          188.90636    128.54718   0.005025126 
+  166          184.69392    128.56088   0.006024096 
+  183          182.00377    128.57463   0.005464481 
+  183          181.0688     128.58844   0.005464481 
+  173          181.87943    128.6023    0.005780347 
+  184          184.04134    128.61622   0.005434783 
+  206          186.1874     128.6302    0.004854369 
+  156          186.62224    128.64423   0.006410256 
+  164          185.20142    128.65831   0.006097561 
+  178          183.07972    128.67246   0.005617978 
+  183          181.31291    128.68665   0.005464481 
+  202          180.24888    128.70091   0.004950495 
+  166          179.73836    128.71522   0.006024096 
+  183          179.38403    128.72959   0.005464481 
+  170          179.73476    128.74402   0.005882353 
+  172          181.80779    128.7585    0.005813953 
+  168          185.20271    128.77304   0.005952381 
+  154          187.41738    128.78764   0.006493506 
+  158          186.09847    128.8023    0.006329114 
+  174          181.70678    128.81702   0.005747126 
+  190          176.56501    128.83179   0.005263158 
+  169          172.61871    128.84663   0.00591716 
+  160          170.40149    128.86152   0.00625   
+  167          169.47078    128.87647   0.005988024 
+  181          169.15778    128.89149   0.005524862 
+  162          169.44805    128.90656   0.00617284 
+  190          170.84216    128.92169   0.005263158 
+  186          173.34753    128.93689   0.005376344 
+  170          175.98392    128.95214   0.005882353 
+  158          177.57926    128.96746   0.006329114 
+  171          177.77793    128.98283   0.005847953 
+  159          176.08895    128.99827   0.006289308 
+  164          172.16722    129.01377   0.006097561 
+  148          167.39693    129.02934   0.006756757 
+  137          163.36603    129.04496   0.00729927 
+  193          160.54083    129.06065   0.005181347 
+  159          158.7859     129.0764    0.006289308 
+  131          157.91553    129.09222   0.007633588 
+  163          157.84377    129.1081    0.006134969 
+  160          158.60374    129.12404   0.00625   
+  152          160.28497    129.14004   0.006578947 
+  159          162.79335    129.15611   0.006289308 
+  154          165.44083    129.17225   0.006493506 
+  167          167.11825    129.18845   0.005988024 
+  171          167.11998    129.20471   0.005847953 
+  165          165.55884    129.22105   0.006060606 
+  160          163.79658    129.23744   0.00625   
+  154          163.29892    129.25391   0.006493506 
+  165          164.6791     129.27043   0.006060606 
+  179          167.76098    129.28703   0.005586592 
+  178          171.11479    129.30369   0.005617978 
+  159          172.07406    129.32042   0.006289308 
+  150          169.77648    129.33722   0.006666667 
+  169          166.42184    129.35409   0.00591716 
+  174          163.94895    129.37102   0.005747126 
+  160          162.49387    129.38802   0.00625   
+  183          161.38916    129.40509   0.005464481 
+  166          160.64767    129.42223   0.006024096 
+  138          160.89053    129.43944   0.007246377 
+  178          162.54991    129.45672   0.005617978 
+  197          165.72131    129.47407   0.005076142 
+  167          169.85732    129.49149   0.005988024 
+  176          173.27849    129.50898   0.005681818 
+  187          174.4955     129.52654   0.005347594 
+  180          174.06788    129.54418   0.005555556 
+  182          172.79851    129.56188   0.005494505 
+  192          170.89878    129.57966   0.005208333 
+  183          169.18838    129.5975    0.005464481 
+  175          168.41541    129.61542   0.005714286 
+  183          168.73262    129.63342   0.005464481 
+  207          170.07332    129.65148   0.004830918 
+  193          172.45257    129.66963   0.005181347 
+  185          175.72892    129.68784   0.005405405 
+  173          179.41385    129.70613   0.005780347 
+  161          183.14691    129.72449   0.00621118 
+  228          187.18345    129.74293   0.004385965 
+  223          191.99491    129.76144   0.004484305 
+  207          197.8483     129.78003   0.004830918 
+  236          205.44118    129.79869   0.004237288 
+  219          215.81575    129.81743   0.00456621 
+  257          229.91013    129.83625   0.003891051 
+  240          248.78199    129.85514   0.004166667 
+  326          273.71401    129.87411   0.003067485 
+  319          307.16213    129.89316   0.003134796 
+  411          356.3153     129.91229   0.00243309 
+  484          436.35794    129.93149   0.002066116 
+  643          574.10623    129.95077   0.00155521 
+  973          811.1715     129.97013   0.001027749 
+  1249         1176.53575   129.98958   0.000800641 
+  1395         1517.81417   130.0091    0.000716846 
+  1306         1440.99643   130.0287    0.000765697 
+  1057         1062.18127   130.04838   0.000946074 
+  792          747.33934    130.06814   0.001262626 
+  607          560.56041    130.08798   0.001647446 
+  528          461.81226    130.10791   0.001893939 
+  431          417.63551    130.12791   0.002320186 
+  425          413.63301    130.148     0.002352941 
+  536          450.09176    130.16817   0.001865672 
+  570          535.22259    130.18842   0.001754386 
+  673          674.24914    130.20876   0.001485884 
+  805          846.76374    130.22918   0.001242236 
+  756          909.38559    130.24968   0.001322751 
+  664          749.30881    130.27027   0.001506024 
+  604          546.37866    130.29095   0.001655629 
+  400          407.81079    130.3117    0.0025    
+  356          325.79589    130.33255   0.002808989 
+  314          278.11569    130.35348   0.003184713 
+  251          250.45319    130.37449   0.003984064 
+  253          235.52396    130.3956    0.003952569 
+  232          229.32387    130.41679   0.004310345 
+  227          225.94569    130.43806   0.004405286 
+  227          216.8022     130.45943   0.004405286 
+  197          203.09223    130.48088   0.005076142 
+  209          191.72741    130.50242   0.004784689 
+  200          184.26313    130.52405   0.005     
+  200          179.222      130.54577   0.005     
+  175          174.50708    130.56758   0.005714286 
+  153          169.55089    130.58948   0.006535948 
+  175          165.10045    130.61147   0.005714286 
+  177          161.56648    130.63356   0.005649718 
+  197          158.91086    130.65573   0.005076142 
+  183          156.96572    130.67799   0.005464481 
+  167          155.57323    130.70035   0.005988024 
+  144          154.64271    130.7228    0.006944444 
+  174          154.19786    130.74534   0.005747126 
+  160          154.32468    130.76798   0.00625   
+  160          154.9638     130.79071   0.00625   
+  155          155.61698    130.81353   0.006451613 
+  169          155.60431    130.83645   0.00591716 
+  126          154.85213    130.85947   0.007936508 
+  153          153.77463    130.88258   0.006535948 
+  175          152.84453    130.90578   0.005714286 
+  156          152.31081    130.92908   0.006410256 
+  160          152.3209     130.95248   0.00625   
+  144          152.98695    130.97598   0.006944444 
+  178          154.21243    130.99957   0.005617978 
+  150          155.47522    131.02326   0.006666667 
+  168          155.72037    131.04706   0.005952381 
+  150          154.55708    131.07094   0.006666667 
+  155          152.92396    131.09493   0.006451613 
+  133          151.60631    131.11902   0.007518797 
+  139          150.68533    131.14321   0.007194245 
+  146          150.13873    131.1675    0.006849315 
+  163          150.06135    131.19189   0.006134969 
+  155          150.55689    131.21639   0.006451613 
+  162          151.7824     131.24098   0.00617284 
+  156          153.92357    131.26568   0.006410256 
+  152          157.06368    131.29048   0.006578947 
+  149          160.99033    131.31538   0.006711409 
+  147          164.82769    131.34039   0.006802721 
+  123          166.95703    131.3655    0.008130081 
+  170          165.83333    131.39072   0.005882353 
+  180          162.20618    131.41604   0.005555556 
+  149          158.48682    131.44147   0.006711409 
+  152          156.11786    131.467     0.006578947 
+  160          155.46084    131.49264   0.00625   
+  162          156.51744    131.51839   0.00617284 
+  154          158.90225    131.54425   0.006493506 
+  139          161.00571    131.57021   0.007194245 
+  155          161.00337    131.59628   0.006451613 
+  157          160.21416    131.62247   0.006369427 
+  163          160.41724    131.64876   0.006134969 
+  177          161.11935    131.67516   0.005649718 
+  159          160.90111    131.70167   0.006289308 
+  156          159.3447     131.72829   0.006410256 
+  149          157.13817    131.75503   0.006711409 
+  143          155.18348    131.78187   0.006993007 
+  159          153.96009    131.80883   0.006289308 
+  163          153.54781    131.8359    0.006134969 
+  154          153.68795    131.86309   0.006493506 
+  147          153.48118    131.89039   0.006802721 
+  128          152.16437    131.9178    0.0078125 
+  152          150.57995    131.94533   0.006578947 
+  153          149.67681    131.97297   0.006535948 
+  132          149.60416    132.00073   0.007575758 
+  153          150.14943    132.02861   0.006535948 
+  151          150.98964    132.0566    0.006622517 
+  146          152.05309    132.08471   0.006849315 
+  162          153.70224    132.11294   0.00617284 
+  150          156.24262    132.14129   0.006666667 
+  173          159.47044    132.16976   0.005780347 
+  175          162.2073     132.19834   0.005714286 
+  165          162.92223    132.22705   0.006060606 
+  141          161.40178    132.25587   0.007092199 
+  168          158.31816    132.28482   0.005952381 
+  192          154.65088    132.31389   0.005208333 
+  166          151.47761    132.34308   0.006024096 
+  175          149.2558     132.3724    0.005714286 
+  140          147.96654    132.40183   0.007142857 
+  147          147.4995     132.4314    0.006802721 
+  136          147.78843    132.46108   0.007352941 
+  147          148.80346    132.49089   0.006802721 
+  158          150.3669     132.52083   0.006329114 
+  160          151.87649    132.55089   0.00625   
+  142          152.55133    132.58108   0.007042254 
+  140          152.25414    132.61139   0.007142857 
+  160          151.32035    132.64184   0.00625   
+  156          150.2601     132.67241   0.006410256 
+  159          149.62615    132.70311   0.006289308 
+  161          149.5911     132.73394   0.00621118 
+  160          149.90805    132.76489   0.00625   
+  127          150.09199    132.79598   0.007874016 
+  144          149.99712    132.8272    0.006944444 
+  165          149.98885    132.85855   0.006060606 
+  156          150.29667    132.89004   0.006410256 
+  144          150.96838    132.92165   0.006944444 
+  136          152.0351     132.9534    0.007352941 
+  158          153.41237    132.98529   0.006329114 
+  160          154.93491    133.0173    0.00625   
+  153          155.89983    133.04946   0.006535948 
+  149          155.31954    133.08174   0.006711409 
+  152          153.49826    133.11417   0.006578947 
+  143          151.57186    133.14673   0.006993007 
+  149          150.00981    133.17942   0.006711409 
+  160          148.79667    133.21226   0.00625   
+  148          147.99773    133.24523   0.006756757 
+  153          147.637      133.27835   0.006535948 
+  156          147.65677    133.3116    0.006410256 
+  165          148.02678    133.34499   0.006060606 
+  162          148.68517    133.37852   0.00617284 
+  149          149.56144    133.4122    0.006711409 
+  167          150.39198    133.44602   0.005988024 
+  174          150.68481    133.47998   0.005747126 
+  142          150.50474    133.51408   0.007042254 
+  128          150.47246    133.54832   0.0078125 
+  188          150.80088    133.58271   0.005319149 
+  147          150.99511    133.61725   0.006802721 
+  137          150.51026    133.65193   0.00729927 
+  182          149.4615     133.68676   0.005494505 
+  157          148.28214    133.72173   0.006369427 
+  157          147.31757    133.75686   0.006369427 
+  147          146.7617     133.79213   0.006802721 
+  144          146.66898    133.82754   0.006944444 
+  160          147.03684    133.86311   0.00625   
+  149          147.66919    133.89883   0.006711409 
+  183          148.82131    133.9347    0.005464481 
+  163          150.14501    133.97072   0.006134969 
+  133          151.41085    134.00689   0.007518797 
+  167          152.34863    134.04322   0.005988024 
+  157          152.87296    134.07969   0.006369427 
+  139          153.11101    134.11633   0.007194245 
+  149          152.91753    134.15311   0.006711409 
+  167          152.0005     134.19005   0.005988024 
+  149          150.64485    134.22715   0.006711409 
+  162          149.41371    134.2644    0.00617284 
+  140          148.53864    134.30181   0.007142857 
+  141          148.27041    134.33938   0.007092199 
+  140          148.46466    134.37711   0.007142857 
+  145          148.98493    134.41499   0.006896552 
+  155          149.69228    134.45304   0.006451613 
+  137          150.53094    134.49124   0.00729927 
+  143          151.60109    134.52961   0.006993007 
+  130          152.84146    134.56814   0.007692308 
+  145          153.598      134.60683   0.006896552 
+  143          153.09637    134.64568   0.006993007 
+  145          151.58395    134.6847    0.006896552 
+  121          149.92147    134.72388   0.008264463 
+  129          148.60233    134.76323   0.007751938 
+  139          147.94766    134.80274   0.007194245 
+  143          147.46458    134.84242   0.006993007 
+  150          147.29981    134.88227   0.006666667 
+  166          147.39596    134.92228   0.006024096 
+  166          147.71064    134.96247   0.006024096 
+  170          148.21939    135.00282   0.005882353 
+  155          148.83285    135.04334   0.006451613 
+  127          149.33408    135.08404   0.007874016 
+  161          149.46103    135.1249    0.00621118 
+  149          149.24713    135.16594   0.006711409 
+  167          149.02138    135.20715   0.005988024 
+  159          148.98953    135.24853   0.006289308 
+  137          149.0506     135.29009   0.00729927 
+  157          149.14634    135.33182   0.006369427 
+  147          149.43889    135.37372   0.006802721 
+  151          150.05942    135.41581   0.006622517 
+  144          151.19018    135.45807   0.006944444 
+  143          152.66415    135.50051   0.006993007 
+  155          154.57488    135.54313   0.006451613 
+  172          156.60745    135.58592   0.005813953 
+  168          158.03425    135.6289    0.005952381 
+  142          158.29295    135.67206   0.007042254 
+  137          157.85185    135.71539   0.00729927 
+  157          157.6319     135.75892   0.006369427 
+  164          158.12888    135.80262   0.006097561 
+  157          159.4015     135.84651   0.006369427 
+  194          161.30129    135.89058   0.005154639 
+  162          163.33573    135.93484   0.00617284 
+  172          164.95317    135.97928   0.005813953 
+  163          166.44932    136.02391   0.006134969 
+  156          168.71036    136.06873   0.006410256 
+  145          171.57227    136.11373   0.006896552 
+  173          172.85745    136.15893   0.005780347 
+  170          171.00517    136.20431   0.005882353 
+  173          167.74196    136.24989   0.005780347 
+  150          165.01688    136.29565   0.006666667 
+  148          163.41801    136.34161   0.006756757 
+  179          162.88374    136.38776   0.005586592 
+  184          163.2453     136.43411   0.005434783 
+  178          164.25436    136.48065   0.005617978 
+  172          165.51471    136.52738   0.005813953 
+  185          166.7598     136.57431   0.005405405 
+  178          168.10368    136.62144   0.005617978 
+  165          169.62943    136.66876   0.006060606 
+  170          170.90767    136.71628   0.005882353 
+  185          171.12641    136.76401   0.005405405 
+  176          170.51623    136.81193   0.005681818 
+  198          170.29916    136.86005   0.005050505 
+  173          171.09267    136.90837   0.005780347 
+  193          172.95576    136.9569    0.005181347 
+  172          175.72133    137.00563   0.005813953 
+  183          178.81057    137.05456   0.005464481 
+  206          181.10563    137.1037    0.004854369 
+  176          182.02148    137.15304   0.005681818 
+  193          182.36048    137.20259   0.005181347 
+  198          183.08918    137.25235   0.005050505 
+  189          184.54012    137.30232   0.005291005 
+  190          186.82737    137.35249   0.005263158 
+  201          190.13043    137.40288   0.004975124 
+  215          194.63458    137.45347   0.004651163 
+  217          200.44183    137.50428   0.004608295 
+  202          207.39649    137.55529   0.004950495 
+  209          214.94315    137.60652   0.004784689 
+  238          222.66304    137.65797   0.004201681 
+  235          230.87471    137.70963   0.004255319 
+  242          240.14939    137.7615    0.004132231 
+  258          251.37881    137.8136    0.003875969 
+  275          266.06368    137.8659    0.003636364 
+  283          285.98036    137.91843   0.003533569 
+  310          313.31759    137.97118   0.003225806 
+  363          351.44597    138.02414   0.002754821 
+  421          406.20235    138.07733   0.002375297 
+  553          488.24574    138.13074   0.001808318 
+  676          617.23505    138.18437   0.00147929 
+  977          827.54564    138.23822   0.001023541 
+  1280         1169.90597   138.2923    0.00078125 
+  1763         1672.34364   138.3466    0.000567215 
+  2060         2144.91318   138.40113   0.000485437 
+  1952         2101.8354    138.45589   0.000512295 
+  1559         1606.2488    138.51087   0.000641437 
+  1187         1135.76699   138.56608   0.00084246 
+  880          830.32348    138.62152   0.001136364 
+  673          652.44941    138.67719   0.001485884 
+  658          554.67132    138.7331    0.001519757 
+  588          508.03684    138.78923   0.00170068 
+  599          500.03975    138.8456    0.001669449 
+  630          530.96732    138.9022    0.001587302 
+  731          612.94436    138.95904   0.001367989 
+  871          768.25248    139.01611   0.001148106 
+  1035         1006.60624   139.07342   0.000966184 
+  1132         1222.19664   139.13097   0.000883392 
+  1061         1172.81705   139.18876   0.000942507 
+  857          910.7647     139.24678   0.001166861 
+  689          670.12242    139.30505   0.001451379 
+  536          511.93801    139.36355   0.001865672 
+  464          415.29428    139.4223    0.002155172 
+  371          355.73503    139.48129   0.002695418 
+  304          317.50139    139.54053   0.003289474 
+  323          291.75097    139.60001   0.003095975 
+  281          273.64123    139.65974   0.003558719 
+  266          260.39177    139.71971   0.003759398 
+  231          250.23642    139.77994   0.004329004 
+  281          242.12963    139.84041   0.003558719 
+  236          235.58916    139.90113   0.004237288 
+  241          230.31963    139.9621    0.004149378 
+  231          226.0176     140.02332   0.004329004 
+  233          222.39172    140.0848    0.004291845 
+  190          219.08423    140.14653   0.005263158 
+  228          215.60043    140.20851   0.004385965 
+  214          211.77219    140.27075   0.004672897 
+  205          207.89499    140.33324   0.004878049 
+  220          204.50594    140.396     0.004545455 
+  223          201.63715    140.45901   0.004484305 
+  238          199.25484    140.52228   0.004201681 
+  205          197.28394    140.58581   0.004878049 
+  191          195.65611    140.6496    0.005235602 
+  180          194.32048    140.71366   0.005555556 
+  181          193.23168    140.77798   0.005524862 
+  189          192.34015    140.84256   0.005291005 
+  198          191.59527    140.90741   0.005050505 
+  169          190.90817    140.97252   0.00591716 
+  199          190.09491    141.03791   0.005025126 
+  206          189.04393    141.10356   0.004854369 
+  217          188.04832    141.16948   0.004608295 
+  174          187.30563    141.23567   0.005747126 
+  187          186.90293    141.30213   0.005347594 
+  157          186.83018    141.36886   0.006369427 
+  171          187.03247    141.43587   0.005847953 
+  193          187.42736    141.50315   0.005181347 
+  179          187.93895    141.57071   0.005586592 
+  179          188.53766    141.63854   0.005586592 
+  167          189.21825    141.70665   0.005988024 
+  209          189.97743    141.77505   0.004784689 
+  175          190.83032    141.84371   0.005714286 
+  193          191.82033    141.91267   0.005181347 
+  198          193.02916    141.9819    0.005050505 
+  210          194.5908     142.05141   0.004761905 
+  190          196.70569    142.12121   0.005263158 
+  189          199.64133    142.1913    0.005291005 
+  201          203.6565     142.26166   0.004975124 
+  226          208.62139    142.33232   0.004424779 
+  224          213.21236    142.40327   0.004464286 
+  208          215.27154    142.4745    0.004807692 
+  196          214.83135    142.54602   0.005102041 
+  210          213.9309     142.61784   0.004761905 
+  210          213.13558    142.68995   0.004761905 
+  195          211.3144     142.76235   0.005128205 
+  189          207.77963    142.83504   0.005291005 
+  178          203.30464    142.90803   0.005617978 
+  198          199.10046    142.98132   0.005050505 
+  187          195.81599    143.05491   0.005347594 
+  225          193.6142     143.12879   0.004444444 
+  205          192.49982    143.20298   0.004878049 
+  215          192.37505    143.27746   0.004651163 
+  240          192.73724    143.35225   0.004166667 
+  213          192.46963    143.42734   0.004694836 
+  196          191.003      143.50274   0.005102041 
+  204          189.17645    143.57844   0.004901961 
+  204          187.64479    143.65444   0.004901961 
+  204          186.03826    143.73076   0.004901961 
+  207          183.76043    143.80738   0.004830918 
+  196          180.86134    143.88432   0.005102041 
+  191          177.88132    143.96156   0.005235602 
+  175          175.26602    144.03912   0.005714286 
+  198          173.18604    144.11699   0.005050505 
+  187          171.62988    144.19517   0.005347594 
+  196          170.48501    144.27367   0.005102041 
+  184          169.55486    144.35249   0.005434783 
+  174          168.67042    144.43163   0.005747126 
+  199          167.88428    144.51108   0.005025126 
+  175          167.40152    144.59086   0.005714286 
+  201          167.39109    144.67095   0.004975124 
+  189          167.9457     144.75137   0.005291005 
+  166          169.03481    144.83211   0.006024096 
+  183          170.29375    144.91318   0.005464481 
+  164          170.8612     144.99457   0.006097561 
+  175          170.04308    145.07629   0.005714286 
+  180          168.25828    145.15834   0.005555556 
+  174          166.43661    145.24072   0.005747126 
+  184          165.07237    145.32343   0.005434783 
+  178          164.2083     145.40647   0.005617978 
+  213          163.70269    145.48985   0.004694836 
+  175          163.43448    145.57356   0.005714286 
+  172          163.35997    145.6576    0.005813953 
+  175          163.44072    145.74198   0.005714286 
+  152          163.68398    145.8267    0.006578947 
+  171          164.17914    145.91176   0.005847953 
+  171          164.95083    145.99716   0.005847953 
+  174          165.76816    146.0829    0.005747126 
+  175          166.19463    146.16898   0.005714286 
+  205          166.10198    146.2554    0.004878049 
+  168          165.88481    146.34218   0.005952381 
+  177          165.96961    146.42929   0.005649718 
+  165          166.55834    146.51676   0.006060606 
+  177          167.74348    146.60458   0.005649718 
+  181          169.63048    146.69274   0.005524862 
+  193          172.39636    146.78126   0.005181347 
+  174          176.34514    146.87013   0.005747126 
+  181          182.04561    146.95935   0.005524862 
+  187          190.5896     147.04893   0.005347594 
+  222          203.89302    147.13886   0.004504505 
+  229          224.65917    147.22915   0.004366812 
+  252          254.511      147.3198    0.003968254 
+  288          285.77186    147.41081   0.003472222 
+  268          292.86726    147.50219   0.003731343 
+  265          267.89018    147.59392   0.003773585 
+  225          237.7271     147.68602   0.004444444 
+  222          217.08799    147.77848   0.004504505 
+  205          205.92186    147.87132   0.004878049 
+  198          201.7031     147.96451   0.005050505 
+  223          202.91437    148.05808   0.004484305 
+  219          209.33735    148.15202   0.00456621 
+  236          221.85156    148.24633   0.004237288 
+  196          242.0081     148.34101   0.005102041 
+  246          270.42516    148.43607   0.004065041 
+  257          300.79889    148.5315    0.003891051 
+  283          316.68821    148.62731   0.003533569 
+  269          310.39213    148.7235    0.003717472 
+  265          285.44009    148.82006   0.003773585 
+  245          252.47592    148.91701   0.004081633 
+  248          225.64399    149.01434   0.004032258 
+  216          208.15748    149.11205   0.00462963 
+  198          197.78051    149.21015   0.005050505 
+  215          192.26316    149.30863   0.004651163 
+  164          190.32378    149.40751   0.006097561 
+  198          191.50661    149.50677   0.005050505 
+  179          195.90121    149.60642   0.005586592 
+  249          203.74191    149.70646   0.004016064 
+  209          214.31959    149.80689   0.004784689 
+  233          222.79345    149.90772   0.004291845 
+  200          220.85131    150.00894   0.005     
+  183          209.61451    150.11057   0.005464481 
+  191          197.61244    150.21258   0.005235602 
+  193          188.46511    150.315     0.005181347 
+  209          181.90679    150.41782   0.004784689 
+  164          177.21004    150.52105   0.006097561 
+  157          173.91469    150.62467   0.006369427 
+  168          171.67553    150.7287    0.005952381 
+  188          170.21586    150.83314   0.005319149 
+  165          169.33669    150.93799   0.006060606 
+  157          168.88806    151.04324   0.006369427 
+  141          168.7353     151.14891   0.007092199 
+  136          168.75956    151.25498   0.007352941 
+  162          168.87397    151.36147   0.00617284 
+  162          169.03572    151.46838   0.00617284 
+  153          169.26841    151.5757    0.006535948 
+  160          169.60515    151.68344   0.00625   
+  152          169.9901     151.7916    0.006578947 
+  176          170.36638    151.90018   0.005681818 
+  159          170.81003    152.00918   0.006289308 
+  144          171.42502    152.1186    0.006944444 
+  173          172.11968    152.22845   0.005780347 
+  160          172.48765    152.33873   0.00625   
+  167          172.16248    152.44943   0.005988024 
+  164          171.32558    152.56056   0.006097561 
+  176          170.43195    152.67213   0.005681818 
+  165          169.7029     152.78412   0.006060606 
+  158          169.10659    152.89655   0.006329114 
+  149          168.59695    153.00941   0.006711409 
+  155          168.22394    153.12271   0.006451613 
+  155          168.05934    153.23645   0.006451613 
+  153          168.13929    153.35063   0.006535948 
+  158          168.47531    153.46525   0.006329114 
+  155          169.06288    153.58031   0.006451613 
+  149          169.8643     153.69581   0.006711409 
+  148          170.71022    153.81176   0.006756757 
+  153          171.20154    153.92815   0.006535948 
+  141          170.96304    154.045     0.007092199 
+  168          170.11189    154.16229   0.005952381 
+  165          169.11009    154.28004   0.006060606 
+  146          168.25909    154.39823   0.006849315 
+  152          167.60076    154.51689   0.006578947 
+  167          167.09135    154.63599   0.005988024 
+  178          166.70567    154.75556   0.005617978 
+  158          166.42561    154.87558   0.006329114 
+  153          166.24261    154.99606   0.006535948 
+  162          166.17319    155.11701   0.00617284 
+  186          166.23092    155.23842   0.005376344 
+  161          166.40954    155.36029   0.00621118 
+  178          166.66316    155.48263   0.005617978 
+  189          166.89363    155.60544   0.005291005 
+  148          166.99714    155.72872   0.006756757 
+  167          166.97061    155.85247   0.005988024 
+  157          166.92225    155.97669   0.006369427 
+  163          166.9535     156.10138   0.006134969 
+  156          167.10027    156.22655   0.006410256 
+  171          167.34755    156.3522    0.005847953 
+  167          167.63846    156.47833   0.005988024 
+  160          167.9023     156.60493   0.00625   
+  180          168.12574    156.73202   0.005555556 
+  187          168.3624     156.8596    0.005347594 
+  143          168.667      156.98765   0.006993007 
+  154          169.05982    157.1162    0.006493506 
+  152          169.53774    157.24523   0.006578947 
+  159          170.08974    157.37475   0.006289308 
+  156          170.70499    157.50477   0.006410256 
+  156          171.36364    157.63528   0.006410256 
+  165          172.03349    157.76628   0.006060606 
+  134          172.72835    157.89778   0.007462687 
+  150          173.52936    158.02977   0.006666667 
+  182          174.52816    158.16227   0.005494505 
+  177          175.79381    158.29526   0.005649718 
+  154          177.37563    158.42876   0.006493506 
+  177          179.29289    158.56277   0.005649718 
+  166          181.4247     158.69728   0.006024096 
+  182          183.31516    158.83229   0.005494505 
+  172          184.30532    158.96782   0.005813953 
+  160          184.24264    159.10386   0.00625   
+  182          183.72987    159.24041   0.005494505 
+  188          183.42336    159.37748   0.005319149 
+  158          183.60943    159.51506   0.006329114 
+  191          184.33914    159.65315   0.005235602 
+  184          185.59628    159.79177   0.005434783 
+  190          187.31706    159.93091   0.005263158 
+  173          189.2866     160.07057   0.005780347 
+  178          191.22409    160.21076   0.005617978 
+  180          193.07253    160.35147   0.005555556 
+  194          194.9498     160.49271   0.005154639 
+  156          196.96816    160.63448   0.006410256 
+  155          199.31897    160.77677   0.006451613 
+  193          202.15374    160.91961   0.005181347 
+  194          205.51467    161.06297   0.005154639 
+  216          209.5782     161.20688   0.00462963 
+  169          214.49782    161.35132   0.00591716 
+  192          219.20794    161.4963    0.005208333 
+  225          221.43512    161.64182   0.004444444 
+  214          221.99704    161.78788   0.004672897 
+  232          224.62403    161.93449   0.004310345 
+  214          232.05183    162.08165   0.004672897 
+  245          246.41022    162.22935   0.004081633 
+  258          270.64481    162.3776    0.003875969 
+  286          307.48363    162.52641   0.003496503 
+  347          350.30949    162.67577   0.002881844 
+  354          368.82479    162.82568   0.002824859 
+  310          342.58975    162.97615   0.003225806 
+  271          300.75871    163.12718   0.003690037 
+  256          268.45778    163.27877   0.00390625 
+  229          248.62481    163.43092   0.004366812 
+  264          237.65854    163.58364   0.003787879 
+  220          231.42926    163.73692   0.004545455 
+  213          226.89566    163.89077   0.004694836 
+  199          223.69848    164.04519   0.005025126 
+  211          222.58111    164.20018   0.004739336 
+  221          224.35752    164.35574   0.004524887 
+  282          230.38403    164.51188   0.003546099 
+  250          242.43935    164.66859   0.004     
+  253          261.20468    164.82588   0.003952569 
+  279          280.0456     164.98375   0.003584229 
+  256          281.63263    165.14221   0.00390625 
+  241          263.78826    165.30125   0.004149378 
+  230          243.51531    165.46087   0.004347826 
+  223          228.74176    165.62108   0.004484305 
+  214          218.74354    165.78188   0.004672897 
+  191          211.67158    165.94327   0.005235602 
+  209          206.59496    166.10525   0.004784689 
+  186          203.04271    166.26783   0.005376344 
+  187          200.50259    166.43101   0.005347594 
+  196          198.50664    166.59478   0.005102041 
+  174          196.84426    166.75916   0.005747126 
+  191          195.46647    166.92413   0.005235602 
+  202          194.37501    167.08971   0.004950495 
+  181          193.64879    167.2559    0.005524862 
+  185          193.3782     167.42269   0.005405405 
+  186          193.54942    167.5901    0.005376344 
+  187          194.0115     167.75811   0.005347594 
+  159          194.49885    167.92674   0.006289308 
+  193          194.7379     168.09598   0.005181347 
+  187          194.61239    168.26584   0.005347594 
+  202          194.23915    168.43632   0.004950495 
+  211          193.82407    168.60743   0.004739336 
+  196          193.40616    168.77915   0.005102041 
+  181          192.94332    168.9515    0.005524862 
+  176          192.52469    169.12447   0.005681818 
+  172          192.25236    169.29808   0.005813953 
+  199          192.11911    169.47231   0.005025126 
+  199          192.12535    169.64718   0.005025126 
+  189          192.33897    169.82268   0.005291005 
+  190          192.79642    169.99882   0.005263158 
+  198          193.40354    170.1756    0.005050505 
+  207          193.93798    170.35301   0.004830918 
+  213          194.24088    170.53107   0.004694836 
+  186          194.41337    170.70978   0.005376344 
+  172          194.69302    170.88913   0.005813953 
+  180          195.22958    171.06912   0.005555556 
+  215          196.02732    171.24977   0.004651163 
+  207          196.98531    171.43107   0.004830918 
+  186          197.86003    171.61303   0.005376344 
+  162          198.72629    171.79564   0.00617284 
+  191          199.27786    171.9789    0.005235602 
+  192          199.49334    172.16283   0.005208333 
+  197          199.61365    172.34742   0.005076142 
+  204          199.89339    172.53268   0.004901961 
+  207          200.43637    172.7186    0.004830918 
+  182          201.21168    172.90519   0.005494505 
+  194          202.12106    173.09244   0.005154639 
+  203          203.10538    173.28037   0.004926108 
+  216          204.22049    173.46898   0.00462963 
+  220          205.5725     173.65826   0.004545455 
+  218          207.24875    173.84822   0.004587156 
+  198          209.26448    174.03886   0.005050505 
+  189          211.80367    174.23018   0.005291005 
+  201          214.85293    174.42218   0.004975124 
+  200          218.34119    174.61488   0.005     
+  225          221.96179    174.80826   0.004444444 
+  200          225.14001    175.00233   0.005     
+  227          227.32134    175.19709   0.004405286 
+  231          228.58654    175.39255   0.004329004 
+  229          229.58121    175.5887    0.004366812 
+  203          230.63075    175.78556   0.004926108 
+  207          231.43154    175.98311   0.004830918 
+  238          231.66627    176.18137   0.004201681 
+  204          231.52077    176.38033   0.004901961 
+  216          231.40893    176.58      0.00462963 
+  207          231.61505    176.78038   0.004830918 
+  232          232.28353    176.98147   0.004310345 
+  196          233.48717    177.18327   0.005102041 
+  221          235.25591    177.38579   0.004524887 
+  235          237.57797    177.58903   0.004255319 
+  217          240.35307    177.79299   0.004608295 
+  234          243.30295    177.99766   0.004273504 
+  228          246.05257    178.20307   0.004385965 
+  227          248.5223     178.4092    0.004405286 
+  265          251.06206    178.61605   0.003773585 
+  236          253.9987     178.82364   0.004237288 
+  256          257.33025    179.03196   0.00390625 
+  288          260.93368    179.24102   0.003472222 
+  263          264.9442     179.45081   0.003802281 
+  264          269.87423    179.66134   0.003787879 
+  278          276.61013    179.87261   0.003597122 
+  323          286.22462    180.08463   0.003095975 
+  342          299.13343    180.29739   0.002923977 
+  341          312.76639    180.5109    0.002932551 
+  351          319.94554    180.72516   0.002849003 
+  325          316.85154    180.94017   0.003076923 
+  330          309.5561     181.15594   0.003030303 
+  353          304.14599    181.37247   0.002832861 
+  310          302.01304    181.58975   0.003225806 
+  370          302.58721    181.80779   0.002702703 
+  364          305.26639    182.0266    0.002747253 
+  301          309.75278    182.24617   0.003322259 
+  326          315.89275    182.46651   0.003067485 
+  355          323.60322    182.68762   0.002816901 
+  383          332.92653    182.90951   0.002610966 
+  339          344.14616    183.13216   0.002949853 
+  387          357.8135     183.3556    0.002583979 
+  354          374.49323    183.57981   0.002824859 
+  380          393.97778    183.80481   0.002631579 
+  418          413.90327    184.03058   0.002392344 
+  458          431.27407    184.25715   0.002183406 
+  447          447.79263    184.4845    0.002237136 
+  483          467.9873     184.71264   0.002070393 
+  520          494.5011     184.94158   0.001923077 
+  572          528.53293    185.17131   0.001748252 
+  620          571.42365    185.40183   0.001612903 
+  672          625.71938    185.63316   0.001488095 
+  740          695.66901    185.86529   0.001351351 
+  849          786.80858    186.09822   0.001177856 
+  986          904.8369     186.33196   0.001014199 
+  1133         1056.89611   186.56651   0.000882613 
+  1432         1260.94414   186.80187   0.000698324 
+  1757         1554.69986   187.03804   0.000569152 
+  2415         2000.30696   187.27503   0.000414079 
+  3178         2692.35726   187.51284   0.000314663 
+  4527         3753.98438   187.75147   0.000220897 
+  6169         5234.92876   187.99092   0.000162101 
+  7239         6713.60529   188.23119   0.000138141 
+  7124         7034.62349   188.4723    0.000140371 
+  5910         5858.12641   188.71423   0.000169205 
+  4809         4305.70346   188.957     0.000207943 
+  3583         3105.96955   189.2006    0.000279096 
+  2808         2318.11472   189.44503   0.000356125 
+  2295         1826.67654   189.69031   0.00043573 
+  1967         1528.28178   189.93643   0.000508388 
+  1748         1355.63788   190.18339   0.000572082 
+  1590         1271.27894   190.4312    0.000628931 
+  1539         1262.07303   190.67986   0.000649773 
+  1626         1335.26782   190.92937   0.000615006 
+  1821         1516.88078   191.17973   0.000549149 
+  2192         1853.56213   191.43095   0.000456204 
+  2815         2401.91786   191.68303   0.00035524 
+  3454         3145.40076   191.93597   0.000289519 
+  3858         3753.04641   192.18977   0.000259202 
+  3702         3643.14533   192.44444   0.000270124 
+  3076         2908.35955   192.69998   0.000325098 
+  2425         2137.24689   192.95639   0.000412371 
+  1817         1573.23391   193.21367   0.000550358 
+  1436         1200.41729   193.47183   0.000696379 
+  1150         957.10431    193.73086   0.000869565 
+  980          794.86821    193.99078   0.001020408 
+  834          682.57061    194.25158   0.001199041 
+  712          601.35195    194.51327   0.001404494 
+  666          540.04679    194.77584   0.001501502 
+  544          492.20645    195.03931   0.001838235 
+  530          454.21779    195.30366   0.001886792 
+  462          423.89653    195.56892   0.002164502 
+  433          399.66856    195.83507   0.002309469 
+  430          380.33992    196.10212   0.002325581 
+  393          364.95011    196.37008   0.002544529 
+  377          352.65524    196.63894   0.00265252 
+  339          342.5804     196.90871   0.002949853 
+  328          333.97628    197.17939   0.00304878 
+  310          326.59818    197.45098   0.003225806 
+  329          320.61915    197.72349   0.003039514 
+  332          316.02224    197.99692   0.003012048 
+  306          311.96679    198.27127   0.003267974 
+  292          307.02419    198.54655   0.003424658 
+  303          300.72269    198.82274   0.00330033 
+  288          293.89456    199.09987   0.003472222 
+  269          287.41408    199.37793   0.003717472 
+  293          281.76179    199.65692   0.003412969 
+  298          277.16907    199.93685   0.003355705 
+  276          273.64209    200.21772   0.003623188 
+  291          271.06008    200.49953   0.003436426 
+  263          269.34638    200.78229   0.003802281 
+  291          268.47952    201.06599   0.003436426 
+  240          268.35103    201.35064   0.004166667 
+  257          268.79898    201.63624   0.003891051 
+  268          269.8587     201.9228    0.003731343 
+  259          271.90293    202.21032   0.003861004 
+  284          275.49399    202.49879   0.003521127 
+  247          281.00548    202.78823   0.004048583 
+  235          288.54133    203.07863   0.004255319 
+  274          298.03446    203.37      0.003649635 
+  277          307.10566    203.66234   0.003610108 
+  312          308.92022    203.95566   0.003205128 
+  276          299.92416    204.24995   0.003623188 
+  256          286.21789    204.54522   0.00390625 
+  239          274.21233    204.84147   0.0041841 
+  219          265.64415    205.1387    0.00456621 
+  247          260.11519    205.43693   0.004048583 
+  249          256.94989    205.73614   0.004016064 
+  252          255.6822     206.03634   0.003968254 
+  243          256.05345    206.33754   0.004115226 
+  222          257.98672    206.63973   0.004504505 
+  232          261.63682    206.94293   0.004310345 
+  244          267.46916    207.24712   0.004098361 
+  224          276.32971    207.55233   0.004464286 
+  253          289.4164     207.85854   0.003952569 
+#--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--#
+
+# start Validation Reply Form
+_vrf_PLAT741_NEW5minmill_phase_1 # for all atoms in 1_quartz
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT741_NEW5minmill_phase_3 # for all atoms in 3_pyrrhotite
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT741_NEW5minmill_phase_4 # for all atoms in 4_rutile
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT741_NEW5minmill_phase_2 # for all atoms in 2_albite
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT155_NEW5minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT141_NEW5minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT142_NEW5minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT143_NEW5minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT144_NEW5minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT145_NEW5minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT146_NEW5minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT151_NEW5minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+# end Validation Reply Form

--- a/data/hamish/fixed/vb5042sup9.cif
+++ b/data/hamish/fixed/vb5042sup9.cif
@@ -1,0 +1,6669 @@
+
+data_NEW10minmill_publ
+_audit_creation_method  "created in GSAS-II"
+_audit_creation_date  2021-08-04T18:46
+_audit_author_name  "McDougall, Hamish"
+_audit_update_record
+   "2021-08-04T18:46  Initial software-generated CIF"
+_pd_block_id  2021-08-04T18:46|NEW10minmill|McDougallHamish|Overall
+# GSAS-II edited template follows Publication_Template
+#=============================================================================
+# this information describes the project, paper etc. for the CIF             #
+# Acta Cryst. Section C papers and editorial correspondence is generated     #
+# from the information in this section                                       #
+#                                                                            #
+#   (from)   CIF submission form for Rietveld refinements (Acta Cryst. C)    #
+#                                                 Version 14 December 1998   #
+#=============================================================================
+# 1. SUBMISSION DETAILS
+
+_publ_contact_author_name             "Suzanne Neville; Vanessa Peterson; Christophe Didier"   # Name of author for correspondence
+_publ_contact_author_address             # Address of author for correspondence
+; ?
+;
+_publ_contact_author_email           "s.neville@unsw.edu.au; vanessa.peterson@ansto.gov.au; drchristophedidier@gmail.com"
+_publ_contact_author_fax             ?
+_publ_contact_author_phone           ?
+
+_publ_contact_letter
+; ?
+;
+   
+_publ_requested_journal              ?
+_publ_requested_coeditor_name        ?
+_publ_requested_category             ?   # Acta C: one of CI/CM/CO/FI/FM/FO
+
+#==============================================================================
+
+# 2. PROCESSING SUMMARY (IUCr Office Use Only)
+
+_journal_data_validation_number      ?
+
+_journal_date_recd_electronic        ?
+_journal_date_to_coeditor            ?
+_journal_date_from_coeditor          ?
+_journal_date_accepted               ?
+_journal_date_printers_first         ?
+_journal_date_printers_final         ?
+_journal_date_proofs_out             ?
+_journal_date_proofs_in              ?
+_journal_coeditor_name               ?
+_journal_coeditor_code               ?
+_journal_coeditor_notes
+; ?
+;
+_journal_techeditor_code             ?
+_journal_techeditor_notes
+; ?
+;
+_journal_coden_ASTM                  ?
+_journal_name_full                   ?
+_journal_year                        ?
+_journal_volume                      ?
+_journal_issue                       ?
+_journal_page_first                  ?
+_journal_page_last                   ?
+_journal_paper_category              ?
+_journal_suppl_publ_number           ?
+_journal_suppl_publ_pages            ?
+
+#==============================================================================
+
+# 3. TITLE AND AUTHOR LIST
+
+_publ_section_title
+; ?
+;
+_publ_section_title_footnote
+; ?
+;         
+ 
+# The loop structure below should contain the names and addresses of all 
+# authors, in the required order of publication. Repeat as necessary.
+
+loop_
+	_publ_author_name
+        _publ_author_footnote
+	_publ_author_address
+ ?                                   #<--'Last name, first name' 
+; ?
+;
+; ?
+;
+
+#==============================================================================
+
+# 4. TEXT
+
+_publ_section_synopsis
+;  ?
+;
+_publ_section_abstract                         
+; ?
+;          
+_publ_section_comment                          
+; ?
+;
+_publ_section_exptl_prep      # Details of the preparation of the sample(s)
+                              # should be given here. 
+; ?
+;
+_publ_section_exptl_refinement                  
+; ?
+;
+_publ_section_references
+; ?
+;
+_publ_section_figure_captions
+; ?
+;
+_publ_section_acknowledgements
+; ?
+;
+
+#=============================================================================
+# 5. OVERALL REFINEMENT & COMPUTING DETAILS
+
+_refine_special_details
+; ?
+;
+_pd_proc_ls_special_details
+; ?
+;
+
+# The following items are used to identify the programs used.
+_computing_molecular_graphics     ?
+_computing_publication_material   ?
+
+_refine_ls_weighting_scheme       ?        
+_refine_ls_weighting_details      ?
+_refine_ls_hydrogen_treatment     ?        
+_refine_ls_extinction_method      ?        
+_refine_ls_extinction_coef        ?         
+_refine_ls_number_constraints     ?        
+
+_refine_ls_restrained_S_all       ?        
+_refine_ls_restrained_S_obs       ?
+
+#==============================================================================
+# 6. SAMPLE PREPARATION DATA
+
+# (In the unusual case where multiple samples are used in a single
+#  Rietveld study, this information should be moved into the phase
+#  blocks)
+
+# The following three fields describe the preparation of the material.
+# The cooling rate is in K/min.  The pressure at which the sample was  
+# prepared is in kPa.  The temperature of preparation is in K.
+               
+_pd_prep_cool_rate                N/A        
+_pd_prep_pressure                 101.3        
+_pd_prep_temperature              298         
+
+_pd_char_colour                   ?       # use ICDD colour descriptions
+
+data_NEW10minmill_overall
+_pd_proc_info_datetime  2021-08-04T18:46
+_pd_calc_method  "Rietveld Refinement"
+_computing_structure_refinement
+   "GSAS-II (Toby & Von Dreele, J. Appl. Cryst. 46, 544-549, 2013)"
+_refine_ls_number_parameters  30
+_refine_ls_goodness_of_fit_all  2.138
+_refine_ls_shift/su_max  0.1571
+
+# OVERALL WEIGHTED R-FACTOR
+_refine_ls_wR_factor_obs  0.08569
+_refine_ls_matrix_type  full
+# POINTERS TO PHASE AND HISTOGRAM BLOCKS
+loop_   _pd_phase_block_id
+  2021-08-04T18:46|NEW10minmill|phase_0|McDougallHamish
+  2021-08-04T18:46|NEW10minmill|phase_2|McDougallHamish
+  2021-08-04T18:46|NEW10minmill|phase_4|McDougallHamish
+  2021-08-04T18:46|NEW10minmill|phase_1|McDougallHamish
+  2021-08-04T18:46|NEW10minmill|phase_3|McDougallHamish
+_pd_block_diffractogram_id
+;
+2021-08-04T18:46|NEW10minmill|McDougallHamish|PANalytical,Co-EmpyreanII_hist_0
+;
+
+data_NEW10minmill_phase_0
+# Information for phase 0
+_pd_block_id  2021-08-04T18:46|NEW10minmill|phase_0|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for FeS2 follows
+_pd_phase_name  FeS2
+_cell_length_a  5.419877(30)
+_cell_length_b  5.419877(30)
+_cell_length_c  5.419877(30)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  90
+_cell_volume  159.2093(27)
+_exptl_crystal_density_diffrn  5.0050
+_symmetry_cell_setting  cubic
+_symmetry_space_group_name_H-M  "P a -3"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  z,x,y
+     3  y,z,x
+     4  1/2+x,y,1/2-z
+     5  1/2-z,1/2+x,y
+     6  y,1/2-z,1/2+x
+     7  -z,1/2+x,1/2-y
+     8  1/2-y,-z,1/2+x
+     9  1/2+y,1/2-z,-x
+    10  -x,1/2+y,1/2-z
+    11  1/2-z,-x,1/2+y
+    12  1/2+x,1/2-y,-z
+    13  -x,-y,-z
+    14  -z,-x,-y
+    15  -y,-z,-x
+    16  1/2-x,-y,1/2+z
+    17  1/2+z,1/2-x,-y
+    18  -y,1/2+z,1/2-x
+    19  z,1/2-x,1/2+y
+    20  1/2+y,z,1/2-x
+    21  1/2-y,1/2+z,x
+    22  x,1/2-y,1/2+z
+    23  1/2+z,x,1/2-y
+    24  1/2-x,1/2+y,z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Fe1    Fe   0.00000     0.00000     0.00000     1.000      Uiso 0.00873(29) 4   
+S2     S    0.38482(10) 0.38482     0.38482     1.000      Uiso 0.00867(31) 8   
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Fe   4      11.7695    7.3573     3.5222     2.3045     4.7611     0.3072     15.3535    76.8805    1.0369     0.945
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S    8      6.9053     5.2034     1.4379     1.5863     1.4679     22.2151    0.2536     56.172     0.8669     0.2847
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Fe S2"
+_chemical_formula_weight  119.97
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Fe1    S2     2.26483(15)   1_555    4_455 yes
+  Fe1    S2     2.26483(15)   1_555    5_545 yes
+  Fe1    S2     2.26483(15)   1_555    6_554 yes
+  Fe1    S2     2.26483(15)   1_555    7_545 yes
+  Fe1    S2     2.26483(15)   1_555    8_554 yes
+  Fe1    S2     2.2648(5)    1_555    9_455 yes
+  S2     Fe1    2.26483(15)   1_555    4_555 yes
+  S2     Fe1    2.26483(15)   1_555    5_555 yes
+  S2     Fe1    2.2648(5)    1_555    6_555 yes
+  S2     S2     2.1625(6)    1_555   13_666 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.1814(11), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW10minmill_phase_2
+# Information for phase 2
+_pd_block_id  2021-08-04T18:46|NEW10minmill|phase_2|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for NaAlSi3O8 follows
+_pd_phase_name  NaAlSi3O8
+_cell_length_a  8.137
+_cell_length_b  12.785
+_cell_length_c  7.1583
+_cell_angle_alpha  94.26
+_cell_angle_beta   116.6
+_cell_angle_gamma  87.71
+_cell_volume  664.008
+_exptl_crystal_density_diffrn  2.6230
+_symmetry_cell_setting  triclinic
+_symmetry_space_group_name_H-M  "C -1"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -x,-y,-z
+     3  1/2+x,1/2+y,z
+     4  1/2-x,1/2-y,-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Al1    Al3+ 0.00887     0.16846     0.20805     1.000      Uani 0.007      4   
+Si1    Si4+ 0.00375     0.82051     0.23737     1.000      Uani 0.006      4   
+Si2    Si4+ 0.69162     0.11021     0.31466     1.000      Uani 0.006      4   
+Si3    Si4+ 0.68129     0.88190     0.36076     1.000      Uani 0.006      4   
+Na1    Na1+ 0.26799     0.98865     0.14650     1.000      Uani 0.031      4   
+O1     O2-  0.00490     0.13103     0.96660     1.000      Uani 0.012      4   
+O2     O2-  0.59176     0.99756     0.28040     1.000      Uani 0.008      4   
+O3     O2-  0.81230     0.10966     0.19010     1.000      Uani 0.014      4   
+O4     O2-  0.82000     0.85101     0.25870     1.000      Uani 0.018      4   
+O5     O2-  0.01288     0.30238     0.27060     1.000      Uani 0.011      4   
+O6     O2-  0.02329     0.69368     0.22910     1.000      Uani 0.011      4   
+O7     O2-  0.20780     0.10896     0.38900     1.000      Uani 0.011      4   
+O8     O2-  0.18400     0.86817     0.43620     1.000      Uani 0.012      4   
+
+loop_
+   _atom_site_aniso_label
+   _atom_site_aniso_U_11
+   _atom_site_aniso_U_22
+   _atom_site_aniso_U_33
+   _atom_site_aniso_U_12
+   _atom_site_aniso_U_13
+   _atom_site_aniso_U_23
+Al1    0.0074      0.0068      0.0061      -0.0009     0.0031      0.0004      
+Si1    0.0068      0.0065      0.0055      0.0011      0.0030      0.0008      
+Si2    0.0061      0.0055      0.0073      -0.0002     0.0025      0.0004      
+Si3    0.0060      0.0055      0.0074      0.0006      0.0028      0.0009      
+Na1    0.0136      0.0471      0.0315      -0.0050     0.0084      -0.0219     
+O1     0.0164      0.0122      0.0074      -0.0002     0.0067      0.0014      
+O2     0.0074      0.0056      0.0119      0.0003      0.0033      0.0020      
+O3     0.0117      0.0130      0.0162      -0.0040     0.0093      -0.0017     
+O4     0.0134      0.0179      0.0216      0.0046      0.0129      0.0020      
+O5     0.0103      0.0076      0.0150      -0.0020     0.0052      -0.0009     
+O6     0.0101      0.0071      0.0145      0.0022      0.0034      0.0012      
+O7     0.0120      0.0129      0.0080      0.0024      0.0013      0.0015      
+O8     0.0140      0.0140      0.0084      -0.0026     -0.0002     -0.0006     
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Al   4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Na   4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  O    32     ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si   12     ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Al Na O8 Si3"
+_chemical_formula_weight  262.22
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Al1    O1     1.74519      1_555    1_554 yes
+  Al1    O3     1.7429       1_555    1_455 yes
+  Al1    O5     1.73509      1_555    1_555 yes
+  Al1    O7     1.74556      1_555    1_555 yes
+  Si1    O1     1.59985      1_555    2_566 yes
+  Si1    O4     1.59997      1_555    1_455 yes
+  Si1    O6     1.62225      1_555    1_555 yes
+  Si1    O8     1.61907      1_555    1_555 yes
+  Si2    O2     1.63011      1_555    1_545 yes
+  Si2    O3     1.59435      1_555    1_555 yes
+  Si2    O6     1.61836      1_555    3_545 yes
+  Si2    O8     1.6168       1_555    2_666 yes
+  Si3    O2     1.64718      1_555    1_555 yes
+  Si3    O4     1.61975      1_555    1_555 yes
+  Si3    O5     1.59682      1_555    3_555 yes
+  Si3    O7     1.60203      1_555    2_666 yes
+  Na1    O1     2.66887      1_555    1_564 yes
+  Na1    O1     2.53079      1_555    2_566 yes
+  Na1    O2     2.3704       1_555    1_555 yes
+  Na1    O3     2.45321      1_555    2_665 yes
+  Na1    O7     2.43384      1_555    1_565 yes
+  O1     Al1    1.74519      1_555    1_556 yes
+  O1     Si1    1.59985      1_555    2_566 yes
+  O1     Na1    2.66887      1_555    1_546 yes
+  O1     Na1    2.53079      1_555    2_566 yes
+  O2     Si2    1.63011      1_555    1_565 yes
+  O2     Si3    1.64718      1_555    1_555 yes
+  O2     Na1    2.3704       1_555    1_555 yes
+  O3     Al1    1.7429       1_555    1_655 yes
+  O3     Si2    1.59435      1_555    1_555 yes
+  O3     Na1    2.45321      1_555    2_665 yes
+  O4     Si1    1.59997      1_555    1_655 yes
+  O4     Si3    1.61975      1_555    1_555 yes
+  O5     Al1    1.73509      1_555    1_555 yes
+  O5     Si3    1.59682      1_555    3_445 yes
+  O6     Si1    1.62225      1_555    1_555 yes
+  O6     Si2    1.61836      1_555    3_455 yes
+  O7     Al1    1.74556      1_555    1_555 yes
+  O7     Si3    1.60203      1_555    2_666 yes
+  O7     Na1    2.43384      1_555    1_545 yes
+  O8     Si1    1.61907      1_555    1_555 yes
+  O8     Si2    1.6168       1_555    2_666 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Al1    O3     102.836       1_554  1_555    1_455 yes
+  O1     Al1    O5     116.047       1_554  1_555    1_555 yes
+  O3     Al1    O5     112.215       1_455  1_555    1_555 yes
+  O1     Al1    O7     104.004       1_554  1_555    1_555 yes
+  O3     Al1    O7     111.151       1_455  1_555    1_555 yes
+  O5     Al1    O7     110.14        1_555  1_555    1_555 yes
+  O1     Si1    O4     109.433       2_566  1_555    1_455 yes
+  O1     Si1    O6     112.47        2_566  1_555    1_555 yes
+  O4     Si1    O6     108.187       1_455  1_555    1_555 yes
+  O1     Si1    O8     107.176       2_566  1_555    1_555 yes
+  O4     Si1    O8     111.446       1_455  1_555    1_555 yes
+  O6     Si1    O8     108.16        1_555  1_555    1_555 yes
+  O2     Si2    O3     111.144       1_545  1_555    1_555 yes
+  O2     Si2    O6     104.24        1_545  1_555    3_545 yes
+  O3     Si2    O6     112.114       1_555  1_555    3_545 yes
+  O2     Si2    O8     106.97        1_545  1_555    2_666 yes
+  O3     Si2    O8     111.591       1_555  1_555    2_666 yes
+  O6     Si2    O8     110.422       3_545  1_555    2_666 yes
+  O2     Si3    O4     107.269       1_555  1_555    1_555 yes
+  O2     Si3    O5     105.914       1_555  1_555    3_555 yes
+  O4     Si3    O5     110.224       1_555  1_555    3_555 yes
+  O2     Si3    O7     108.565       1_555  1_555    2_666 yes
+  O4     Si3    O7     110.208       1_555  1_555    2_666 yes
+  O5     Si3    O7     114.328       3_555  1_555    2_666 yes
+  Al1    O1     Si1    141.397       1_556  1_555    2_566 yes
+  Si2    O2     Si3    130.019       1_565  1_555    1_555 yes
+  Si2    O2     Na1    120.351       1_565  1_555    1_555 yes
+  Si3    O2     Na1    108.811       1_555  1_555    1_555 yes
+  Al1    O3     Si2    139.461       1_655  1_555    1_555 yes
+  Si1    O4     Si3    161.151       1_655  1_555    1_555 yes
+  Al1    O5     Si3    129.689       1_555  1_555    3_445 yes
+  Si1    O6     Si2    135.676       1_555  1_555    3_455 yes
+  Al1    O7     Si3    133.943       1_555  1_555    2_666 yes
+  Si1    O8     Si2    151.747       1_555  1_555    2_666 yes
+_pd_proc_ls_pref_orient_corr  none
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.099(8), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW10minmill_phase_4
+# Information for phase 4
+_pd_block_id  2021-08-04T18:46|NEW10minmill|phase_4|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Pyrrhotite 4M follows
+_pd_phase_name  "Pyrrhotite 4M"
+_cell_length_a  11.95(4)
+_cell_length_b  6.850(5)
+_cell_length_c  12.84(5)
+_cell_angle_alpha  90
+_cell_angle_beta   117.23(8)
+_cell_angle_gamma  90
+_cell_volume  934.4(6)
+_exptl_crystal_density_diffrn  4.6021
+_symmetry_cell_setting  monoclinic
+_symmetry_space_group_name_H-M  "C 2/c"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -x,y,1/2-z
+     3  -x,-y,-z
+     4  x,-y,1/2+z
+     5  1/2+x,1/2+y,z
+     6  1/2-x,1/2+y,1/2-z
+     7  1/2-x,1/2-y,-z
+     8  1/2+x,1/2-y,1/2+z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+S1     S    0.01800     0.38330     0.11960     1.000      Uiso 0.010      8   
+S2     S    0.02910     0.11420     0.63900     1.000      Uiso 0.010      8   
+Fe3    Fe   0.10860     0.10250     0.49980     1.000      Uiso 0.010      8   
+S4     S    0.23410     0.13550     0.38260     1.000      Uiso 0.010      8   
+Fe5    Fe   0.24180     0.36600     0.24680     1.000      Uiso 0.010      8   
+S6     S    0.26790     0.13400     0.12360     1.000      Uiso 0.010      8   
+Fe7    Fe   0.38720     0.15000     0.01260     1.000      Uiso 0.010      8   
+Fe8    Fe   0.00000     0.14720     0.25000     1.000      Uiso 0.010      4   
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Fe   28     11.7695    7.3573     3.5222     2.3045     4.7611     0.3072     15.3535    76.8805    1.0369     0.945
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S    32     6.9053     5.2034     1.4379     1.5863     1.4679     22.2151    0.2536     56.172     0.8669     0.2847
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Fe7 S8"
+_chemical_formula_weight  647.41
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  S1     Fe3    2.49323      1_555    2_555 yes
+  S1     Fe5    2.41557      1_555    1_555 yes
+  S1     Fe7    2.38804      1_555    5_455 yes
+  S1     Fe7    2.44444      1_555    7_555 yes
+  S1     Fe8    2.40722      1_555    1_555 yes
+  S2     Fe3    2.37832      1_555    1_555 yes
+  S2     Fe3    2.3245       1_555    3_556 yes
+  S2     Fe5    2.44705      1_555    7_556 yes
+  S2     Fe7    2.36633      1_555    8_456 yes
+  S2     Fe8    2.41078      1_555    3_556 yes
+  Fe3    S1     2.49323      1_555    2_555 yes
+  Fe3    S2     2.37832      1_555    1_555 yes
+  Fe3    S2     2.3245       1_555    3_556 yes
+  Fe3    S6     2.45057      1_555    4_556 yes
+  S4     Fe5    2.38508      1_555    1_555 yes
+  Fe5    S1     2.41557      1_555    1_555 yes
+  Fe5    S2     2.44705      1_555    7_556 yes
+  Fe5    S4     2.38508      1_555    1_555 yes
+  Fe5    S6     2.36147      1_555    1_555 yes
+  S6     Fe3    2.45057      1_555    4_555 yes
+  S6     Fe5    2.36147      1_555    1_555 yes
+  S6     Fe7    2.43592      1_555    1_555 yes
+  S6     Fe7    2.39083      1_555    7_555 yes
+  Fe7    S1     2.38804      1_555    5_545 yes
+  Fe7    S1     2.44444      1_555    7_555 yes
+  Fe7    S2     2.36633      1_555    8_555 yes
+  Fe7    S6     2.43592      1_555    1_555 yes
+  Fe7    S6     2.39083      1_555    7_555 yes
+  Fe8    S1     2.40722      1_555    1_555 yes
+  Fe8    S1     2.40722      1_555    2_555 yes
+  Fe8    S2     2.41078      1_555    3_556 yes
+  Fe8    S2     2.41078      1_555    4_555 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.0294(29), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW10minmill_phase_1
+# Information for phase 1
+_pd_block_id  2021-08-04T18:46|NEW10minmill|phase_1|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for SiO2 follows
+_pd_phase_name  SiO2
+_cell_length_a  4.9161(5)
+_cell_length_b  4.9161(5)
+_cell_length_c  5.4064(5)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  120
+_cell_volume  113.159(11)
+_exptl_crystal_density_diffrn  2.6451
+_symmetry_cell_setting  trigonal
+_symmetry_space_group_name_H-M  "P 32 2 1"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -y,x-y,2/3+z
+     3  y-x,-x,1/3+z
+     4  y,x,-z
+     5  -x,y-x,2/3-z
+     6  x-y,-y,1/3-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Si1    Si4+ 0.47000     0.00000     0.66670     1.000      Uani 0.006      3   
+O1     O2-  0.41460     0.26780     0.78543     1.000      Uani 0.011      6   
+
+loop_
+   _atom_site_aniso_label
+   _atom_site_aniso_U_11
+   _atom_site_aniso_U_22
+   _atom_site_aniso_U_33
+   _atom_site_aniso_U_12
+   _atom_site_aniso_U_13
+   _atom_site_aniso_U_23
+Si1    0.0073      0.0059      0.0053      0.0029      0.0003      0.0006      
+O1     0.0120      0.0105      0.0118      0.0065      -0.0029     -0.0040     
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  O    6      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si   3      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  3
+_chemical_formula_sum  "O2 Si"
+_chemical_formula_weight  60.08
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Si1    O1     1.60564      1_555    1_555 yes
+  Si1    O1     1.61191      1_555    2_654 yes
+  Si1    O1     1.61165      1_555    5_656 yes
+  Si1    O1     1.60578      1_555    6_556 yes
+  O1     Si1    1.60564      1_555    1_555 yes
+  O1     Si1    1.61191      1_555    3_665 yes
+  O1     Si1    1.61165      1_555    5_666 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Si1    O1     110.253       1_555  1_555    2_654 yes
+  O1     Si1    O1     108.751       1_555  1_555    5_656 yes
+  O1     Si1    O1     109.68        2_654  1_555    5_656 yes
+  O1     Si1    O1     109.159       1_555  1_555    6_556 yes
+  O1     Si1    O1     108.731       2_654  1_555    6_556 yes
+  O1     Si1    O1     110.259       5_656  1_555    6_556 yes
+  Si1    O1     Si1    143.831       1_555  1_555    3_665 yes
+  Si1    O1     Si1    143.835       1_555  1_555    5_666 yes
+  Si1    O1     Si1    0.009         3_665  1_555    5_666 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.151(8), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW10minmill_phase_3
+# Information for phase 3
+_pd_block_id  2021-08-04T18:46|NEW10minmill|phase_3|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for TiO2 follows
+_pd_phase_name  TiO2
+_cell_length_a  4.5991(7)
+_cell_length_b  4.5991(7)
+_cell_length_c  2.9603(7)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  90
+_cell_volume  62.617(16)
+_exptl_crystal_density_diffrn  4.2376
+_symmetry_cell_setting  tetragonal
+_symmetry_space_group_name_H-M  "P 42/m n m"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  1/2-y,1/2+x,1/2+z
+     3  -x,-y,z
+     4  1/2+y,1/2-x,1/2+z
+     5  1/2-x,1/2+y,1/2+z
+     6  -y,-x,z
+     7  1/2+x,1/2-y,1/2+z
+     8  y,x,z
+     9  -x,-y,-z
+    10  1/2+y,1/2-x,1/2-z
+    11  x,y,-z
+    12  1/2-y,1/2+x,1/2-z
+    13  1/2+x,1/2-y,1/2-z
+    14  y,x,-z
+    15  1/2-x,1/2+y,1/2-z
+    16  -y,-x,-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Ti1    Ti4+ 0.00000     0.00000     0.00000     1.000      Uani 0.006      2   
+O1     O2-  0.30493     0.30493     0.00000     1.000      Uani 0.006      4   
+
+loop_
+   _atom_site_aniso_label
+   _atom_site_aniso_U_11
+   _atom_site_aniso_U_22
+   _atom_site_aniso_U_33
+   _atom_site_aniso_U_12
+   _atom_site_aniso_U_13
+   _atom_site_aniso_U_23
+Ti1    0.0070      0.0070      0.0047      -0.0002     0.0000      0.0000      
+O1     0.0060      0.0060      0.0045      -0.0019     0.0000      0.0000      
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  O    4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Ti   2      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  2
+_chemical_formula_sum  "O2 Ti"
+_chemical_formula_weight  79.9
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Ti1    O1     1.98331      1_555    1_555 yes
+  Ti1    O1     1.94953      1_555    2_544 yes
+  Ti1    O1     1.94953      1_555    2_545 yes
+  Ti1    O1     1.98331      1_555    3_555 yes
+  Ti1    O1     1.94953      1_555    4_454 yes
+  Ti1    O1     1.94953      1_555    4_455 yes
+  O1     Ti1    1.98331      1_555    1_555 yes
+  O1     Ti1    1.94953      1_555    2_554 yes
+  O1     Ti1    1.94953      1_555    2_555 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Ti1    O1     90            1_555  1_555    2_544 yes
+  O1     Ti1    O1     90            1_555  1_555    2_545 yes
+  O1     Ti1    O1     98.795        2_544  1_555    2_545 yes
+  O1     Ti1    O1     180           1_555  1_555    3_555 yes
+  O1     Ti1    O1     90            2_544  1_555    3_555 yes
+  O1     Ti1    O1     90            2_545  1_555    3_555 yes
+  O1     Ti1    O1     90            1_555  1_555    4_454 yes
+  O1     Ti1    O1     81.205        2_544  1_555    4_454 yes
+  O1     Ti1    O1     180           2_545  1_555    4_454 yes
+  O1     Ti1    O1     90            3_555  1_555    4_454 yes
+  O1     Ti1    O1     90            1_555  1_555    4_455 yes
+  O1     Ti1    O1     180           2_544  1_555    4_455 yes
+  O1     Ti1    O1     81.205        2_545  1_555    4_455 yes
+  O1     Ti1    O1     90            3_555  1_555    4_455 yes
+  O1     Ti1    O1     98.795        4_454  1_555    4_455 yes
+  Ti1    O1     Ti1    130.602       1_555  1_555    2_554 yes
+  Ti1    O1     Ti1    130.602       1_555  1_555    2_555 yes
+  Ti1    O1     Ti1    98.795        2_554  1_555    2_555 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.200, 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW10minmill_pwd_0
+_pd_proc_ls_profile_function
+;
+Finger-Cox-Jephcoat function parameters U, V, W, X, Y, SH/L:
+  peak variance(Gauss) = Utan(Th)^2^+Vtan(Th)+W:
+  peak HW(Lorentz) = X/cos(Th)+Ytan(Th); SH/L = S/L+H/L
+  U, V, W in (centideg)^2^, X & Y in centideg
+    0.000, 0.000, 1.089, 0.882, 1.689, 0.058, 
+;
+# Information for histogram 0: PWDR BAT3_10min_milla_30mm_MonicaHamish_Ruoming_step size 0_10_min_mill_a.xrdml Scan 1
+_pd_block_id
+;
+2021-08-04T18:46|NEW10minmill|McDougallHamish|PANalytical,Co-EmpyreanII_hist_0
+;
+# GSAS-II edited template follows Instrument_Template
+#==============================================================================
+# 9. INSTRUMENT CHARACTERIZATION
+
+_exptl_special_details
+; ?
+;
+
+# if regions of the data are excluded, the reason(s) are supplied here:
+_pd_proc_info_excluded_regions
+; ?
+;
+
+# The following item is used to identify the equipment used to record 
+# the powder pattern when the diffractogram was measured at a laboratory 
+# other than the authors' home institution, e.g. when neutron or synchrotron
+# radiation is used.
+
+_pd_instr_location
+; ?
+;
+_pd_calibration_special_details           # description of the method used
+                                          # to calibrate the instrument
+; ?
+;
+
+_diffrn_source                    Co-Ka       
+_diffrn_source_target             Co
+_diffrn_source_type               Graded_Flat
+_diffrn_measurement_device_type   Panalytical_Reflection_Transmission       
+_diffrn_detector                  PIXcel1D       
+_diffrn_detector_type             Empyrean_II       # make or model of detector
+
+_pd_meas_scan_method              ?       # options are 'step', 'cont',
+                                          # 'tof', 'fixed' or
+                                          # 'disp' (= dispersive)
+_pd_meas_special_details
+;  ?
+;
+
+# The following two items identify the program(s) used (if appropriate).
+_computing_data_collection        ?        
+_computing_data_reduction         ?                   
+
+# Describe any processing performed on the data, prior to refinement.
+# For example: a manual Lp correction or a precomputed absorption correction
+_pd_proc_info_data_reduction      ?
+
+# The following item is used for angular dispersive measurements only.
+
+_diffrn_radiation_monochromator   ?        
+
+# The following items are used to define the size of the instrument.
+# Not all distances are appropriate for all instrument types.
+
+_pd_instr_dist_src/mono           ?
+_pd_instr_dist_mono/spec          ?
+_pd_instr_dist_src/spec           ?
+_pd_instr_dist_spec/anal          ?
+_pd_instr_dist_anal/detc          ?
+_pd_instr_dist_spec/detc          ?
+
+# 10. Specimen size and mounting information
+
+# The next three fields give the specimen dimensions in mm.  The equatorial 
+# plane contains the incident and diffracted beam.
+
+_pd_spec_size_axial               ?       # perpendicular to 
+                                          # equatorial plane
+
+_pd_spec_size_equat               ?       # parallel to 
+                                          # scattering vector 
+                                          # in transmission
+
+_pd_spec_size_thick               ?       # parallel to 
+                                          # scattering vector 
+                                          # in reflection
+
+_pd_spec_mounting                         # This field should be
+                                          # used to give details of the 
+                                          # container.
+; ?
+;
+
+_pd_spec_mount_mode               ?       # options are 'reflection' 
+                                          # or 'transmission'
+    
+_pd_spec_shape                    ?       # options are 'cylinder' 
+                                          # 'flat_sheet' or 'irregular'
+
+
+loop_
+     _atom_type_symbol
+     _atom_type_scat_dispersion_real
+     _atom_type_scat_dispersion_imag
+     _atom_type_scat_dispersion_source
+  Al        0.255   0.328   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Fe       -3.332   0.490   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Na        0.167   0.167   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  O         0.063   0.044   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S         0.371   0.733   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si        0.298   0.438   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Ti       -0.063   2.321   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+_diffrn_radiation_type  K\a~1,2~
+loop_
+   _diffrn_radiation_wavelength
+   _diffrn_radiation_wavelength_wt
+   _diffrn_radiation_wavelength_id
+  1.78892         1.0             1     
+  1.79278         0.5000          2     
+
+# PHASE TABLE
+loop_
+   _pd_phase_id
+   _pd_phase_block_id
+   _pd_phase_mass_%
+  .  2021-08-04T18:46|NEW10minmill|phase_0|McDougallHamish  0.8323(26)
+  2  2021-08-04T18:46|NEW10minmill|phase_2|McDougallHamish  0.0800(23)
+  4  2021-08-04T18:46|NEW10minmill|phase_4|McDougallHamish  0.0310(13)
+  1  2021-08-04T18:46|NEW10minmill|phase_1|McDougallHamish  0.0496(8)
+  3  2021-08-04T18:46|NEW10minmill|phase_3|McDougallHamish  0.0071(4)
+loop_
+   _gsas_proc_phase_R_F_factor
+   _gsas_proc_phase_R_Fsqd_factor
+   _gsas_proc_phase_id
+   _gsas_proc_phase_block_id
+    0.02834  0.05852  .  2021-08-04T18:46|NEW10minmill|phase_0|McDougallHamish
+    0.07538  0.14790  2  2021-08-04T18:46|NEW10minmill|phase_2|McDougallHamish
+    0.06852  0.10954  4  2021-08-04T18:46|NEW10minmill|phase_4|McDougallHamish
+    0.05761  0.12259  1  2021-08-04T18:46|NEW10minmill|phase_1|McDougallHamish
+    0.06165  0.16172  3  2021-08-04T18:46|NEW10minmill|phase_3|McDougallHamish
+_pd_proc_ls_prof_R_factor     0.06725
+_pd_proc_ls_prof_wR_factor    0.08569
+_gsas_proc_ls_prof_R_B_factor   0.07918
+_gsas_proc_ls_prof_wR_B_factor  0.09806
+_pd_proc_ls_prof_wR_expected  0.04024
+_diffrn_radiation_probe  x-ray
+_diffrn_radiation_polarisn_ratio  0.7000
+_pd_proc_ls_background_function
+;
+Background function: "chebyschev-1" function with 7 terms:
+    433.0(13), -482.0(20), 358.5(19), -178.2(17), 94.3(16), -31.7(12), 
+    13.8(11), 
+;
+_diffrn_ambient_temperature  300
+_diffrn_ambient_pressure  100
+
+# STRUCTURE FACTOR TABLE
+loop_
+   _pd_refln_phase_id
+   _refln_index_h
+   _refln_index_k
+   _refln_index_l
+   _refln_F_squared_meas
+   _refln_F_squared_calc
+   _refln_phase_calc
+   _refln_d_spacing
+   _gsas_i100_meas
+  .  1    1    1    957.3089   866.0114   0.0     3.12917  25.11  
+  .  2    .    .    6573.2864  6225.3214  -0.0    2.70994  95.61  
+  .  2    1    .    3501.4339  3351.6775  0.0     2.42384  80.45  
+  .  2    1    1    1747.0066  1704.1977  -180.0  2.21266  66.17  
+  .  2    2    .    3092.7766  3271.1756  -0.0    1.91622  43.23  
+  .  2    2    1    38.6663    36.3198    -0.0    1.80663  0.96   
+  .  3    1    1    4948.6024  5166.5587  -0.0    1.63415  100.00 
+  .  2    2    2    2067.6059  2295.3306  0.0     1.56458  12.81  
+  .  3    .    2    2880.4590  2977.3091  -0.0    1.50320  24.87  
+  .  3    1    2    557.3370   584.3306   0.0     1.44852  9.02   
+  .  3    2    1    1522.8167  1596.5714  180.0   1.44852  24.65  
+  .  4    .    .    357.8304   371.7594   -180.0  1.35497  1.30   
+  .  3    2    2    32.5548    38.0617    -0.0    1.31451  0.46   
+  .  4    1    .    83.8591    98.0445    -0.0    1.31451  0.59   
+  .  4    1    1    51.1878    53.0339    180.0   1.27748  0.69   
+  .  3    3    1    533.8767   544.7040   -0.0    1.24341  7.04   
+  .  4    .    2    865.9177   860.6685   0.0     1.21192  5.60   
+  .  4    2    .    865.9177   860.6685   0.0     1.21192  5.60   
+  .  4    1    2    1.3251     1.2882     -0.0    1.18271  0.02   
+  .  4    2    1    1358.1702  1320.3279  -180.0  1.18271  17.36  
+  .  3    3    2    708.0283   673.2342   0.0     1.15552  9.00   
+  .  4    2    2    1041.0094  978.3322   0.0     1.10633  13.35  
+  .  4    3    .    113.7057   116.2068   -0.0    1.08398  0.74   
+  .  4    1    3    52.6491    63.2817    -180.0  1.06293  0.70   
+  .  4    3    1    19.2691    23.1605    0.0     1.06293  0.26   
+  .  3    3    3    1663.3884  1503.3697  -0.0    1.04306  7.61   
+  .  5    1    1    3383.0613  3057.6092  -0.0    1.04306  46.43  
+  1  1    .    .    241.5298   242.5263   180.0   4.25750  0.32   
+  1  1    .    1    703.8523   634.5057   120.0   3.34486  0.56   
+  1  1    .    -1   1674.4384  1509.4657  -120.0  3.34486  1.34   
+  1  1    1    .    364.7797   343.8874   -155.6  2.45807  0.15   
+  1  1    .    2    311.7914   298.8540   -120.0  2.28207  0.11   
+  1  1    .    -2   89.9353    86.2036    -60.0   2.28207  0.03   
+  1  1    1    1    95.9351    96.0668    82.9    2.23765  0.07   
+  1  2    .    .    303.0328   308.9202   0.0     2.12875  0.09   
+  1  2    .    -1   94.2269    77.2271    60.0    1.98074  0.03   
+  1  2    .    1    225.8169   185.0766   -60.0   1.98074  0.06   
+  1  1    1    2    518.8016   602.9051   9.8     1.81862  0.23   
+  1  .    .    3    100.3009   94.4436    0.0     1.80214  0.01   
+  1  2    .    2    92.1995    82.0960    60.0    1.67243  0.02   
+  1  2    .    -2   409.1152   364.2832   120.0   1.67243  0.08   
+  1  1    .    -3   220.6864   203.8693   180.0   1.65958  0.04   
+  1  1    .    3    2.7998     2.5864     0.0     1.65958  0.00   
+  1  2    1    .    15.3401    14.6469    -38.9   1.60919  0.01   
+  1  2    1    -1   328.6250   356.4111   95.9    1.54232  0.11   
+  1  2    1    1    282.8355   306.7501   -109.6  1.54232  0.09   
+  1  1    1    3    146.8409   142.5897   117.5   1.45338  0.04   
+  1  3    .    .    86.2773    76.3720    -180.0  1.41917  0.01   
+  1  2    1    -2   343.6953   413.8536   -123.3  1.38273  0.09   
+  1  2    1    2    106.7141   128.4976   143.4   1.38273  0.03   
+  1  2    .    -3   257.0681   292.6770   -0.0    1.37544  0.03   
+  1  2    .    3    905.1559   1030.5376  0.0     1.37544  0.12   
+  1  3    .    -1   713.8452   815.9930   -120.0  1.37266  0.09   
+  1  3    .    1    0.8893     1.0166     -60.0   1.37266  0.00   
+  1  1    .    -4   107.6269   120.2849   -120.0  1.28824  0.01   
+  1  1    .    4    354.7659   396.4901   120.0   1.28824  0.04   
+  1  3    .    -2   179.2909   208.3599   120.0   1.25653  0.02   
+  1  3    .    2    408.7313   475.0001   -120.0  1.25653  0.05   
+  1  2    2    .    272.7680   371.1277   -16.5   1.22904  0.03   
+  1  2    1    -3   68.6240    71.0196    179.1   1.20031  0.02   
+  1  2    1    3    291.2964   301.4652   -134.8  1.20031  0.07   
+  1  2    2    1    110.0497   105.6117   88.6    1.19846  0.03   
+  1  1    1    4    361.6511   334.2134   -14.4   1.18436  0.08   
+  1  3    1    .    384.9357   361.6377   121.4   1.18082  0.09   
+  1  3    1    -1   216.7459   189.9626   -18.5   1.15362  0.05   
+  1  3    1    1    72.3475    63.4075    16.4    1.15362  0.02   
+  1  2    .    4    66.7066    70.6901    120.0   1.14104  0.01   
+  1  2    .    -4   1.3909     1.4739     -120.0  1.14104  0.00   
+  1  2    2    2    3.1506     3.3523     -9.9    1.11882  0.00   
+  1  3    .    -3   7.0174     6.6897     -0.0    1.11495  0.00   
+  1  3    .    3    65.8134    62.7403    -180.0  1.11495  0.01   
+  1  3    1    -2   281.0886   304.4208   -8.9    1.08209  0.06   
+  1  3    1    2    114.8445   124.3773   59.1    1.08209  0.03   
+  1  4    .    .    121.4439   168.2186   0.0     1.06438  0.01   
+  1  1    .    -5   406.3863   346.3251   120.0   1.04801  0.05   
+  1  1    .    5    152.4573   129.9251   -120.0  1.04801  0.02   
+  1  4    .    -1   36.5478    31.4136    60.0    1.04433  0.00   
+  1  4    .    1    337.1343   289.7739   120.0   1.04433  0.04   
+  1  2    1    -4   8.3831     10.8635    51.2    1.03496  0.00   
+  1  2    1    4    185.9177   240.9267   -129.5  1.03496  0.05   
+  2  .    .    1    2728.4582  685.7541   180.0   6.38786  0.04   
+  2  .    2    .    1470.4505  396.3962   180.0   6.37466  0.02   
+  2  1    1    .    746.0457   238.2363   -0.0    6.33955  0.01   
+  2  1    -1   .    820.9501   287.4879   -0.0    6.29869  0.01   
+  2  1    1    -1   780.5624   406.2352   180.0   5.91009  0.01   
+  2  1    -1   -1   1019.2111  415.6378   -180.0  5.58552  0.01   
+  2  .    2    -1   11.3192    16.5792    0.0     4.66174  0.00   
+  2  .    2    1    2.2892     1.8371     180.0   4.37623  0.00   
+  2  2    .    -1   20485.8978 21037.4763 -0.0    4.02732  0.10   
+  2  1    -1   1    2714.0614  3767.3897  -0.0    3.85265  0.01   
+  2  1    1    1    9298.2745  10390.3834 0.0     3.77565  0.05   
+  2  1    3    .    7838.9204  5886.9121  180.0   3.68167  0.03   
+  2  1    3    -1   5848.3851  4505.3267  0.0     3.66562  0.02   
+  2  1    -3   .    12994.1672 11675.3013 180.0   3.65766  0.05   
+  2  2    .    .    2.2840     2.5781     0.0     3.63776  0.00   
+  2  1    1    -2   6232.2242  4328.5159  0.0     3.50520  0.03   
+  2  2    2    -1   3241.4443  1650.0035  180.0   3.48122  0.01   
+  2  1    -3   -1   58.6800    12.1276    0.0     3.43616  0.00   
+  2  1    -1   -2   6704.6566  5251.4578  0.0     3.37264  0.03   
+  2  2    -2   -1   349.5192   364.8637   0.0     3.33313  0.00   
+  2  2    .    -2   28157.0918 26655.4799 -180.0  3.21484  0.09   
+  2  .    .    2    38714.0270 37071.8044 -180.0  3.19393  0.14   
+  2  .    4    .    25961.2348 25362.8195 180.0   3.18733  0.08   
+  2  2    2    .    14800.3173 13873.6743 180.0   3.16977  0.05   
+  2  2    -2   .    15540.7312 14946.6082 -180.0  3.14934  0.05   
+  2  1    -3   1    13776.4918 11175.2497 -180.0  2.96418  0.04   
+  2  2    2    -2   8257.1640  7187.5067  0.0     2.95504  0.02   
+  2  .    2    -2   5231.9929  5310.5610  0.0     2.93060  0.01   
+  2  .    4    -1   7738.0372  8585.7945  0.0     2.92677  0.02   
+  2  1    3    1    5877.1164  6897.0276  180.0   2.86133  0.02   
+  2  1    3    -2   1484.7763  1923.0466  -0.0    2.83885  0.00   
+  2  2    -2   -2   165.1786   183.4547   -0.0    2.79276  0.00   
+  2  .    2    2    172.1154   191.6414   0.0     2.78600  0.00   
+  2  .    4    1    348.2305   387.5360   -0.0    2.78271  0.00   
+  2  2    .    1    112.0671   109.5836   -0.0    2.68712  0.00   
+  2  3    1    -1   428.8453   431.0071   -180.0  2.66293  0.00   
+  2  1    -3   -2   6544.7215  6171.6319  -0.0    2.63839  0.01   
+  2  3    -1   -1   36.8745    33.5476    -180.0  2.62530  0.00   
+  2  2    4    -1   15179.0312 12550.4891 -180.0  2.55995  0.03   
+  2  3    1    -2   2467.8044  1812.0722  180.0   2.53704  0.00   
+  2  1    -1   2    809.4548   667.2869   180.0   2.51139  0.00   
+  2  2    -2   1    1978.8942  1686.7859  -180.0  2.49495  0.00   
+  2  3    -1   -2   549.3332   451.5613   180.0   2.48043  0.00   
+  2  1    1    2    121.6361   110.2849   180.0   2.46610  0.00   
+  2  2    2    1    1451.2447  1367.0046  -180.0  2.45771  0.00   
+  2  2    -4   -1   10729.8051 10453.7459 -180.0  2.44277  0.02   
+  2  1    5    -1   4267.1260  4093.1663  -0.0    2.42941  0.01   
+  2  1    5    .    57.8824    64.0884    180.0   2.41202  0.00   
+  2  2    4    .    3554.2764  3944.1458  -0.0    2.40628  0.01   
+  2  1    -5   .    1981.7339  2230.8323  180.0   2.40074  0.00   
+  2  2    -4   .    1834.1331  2079.3222  -0.0    2.38844  0.00   
+  2  3    1    .    1401.9970  1565.2946  -0.0    2.38575  0.00   
+  2  3    -1   .    1832.0243  2090.0863  -0.0    2.37918  0.00   
+  2  2    .    -3   7.1906     7.3701     180.0   2.35133  0.00   
+  2  2    4    -2   2.7902     2.9331     0.0     2.34729  0.00   
+  2  1    1    -3   96.2721    110.8373   -0.0    2.33656  0.00   
+  2  .    4    -2   855.2353   884.3144   -180.0  2.33087  0.00   
+  2  3    3    -1   16027.9410 9809.7794  180.0   2.31766  0.02   
+  2  1    -5   -1   1738.6554  1044.9800  0.0     2.31526  0.00   
+  2  1    -1   -3   2456.0590  2291.2470  -0.0    2.27750  0.00   
+  2  2    2    -3   203.2989   155.6865   -0.0    2.26146  0.00   
+  2  3    3    -2   19.9691    15.9172    0.0     2.25070  0.00   
+  2  3    -3   -1   3088.8065  2703.2457  -180.0  2.24518  0.00   
+  2  1    -3   2    867.7598   824.7896   -0.0    2.22556  0.00   
+  2  .    4    2    1755.9692  2085.0250  0.0     2.18812  0.00   
+  2  2    -4   -2   1204.9352  1431.8638  0.0     2.18799  0.00   
+  2  1    -5   1    3488.3190  4194.8986  180.0   2.18493  0.00   
+  2  2    -2   -3   1302.1450  1851.4932  0.0     2.15451  0.00   
+  2  1    5    -2   255.2295   312.7232   -180.0  2.15169  0.00   
+  2  3    1    -3   163.0051   204.6119   0.0     2.13824  0.00   
+  2  3    -3   -2   418.2222   512.1941   180.0   2.13724  0.00   
+  2  1    3    2    159.3835   174.4523   -180.0  2.13433  0.00   
+  2  .    .    3    442.9583   454.6548   -0.0    2.12929  0.00   
+  2  .    6    .    11295.3045 11042.6256 -0.0    2.12489  0.01   
+  2  1    3    -3   704.2241   674.2906   -180.0  2.11876  0.00   
+  2  1    5    1    4845.7666  4734.7647  180.0   2.11595  0.01   
+  2  3    3    .    1434.5089  1496.6439  -180.0  2.11318  0.00   
+  2  3    -3   .    123.6486   182.7827   -180.0  2.09956  0.00   
+  2  3    -1   -3   1867.0032  2416.5634  0.0     2.08973  0.00   
+  2  2    -4   1    7395.2816  8370.0925  180.0   2.07604  0.01   
+  2  .    2    -3   269.9065   286.8930   -180.0  2.05903  0.00   
+  2  .    6    -1   77.2142    83.9001    -0.0    2.05549  0.00   
+  2  2    4    1    2178.0633  2723.1302  180.0   2.03350  0.00   
+  2  4    .    -2   982.6450   1673.8545  -0.0    2.01366  0.00   
+  2  1    -5   -2   663.9899   976.2191   -0.0    2.00557  0.00   
+  2  4    .    -1   2630.6892  3207.5402  -0.0    2.00025  0.00   
+  2  2    .    2    785.8725   914.6787   0.0     1.99827  0.00   
+  2  1    -3   -3   1963.9638  2006.9284  -0.0    1.99351  0.00   
+  2  .    2    3    1569.5152  1320.4879  0.0     1.98235  0.00   
+  2  .    6    1    6028.1264  4760.1395  0.0     1.97919  0.01   
+  2  3    -1   1    2421.6210  1778.1424  0.0     1.97162  0.00   
+  2  3    3    -3   1007.0330  747.2487   -180.0  1.97003  0.00   
+  2  3    1    1    921.8715   1049.8991  0.0     1.96352  0.00   
+  2  2    4    -3   182.1304   210.6125   -180.0  1.96339  0.00   
+  2  4    2    -2   1198.8315  1505.1300  0.0     1.94723  0.00   
+  2  2    -2   2    4024.5684  4434.5615  -0.0    1.92633  0.00   
+  2  4    2    -1   176.7810   195.3738   0.0     1.92397  0.00   
+  2  2    6    -1   23.8191    25.7092    -0.0    1.91781  0.00   
+  2  4    -2   -2   13853.4574 14612.2943 -0.0    1.89414  0.01   
+  2  4    -2   -1   78.3639    83.9894    180.0   1.89341  0.00   
+  2  3    5    -1   2988.4043  3253.1319  -180.0  1.88804  0.00   
+  2  2    2    2    10268.8974 11147.4650 -0.0    1.88782  0.01   
+  2  3    -3   -3   190.1407   242.1347   -0.0    1.86184  0.00   
+  2  3    5    -2   115.6597   151.7748   -180.0  1.86122  0.00   
+  2  4    .    -3   13474.9796 17227.6438 -180.0  1.84958  0.01   
+  2  2    -6   -1   548.4216   630.1904   -180.0  1.84310  0.00   
+  2  1    -5   2    28.7318    32.7906    -180.0  1.84286  0.00   
+  2  2    6    .    5574.6151  5973.8074  -0.0    1.84084  0.01   
+  2  2    6    -2   3154.5639  2234.4122  -180.0  1.83281  0.00   
+  2  1    -1   3    2908.5277  2403.8627  -180.0  1.82957  0.00   
+  2  2    -6   .    12829.9633 11170.3478 0.0     1.82883  0.01   
+  2  2    -4   -3   387.8937   351.5785   -0.0    1.82817  0.00   
+  2  .    4    -3   6450.3436  6600.1943  180.0   1.82454  0.01   
+  2  3    -5   -1   509.7582   547.0575   -180.0  1.82305  0.00   
+  2  .    6    -2   8725.2500  9376.7847  -180.0  1.82300  0.01   
+  2  4    .    .    14539.6429 16544.7345 -0.0    1.81888  0.01   
+  2  3    -3   1    1253.9980  1388.1619  -0.0    1.81269  0.00   
+  2  4    2    -3   1791.7262  1698.2109  -0.0    1.80678  0.00   
+  2  1    1    3    14079.0635 13204.6231 -180.0  1.80269  0.02   
+  2  3    3    1    493.5937   659.8672   -0.0    1.79396  0.00   
+  2  1    5    -3   28.4024    36.9138    180.0   1.79152  0.00   
+  2  1    7    -1   335.7249   370.2527   -180.0  1.78554  0.00   
+  2  2    .    -4   26907.2175 29304.7955 0.0     1.78457  0.03   
+  2  1    7    .    1465.8184  1186.7943  -0.0    1.76994  0.00   
+  2  3    5    .    482.7464   192.4714   -180.0  1.76391  0.00   
+  2  1    -7   .    4801.4245  1861.7091  0.0     1.76369  0.00   
+  2  1    5    2    5044.5830  1478.1411  -180.0  1.75728  0.00   
+  2  3    -5   -2   836.2188   292.8600   -180.0  1.75539  0.00   
+  2  2    2    -4   10946.1981 5374.4235  180.0   1.75260  0.01   
+  2  4    2    .    6564.9267  3240.2714  180.0   1.75255  0.01   
+  2  3    -5   .    1.1450     0.6787     -180.0  1.75073  0.00   
+  2  4    -2   -3   2051.6269  1498.9920  -180.0  1.74735  0.00   
+  2  4    -2   .    2000.5557  1478.3757  -180.0  1.74562  0.00   
+  2  4    4    -2   14494.0553 11156.5991 -180.0  1.74061  0.01   
+  2  3    1    -4   14.7950    11.6942    0.0     1.73791  0.00   
+  2  1    1    -4   1236.4780  931.5858   180.0   1.73044  0.00   
+  2  .    4    3    1665.8620  1649.4123  180.0   1.72108  0.00   
+  2  1    -7   -1   549.8733   544.5769   -0.0    1.72100  0.00   
+  2  2    -4   2    5163.3512  5111.9528  -180.0  1.72066  0.00   
+  2  .    6    2    4099.4098  4043.0244  180.0   1.71979  0.00   
+  2  2    -6   -2   5820.0222  5843.5104  180.0   1.71808  0.00   
+  2  1    -3   3    3845.4278  3889.7621  0.0     1.71755  0.00   
+  2  4    4    -1   3380.0768  3425.3612  -0.0    1.71605  0.00   
+  2  3    -1   -4   31.2977    26.3196    -0.0    1.70384  0.00   
+  2  3    5    -3   2303.1762  1781.5059  180.0   1.70048  0.00   
+  2  1    -1   -4   1529.1314  1087.2281  180.0   1.69839  0.00   
+  2  2    -2   -4   8317.6259  6607.2640  -0.0    1.68632  0.01   
+  2  2    -6   1    144.6685   111.8094   180.0   1.68403  0.00   
+  2  1    -7   1    1409.5518  1037.6002  0.0     1.67991  0.00   
+  2  1    7    -2   3502.5476  3014.1863  0.0     1.67337  0.00   
+  2  4    -4   -1   3606.6975  3113.5342  -0.0    1.67328  0.00   
+  2  1    -5   -3   353.2151   322.6770   -180.0  1.66739  0.00   
+  2  2    4    2    7610.4468  6980.1241  -180.0  1.66673  0.01   
+  2  4    -4   -2   3263.2166  2996.9232  -180.0  1.66656  0.00   
+  2  1    3    3    638.5733   605.4945   0.0     1.65314  0.00   
+  2  3    3    -4   491.4550   474.5918   180.0   1.65084  0.00   
+  2  2    6    1    15.6312    15.0623    180.0   1.64996  0.00   
+  2  4    4    -3   87.2732    81.5092    0.0     1.64497  0.00   
+  2  1    3    -4   1339.7952  1267.0308  -180.0  1.64299  0.00   
+  2  2    6    -3   423.3684   438.3802   0.0     1.63845  0.00   
+  2  1    7    1    924.0563   959.6711   0.0     1.63566  0.00   
+  2  5    1    -2   64.8779    62.3555    -180.0  1.62122  0.00   
+  2  2    4    -4   7.0483     6.6299     0.0     1.60885  0.00   
+  2  3    -1   2    255.4569   237.1891   -180.0  1.60779  0.00   
+  2  4    .    -4   27.6864    25.5451    0.0     1.60742  0.00   
+  2  5    -1   -2   118.5864   104.4782   -0.0    1.60481  0.00   
+  2  3    1    2    5.3465     3.3755     -180.0  1.59704  0.00   
+  2  .    .    4    2725.6513  1719.5025  -0.0    1.59697  0.00   
+  2  .    8    .    6424.7810  4104.7411  -0.0    1.59366  0.00   
+  2  3    -5   -3   8668.2991  7048.0684  -180.0  1.58673  0.01   
+  2  4    2    -4   6845.8106  5767.4424  -180.0  1.58523  0.00   
+  2  4    4    .    95.1519    80.5872    180.0   1.58489  0.00   
+  2  3    -5   1    3741.4032  3541.7994  0.0     1.57987  0.00   
+  2  1    -7   -2   106.6445   106.0592   180.0   1.57566  0.00   
+  2  4    -4   .    975.3462   972.7791   180.0   1.57467  0.00   
+  2  4    .    1    1306.4929  1313.3627  0.0     1.57405  0.00   
+  2  .    2    -4   6798.6378  6835.8768  -180.0  1.57267  0.01   
+  2  5    1    -1   1835.0121  1838.8969  0.0     1.57223  0.00   
+  2  5    1    -3   4.4523     4.5305     0.0     1.57056  0.00   
+  2  .    8    -1   4901.8943  5105.5113  -180.0  1.56971  0.00   
+  2  3    -3   -4   205.6999   222.0271   -180.0  1.56739  0.00   
+  2  1    -3   -4   1071.2148  1168.3240  -180.0  1.56437  0.00   
+  2  5    -1   -1   3256.0103  3532.8589  -0.0    1.56314  0.00   
+  2  3    5    1    6116.0553  6630.5027  -0.0    1.55930  0.00   
+  2  2    .    3    1626.3148  1763.6711  -180.0  1.55911  0.00   
+  2  4    -4   -3   616.9240   668.2938   0.0     1.55805  0.00   
+  2  .    6    -3   50.4984    50.4752    180.0   1.55391  0.00   
+  2  5    -1   -3   3303.9720  3177.9812  180.0   1.54983  0.00   
+  2  5    3    -2   1928.4693  1684.3120  0.0     1.53962  0.00   
+  2  3    7    -1   368.3741   255.3064   -0.0    1.53554  0.00   
+  2  4    -2   -4   6107.2320  4566.3850  180.0   1.53333  0.00   
+  2  4    -2   1    466.9575   360.2122   -0.0    1.53138  0.00   
+  2  2    -2   3    4744.8683  3884.5431  0.0     1.52972  0.00   
+  2  1    -5   3    150.0359   114.2358   180.0   1.52775  0.00   
+  2  .    2    4    2673.5828  1999.2534  180.0   1.52655  0.00   
+  2  3    7    -2   1897.5777  1417.6951  180.0   1.52649  0.00   
+  2  4    2    1    74.6423    55.0425    -0.0    1.52494  0.00   
+  2  .    8    1    72.9013    53.4117    0.0     1.52385  0.00   
+  2  3    -3   2    974.8984   713.5252   0.0     1.52351  0.00   
+  2  2    -6   -3   1383.7282  972.3599   180.0   1.52111  0.00   
+  2  1    -7   2    2780.8590  2092.8268  180.0   1.51406  0.00   
+  2  2    -4   -4   4038.7782  3475.0688  -180.0  1.51008  0.00   
+  2  2    8    -1   9215.6762  8932.7653  0.0     1.50687  0.01   
+  2  5    3    -3   11077.3338 11216.4371 -0.0    1.50125  0.01   
+  2  2    2    3    259.2061   261.4234   0.0     1.49966  0.00   
+  2  5    -3   -2   1286.8236  1283.3165  0.0     1.49852  0.00   
+  2  4    6    -2   1654.6707  1643.4734  -180.0  1.49804  0.00   
+  2  3    3    2    2941.2324  2828.3266  0.0     1.49651  0.00   
+  2  5    3    -1   1598.5622  1375.8687  180.0   1.49230  0.00   
+  2  1    7    -3   1158.4425  963.7100   -0.0    1.49138  0.00   
+  2  3    5    -4   1241.2761  976.7543   0.0     1.48741  0.00   
+  2  3    -7   -1   5.4519     4.1505     -180.0  1.48641  0.00   
+  2  2    -6   2    2969.5256  2225.9899  -180.0  1.48209  0.00   
+  2  1    5    -4   717.6713   569.2303   -0.0    1.48061  0.00   
+  2  4    4    -4   1160.9565  936.8644   -0.0    1.47752  0.00   
+  2  4    6    -1   3008.5009  2425.3077  -0.0    1.47727  0.00   
+  2  2    8    -2   2460.8108  2036.6290  -0.0    1.46947  0.00   
+  2  5    -3   -1   2703.5149  2250.7625  180.0   1.46932  0.00   
+  2  .    4    -4   1978.5686  1799.2981  0.0     1.46530  0.00   
+  2  2    8    .    18605.7911 17372.8918 180.0   1.46378  0.01   
+  2  .    8    -2   2859.5612  2670.5014  0.0     1.46338  0.00   
+  2  3    7    .    1470.8122  1344.4772  -0.0    1.46164  0.00   
+  2  .    6    3    11128.6952 9727.2084  -180.0  1.45874  0.01   
+  2  2    -8   -1   320.1597   277.6153   0.0     1.45806  0.00   
+  2  2    -8   .    16688.9818 14971.6548 -180.0  1.45572  0.01   
+  2  1    5    3    87.8023    84.4701    0.0     1.45352  0.00   
+  2  3    -7   .    1873.9911  1874.7884  -0.0    1.45113  0.00   
+  2  5    -3   -3   3872.0183  3973.0050  -0.0    1.44873  0.00   
+  2  1    7    2    331.9477   339.6716   180.0   1.44736  0.00   
+  2  5    1    .    458.6674   468.7582   0.0     1.44694  0.00   
+  2  5    -1   .    282.6789   282.6566   0.0     1.44450  0.00   
+  2  3    -7   -2   409.2104   407.5222   -180.0  1.44435  0.00   
+  2  5    1    -4   377.7103   376.0669   -0.0    1.44434  0.00   
+  2  4    6    -3   5241.1739  4799.2632  180.0   1.44037  0.00   
+  2  3    7    -3   2301.9844  2066.9126  0.0     1.43858  0.00   
+  2  4    -6   -1   15659.0859 13974.0377 -0.0    1.43651  0.01   
+  2  1    -1   4    2022.2647  1747.7612  -0.0    1.43156  0.00   
+  2  2    6    2    15964.0944 14127.5120 -180.0  1.43067  0.01   
+  2  4    -6   -2   11844.1337 11494.7453 -180.0  1.42772  0.01   
+  2  3    1    -5   54.9594    54.5453    0.0     1.42498  0.00   
+  2  2    -4   3    9374.6947  9304.7725  -0.0    1.42492  0.01   
+  2  5    -1   -4   6389.2400  6191.0063  0.0     1.42367  0.00   
+  2  2    .    -5   593.5681   530.6717   -0.0    1.41970  0.00   
+  2  2    6    -4   4615.2929  4109.1661  -0.0    1.41942  0.00   
+  2  4    -4   1    2697.6455  2328.2327  -180.0  1.41643  0.00   
+  2  1    1    4    11301.8165 9765.5200  -0.0    1.41417  0.01   
+  2  2    2    -5   146.5649   102.1798   180.0   1.40774  0.00   
+  2  4    4    1    6489.3720  4251.1055  -180.0  1.40628  0.00   
+  2  1    9    -1   501.9493   313.3806   180.0   1.40427  0.00   
+  2  3    -1   -5   970.6387   559.2035   180.0   1.40173  0.00   
+  2  5    5    -2   147.9292   121.8591   180.0   1.39689  0.00   
+  2  4    -4   -4   398.5706   333.7965   -180.0  1.39638  0.00   
+  2  5    3    -4   13071.4934 10290.7248 -180.0  1.39407  0.01   
+  2  .    4    4    738.8869   603.2489   180.0   1.39300  0.00   
+  2  1    9    .    7071.6988  6061.3448  -180.0  1.39244  0.00   
+  2  .    8    2    917.3023   841.8614   -0.0    1.39135  0.00   
+  2  1    -7   -3   9.2757     8.6161     0.0     1.39082  0.00   
+  2  2    -8   -2   420.2243   389.1003   0.0     1.38958  0.00   
+  2  1    -9   .    5291.1320  5032.6219  -180.0  1.38852  0.00   
+  2  3    -5   -4   741.1265   712.8918   180.0   1.38828  0.00   
+  2  1    -5   -4   12.2345    12.2841    -0.0    1.38705  0.00   
+  2  4    6    .    6829.9552  6881.9956  0.0     1.38694  0.00   
+  2  2    -8   1    2262.6272  2583.5813  -0.0    1.38353  0.00   
+  2  3    -5   2    96.4709    107.7060   180.0   1.38139  0.00   
+  2  1    -3   4    10372.8561 11498.8556 180.0   1.38001  0.01   
+  2  3    3    -5   543.4759   601.2645   -0.0    1.37984  0.00   
+  2  5    3    .    1866.3011  2064.1961  180.0   1.37983  0.00   
+  2  2    4    3    7057.7669  7682.9819  -0.0    1.37735  0.00   
+  2  4    -6   .    2658.1277  2929.6322  0.0     1.37669  0.00   
+  2  5    -3   .    1665.4571  1846.9850  -180.0  1.37349  0.00   
+  2  4    .    -5   8897.2031  9852.1453  -0.0    1.37263  0.01   
+  2  5    5    -3   931.3923   1000.1841  -0.0    1.37203  0.00   
+  2  1    1    -5   59.0399    51.8333    180.0   1.36876  0.00   
+  2  2    8    -3   1094.2697  897.0709   0.0     1.36740  0.00   
+  2  2    -2   -5   967.1109   890.9937   -180.0  1.36475  0.00   
+  2  1    -9   -1   2429.4585  2521.2414  180.0   1.36346  0.00   
+  2  4    2    -5   10265.0113 11335.5971 180.0   1.36264  0.01   
+  2  2    8    1    3372.2291  3611.9875  -180.0  1.35827  0.00   
+  2  5    5    -1   843.3860   870.4892   -180.0  1.35737  0.00   
+  2  4    -6   -3   3842.3274  4126.3352  180.0   1.35385  0.00   
+  2  3    -7   1    522.8480   576.4772   0.0     1.35312  0.00   
+  2  1    9    -2   13401.0100 16147.0686 0.0     1.35152  0.01   
+  2  6    .    -2   13967.6645 16981.3924 180.0   1.35133  0.01   
+  2  1    -9   1    2978.9377  3741.5161  -0.0    1.35032  0.00   
+  2  1    -1   -5   8897.8997  10683.9602 -0.0    1.34891  0.01   
+  2  3    5    2    178.2792   209.3398   0.0     1.34817  0.00   
+  2  5    -5   -2   506.9120   568.7530   180.0   1.34647  0.00   
+  2  4    .    2    19704.6055 20266.7951 180.0   1.34356  0.01   
+  2  6    .    -3   464.0101   424.9852   0.0     1.34244  0.00   
+  2  3    -7   -3   1104.4908  987.1236   180.0   1.34218  0.00   
+  2  5    -3   -4   22.3736    19.4544    -0.0    1.34037  0.00   
+  2  3    7    1    515.8733   545.2034   0.0     1.33504  0.00   
+  2  1    3    4    273.9717   303.9072   180.0   1.33473  0.00   
+  2  2    4    -5   1885.9692  2138.1647  -0.0    1.33359  0.00   
+  2  6    2    -2   6573.1690  7470.5514  0.0     1.33146  0.00   
+  2  3    -1   3    454.1816   551.6386   -0.0    1.32984  0.00   
+  2  5    -5   -1   2547.8006  3077.6343  -180.0  1.32879  0.00   
+  2  1    -7   3    680.9266   845.5145   -180.0  1.32789  0.00   
+  2  1    3    -5   10436.3651 12956.3684 180.0   1.32785  0.01   
+  2  4    6    -4   987.2156   1219.1637  0.0     1.32754  0.00   
+  2  6    2    -3   4.8739     6.0091     -0.0    1.32656  0.00   
+  2  4    -2   -5   2588.2682  3146.4347  0.0     1.32203  0.00   
+  2  1    9    1    857.1138   1105.1306  -0.0    1.32057  0.00   
+  2  4    -2   2    1720.6005  2255.4357  0.0     1.32028  0.00   
+  2  3    1    3    2454.2645  3237.6008  0.0     1.32015  0.00   
+  2  2    -6   -4   86.1665    114.0134   0.0     1.31919  0.00   
+  2  3    -3   -5   1648.0979  2179.7868  180.0   1.31918  0.00   
+  2  .    6    -4   2974.3976  3685.3963  0.0     1.31717  0.00   
+  2  .    8    -3   3755.8890  4546.6333  -0.0    1.31636  0.00   
+  2  6    -2   -2   299.1850   330.6363   180.0   1.31265  0.00   
+  2  4    2    2    496.8308   505.4413   0.0     1.30914  0.00   
+  2  5    -5   -3   6502.1225  6208.9517  0.0     1.30653  0.00   
+  2  3    7    -4   12.0896    11.5530    -180.0  1.30602  0.00   
+  2  6    .    -1   783.4058   635.2341   -0.0    1.30261  0.00   
+  2  6    -2   -3   5944.1177  4797.6968  0.0     1.30107  0.00   
+  2  1    7    -4   1016.4060  816.7390   180.0   1.30069  0.00   
+  2  4    4    -5   958.3726   839.8412   -180.0  1.29576  0.00   
+  2  5    -1   1    633.2490   560.8179   -180.0  1.29287  0.00   
+  2  5    5    -4   113.1973   102.0732   -0.0    1.29210  0.00   
+  2  5    1    1    233.5428   213.0414   180.0   1.29128  0.00   
+  2  5    1    -5   1219.7573  1297.0866  -180.0  1.28850  0.00   
+  2  1    -9   -2   6962.4103  7594.2794  0.0     1.28440  0.00   
+  2  3    -3   3    3499.5624  3821.2749  180.0   1.28422  0.00   
+  2  2    -6   3    88.1406    97.9036    -0.0    1.28363  0.00   
+  2  3    5    -5   2729.7962  3037.5557  -0.0    1.28334  0.00   
+  2  6    2    -1   2310.1126  2446.8719  180.0   1.28151  0.00   
+  2  4    8    -2   14249.5295 16043.2073 -0.0    1.27998  0.01   
+  2  6    .    -4   4121.9175  4642.8182  0.0     1.27913  0.00   
+  2  1    -5   4    0.2476     0.2762     -0.0    1.27885  0.00   
+  2  .    .    5    1430.3546  1504.7953  0.0     1.27757  0.00   
+  2  2    -8   -3   928.7562   969.8153   0.0     1.27578  0.00   
+  2  1    -3   -5   1583.3759  1649.0848  -180.0  1.27554  0.00   
+  2  .    10   .    5412.0383  5612.4673  -0.0    1.27493  0.00   
+  2  3    9    -1   546.8058   567.6734   180.0   1.27318  0.00   
+  2  3    9    -2   199.8194   209.3409   0.0     1.27118  0.00   
+  2  6    -2   -1   571.7704   604.9530   -180.0  1.27102  0.00   
+  2  5    -1   -5   3029.1933  3287.3648  -0.0    1.27057  0.00   
+  2  4    -6   1    1976.1596  2157.0193  180.0   1.27033  0.00   
+  2  2    .    4    5012.2439  5970.9564  -0.0    1.26862  0.00   
+  2  6    2    -4   2198.5146  2642.8907  -180.0  1.26852  0.00   
+  2  .    2    -5   3381.0127  4140.6925  180.0   1.26818  0.00   
+  2  2    -8   2    12787.6023 15669.9235 0.0     1.26800  0.01   
+  2  5    5    .    1258.4550  1539.1640  -0.0    1.26791  0.00   
+  2  .    10   -1   584.1900   722.1628   -180.0  1.26570  0.00   
+  2  4    8    -1   100.2674   116.1733   180.0   1.26381  0.00   
+  2  2    -4   -5   30.8877    34.2839    180.0   1.26302  0.00   
+  2  1    -9   2    375.3115   407.6104   0.0     1.26267  0.00   
+  2  6    4    -2   3726.6066  4060.9393  -0.0    1.26012  0.00   
+  2  1    7    3    1300.3511  1423.0605  -180.0  1.25993  0.00   
+  2  5    -5   .    1139.8766  1251.7915  -0.0    1.25974  0.00   
+  2  4    6    1    32.1003    35.4122    180.0   1.25938  0.00   
+  2  6    4    -3   5224.7139  5742.7030  -180.0  1.25904  0.00   
+  2  3    3    3    31.7114    34.1056    0.0     1.25855  0.00   
+  2  2    -2   4    2454.1125  2630.4316  180.0   1.25569  0.00   
+  2  5    3    -5   7443.3585  7849.9862  180.0   1.25548  0.00   
+  2  1    9    -3   488.8869   446.4585   -180.0  1.25310  0.00   
+  2  4    -4   2    3004.1030  2913.1494  0.0     1.24747  0.00   
+  2  4    8    -3   1630.5818  1591.0184  -180.0  1.24643  0.00   
+  2  5    -3   1    157.0945   154.1169   -180.0  1.24419  0.00   
+  2  4    -6   -4   4444.3706  4649.8078  0.0     1.24074  0.00   
+  2  1    5    -5   19.9463    20.8490    -0.0    1.24058  0.00   
+  2  6    -2   -4   112.1528   116.0421   -0.0    1.24022  0.00   
+  2  5    3    1    846.0507   865.0651   -180.0  1.23993  0.00   
+  2  .    6    4    4352.4183  4402.8269  -0.0    1.23960  0.00   
+  2  .    8    3    2487.7025  2523.8232  0.0     1.23892  0.00   
+  2  5    7    -2   48.0469    48.4702    -180.0  1.23815  0.00   
+  2  .    2    5    6.2974     6.1649     -0.0    1.23770  0.00   
+  2  3    -9   -1   2087.5529  1878.7146  -180.0  1.23697  0.00   
+  2  .    10   1    80.3162    69.0195    180.0   1.23540  0.00   
+  2  2    8    -4   0.7849     0.6712     -0.0    1.23509  0.00   
+  2  2    2    4    221.1096   202.3679   180.0   1.23305  0.00   
+  2  2    10   -1   733.6316   674.5837   -0.0    1.23266  0.00   
+  2  2    6    3    641.8009   591.5126   -0.0    1.23202  0.00   
+  2  4    -8   -1   1337.7484  1660.8265  180.0   1.22975  0.00   
+  2  4    4    2    5586.5375  7216.8110  -0.0    1.22886  0.00   
+  2  6    -4   -2   5765.5285  7429.0559  0.0     1.22874  0.00   
+  2  4    -4   -5   4722.1336  5935.8119  180.0   1.22833  0.00   
+  2  3    9    .    169.3717   207.1256   180.0   1.22722  0.00   
+  2  2    8    2    15714.1791 16367.8700 -0.0    1.22501  0.01   
+  2  3    -7   2    4.2615     4.4310     -180.0  1.22493  0.00   
+  2  5    7    -3   725.5900   701.3947   180.0   1.22357  0.00   
+  2  5    -5   -4   554.1466   527.2945   -180.0  1.22255  0.00   
+  2  2    6    -5   97.2630    93.3157    -0.0    1.22244  0.00   
+  2  3    9    -3   3947.1429  3989.5508  -0.0    1.22187  0.00   
+  2  4    -8   -2   15296.6998 15576.6760 0.0     1.22139  0.01   
+  2  1    5    4    3308.8409  2923.6151  -180.0  1.22003  0.00   
+  2  3    -9   .    71.6467    63.1939    -0.0    1.21922  0.00   
+  2  6    -4   -3   1.9347     1.6171     -180.0  1.21643  0.00   
+  2  6    4    -1   11.0781    10.2523    180.0   1.21473  0.00   
+  2  2    10   -2   3448.9749  3195.8904  -180.0  1.21471  0.00   
+  2  3    -7   -4   10.0663    9.5153     0.0     1.21279  0.00   
+  2  6    .    .    13778.5293 13100.2263 0.0     1.21259  0.01   
+  2  1    9    2    1840.2120  1749.7864  0.0     1.21259  0.00   
+  2  .    4    -5   54.0561    51.4047    -180.0  1.21258  0.00   
+  2  1    -7   -4   707.6090   673.8718   0.0     1.21254  0.00   
+  2  6    4    -4   204.9296   199.9465   0.0     1.21185  0.00   
+  2  .    10   -2   2483.9633  2393.1814  180.0   1.21068  0.00   
+  2  3    -9   -2   2.5317     2.4088     0.0     1.20966  0.00   
+  2  5    7    -1   1008.9761  919.5910   -0.0    1.20764  0.00   
+  2  5    -3   -5   1835.1936  1669.4106  -180.0  1.20756  0.00   
+  2  2    10   .    13.5745    11.8619    180.0   1.20601  0.00   
+  2  3    -5   -5   5822.7251  5223.5291  -0.0    1.20426  0.00   
+  2  4    8    .    2123.5994  2036.1638  -180.0  1.20314  0.00   
+  2  2    -10  .    1214.3296  1234.3417  180.0   1.20037  0.00   
+  2  2    -10  -1   1962.3207  1881.5821  0.0     1.19900  0.00   
+  2  2    -4   4    0.0045     0.0043     180.0   1.19841  0.00   
+  2  3    -5   3    5427.1992  5149.8089  -180.0  1.19827  0.00   
+  2  6    -4   -1   4365.3486  4013.4094  180.0   1.19705  0.00   
+  2  4    -8   .    2035.9869  1701.7086  -180.0  1.19422  0.00   
+  2  4    6    -5   6476.0238  5356.2972  -0.0    1.19366  0.00   
+  2  6    2    .    8007.4798  6359.8747  -180.0  1.19287  0.00   
+  2  3    1    -6   217.8042   172.0799   180.0   1.19278  0.00   
+  2  3    7    2    269.2895   210.6961   180.0   1.19262  0.00   
+  2  6    -2   .    2617.4167  1825.4606  -180.0  1.18959  0.00   
+  2  5    -7   -2   335.8528   235.2689   -180.0  1.18926  0.00   
+  2  5    5    -5   687.9022   652.0282   -0.0    1.18202  0.00   
+  2  6    .    -5   1984.5861  1859.8386  -0.0    1.18139  0.00   
+  2  5    -7   -1   1265.6058  1170.6276  -0.0    1.17956  0.00   
+  2  3    -1   -6   11486.7218 10651.6340 0.0     1.17652  0.01   
+  2  1    -9   -3   3678.0668  3479.3329  -0.0    1.17569  0.00   
+  2  4    .    -6   734.0877   694.8770   -180.0  1.17567  0.00   
+  2  6    2    -5   727.2542   690.4314   180.0   1.17553  0.00   
+  2  4    8    -4   5203.6228  5262.2410  180.0   1.17365  0.00   
+  2  1    -1   5    43.7163    44.3347    0.0     1.17349  0.00   
+  2  2    .    -6   3130.6605  3262.2227  -180.0  1.17258  0.00   
+  2  4    2    -6   750.2345   785.7923   0.0     1.17185  0.00   
+  2  4    -8   -3   486.3248   512.5086   -0.0    1.17167  0.00   
+  2  1    -5   -5   5071.3531  5414.4867  -180.0  1.17131  0.00   
+  2  3    3    -6   3080.3984  3178.6335  180.0   1.16840  0.00   
+  2  5    7    -4   5764.3448  5932.4007  0.0     1.16833  0.00   
+  2  2    2    -6   432.8493   444.4424   0.0     1.16828  0.00   
+  2  .    8    -4   6809.7159  6734.2463  -180.0  1.16544  0.00   
+  2  3    5    3    9590.7137  9033.3981  -180.0  1.16397  0.01   
+  2  6    -4   -4   1435.1663  1331.0105  -180.0  1.16381  0.00   
+  2  3    7    -5   1278.9599  1180.8749  180.0   1.16377  0.00   
+  2  3    -9   1    30.9311    24.5109    -0.0    1.16177  0.00   
+  2  1    1    5    2579.6366  1984.2370  0.0     1.16142  0.00   
+  2  2    -10  1    533.5763   408.7012   -180.0  1.16134  0.00   
+  2  .    4    5    4831.4313  3674.6390  -180.0  1.16082  0.00   
+  2  6    6    -3   737.7383   572.9928   0.0     1.16041  0.00   
+  2  5    -5   1    10.3817    8.2052     180.0   1.16017  0.00   
+  2  7    1    -3   408.3755   326.8856   180.0   1.15995  0.00   
+  2  2    4    4    417.2425   334.7388   180.0   1.15990  0.00   
+  2  .    10   2    2399.6828  1953.1670  -180.0  1.15916  0.00   
+  2  5    -7   -3   17.0768    13.9221    0.0     1.15905  0.00   
+  2  6    6    -2   1296.9719  1062.5954  180.0   1.15883  0.00   
+  2  2    -10  -2   1064.0216  927.1428   -180.0  1.15763  0.00   
+  2  2    10   -3   522.5174   456.9863   180.0   1.15752  0.00   
+  2  1    -7   4    8902.8579  7894.1741  -0.0    1.15699  0.00   
+  2  1    11   -1   188.9460   172.4013   -0.0    1.15488  0.00   
+  2  5    5    1    16.3175    14.5872    180.0   1.15443  0.00   
+  2  4    .    3    439.9200   372.8509   -0.0    1.15214  0.00   
+  2  7    -1   -3   245.1872   190.7937   -0.0    1.15103  0.00   
+  2  1    -9   3    505.2015   390.2848   -180.0  1.15086  0.00   
+  2  7    1    -2   523.1740   417.6649   180.0   1.14957  0.00   
+  2  6    -2   -5   4.2472     3.3422     180.0   1.14818  0.00   
+  2  2    -8   -4   1469.6216  1241.1393  -0.0    1.14713  0.00   
+  2  3    9    1    991.1431   840.9132   -180.0  1.14703  0.00   
+  2  1    -3   5    153.8722   131.0137   -0.0    1.14691  0.00   
+  2  4    -6   2    1028.9338  884.2580   -180.0  1.14653  0.00   
+  2  1    11   .    742.7516   673.8595   0.0     1.14593  0.00   
+  2  3    -9   -3   7368.9357  6842.7549  -0.0    1.14539  0.00   
+  2  1    -11  .    59.8109    56.5171    180.0   1.14326  0.00   
+  2  7    -1   -2   272.4329   258.5173   180.0   1.14319  0.00   
+  2  2    10   1    2202.8514  2221.3310  -180.0  1.14260  0.00   
+  2  2    -6   -5   8154.0878  8280.7099  -0.0    1.14253  0.00   
+  2  5    -1   2    0.2454     0.2523     -180.0  1.14237  0.00   
+  2  4    -2   -6   153.1306   159.9954   -0.0    1.14109  0.00   
+  2  5    7    .    1519.9342  1584.2307  0.0     1.14103  0.00   
+  2  3    9    -4   3439.2555  3452.1120  -180.0  1.13977  0.00   
+  2  4    -2   3    671.6890   675.3480   180.0   1.13965  0.00   
+  2  2    -8   3    932.0397   940.5804   180.0   1.13923  0.00   
+  2  5    1    2    151.4686   151.0052   180.0   1.13897  0.00   
+  2  2    -2   -6   469.0669   457.5743   180.0   1.13875  0.00   
+  2  5    1    -6   92.9398    92.8501    180.0   1.13644  0.00   
+  2  6    4    .    10012.6347 9886.1889  -180.0  1.13618  0.00   
+  2  1    9    -4   6640.3893  6387.1239  180.0   1.13575  0.00   
+  2  7    1    -4   116.0235   104.3489   0.0     1.13318  0.00   
+  2  5    -7   .    649.7717   561.3250   0.0     1.13270  0.00   
+  2  6    4    -5   4161.0031  3560.8356  -0.0    1.13225  0.00   
+  2  7    3    -3   1994.3849  1752.7599  180.0   1.13164  0.00   
+  2  1    7    -5   2078.4363  1876.4532  -0.0    1.13113  0.00   
+  2  4    4    -6   80.7413    74.0198    180.0   1.13073  0.00   
+  2  6    -4   .    9837.6381  8996.3605  -180.0  1.13052  0.00   
+  2  1    1    -6   13.9585    12.7255    180.0   1.13041  0.00   
+  2  4    2    3    29.5572    26.9687    0.0     1.12798  0.00   
+  2  1    11   -2   3728.2633  4054.5939  -180.0  1.12721  0.00   
+  2  2    4    -6   555.2957   617.9103   -180.0  1.12706  0.00   
+  2  1    -11  -1   71.8389    80.5660    180.0   1.12692  0.00   
+  2  .    6    -5   739.9295   825.3110   -0.0    1.12677  0.00   
+  2  .    10   -3   24.0012    25.1309    180.0   1.12560  0.00   
+  2  6    6    -4   1020.2757  1116.6065  -0.0    1.12535  0.00   
+  2  4    -8   1    1194.4685  1428.0735  -0.0    1.12500  0.00   
+  2  4    6    2    408.8594   491.6513   180.0   1.12497  0.00   
+  2  3    -3   -6   1985.2449  2679.1058  0.0     1.12421  0.00   
+  2  1    -11  1    397.3238   520.4388   180.0   1.12385  0.00   
+  2  3    -1   4    54.2633    62.3074    180.0   1.12290  0.00   
+  2  7    -1   -4   299.6530   340.7362   180.0   1.12266  0.00   
+  2  6    -6   -2   5.1779     5.8815     -0.0    1.12259  0.00   
+  2  5    -1   -6   3154.8180  3679.1020  -180.0  1.12188  0.00   
+  2  6    6    -1   16.6529    18.5196    -180.0  1.12105  0.00   
+  2  7    3    -2   441.9040   466.2613   -180.0  1.11981  0.00   
+  2  5    -5   -5   3271.7477  3254.1700  180.0   1.11710  0.00   
+  2  1    -1   -6   1574.3996  1573.1101  -180.0  1.11699  0.00   
+  2  4    -6   -5   12.3229    12.1624    -180.0  1.11621  0.00   
+  2  5    3    -6   3720.2381  3572.8767  0.0     1.11574  0.00   
+  2  3    1    4    597.6515   557.2568   180.0   1.11489  0.00   
+  2  4    8    1    3256.8702  3030.2470  -0.0    1.11486  0.00   
+  2  1    3    5    243.9117   208.8946   -180.0  1.11404  0.00   
+  2  2    -6   4    2045.9922  1626.0861  -0.0    1.11278  0.00   
+  2  6    -6   -3   11140.1930 9170.8262  180.0   1.11104  0.01   
+  2  5    -3   2    28.2221    23.9804    -180.0  1.11049  0.00   
+  2  3    5    -6   88.2040    75.3696    -0.0    1.11017  0.00   
+  2  1    3    -6   4292.6830  3749.4968  0.0     1.10915  0.00   
+  2  7    3    -4   967.7274   851.8273   -0.0    1.10885  0.00   
+  2  7    -3   -3   9.0521     8.0510     -0.0    1.10731  0.00   
+  2  7    1    -1   603.6012   540.2195   -180.0  1.10485  0.00   
+  2  6    .    1    3162.3881  2851.2916  180.0   1.10441  0.00   
+  2  1    11   1    390.9620   353.4958   0.0     1.10278  0.00   
+  2  7    -3   -2   8.5621     7.6618     -0.0    1.10240  0.00   
+  2  4    10   -2   320.7294   293.9448   -180.0  1.10139  0.00   
+  2  7    -1   -1   607.6533   560.8360   -180.0  1.10125  0.00   
+  2  5    3    2    99.9324    92.4856    -180.0  1.10119  0.00   
+  2  2    8    -5   3959.6259  3728.5603  180.0   1.10077  0.00   
+  2  6    -6   -1   6.5779     6.2337     0.0     1.10033  0.00   
+  2  5    -7   -4   138.1564   136.6182   0.0     1.09716  0.00   
+  2  3    -3   4    146.0121   143.6453   -0.0    1.09706  0.00   
+  2  1    7    4    60.0531    57.0295    -0.0    1.09661  0.00   
+  2  .    8    4    3134.8643  2959.2417  180.0   1.09406  0.00   
+  2  4    -8   -4   3929.5051  3685.4545  -180.0  1.09399  0.00   
+  2  4    -4   3    2368.1696  2186.7268  180.0   1.09385  0.00   
+  2  3    -7   3    1966.2739  1814.2931  0.0     1.09384  0.00   
+  2  1    9    3    334.5495   308.2223   180.0   1.09383  0.00   
+  2  2    -10  2    4.1600     3.3265     -0.0    1.09247  0.00   
+  2  2    8    3    482.3432   379.8198   0.0     1.09126  0.00   
+  2  5    9    -2   2241.8698  1582.6840  -0.0    1.09021  0.00   
+  2  4    10   -1   2.2790     1.7369     -180.0  1.08903  0.00   
+  2  6    -2   1    1.9942     1.5406     -180.0  1.08894  0.00   
+  2  1    -5   5    7196.2432  5646.2565  0.0     1.08884  0.00   
+  2  6    2    1    297.4073   245.3481   -0.0    1.08745  0.00   
+  2  2    -10  -3   752.9845   617.4947   180.0   1.08733  0.00   
+  2  5    7    -5   111.3689   91.0318    -180.0  1.08704  0.00   
+  2  6    -4   -5   453.8071   422.0173   180.0   1.08477  0.00   
+  2  3    -7   -5   3027.2473  3180.2930  0.0     1.08232  0.00   
+  2  5    9    -3   34.9487    37.0056    -180.0  1.08217  0.00   
+  2  4    10   -3   467.5741   496.5346   180.0   1.08176  0.00   
+  2  4    8    -5   383.7132   416.8216   0.0     1.08002  0.00   
+  2  7    -3   -4   438.0826   475.9937   -180.0  1.08002  0.00   
+  2  3    11   -2   1075.8131  1209.7235  180.0   1.07973  0.00   
+  2  3    -9   2    1002.6541  1162.0253  -0.0    1.07952  0.00   
+  2  1    -11  -2   421.7291   505.5742   -0.0    1.07909  0.00   
+  2  3    11   -1   2113.5759  2531.9784  -180.0  1.07901  0.00   
+  2  4    -4   -6   51.7723    79.4879    0.0     1.07725  0.00   
+  2  7    3    -1   250.9733   517.9063   0.0     1.07642  0.00   
+  2  7    1    -5   11.8443    25.2106    -0.0    1.07626  0.00   
+  2  5    -3   -6   639.3992   1371.1187  180.0   1.07586  0.00   
+  2  2    10   -4   1327.8547  2842.5457  0.0     1.07584  0.00   
+  2  2    -4   -6   89.9786    186.5753   0.0     1.07568  0.00   
+  2  3    3    4    324.6236   560.4316   180.0   1.07511  0.00   
+  2  1    -11  2    387.6898   558.2780   -180.0  1.07370  0.00   
+  2  7    5    -3   650.5039   928.6481   180.0   1.07351  0.00   
+  2  4    4    3    575.4928   818.8776   180.0   1.07348  0.00   
+  2  1    -3   -6   122.2456   135.6225   180.0   1.07233  0.00   
+  2  6    .    -6   3.5778     4.1780     -180.0  1.07161  0.00   
+  2  1    11   -3   393.4458   540.3856   180.0   1.07008  0.00   
+  2  6    2    -6   64.1906    107.8329   0.0     1.06912  0.00   
+  2  6    -6   -4   311.2178   552.9788   0.0     1.06862  0.00   
+  2  5    9    -1   525.9255   1026.4794  0.0     1.06732  0.00   
+  2  2    6    4    2148.3049  4143.5979  0.0     1.06716  0.00   
+  2  7    -3   -1   105.9362   173.9010   0.0     1.06652  0.00   
+  2  2    .    5    1304.1458  1937.9253  0.0     1.06580  0.00   
+  2  .    6    5    242.2022   358.8678   0.0     1.06561  0.00   
+  2  7    -1   -5   2222.2550  3288.8085  0.0     1.06535  0.00   
+  2  5    5    -6   302.9866   447.2840   -180.0  1.06509  0.00   
+  2  .    .    6    37.4394    53.4823    180.0   1.06464  0.00   
+  2  .    10   3    2298.2154  3276.3246  0.0     1.06463  0.00   
+  2  4    6    -6   25.3180    31.3322    -180.0  1.06282  0.00   
+  2  6    6    -5   346.6380   434.3157   -0.0    1.06260  0.00   
+  2  .    12   .    89.1131    112.6819   180.0   1.06244  0.00   
+  2  4    -10  -1   851.3820   1132.6677  180.0   1.06171  0.00   
+  2  7    5    -2   3352.6358  4496.3914  -180.0  1.06153  0.00   
+  2  .    2    -6   552.3301   748.1993   0.0     1.06104  0.00   
+  2  5    -7   1    718.8066   969.1237   180.0   1.06052  0.00   
+  2  1    -9   -4   1285.7262  1706.8793  -180.0  1.06015  0.00   
+  2  2    -2   5    2502.7631  3313.4198  -180.0  1.05994  0.00   
+  2  3    -9   -4   10.3246    13.6703    -180.0  1.05993  0.00   
+  2  2    6    -6   208.1139   288.6216   -180.0  1.05938  0.00   
+  2  .    12   -1   899.8288   1340.4500  -0.0    1.05892  0.00   
+  2  1    -7   -5   5.0451     7.5059     -180.0  1.05860  0.00   
+  2  1    5    -6   31.8951    47.4061    -180.0  1.05858  0.00   
+  2  2    10   2    910.2155   1237.1699  -0.0    1.05797  0.00   
+  2  3    7    3    9.9735     12.9031    -180.0  1.05758  0.00   
+  2  7    3    -5   1741.7264  2239.1302  -180.0  1.05718  0.00   
+  2  6    6    .    332.7920   461.7745   -0.0    1.05659  0.00   
+  2  7    5    -4   1531.7242  2051.4003  0.0     1.05581  0.00   
+  2  4    -10  -2   2442.1392  3145.7849  0.0     1.05450  0.00   
+  2  5    7    1    28.7929    37.2884    180.0   1.05440  0.00   
+  2  6    8    -3   7539.3493  8866.7538  -0.0    1.05196  0.00   
+  2  3    -11  -1   222.8550   261.5320   -0.0    1.05193  0.00   
+  2  5    -5   2    4946.1203  5387.0808  -180.0  1.05131  0.00   
+  2  3    9    2    811.2607   862.2832   -0.0    1.05108  0.00   
+  2  3    11   -3   643.1948   673.7850   180.0   1.05082  0.00   
+  2  6    -6   .    501.0021   488.9045   -0.0    1.04978  0.00   
+  2  6    8    -2   368.8696   331.3808   0.0     1.04899  0.00   
+  2  3    11   .    458.9451   407.0557   -0.0    1.04881  0.00   
+  2  3    -5   -6   1400.6854  1235.7557  -180.0  1.04872  0.00   
+  2  4    10   .    72.1617    61.4161    -0.0    1.04771  0.00   
+  2  5    -9   -2   2632.2108  2208.3085  -0.0    1.04729  0.00   
+  2  5    9    -4   258.7651   228.7958   -180.0  1.04516  0.00   
+  2  6    -2   -6   1473.0384  1293.5044  -0.0    1.04487  0.00   
+  2  6    -4   1    3600.5931  3160.5795  -0.0    1.04485  0.00   
+  2  3    -5   4    2636.4263  2301.6767  -0.0    1.04377  0.00   
+  2  3    9    -5   2047.7344  1817.7670  180.0   1.04328  0.00   
+  2  1    5    5    1824.9895  1623.2967  -0.0    1.04294  0.00   
+  2  3    -11  .    1573.1234  1387.3612  0.0     1.04270  0.00   
+  2  2    2    5    299.8405   264.3036   0.0     1.04269  0.00   
+  2  5    -9   -1   72.1183    62.5557    0.0     1.04240  0.00   
+  2  6    4    1    1187.5434  1021.8291  -0.0    1.04223  0.00   
+  2  4    -10  .    625.3891   554.7785   -0.0    1.04034  0.00   
+  2  2    12   -1   4351.6606  3828.0670  -180.0  1.03971  0.00   
+  2  .    2    6    1696.2466  1492.8101  0.0     1.03949  0.00   
+  2  7    -5   -3   3994.1738  3517.5593  180.0   1.03943  0.00   
+  2  5    5    2    4591.3950  4324.4718  -180.0  1.03825  0.00   
+  2  4    -8   2    307.9346   298.1823   -0.0    1.03802  0.00   
+  2  6    4    -6   1286.3949  1251.2761  -180.0  1.03798  0.00   
+  2  .    12   1    331.1611   335.8693   -0.0    1.03750  0.00   
+  2  7    -5   -2   1443.9420  1492.9651  -180.0  1.03709  0.00   
+  2  7    1    .    1205.0828  1264.8986  -0.0    1.03656  0.00   
+  2  1    -9   4    2.4913     2.8086     180.0   1.03594  0.00   
+  2  1    11   2    1471.9509  1702.3367  180.0   1.03580  0.00   
+  2  7    -1   .    1471.0620  1823.6465  -0.0    1.03529  0.00   
+  2  4    10   -4   7.2586     9.1218     0.0     1.03486  0.00   
+  2  3    -11  -2   1120.4034  1522.0493  -180.0  1.03326  0.00   
+  3  1    1    .    1445.1945  1272.1351  -0.0    3.25208  0.03   
+  3  1    .    1    545.1091   492.3054   -0.0    2.48925  0.01   
+  3  2    .    .    128.0343   149.2770   -0.0    2.29957  0.00   
+  3  1    1    1    314.5256   374.9846   180.0   2.18917  0.01   
+  3  2    1    .    140.6268   152.8499   0.0     2.05680  0.00   
+  3  2    1    1    1008.6240  880.3927   -0.0    1.68912  0.02   
+  3  2    2    .    1085.7816  1143.4700  -0.0    1.62604  0.01   
+  3  .    .    2    1766.4198  1418.0349  -0.0    1.48017  0.00   
+  3  3    1    .    377.0293   356.8641   -0.0    1.45437  0.00   
+  3  2    2    1    28.0615    28.2488    180.0   1.42520  0.00   
+  3  3    .    1    822.7128   1055.5915  -0.0    1.36133  0.01   
+  3  1    1    2    421.1132   541.6489   -0.0    1.34719  0.00   
+  3  3    1    1    35.3680    32.7655    0.0     1.30535  0.00   
+  3  3    2    .    14.4759    15.0323    180.0   1.27557  0.00   
+  3  2    .    2    150.7319   145.3457   -0.0    1.24463  0.00   
+  3  2    1    2    40.2784    42.1744    0.0     1.20141  0.00   
+  3  3    2    1    143.3821   154.5305   -0.0    1.17145  0.00   
+  3  4    .    .    522.2409   422.3425   -0.0    1.14978  0.00   
+  3  4    1    .    83.3697    78.7307    180.0   1.11545  0.00   
+  3  2    2    2    547.1205   562.7841   -0.0    1.09458  0.00   
+  3  3    3    .    577.0749   592.5639   -0.0    1.08403  0.00   
+  3  4    1    1    315.4361   271.8264   -0.0    1.04381  0.00   
+  3  3    1    2    213.7352   220.8812   -0.0    1.03740  0.00   
+  4  1    1    .    9128.6784  5228.4628  0.0     5.75712  0.00   
+  4  1    1    -1   2489.6354  1404.0285  0.0     5.74499  0.00   
+  4  .    .    2    12804.2604 6637.1207  0.0     5.70850  0.00   
+  4  2    .    .    1992.6110  778.0303   180.0   5.31188  0.00   
+  4  2    .    -2   27682.5647 11512.4620 0.0     5.27405  0.00   
+  4  1    1    1    9925.3893  5910.4373  -180.0  4.69390  0.00   
+  4  1    1    -2   732.1413   470.7689   -180.0  4.67424  0.00   
+  4  1    1    2    1914.2781  1807.7940  -180.0  3.62866  0.00   
+  4  1    1    -3   6736.1090  6212.2295  180.0   3.61352  0.00   
+  4  .    2    .    5789.6904  1735.5337  180.0   3.42507  0.00   
+  4  3    1    -1   2712.8574  1015.8549  -0.0    3.40815  0.00   
+  4  3    1    -2   7721.9704  3189.7832  180.0   3.40061  0.00   
+  4  .    2    1    6173.8167  4999.9766  -0.0    3.28063  0.00   
+  4  2    .    2    13660.1410 11595.1621 -0.0    3.22237  0.00   
+  4  2    .    -4   5521.8370  5001.5029  180.0   3.19707  0.00   
+  4  3    1    .    2443.3635  2138.6790  0.0     3.14576  0.00   
+  4  3    1    -3   3203.1214  2676.9485  180.0   3.12805  0.00   
+  4  4    .    -2   115900.9301 81005.2590 -180.0  2.98678  0.01   
+  4  2    2    -1   101547.1273 74974.4061 -0.0    2.97131  0.01   
+  4  .    2    2    830.6658   792.0140   0.0     2.93698  0.00   
+  4  2    2    .    1236.7570  1807.4000  0.0     2.87856  0.00   
+  4  2    2    -2   386.0973   528.8583   -0.0    2.87249  0.00   
+  4  1    1    3    1963.8211  2485.3846  -0.0    2.86476  0.00   
+  4  1    1    -4   4758.3003  5800.7943  -0.0    2.85432  0.00   
+  4  .    .    4    8476.0596  10332.6990 -0.0    2.85425  0.00   
+  4  3    1    1    3581.4873  3755.5610  -180.0  2.75914  0.00   
+  4  3    1    -4   3020.2864  3264.9087  -0.0    2.73926  0.00   
+  4  4    .    .    74244.6955 71155.6385 0.0     2.65594  0.00   
+  4  2    2    1    143517.9841 132877.6779 0.0     2.64033  0.01   
+  4  2    2    -3   73214.9489 66210.9067 -180.0  2.63099  0.01   
+  4  4    .    -4   153253.4403 140757.4165 180.0   2.63703  0.01   
+  4  .    2    3    18334.2351 14168.9224 180.0   2.54585  0.00   
+  4  3    1    2    8854.2024  9780.7432  -180.0  2.37688  0.00   
+  4  3    1    -5   5570.7563  5864.9894  -0.0    2.35910  0.00   
+  4  2    2    2    137.9518   143.7218   -180.0  2.34695  0.00   
+  4  2    2    -4   861.5124   880.9787   180.0   2.33712  0.00   
+  4  1    1    4    2903.3916  2966.0204  -0.0    2.33701  0.00   
+  4  1    1    -5   325.3178   299.8592   -0.0    2.32972  0.00   
+  4  4    2    -2   1651.7191  1407.7572  -0.0    2.25109  0.00   
+  4  5    1    -2   2424.5227  2126.1968  180.0   2.24699  0.00   
+  4  5    1    -3   596.8589   539.9195   180.0   2.24338  0.00   
+  4  1    3    .    54.5260    52.3498    0.0     2.23240  0.00   
+  4  1    3    -1   4342.8992  4174.3249  -0.0    2.23169  0.00   
+  4  4    2    -1   898.7583   918.3342   0.0     2.21132  0.00   
+  4  4    2    -3   12450.2349 13297.0101 -0.0    2.20583  0.00   
+  4  .    2    4    842.5338   966.5437   180.0   2.19269  0.00   
+  4  5    1    -1   8768.7065  11536.3543 -0.0    2.16794  0.00   
+  4  1    3    1    815.5133   1029.6032  -0.0    2.15229  0.00   
+  4  1    3    -2   8856.2156  10946.2520 0.0     2.15038  0.00   
+  4  5    1    -4   529.0446   710.8684   -180.0  2.15826  0.00   
+  4  2    .    4    1401.0999  1633.1560  0.0     2.13910  0.00   
+  4  2    .    -6   6866.0285  7213.4493  0.0     2.12673  0.00   
+  4  4    2    .    558.4607   728.4469   -180.0  2.09885  0.00   
+  4  4    2    -4   444.3896   548.6870   -180.0  2.08948  0.00   
+  4  4    .    2    260148.0829 286221.3519 180.0   2.07255  0.01   
+  4  2    2    3    273843.3029 292718.2813 0.0     2.06286  0.01   
+  4  2    2    -5   270625.8406 297005.3196 0.0     2.05396  0.01   
+  4  4    .    -6   276278.6946 302633.0236 -180.0  2.05462  0.01   
+  4  3    1    3    975.2244   1082.3187  -180.0  2.04981  0.00   
+  4  3    1    -6   128.2978   154.8230   -0.0    2.03514  0.00   
+  4  5    1    .    603.0531   772.1001   180.0   2.02937  0.00   
+  4  1    3    2    9886.0867  13994.1542 -0.0    2.01442  0.00   
+  4  1    3    -3   873.8303   1236.4908  -0.0    2.01182  0.00   
+  4  5    1    -5   10137.2531 14176.1263 -0.0    2.01618  0.00   
+  4  3    3    -1   8339.4428  7013.3013  -0.0    1.97420  0.00   
+  4  3    3    -2   221.8669   187.8868   0.0     1.97272  0.00   
+  4  1    1    5    4115.7780  4617.6850  180.0   1.96234  0.00   
+  4  6    .    -2   942.3072   972.9793   180.0   1.96447  0.00   
+  4  1    1    -6   1204.9561  1562.3504  -0.0    1.95706  0.00   
+  4  6    .    -4   13735.5597 17299.1482 -180.0  1.95870  0.00   
+  4  4    2    1    17427.0027 20968.4796 -0.0    1.94310  0.00   
+  4  4    2    -5   62.5134    70.9491    180.0   1.93197  0.00   
+  4  3    3    .    9082.7309  9823.0333  180.0   1.91904  0.00   
+  4  3    3    -3   2603.7756  2765.6462  -0.0    1.91500  0.00   
+  4  .    .    6    1633.2883  1708.2631  -0.0    1.90283  0.00   
+  4  .    2    5    86.7522    90.1411    -180.0  1.89990  0.00   
+  4  5    1    1    2207.6882  2505.3220  -180.0  1.86271  0.00   
+  4  1    3    3    2899.8899  3418.2280  0.0     1.84952  0.00   
+  4  1    3    -4   444.1345   508.0697   -180.0  1.84670  0.00   
+  4  5    1    -6   2485.0239  2902.7977  -180.0  1.84845  0.00   
+  4  3    3    1    3168.1456  3292.1807  -0.0    1.82016  0.00   
+  4  3    3    -4   14342.7956 15058.0591 -180.0  1.81442  0.00   
+  4  2    2    4    1910.5318  2005.1019  180.0   1.81433  0.00   
+  4  2    2    -6   112.2930   110.8992   -0.0    1.80676  0.00   
+  4  3    1    4    1131.2568  1172.6193  -0.0    1.78363  0.00   
+  4  4    2    2    699.6815   570.2454   -0.0    1.77318  0.00   
+  4  3    1    -7   947.5682   721.9792   -180.0  1.77181  0.00   
+  4  6    .    .    46485.8725 33194.4176 180.0   1.77063  0.00   
+  4  4    2    -6   2871.8180  1199.0522  -0.0    1.76192  0.00   
+  4  6    .    -6   5.1808     2.0490     0.0     1.75802  0.00   
+  4  6    2    -3   410044.3791 370366.9259 -180.0  1.72143  0.01   
+  4  .    4    .    374081.6825 347791.6477 -180.0  1.71254  0.01   
+  4  6    2    -2   468.5920   389.9210   -0.0    1.70408  0.00   
+  4  6    2    -4   2008.0235  1561.2658  180.0   1.70030  0.00   
+  4  .    4    1    4469.4463  3249.6100  -0.0    1.69359  0.00   
+  4  3    3    2    4925.3188  3596.7315  -0.0    1.69640  0.00   
+  4  3    3    -5   13852.7499 10523.7647 0.0     1.68990  0.00   
+  4  5    1    2    3516.6756  2571.5632  -180.0  1.69286  0.00   
+  4  1    1    6    952.7344   742.5307   -0.0    1.68641  0.00   
+  4  1    3    4    57.7915    44.8547    -0.0    1.68172  0.00   
+  4  1    1    -7   16026.6820 12441.2647 -180.0  1.68245  0.00   
+  4  1    3    -5   5956.7052  4675.3950  0.0     1.67900  0.00   
+  4  5    1    -7   339.4493   266.2206   -180.0  1.67911  0.00   
+  4  .    2    6    1105.8384  1004.1391  0.0     1.66337  0.00   
+  4  2    4    -1   3001.4483  2834.0739  180.0   1.64622  0.00   
+  4  6    2    -1   922.4756   866.7397   -180.0  1.65156  0.00   
+  4  7    1    -3   38.0035    35.5775    180.0   1.65277  0.00   
+  4  5    3    -2   356.6922   336.5635   -180.0  1.64723  0.00   
+  4  7    1    -4   593.8642   558.9717   -0.0    1.65076  0.00   
+  4  5    3    -3   1304.2560  1232.2503  -180.0  1.64580  0.00   
+  4  .    4    2    626.2335   609.5389   -180.0  1.64031  0.00   
+  4  6    2    -5   534.0940   505.9447   -180.0  1.64471  0.00   
+  4  2    4    .    747.0026   751.1044   -0.0    1.62992  0.00   
+  4  2    4    -2   4430.2368  4447.2782  180.0   1.62882  0.00   
+  4  7    1    -2   3745.8528  3580.8228  180.0   1.62109  0.00   
+  4  5    3    -1   1041.9147  966.2701   0.0     1.61531  0.00   
+  4  7    1    -5   990.8818   919.2802   -0.0    1.61541  0.00   
+  4  5    3    -4   4211.4813  3833.4911  -180.0  1.61130  0.00   
+  4  4    .    4    70876.1011 64474.9733 180.0   1.61119  0.00   
+  4  4    2    3    30.7814    27.4115    180.0   1.60834  0.00   
+  4  2    2    5    43467.4006 37144.1292 -180.0  1.60557  0.00   
+  4  2    2    -7   90552.7949 66556.6160 0.0     1.59927  0.00   
+  4  4    2    -7   3603.9987  2584.1012  -0.0    1.59783  0.00   
+  4  4    .    -8   51036.6642 36994.7586 0.0     1.59853  0.00   
+  4  2    4    1    2205.2976  1918.9270  0.0     1.58277  0.00   
+  4  2    4    -3   2076.5124  1870.9134  0.0     1.58075  0.00   
+  4  2    .    6    30429.6441 28946.2323 -0.0    1.57689  0.00   
+  4  6    2    .    323.2359   317.6512   -0.0    1.57288  0.00   
+  4  2    .    -8   4954.2088  4984.3398  -180.0  1.56994  0.00   
+  4  3    1    5    1722.6614  1741.4129  180.0   1.56939  0.00   
+  4  3    3    3    466.7870   484.1839   0.0     1.56463  0.00   
+  4  .    4    3    2798.4708  2908.7315  -0.0    1.56170  0.00   
+  4  6    2    -6   1202.3310  1248.6458  -180.0  1.56402  0.00   
+  4  3    3    -6   1457.3058  1491.8604  -180.0  1.55808  0.00   
+  4  3    1    -8   1799.7269  1861.7114  0.0     1.55987  0.00   
+  4  7    1    -1   1971.2694  2047.1082  -0.0    1.56112  0.00   
+  4  5    3    .    3761.1199  3761.4033  180.0   1.55549  0.00   
+  4  7    1    -6   3890.9881  3796.1172  -180.0  1.55270  0.00   
+  4  5    3    -5   1463.1709  1406.9215  0.0     1.54952  0.00   
+  4  5    1    3    1014.7453  789.2030   0.0     1.53388  0.00   
+  4  1    3    5    9.7542     7.4029     -180.0  1.52468  0.00   
+  4  1    3    -6   1542.1807  1154.4884  0.0     1.52220  0.00   
+  4  5    1    -8   7.1668     5.3441     0.0     1.52138  0.00   
+  4  2    4    2    5205.0947  4241.8442  180.0   1.51224  0.00   
+  4  2    4    -4   2874.2760  2480.9162  -0.0    1.50960  0.00   
+  4  6    .    2    9893.4961  8951.5408  -180.0  1.50724  0.00   
+  4  6    .    -8   4937.9505  4397.8587  -180.0  1.49431  0.00   
+  4  8    .    -4   23010.5720 20190.1236 0.0     1.49339  0.00   
+  4  4    4    -2   25770.2788 20429.5329 -0.0    1.48565  0.00   
+  4  7    1    .    661.4892   523.9364   0.0     1.48175  0.00   
+  4  6    2    1    629.5996   508.4966   180.0   1.47901  0.00   
+  4  5    3    1    1796.5286  1469.8281  180.0   1.47651  0.00   
+  4  4    4    -1   218.1899   180.2923   180.0   1.47405  0.00   
+  4  1    1    7    11096.9431 9091.7882  -0.0    1.47619  0.00   
+  4  4    4    -3   2004.3397  1667.5953  180.0   1.47242  0.00   
+  4  1    1    -8   8929.9046  7407.8451  0.0     1.47312  0.00   
+  4  .    2    7    3010.4320  2503.1732  180.0   1.47256  0.00   
+  4  .    4    4    674.6009   576.6663   180.0   1.46849  0.00   
+  4  5    3    -6   0.2121     0.1797     -180.0  1.46938  0.00   
+  4  7    1    -7   278.8980   232.7336   -180.0  1.47169  0.00   
+  4  6    2    -7   1280.3266  1086.5341  180.0   1.46921  0.00   
+  4  4    2    4    345.4153   309.4549   -180.0  1.45793  0.00   
+  4  4    2    -8   310.4517   302.9912   -180.0  1.44854  0.00   
+  4  8    .    -2   53660.3013 52418.6929 0.0     1.44786  0.00   
+  4  4    4    .    44225.7417 40355.6835 -180.0  1.43928  0.00   
+  4  8    .    -6   42382.1986 39586.7446 -180.0  1.44170  0.00   
+  4  4    4    -4   60508.4853 54046.6468 0.0     1.43625  0.00   
+  4  3    3    4    5171.9435  4617.7330  -180.0  1.43618  0.00   
+  4  2    2    6    0.9149     0.8092     -180.0  1.43238  0.00   
+  4  3    3    -7   1605.1130  1448.2500  0.0     1.42999  0.00   
+  4  2    4    3    2901.9263  2692.4789  180.0   1.42752  0.00   
+  4  2    2    -8   1957.8431  1821.8495  -0.0    1.42716  0.00   
+  4  2    4    -5   1785.5625  1667.9730  180.0   1.42456  0.00   
+  4  .    .    8    287014.8855 267147.3687 -0.0    1.42712  0.00   
+  4  3    1    6    1205.9120  941.1628   180.0   1.39613  0.00   
+  4  5    1    4    877.2063   767.3314   0.0     1.39151  0.00   
+  4  7    1    1    58.5203    50.2466    -180.0  1.39219  0.00   
+  4  3    1    -9   755.0799   710.0031   -0.0    1.38839  0.00   
+  4  4    4    1    3651.2395  3619.1298  -0.0    1.38597  0.00   
+  4  5    3    2    461.7766   442.8188   -180.0  1.38751  0.00   
+  4  1    3    6    3048.6420  3147.4132  0.0     1.38395  0.00   
+  4  4    4    -5   1157.7908  1222.2903  0.0     1.38191  0.00   
+  4  1    3    -7   459.7754   485.6927   -180.0  1.38176  0.00   
+  4  5    3    -7   1016.7987  1075.6125  180.0   1.37991  0.00   
+  4  7    1    -8   219.2787   231.8332   0.0     1.38148  0.00   
+  4  5    1    -9   2997.3601  3171.8690  -0.0    1.38047  0.00   
+  4  6    2    2    241.8435   255.7408   -180.0  1.37957  0.00   
+  4  .    4    5    373.9936   361.1264   -180.0  1.37003  0.00   
+  4  6    2    -8   2.9711     2.8407     0.0     1.36963  0.00   
+  4  8    2    -4   786.8169   740.6559   180.0   1.36893  0.00   
+  4  7    3    -3   3358.1565  3200.0066  -180.0  1.36518  0.00   
+  4  7    3    -4   469.3100   462.7448   -180.0  1.36404  0.00   
+  4  1    5    .    4131.2840  4351.0671  -180.0  1.35878  0.00   
+  4  1    5    -1   54.2354    57.0734    -0.0    1.35862  0.00   
+  4  8    2    -3   1820.1168  1927.1422  180.0   1.36047  0.00   
+  4  8    2    -5   13526.6243 14183.9959 180.0   1.35791  0.00   
+  4  7    3    -2   6452.1116  6976.2993  0.0     1.34716  0.00   
+  4  1    5    1    8086.9402  7402.6017  0.0     1.34008  0.00   
+  4  7    3    -5   2404.5967  2392.5313  180.0   1.34389  0.00   
+  4  1    5    -2   3062.5207  2788.2936  180.0   1.33962  0.00   
+  4  2    4    4    220.3162   204.5003   -180.0  1.33688  0.00   
+  4  2    4    -6   4092.5543  4268.4903  180.0   1.33385  0.00   
+  4  8    2    -2   183.4218   192.6758   0.0     1.33360  0.00   
+  4  8    2    -6   101.1281   116.9837   0.0     1.32879  0.00   
+  4  8    .    .    108968.8833 127051.3804 0.0     1.32797  0.00   
+  4  4    2    5    10862.8611 12829.1260 0.0     1.32490  0.00   
+  4  4    4    2    94397.3452 113690.7835 0.0     1.32017  0.00   
+  4  .    2    8    312.8474   368.7877   180.0   1.31734  0.00   
+  4  4    4    -6   105506.2960 120494.6069 0.0     1.31549  0.00   
+  4  3    3    5    1061.3404  1245.3080  -0.0    1.31705  0.00   
+  4  4    2    -9   4744.2058  5532.0571  180.0   1.31667  0.00   
+  4  8    .    -8   116655.2115 139611.9415 -0.0    1.31851  0.00   
+  4  3    3    -8   6726.3533  7100.1131  180.0   1.31140  0.00   
+  4  7    3    -1   964.6970   1033.0922  180.0   1.31215  0.00   
+  4  1    1    8    148.9111   157.0219   180.0   1.31135  0.00   
+  4  1    1    -9   714.1159   716.4331   180.0   1.30891  0.00   
+  4  1    5    2    1905.5753  1729.2451  180.0   1.30476  0.00   
+  4  1    5    -3   8176.5032  7288.3669  -0.0    1.30405  0.00   
+  4  7    3    -6   7828.3295  7547.9716  -0.0    1.30714  0.00   
+  4  6    4    -3   2774.6686  2354.5174  -0.0    1.29838  0.00   
+  4  9    1    -4   987.0625   843.6936   0.0     1.30173  0.00   
+  4  9    1    -5   304.2378   257.7171   0.0     1.30047  0.00   
+  4  7    1    2    4706.8683  3981.9309  -180.0  1.29994  0.00   
+  4  3    5    -1   676.9404   620.3632   0.0     1.29364  0.00   
+  4  3    5    -2   2371.6085  2183.5705  -0.0    1.29322  0.00   
+  4  5    3    3    381.1509   335.5434   180.0   1.29585  0.00   
+  4  6    4    -2   26.7536    25.5439    0.0     1.29089  0.00   
+  4  4    .    6    19822.4122 18520.1244 180.0   1.29206  0.00   
+  4  6    4    -4   7150.3954  7133.9568  -0.0    1.28925  0.00   
+  4  8    2    -1   9467.0460  8943.5192  180.0   1.29141  0.00   
+  4  5    3    -8   3394.8434  3486.9853  180.0   1.28828  0.00   
+  4  7    1    -9   133.7577   133.2810   180.0   1.28929  0.00   
+  4  2    2    7    15884.2623 16158.5560 -0.0    1.28861  0.00   
+  4  2    2    -9   18439.2320 19800.7206 0.0     1.28427  0.00   
+  4  8    2    -7   400.8236   430.5740   -180.0  1.28487  0.00   
+  4  9    1    -3   5176.4797  5527.0781  180.0   1.28635  0.00   
+  4  4    .    -10  19329.0443 20726.7458 -180.0  1.28335  0.00   
+  4  3    5    .    676.8855   719.1866   -0.0    1.27774  0.00   
+  4  9    1    -6   174.8220   187.2211   -0.0    1.28270  0.00   
+  4  6    2    3    0.3587     0.3842     180.0   1.28136  0.00   
+  4  3    5    -3   5714.0534  6024.5361  -0.0    1.27654  0.00   
+  4  .    4    6    112.5220   118.4775   180.0   1.27292  0.00   
+  4  6    2    -9   438.8112   466.1247   180.0   1.27181  0.00   
+  4  6    4    -1   425.0715   481.2657   -180.0  1.26760  0.00   
+  4  6    4    -5   515.6020   581.1244   -180.0  1.26450  0.00   
+  4  5    1    5    4061.4295  4621.6594  180.0   1.26672  0.00   
+  4  6    .    4    6416.2911  7286.7428  180.0   1.26717  0.00   
+  4  7    3    .    718.2313   803.5252   180.0   1.26395  0.00   
+  4  1    3    7    7831.0377  8423.0771  -0.0    1.26050  0.00   
+  4  1    5    3    33.7190    35.0520    180.0   1.25659  0.00   
+  4  1    3    -8   2916.9855  3097.1421  180.0   1.25859  0.00   
+  4  1    5    -4   3031.7796  3091.9628  180.0   1.25570  0.00   
+  4  7    3    -7   2301.1744  2425.0787  180.0   1.25769  0.00   
+  4  5    1    -10  6742.6041  7062.5162  -180.0  1.25711  0.00   
+  4  6    .    -10  113.6023   117.7110   180.0   1.25641  0.00   
+  4  3    1    7    1638.6181  1614.1267  -0.0    1.25452  0.00   
+  4  9    1    -2   353.1193   362.9584   0.0     1.25602  0.00   
+  4  3    5    1    8759.8908  8322.4019  0.0     1.24726  0.00   
+  4  4    4    3    17.4982    16.4792    0.0     1.24775  0.00   
+  4  9    1    -7   9639.3777  8763.1983  -180.0  1.25037  0.00   
+  4  3    5    -4   1121.8694  1089.7337  -0.0    1.24541  0.00   
+  4  3    1    -10  3201.8244  2992.0824  180.0   1.24815  0.00   
+  4  2    4    5    1196.3550  1149.9417  0.0     1.24645  0.00   
+  4  2    4    -7   801.6947   790.0395   0.0     1.24350  0.00   
+  4  4    4    -7   6606.7777  6538.6159  -0.0    1.24282  0.00   
+  4  2    .    8    28.2975    27.9622    -0.0    1.24308  0.00   
+  4  2    .    -10  2055.9856  2007.7264  180.0   1.23870  0.00   
+  4  8    2    .    759.2592   734.2240   180.0   1.23816  0.00   
+  4  6    4    .    13693.5060 14141.6746 -0.0    1.23097  0.00   
+  4  8    2    -8   596.1880   629.3241   180.0   1.23049  0.00   
+  4  6    4    -6   119.2449   129.6186   -180.0  1.22671  0.00   
+  4  9    1    -1   2958.3506  2745.9583  -0.0    1.21378  0.00   
+  4  3    3    6    908.3705   849.8323   0.0     1.20955  0.00   
+  4  4    2    6    443.3330   412.4297   -0.0    1.20890  0.00   
+  4  7    1    3    77.9209    73.1605    180.0   1.21007  0.00   
+  4  3    5    2    4109.9574  3736.5604  0.0     1.20520  0.00   
+  4  5    3    4    8289.8739  7537.7747  -180.0  1.20654  0.00   
+  4  7    3    1    3003.7748  2740.0570  180.0   1.20699  0.00   
+  4  3    5    -5   52.0871    48.8417    180.0   1.20286  0.00   
+  4  3    3    -9   1034.0269  946.2084   -0.0    1.20451  0.00   
+  4  9    1    -8   2559.4239  2328.9959  0.0     1.20666  0.00   
+  4  1    5    4    4155.0056  3928.7774  180.0   1.19990  0.00   
+  4  4    2    -10  174.7876   165.9924   -0.0    1.20176  0.00   
+  4  1    5    -5   702.5259   654.8785   0.0     1.19891  0.00   
+  4  7    3    -8   5.7570     5.4486     0.0     1.19998  0.00   
+  4  5    3    -9   320.7146   300.8907   180.0   1.19933  0.00   
+  4  7    1    -10  8798.2912  8320.4071  -180.0  1.19992  0.00   
+  4  .    2    9    351.2159   269.6312   -0.0    1.18958  0.00   
+  4  5    5    -2   3749.6524  3018.8319  -0.0    1.18718  0.00   
+  4  5    5    -3   0.1205     0.0988     -0.0    1.18665  0.00   
+  4  6    2    4    344.7362   268.2247   180.0   1.18844  0.00   
+  4  10   .    -4   8869.0904  6819.2609  0.0     1.18930  0.00   
+  4  10   .    -6   13822.3987 11137.7777 0.0     1.18716  0.00   
+  4  6    4    1    1494.9994  1319.5472  0.0     1.18438  0.00   
+  4  .    4    7    310.8062   286.2756   180.0   1.18106  0.00   
+  4  6    4    -7   1934.1463  1785.8753  0.0     1.17933  0.00   
+  4  6    2    -10  2.3936     2.2097     -0.0    1.17955  0.00   
+  4  1    1    9    132.7397   122.6246   -0.0    1.17893  0.00   
+  4  8    .    2    33885.3584 31276.2536 180.0   1.17978  0.00   
+  4  5    5    -1   7616.8233  7302.4121  -180.0  1.17507  0.00   
+  4  1    1    -10  818.3015   763.7273   180.0   1.17695  0.00   
+  4  8    2    1    6315.1042  5843.7913  -180.0  1.17825  0.00   
+  4  5    5    -4   5634.3911  5548.7125  -0.0    1.17352  0.00   
+  4  4    4    4    34267.6264 33769.7454 0.0     1.17348  0.00   
+  4  4    4    -8   28874.6144 28593.8022 -180.0  1.16856  0.00   
+  4  8    2    -9   8380.7512  8436.7352  180.0   1.16999  0.00   
+  4  8    .    -10  38128.4827 38342.1586 0.0     1.16986  0.00   
+  4  2    2    8    101.4315   100.3601   0.0     1.16850  0.00   
+  4  2    2    -10  599.4159   560.5897   -0.0    1.16486  0.00   
+  4  2    4    6    16428.1110 13774.5927 180.0   1.16003  0.00   
+  4  9    1    .    197.5194   176.0223   180.0   1.16327  0.00   
+  4  2    4    -8   2770.5492  2415.0044  0.0     1.15725  0.00   
+  4  3    5    3    3536.2625  3127.0405  0.0     1.15512  0.00   
+  4  5    1    6    58.7741    50.3624    0.0     1.15831  0.00   
+  4  3    5    -6   60.0295    51.3916    -0.0    1.15247  0.00   
+  4  9    1    -9   640.9013   566.9119   180.0   1.15523  0.00   
+  4  1    3    8    3188.9985  2763.3932  0.0     1.15316  0.00   
+  4  5    5    .    7932.1594  6651.7754  -0.0    1.15142  0.00   
+  4  1    3    -9   1.5906     1.3357     -0.0    1.15150  0.00   
+  4  5    5    -5   10207.4742 8491.3154  -180.0  1.14900  0.00   
+  4  5    1    -11  1831.3863  1516.7746  0.0     1.14998  0.00   
+  4  9    3    -4   488.9981   427.6756   0.0     1.14660  0.00   
+  4  .    6    .    2656.9018  2596.7689  -0.0    1.14169  0.00   
+  4  9    3    -5   72.5045    64.9913    -0.0    1.14574  0.00   
+  4  7    3    2    5420.8601  4904.6864  -0.0    1.14538  0.00   
+  4  .    .    10   435.0181   425.1377   -0.0    1.14170  0.00   
+  4  1    5    5    5215.0127  5032.6543  -0.0    1.13876  0.00   
+  4  10   .    -2   16702.1437 16048.9180 0.0     1.14271  0.00   
+  4  1    5    -6   5534.5308  5298.3291  180.0   1.13772  0.00   
+  4  .    6    1    1720.9161  1640.4659  180.0   1.13603  0.00   
+  4  7    3    -9   4869.2042  4668.9703  180.0   1.13807  0.00   
+  4  3    1    8    71.6696    68.5695    180.0   1.13731  0.00   
+  4  10   .    -8   1520.0199  1454.1480  0.0     1.13704  0.00   
+  4  9    3    -3   1498.0645  1428.2991  -180.0  1.13605  0.00   
+  4  9    3    -6   2008.4396  1858.4252  -0.0    1.13354  0.00   
+  4  3    1    -11  33.9158    30.9874    0.0     1.13200  0.00   
+  4  6    4    2    3086.8673  2826.0255  0.0     1.13144  0.00   
+  4  6    4    -8   1999.0600  2097.1131  -0.0    1.12594  0.00   
+  4  10   2    -5   6530.0536  6296.0544  0.0     1.12806  0.00   
+  4  8    4    -4   3907.3778  4159.2534  -180.0  1.12554  0.00   
+  4  2    6    -1   3288.8793  3528.7487  180.0   1.12139  0.00   
+  4  7    1    4    4627.8450  4938.2570  -0.0    1.12548  0.00   
+  4  .    6    2    1335.8073  1369.0916  -180.0  1.11952  0.00   
+  4  5    3    5    1799.8836  1971.6886  -180.0  1.12246  0.00   
+  4  10   2    -4   8.1430     9.0469     180.0   1.12349  0.00   
+  4  8    4    -3   3137.8845  3320.7972  -180.0  1.12083  0.00   
+  4  10   2    -6   159.7478   172.5207   180.0   1.12169  0.00   
+  4  5    5    1    714.9889   709.4788   0.0     1.11827  0.00   
+  4  8    4    -5   1009.3648  1031.3589  180.0   1.11940  0.00   
+  4  2    6    .    5564.8110  5302.4095  180.0   1.11620  0.00   
+  4  2    6    -2   1048.0605  989.3398   180.0   1.11585  0.00   
+  4  5    5    -6   2703.3793  2497.8759  0.0     1.11516  0.00   
+  4  5    3    -10  1696.5576  1597.4314  -0.0    1.11576  0.00   
+  4  7    1    -11  2200.1881  2088.6950  180.0   1.11605  0.00   
+  4  3    3    7    8097.9583  7166.8557  0.0     1.11394  0.00   
+  4  9    3    -2   2201.0807  2022.5437  0.0     1.11500  0.00   
+  4  8    2    2    129.6846   121.0275   0.0     1.11546  0.00   
+  4  9    3    -7   2045.3960  1753.7287  -180.0  1.11104  0.00   
+  4  3    3    -10  301.6702   264.2274   -0.0    1.10948  0.00   
+  4  4    2    7    10441.5622 9279.0283  0.0     1.10827  0.00   
+  4  8    2    -10  40.7380    36.6373    0.0     1.10706  0.00   
+  4  10   2    -3   39666.6109 35203.8950 -180.0  1.10839  0.00   
+  4  9    1    1    4285.4780  3819.0095  -180.0  1.10800  0.00   
+  4  8    4    -2   32353.5063 29359.0716 -180.0  1.10566  0.00   
+  4  2    6    1    29630.2048 27548.7335 -180.0  1.10070  0.00   
+  4  10   2    -7   38518.1260 35019.9858 0.0     1.10493  0.00   
+  4  8    4    -6   32947.7953 30140.2855 0.0     1.10291  0.00   
+  4  2    6    -3   31876.8690 29812.9759 0.0     1.10002  0.00   
+  4  4    2    -11  2371.1926  2176.8388  -0.0    1.10207  0.00   
+  4  3    5    4    75.2132    70.1032    0.0     1.10044  0.00   
+  4  6    2    5    144651.7086 132384.6544 -180.0  1.10275  0.00   
+  4  4    4    5    2899.6600  2696.4068  180.0   1.10069  0.00   
+  4  3    5    -7   3090.3647  2930.0044  0.0     1.09764  0.00   
+  4  9    1    -10  299.2514   280.9621   0.0     1.09951  0.00   
+  4  .    4    8    142449.2053 133831.5365 -180.0  1.09634  0.00   
+  4  4    4    -9   143.1173   133.9399   0.0     1.09596  0.00   
+  4  .    6    3    3825.0154  3383.4803  -0.0    1.09354  0.00   
+  4  6    2    -11  163554.2439 150074.4912 -180.0  1.09463  0.00   
+  4  9    3    -1   1202.4520  1115.8683  0.0     1.08513  0.00   
+  4  .    2    10   133.8629   134.1910   0.0     1.08311  0.00   
+  4  10   2    -2   906.0236   881.0436   -0.0    1.08397  0.00   
+  4  7    3    3    5865.8317  6001.5072  180.0   1.08247  0.00   
+  4  8    4    -1   6.1625     6.5265     0.0     1.08126  0.00   
+  4  2    4    7    125.4053   143.4288   180.0   1.07961  0.00   
+  4  9    3    -8   15.2170    16.9772    180.0   1.08004  0.00   
+  4  5    5    2    4140.9410  5297.2246  0.0     1.07807  0.00   
+  4  2    6    2    323.2789   477.4907   0.0     1.07614  0.00   
+  4  2    4    -9   930.7274   1302.5665  -180.0  1.07706  0.00   
+  4  1    5    6    5113.1081  7480.0027  180.0   1.07640  0.00   
+  4  2    6    -4   2154.1690  3152.1404  -0.0    1.07519  0.00   
+  4  10   2    -8   256.2336   302.3912   0.0     1.07913  0.00   
+  4  8    4    -7   652.6506   885.6814   -0.0    1.07741  0.00   
+  4  1    5    -7   7581.4231  11163.8819 0.0     1.07537  0.00   
+  4  5    5    -7   11.6789    16.5190    0.0     1.07450  0.00   
+  4  6    4    3    1032.1858  1518.5743  -180.0  1.07534  0.00   
+  4  7    3    -10  8395.1274  12283.0876 0.0     1.07519  0.00   
+  4  6    .    6    637.5403   883.9233   180.0   1.07412  0.00   
+  4  6    4    -9   569.7002   817.4912   -180.0  1.06968  0.00   
+  4  1    1    10   1901.4964  2604.5605  -180.0  1.07040  0.00   
+  4  11   1    -5   122.4768   157.5132   180.0   1.07195  0.00   
+  4  11   1    -6   4.3285     5.7138     -180.0  1.07109  0.00   
+  4  4    6    -2   1652.9119  2477.8101  -180.0  1.06644  0.00   
+  4  1    1    -11  27.6406    41.8604    0.0     1.06876  0.00   
+  4  7    5    -3   854.8732   1328.1334  -180.0  1.06750  0.00   
+  4  4    .    8    16294.9201 23578.4335 -0.0    1.06955  0.00   
+  4  7    5    -4   109.7113   168.2003   180.0   1.06696  0.00   
+  4  2    2    9    15774.2190 24417.3666 -0.0    1.06728  0.00   
+  4  6    .    -12  2034.8553  2941.5303  -180.0  1.06569  0.00   
+  4  4    6    -1   1.5233     1.9888     -0.0    1.06212  0.00   
+  4  2    2    -11  15574.8506 21036.3619 -180.0  1.06419  0.00   
+  4  4    6    -3   2144.1174  2812.7886  180.0   1.06151  0.00   
+  4  4    .    -12  21559.3116 28331.7840 -180.0  1.06336  0.00   
+  4  5    1    7    2409.3555  3272.1719  0.0     1.06432  0.00   
+  4  .    6    4    1255.9575  1663.7702  0.0     1.06003  0.00   
+  4  11   1    -4   3896.3173  5133.1272  0.0     1.06347  0.00   
+  4  1    3    9    1216.9658  1612.3386  0.0     1.06002  0.00   
+  4  10   .    .    632.7592   825.0864   0.0     1.06238  0.00   
+  4  7    5    -2   1.2224     1.6286     -0.0    1.05882  0.00   
+  4  11   1    -7   50.4587    66.4677    -180.0  1.06095  0.00   
+  4  1    3    -10  1774.2534  2360.0175  0.0     1.05858  0.00   
+  4  7    5    -5   2976.3672  3876.7540  -180.0  1.05723  0.00   
+  4  5    1    -12  1615.0140  2099.8839  -180.0  1.05709  0.00   
+  4  10   .    -10  3748.4911  4674.1789  0.0     1.05481  0.00   
+  4  4    6    .    1672.2974  1584.3551  0.0     1.04889  0.00   
+  4  8    2    3    19399.3368 22612.1590 180.0   1.05269  0.00   
+  4  10   2    -1   51443.9639 58101.4525 0.0     1.05205  0.00   
+  4  4    6    -4   1280.3590  1165.1403  0.0     1.04771  0.00   
+  4  8    4    .    63884.2630 62147.7315 -180.0  1.04942  0.00   
+  4  9    1    2    125.7824   133.0663   -0.0    1.05090  0.00   
+  4  9    3    .    2523.5000  2360.3626  0.0     1.04859  0.00   
+  4  2    6    3    62092.9033 55650.4545 -180.0  1.04431  0.00   
+  4  7    1    5    1131.9766  1026.1966  0.0     1.04753  0.00   
+  4  2    6    -5   62452.2373 55960.4729 -180.0  1.04315  0.00   
+  4  3    5    5    4058.0467  3636.4681  -0.0    1.04401  0.00   
+  4  10   2    -9   75205.9438 67449.0195 0.0     1.04616  0.00   
+  4  8    4    -8   75341.5573 67560.0505 -180.0  1.04474  0.00   
+  4  5    3    6    1562.9276  1401.9183  -180.0  1.04495  0.00   
+  4  8    2    -11  5.4357     4.8725     0.0     1.04445  0.00   
+  4  11   1    -3   30.7925    27.6167    180.0   1.04628  0.00   
+  4  3    5    -8   423.9296   381.1962   -0.0    1.04119  0.00   
+  4  7    5    -1   5180.9113  4645.3933  -180.0  1.04156  0.00   
+  4  9    3    -9   551.2049   493.5891   -180.0  1.04268  0.00   
+  4  9    1    -11  5542.0828  4960.4562  180.0   1.04235  0.00   
+  4  11   1    -8   5983.6366  5355.4548  0.0     1.04229  0.00   
+  4  7    5    -6   22.0759    20.5743    180.0   1.03905  0.00   
+  4  5    3    -11  177.6638   166.8139   -0.0    1.03882  0.00   
+  4  7    1    -12  604.2498   565.4922   -180.0  1.03892  0.00   
+  4  3    1    9    1060.4359  986.9071   -180.0  1.03910  0.00   
+_reflns_number_total  1184
+_reflns_d_resolution_low    6.388
+_reflns_d_resolution_high   1.033
+
+# POWDER DATA TABLE
+_pd_meas_2theta_range_min  10.01313
+_pd_meas_2theta_range_max  119.99238
+_pd_meas_2theta_range_inc  0.02626
+_pd_proc_2theta_range_min  9.98829
+_pd_proc_2theta_range_max  119.96754
+_pd_proc_2theta_range_inc  0.02626
+_pd_proc_number_of_points  4189
+
+loop_
+   _pd_meas_intensity_total
+   _pd_calc_intensity_total
+   _pd_proc_intensity_bkg_calc
+   _pd_proc_ls_weight
+  2719         .   .  0
+  2601         .   .  0
+  2618         .   .  0
+  2547         .   .  0
+  2601         .   .  0
+  2669         .   .  0
+  2581         .   .  0
+  2630         .   .  0
+  2688         .   .  0
+  2591         .   .  0
+  2594         .   .  0
+  2528         .   .  0
+  2588         .   .  0
+  2581         .   .  0
+  2587         .   .  0
+  2552         .   .  0
+  2624         .   .  0
+  2552         .   .  0
+  2582         .   .  0
+  2548         .   .  0
+  2583         .   .  0
+  2546         .   .  0
+  2559         .   .  0
+  2580         .   .  0
+  2515         .   .  0
+  2439         .   .  0
+  2504         .   .  0
+  2548         .   .  0
+  2547         .   .  0
+  2519         .   .  0
+  2546         .   .  0
+  2402         .   .  0
+  2474         .   .  0
+  2388         .   .  0
+  2439         .   .  0
+  2490         .   .  0
+  2469         .   .  0
+  2482         .   .  0
+  2473         .   .  0
+  2443         .   .  0
+  2547         .   .  0
+  2429         .   .  0
+  2402         .   .  0
+  2429         .   .  0
+  2394         .   .  0
+  2367         .   .  0
+  2432         .   .  0
+  2385         .   .  0
+  2416         .   .  0
+  2420         .   .  0
+  2328         .   .  0
+  2372         .   .  0
+  2367         .   .  0
+  2411         .   .  0
+  2468         .   .  0
+  2240         .   .  0
+  2404         .   .  0
+  2348         .   .  0
+  2324         .   .  0
+  2311         .   .  0
+  2387         .   .  0
+  2271         .   .  0
+  2309         .   .  0
+  2319         .   .  0
+  2378         .   .  0
+  2354         .   .  0
+  2292         .   .  0
+  2303         .   .  0
+  2149         .   .  0
+  2253         .   .  0
+  2277         .   .  0
+  2201         .   .  0
+  2311         .   .  0
+  2247         .   .  0
+  2210         .   .  0
+  2191         .   .  0
+  2297         .   .  0
+  2298         .   .  0
+  2214         .   .  0
+  2292         .   .  0
+  2215         .   .  0
+  2259         .   .  0
+  2168         .   .  0
+  2188         .   .  0
+  2160         .   .  0
+  2213         .   .  0
+  2272         .   .  0
+  2221         .   .  0
+  2130         .   .  0
+  2064         .   .  0
+  2054         .   .  0
+  2118         .   .  0
+  2128         .   .  0
+  2153         .   .  0
+  2173         .   .  0
+  2157         .   .  0
+  2140         .   .  0
+  2120         .   .  0
+  2163         .   .  0
+  2124         .   .  0
+  2151         .   .  0
+  2119         .   .  0
+  2121         .   .  0
+  1980         .   .  0
+  2130         .   .  0
+  2191         .   .  0
+  2039         .   .  0
+  2089         .   .  0
+  2117         .   .  0
+  2002         .   .  0
+  2036         .   .  0
+  2074         .   .  0
+  2043         .   .  0
+  2089         .   .  0
+  2017         .   .  0
+  2021         .   .  0
+  1975         .   .  0
+  2132         .   .  0
+  2025         .   .  0
+  2040         .   .  0
+  2046         .   .  0
+  1919         .   .  0
+  2020         .   .  0
+  1923         .   .  0
+  1998         .   .  0
+  2033         .   .  0
+  1968         .   .  0
+  1984         .   .  0
+  2031         .   .  0
+  1967         .   .  0
+  1975         .   .  0
+  1969         .   .  0
+  1919         .   .  0
+  1962         .   .  0
+  1952         .   .  0
+  1974         .   .  0
+  1917         .   .  0
+  1934         .   .  0
+  1963         .   .  0
+  1862         .   .  0
+  1900         .   .  0
+  1924         .   .  0
+  1840         .   .  0
+  1888         .   .  0
+  1867         .   .  0
+  1894         .   .  0
+  1796         .   .  0
+  1841         .   .  0
+  1915         .   .  0
+  1890         .   .  0
+  1858         .   .  0
+  1841         .   .  0
+  1926         .   .  0
+  1871         .   .  0
+  1859         .   .  0
+  1887         .   .  0
+  1807         .   .  0
+  1707         .   .  0
+  1834         .   .  0
+  1790         .   .  0
+  1794         .   .  0
+  1832         .   .  0
+  1823         .   .  0
+  1763         .   .  0
+  1830         .   .  0
+  1883         .   .  0
+  1798         .   .  0
+  1774         .   .  0
+  1828         .   .  0
+  1785         .   .  0
+  1747         .   .  0
+  1791         .   .  0
+  1747         .   .  0
+  1820         .   .  0
+  1717         .   .  0
+  1673         .   .  0
+  1678         .   .  0
+  1858         .   .  0
+  1733         .   .  0
+  1747         .   .  0
+  1732         .   .  0
+  1626         .   .  0
+  1681         .   .  0
+  1802         .   .  0
+  1681         .   .  0
+  1749         .   .  0
+  1747         .   .  0
+  1772         .   .  0
+  1778         .   .  0
+  1673         .   .  0
+  1643         .   .  0
+  1698         .   .  0
+  1654         .   .  0
+  1613         .   .  0
+  1689         .   .  0
+  1643         .   .  0
+  1667         .   .  0
+  1680         1592.44858   1591.59227  0.000595238 
+  1652         1589.32475   1588.42927  0.000605327 
+  1721         1586.21081   1585.27263  0.000581058 
+  1680         1583.10705   1582.12234  0.000595238 
+  1657         1580.01408   1578.9784   0.0006035 
+  1691         1576.93253   1575.84079  0.000591366 
+  1648         1573.86316   1572.7095   0.000606796 
+  1607         1570.80687   1569.58453  0.000622278 
+  1604         1567.76479   1566.46585  0.000623441 
+  1623         1564.73842   1563.35346  0.000616143 
+  1672         1561.72918   1560.24736  0.000598086 
+  1641         1558.73934   1557.14752  0.000609385 
+  1608         1555.77171   1554.05393  0.000621891 
+  1633         1552.82966   1550.9666   0.00061237 
+  1556         1549.9179    1547.8855   0.000642674 
+  1579         1547.04265   1544.81063  0.000633312 
+  1572         1544.2125    1541.74197  0.000636132 
+  1607         1541.43966   1538.67952  0.000622278 
+  1620         1538.74225   1535.62326  0.000617284 
+  1562         1536.14854   1532.57318  0.000640205 
+  1591         1533.70494   1529.52928  0.000628536 
+  1592         1531.48862   1526.49153  0.000628141 
+  1611         1529.62152   1523.45994  0.000620732 
+  1585         1528.24961   1520.43449  0.000630915 
+  1516         1527.35735   1517.41517  0.000659631 
+  1570         1526.6317    1514.40198  0.000636943 
+  1631         1526.14345   1511.39489  0.000613121 
+  1553         1526.59062   1508.39389  0.000643915 
+  1532         1528.70439   1505.39899  0.000652742 
+  1624         1531.70235   1502.41017  0.000615764 
+  1582         1534.65947   1499.42741  0.000632111 
+  1566         1538.71425   1496.45071  0.00063857 
+  1614         1545.03927   1493.48006  0.000619579 
+  1602         1551.71715   1490.51544  0.00062422 
+  1639         1555.25205   1487.55685  0.000610128 
+  1595         1551.83265   1484.60428  0.000626959 
+  1637         1542.10558   1481.65771  0.000610874 
+  1610         1529.92362   1478.71713  0.000621118 
+  1529         1518.7673    1475.78254  0.000654022 
+  1553         1509.66913   1472.85393  0.000643915 
+  1537         1502.05901   1469.93127  0.000650618 
+  1484         1495.61511   1467.01457  0.000673854 
+  1451         1489.90393   1464.10382  0.00068918 
+  1469         1484.31181   1461.199    0.000680735 
+  1511         1477.68613   1458.3001   0.000661813 
+  1518         1470.52173   1455.40711  0.000658762 
+  1449         1463.87892   1452.52003  0.000690131 
+  1472         1458.3342    1449.63884  0.000679348 
+  1459         1453.71159   1446.76353  0.000685401 
+  1522         1449.68515   1443.89409  0.00065703 
+  1402         1446.02629   1441.03051  0.000713267 
+  1426         1442.60014   1438.17279  0.000701262 
+  1417         1439.32946   1435.3209   0.000705716 
+  1481         1436.1688    1432.47485  0.000675219 
+  1476         1433.08993   1429.63462  0.000677507 
+  1478         1430.07592   1426.8002   0.00067659 
+  1445         1427.11145   1423.97158  0.000692042 
+  1462         1424.18934   1421.14875  0.000683995 
+  1418         1421.30426   1418.33171  0.000705219 
+  1468         1418.45051   1415.52043  0.000681199 
+  1398         1415.62586   1412.71491  0.000715308 
+  1453         1412.8284    1409.91515  0.000688231 
+  1369         1410.057     1407.12112  0.00073046 
+  1392         1407.31662   1404.33283  0.000718391 
+  1389         1404.59697   1401.55026  0.000719942 
+  1405         1401.90726   1398.77339  0.000711744 
+  1371         1399.24384   1396.00223  0.000729395 
+  1380         1396.61534   1393.23676  0.000724638 
+  1387         1394.02123   1390.47697  0.000720981 
+  1435         1391.47562   1387.72285  0.000696864 
+  1418         1388.98222   1384.97439  0.000705219 
+  1411         1386.5671    1382.23159  0.000708717 
+  1382         1384.25803   1379.49442  0.000723589 
+  1409         1382.10393   1376.76289  0.000709723 
+  1370         1380.14778   1374.03698  0.000729927 
+  1354         1378.34336   1371.31667  0.000738552 
+  1446         1376.59707   1368.60198  0.000691563 
+  1413         1375.08426   1365.89287  0.000707714 
+  1435         1374.08509   1363.18935  0.000696864 
+  1336         1373.51226   1360.49139  0.000748503 
+  1373         1372.95234   1357.79901  0.000728332 
+  1386         1372.7635    1355.11217  0.000721501 
+  1359         1373.21606   1352.43088  0.000735835 
+  1426         1373.48691   1349.75512  0.000701262 
+  1373         1372.5321    1347.08488  0.000728332 
+  1370         1369.08897   1344.42016  0.000729927 
+  1306         1363.89822   1341.76095  0.000765697 
+  1349         1358.64372   1339.10723  0.00074129 
+  1340         1354.51179   1336.45899  0.000746269 
+  1289         1351.65526   1333.81623  0.000775795 
+  1355         1349.78026   1331.17893  0.000738007 
+  1325         1348.64394   1328.54709  0.000754717 
+  1288         1348.1116    1325.9207   0.000776398 
+  1360         1348.07285   1323.29975  0.000735294 
+  1324         1348.42525   1320.68422  0.000755287 
+  1348         1348.99981   1318.07411  0.00074184 
+  1317         1349.52793   1315.46941  0.000759301 
+  1297         1349.68203   1312.8701   0.00077101 
+  1301         1349.13839   1310.27619  0.00076864 
+  1336         1347.68552   1307.68765  0.000748503 
+  1347         1345.28823   1305.10449  0.00074239 
+  1338         1342.06152   1302.52669  0.000747384 
+  1302         1338.17656   1299.95423  0.000768049 
+  1247         1333.77566   1297.38712  0.000801925 
+  1364         1328.95427   1294.82534  0.000733138 
+  1383         1323.80132   1292.26889  0.000723066 
+  1253         1318.44125   1289.71775  0.000798085 
+  1314         1313.03433   1287.17191  0.000761035 
+  1259         1307.74279   1284.63136  0.000794281 
+  1348         1302.69554   1282.0961   0.00074184 
+  1269         1297.97507   1279.56612  0.000788022 
+  1295         1293.6272    1277.0414   0.000772201 
+  1303         1289.68086   1274.52194  0.00076746 
+  1206         1286.15955   1272.00773  0.000829187 
+  1313         1283.04013   1269.49875  0.000761615 
+  1219         1280.19867   1266.99501  0.000820345 
+  1294         1277.66617   1264.49648  0.000772798 
+  1273         1275.6712    1262.00317  0.000785546 
+  1377         1274.22506   1259.51505  0.000726216 
+  1175         1272.95787   1257.03213  0.000851064 
+  1353         1272.06127   1254.55439  0.000739098 
+  1230         1271.68484   1252.08182  0.000813008 
+  1286         1271.02888   1249.61442  0.000777605 
+  1320         1269.01324   1247.15217  0.000757576 
+  1253         1264.48288   1244.69507  0.000798085 
+  1226         1258.38571   1242.24311  0.000815661 
+  1290         1252.22139   1239.79627  0.000775194 
+  1190         1246.98182   1237.35455  0.000840336 
+  1246         1242.71775   1234.91794  0.000802568 
+  1243         1239.12198   1232.48643  0.000804505 
+  1202         1235.92614   1230.06001  0.000831947 
+  1241         1232.97657   1227.63867  0.000805802 
+  1239         1230.18582   1225.2224   0.000807103 
+  1245         1227.505     1222.8112   0.000803213 
+  1255         1224.90567   1220.40505  0.000796813 
+  1265         1222.3706    1218.00394  0.000790514 
+  1240         1219.88903   1215.60788  0.000806452 
+  1341         1217.45431   1213.21683  0.000745712 
+  1312         1215.06256   1210.83081  0.000762195 
+  1370         1212.71187   1208.4498   0.000729927 
+  1266         1210.40197   1206.07379  0.000789889 
+  1316         1208.13392   1203.70276  0.000759878 
+  1204         1205.91011   1201.33672  0.000830565 
+  1215         1203.73422   1198.97566  0.000823045 
+  1222         1201.61139   1196.61955  0.000818331 
+  1127         1199.54836   1194.26841  0.000887311 
+  1202         1197.55369   1191.9222   0.000831947 
+  1204         1195.63804   1189.58094  0.000830565 
+  1183         1193.81435   1187.2446   0.000845309 
+  1173         1192.09791   1184.91319  0.000852515 
+  1153         1190.50618   1182.58668  0.000867303 
+  1143         1189.05793   1180.26508  0.000874891 
+  1196         1187.77151   1177.94837  0.00083612 
+  1161         1186.66233   1175.63654  0.000861326 
+  1168         1185.73893   1173.32959  0.000856164 
+  1126         1184.99838   1171.0275   0.000888099 
+  1122         1184.41976   1168.73028  0.000891266 
+  1209         1183.95161   1166.4379   0.00082713 
+  1136         1183.49376   1164.15036  0.000880282 
+  1162         1182.88119   1161.86765  0.000860585 
+  1146         1181.89097   1159.58977  0.0008726 
+  1197         1180.29392   1157.3167   0.000835422 
+  1164         1177.93971   1155.04843  0.000859107 
+  1061         1174.82523   1152.78496  0.000942507 
+  1146         1171.09779   1150.52628  0.0008726 
+  1136         1166.99186   1148.27237  0.000880282 
+  1113         1162.74619   1146.02324  0.000898473 
+  1178         1158.54529   1143.77887  0.000848896 
+  1106         1154.5019    1141.53925  0.000904159 
+  1117         1150.66736   1139.30438  0.000895255 
+  1158         1147.05174   1137.07424  0.000863558 
+  1089         1143.64245   1134.84882  0.000918274 
+  1156         1140.41696   1132.62813  0.000865052 
+  1103         1137.35003   1130.41215  0.000906618 
+  1130         1134.41762   1128.20086  0.000884956 
+  1083         1131.60097   1125.99427  0.000923361 
+  1125         1128.87665   1123.79237  0.000888889 
+  1108         1126.23329   1121.59513  0.000902527 
+  1140         1123.65575   1119.40257  0.000877193 
+  1131         1121.13497   1117.21466  0.000884173 
+  1103         1118.66251   1115.03141  0.000906618 
+  1076         1116.23146   1112.85279  0.000929368 
+  1124         1113.83616   1110.67881  0.00088968 
+  1119         1111.47279   1108.50945  0.000893655 
+  1123         1109.13584   1106.34471  0.000890472 
+  1132         1106.82339   1104.18458  0.000883392 
+  1098         1104.53194   1102.02904  0.000910747 
+  1140         1102.25972   1099.8781   0.000877193 
+  1115         1100.00485   1097.73173  0.000896861 
+  1117         1097.76577   1095.58994  0.000895255 
+  1116         1095.54115   1093.45272  0.000896057 
+  1141         1093.32985   1091.32005  0.000876424 
+  1120         1091.13092   1089.19193  0.000892857 
+  1191         1088.94351   1087.06835  0.000839631 
+  1120         1086.76692   1084.94931  0.000892857 
+  1190         1084.60054   1082.83478  0.000840336 
+  1158         1082.44383   1080.72477  0.000863558 
+  1191         1080.29633   1078.61927  0.000839631 
+  1129         1078.15765   1076.51827  0.00088574 
+  1128         1076.02743   1074.42176  0.000886525 
+  1088         1073.90539   1072.32972  0.000919118 
+  1051         1071.79126   1070.24217  0.000951475 
+  1083         1069.68481   1068.15907  0.000923361 
+  1054         1067.58587   1066.08044  0.000948767 
+  1063         1065.49427   1064.00625  0.000940734 
+  1035         1063.40987   1061.93651  0.000966184 
+  1030         1061.33257   1059.87119  0.000970874 
+  969          1059.26228   1057.8103   0.001031992 
+  1040         1057.19892   1055.75383  0.000961538 
+  1076         1055.14245   1053.70177  0.000929368 
+  1031         1053.09285   1051.6541   0.000969932 
+  1067         1051.0501    1049.61083  0.000937207 
+  985          1049.01422   1047.57194  0.001015228 
+  1005         1046.98524   1045.53742  0.000995025 
+  994          1044.96321   1043.50727  0.001006036 
+  939          1042.94821   1041.48148  0.001064963 
+  993          1040.94033   1039.46004  0.001007049 
+  1039         1038.93971   1037.44295  0.000962464 
+  1002         1036.94649   1035.43019  0.000998004 
+  965          1034.96085   1033.42175  0.001036269 
+  1017         1032.98602   1031.41764  0.000983284 
+  1033         1031.01627   1029.41783  0.000968054 
+  1029         1029.0549    1027.42233  0.000971817 
+  912          1027.10376   1025.43112  0.001096491 
+  1036         1025.16027   1023.4442   0.000965251 
+  1004         1023.22643   1021.46156  0.000996016 
+  971          1021.3028    1019.48319  0.001029866 
+  1026         1019.39006   1017.50908  0.000974659 
+  1032         1017.48901   1015.53923  0.000968992 
+  984          1015.60058   1013.57362  0.00101626 
+  931          1013.72588   1011.61225  0.001074114 
+  1035         1011.86621   1009.65511  0.000966184 
+  1009         1010.02343   1007.70219  0.00099108 
+  1022         1008.19879   1005.75349  0.000978474 
+  981          1006.39483   1003.809    0.001019368 
+  952          1004.6144    1001.86871  0.00105042 
+  1058         1002.86058   999.9326    0.00094518 
+  963          1001.13727   998.00068   0.001038422 
+  945          999.44924    996.07294   0.001058201 
+  1013         997.80247    994.14936   0.000987167 
+  1022         996.20419    992.22995   0.000978474 
+  999          994.66312    990.31469   0.001001001 
+  967          993.18997    988.40357   0.001034126 
+  1030         991.79771    986.49658   0.000970874 
+  944          990.50164    984.59373   0.001059322 
+  1021         989.31985    982.695     0.000979432 
+  1002         988.27189    980.80038   0.000998004 
+  1015         987.37803    978.90986   0.000985222 
+  994          986.6553     977.02345   0.001006036 
+  952          986.11072    975.14112   0.00105042 
+  967          985.72908    973.26288   0.001034126 
+  914          985.458      971.38871   0.001094092 
+  961          985.19172    969.51861   0.001040583 
+  900          984.7672     967.65257   0.001111111 
+  954          983.98862    965.79058   0.001048218 
+  971          982.6833     963.93263   0.001029866 
+  913          980.76515    962.07872   0.00109529 
+  942          978.26392    960.22884   0.001061571 
+  908          975.30556    958.38298   0.001101322 
+  928          972.07396    956.54113   0.001077586 
+  1007         968.75087    954.70329   0.000993049 
+  903          965.46337    952.86945   0.00110742 
+  882          962.27583    951.03959   0.001133787 
+  948          959.22632    949.21372   0.001054852 
+  922          956.28658    947.39183   0.001084599 
+  895          953.44125    945.57391   0.001117318 
+  863          950.71607    943.75994   0.001158749 
+  916          948.11915    941.94993   0.001091703 
+  867          945.65674    940.14386   0.001153403 
+  917          943.31306    938.34173   0.001090513 
+  908          941.06503    936.54354   0.001101322 
+  857          938.89356    934.74926   0.001166861 
+  947          936.78425    932.9589    0.001055966 
+  917          934.72626    931.17245   0.001090513 
+  879          932.71129    929.3899    0.001137656 
+  846          930.73282    927.61124   0.001182033 
+  865          928.78563    925.83647   0.001156069 
+  869          926.86553    924.06558   0.001150748 
+  908          924.96913    922.29855   0.001101322 
+  874          923.09362    920.5354    0.001144165 
+  887          921.24938    918.77609   0.001127396 
+  881          919.40926    917.02064   0.001135074 
+  908          917.59058    915.26903   0.001101322 
+  906          915.77943    913.52125   0.001103753 
+  880          913.981      911.7773    0.001136364 
+  919          912.19436    910.03717   0.001088139 
+  854          910.41872    908.30085   0.00117096 
+  872          908.65343    906.56833   0.001146789 
+  911          906.91781    904.83961   0.001097695 
+  932          905.17178    903.11469   0.001072961 
+  846          903.43471    901.39354   0.001182033 
+  902          901.72732    899.67617   0.001108647 
+  869          900.00741    897.96257   0.001150748 
+  946          898.30121    896.25273   0.001057082 
+  926          896.59757    894.54665   0.001079914 
+  965          894.90184    892.84431   0.001036269 
+  962          893.21398    891.14571   0.001039501 
+  1025         891.53395    889.45085   0.00097561 
+  955          889.86799    887.75971   0.00104712 
+  951          888.20372    886.07228   0.001051525 
+  909          886.54743    884.38857   0.00110011 
+  835          884.90236    882.70856   0.001197605 
+  827          883.33659    881.03225   0.00120919 
+  836          881.70568    879.35963   0.001196172 
+  901          880.08354    877.69069   0.001109878 
+  822          878.50765    876.02542   0.001216545 
+  881          876.91072    874.36383   0.001135074 
+  899          875.31738    872.70589   0.001112347 
+  889          873.73456    871.05161   0.001124859 
+  866          872.16613    869.40097   0.001154734 
+  853          870.60653    867.75398   0.001172333 
+  842          869.05998    866.11061   0.001187648 
+  808          867.52772    864.47088   0.001237624 
+  822          866.01096    862.83476   0.001216545 
+  834          864.51069    861.20225   0.001199041 
+  804          863.02899    859.57335   0.001243781 
+  798          861.56883    857.94804   0.001253133 
+  859          860.1317     856.32633   0.001164144 
+  817          858.71824    854.7082    0.00122399 
+  815          857.33049    853.09365   0.001226994 
+  826          855.96743    851.48266   0.001210654 
+  878          854.63484    849.87524   0.001138952 
+  783          853.34287    848.27138   0.001277139 
+  847          852.1014     846.67106   0.001180638 
+  818          850.92224    845.07429   0.001222494 
+  865          849.8176     843.48105   0.001156069 
+  841          848.80245    841.89134   0.001189061 
+  829          847.8972     840.30515   0.001206273 
+  791          847.12952    838.72247   0.001264223 
+  827          846.53769    837.1433    0.00120919 
+  774          846.17581    835.56764   0.00129199 
+  821          846.12221    833.99546   0.001218027 
+  815          846.49387    832.42678   0.001226994 
+  847          847.47502    830.86157   0.001180638 
+  832          849.37517    829.29984   0.001201923 
+  820          852.76923    827.74157   0.001219512 
+  872          858.81807    826.18677   0.001146789 
+  853          869.75919    824.63542   0.001172333 
+  889          888.46271    823.08751   0.001124859 
+  905          912.61606    821.54304   0.001104972 
+  958          945.06006    820.00201   0.001043841 
+  978          1000.25031   818.4644    0.001022495 
+  1020         1060.43121   816.93021   0.000980392 
+  1206         1142.45973   815.39944   0.000829187 
+  1244         1235.89372   813.87207   0.000803859 
+  1342         1269.56444   812.3481    0.000745156 
+  1243         1208.09977   810.82752   0.000804505 
+  1140         1109.68261   809.31033   0.000877193 
+  1001         1005.27201   807.79652   0.000999001 
+  861          924.70929    806.28608   0.00116144 
+  801          879.64432    804.779     0.001248439 
+  780          854.86674    803.27529   0.001282051 
+  793          839.9498     801.77492   0.001261034 
+  806          829.99179    800.27791   0.001240695 
+  752          822.79218    798.78423   0.001329787 
+  727          817.27293    797.29388   0.001375516 
+  785          812.84379    795.80687   0.001273885 
+  838          809.15456    794.32317   0.001193317 
+  758          805.987      792.84278   0.001319261 
+  797          803.19975    791.3657    0.001254705 
+  798          800.69745    789.89193   0.001253133 
+  764          798.41421    788.42144   0.001308901 
+  796          796.30374    786.95424   0.001256281 
+  821          794.33251    785.49032   0.001218027 
+  766          792.47645    784.02968   0.001305483 
+  735          790.71703    782.5723    0.001360544 
+  739          789.04138    781.11819   0.00135318 
+  725          787.43992    779.66732   0.00137931 
+  732          785.90594    778.21971   0.00136612 
+  733          784.43508    776.77534   0.001364256 
+  755          783.03262    775.3342    0.001324503 
+  704          781.6815     773.89629   0.001420455 
+  739          780.3947     772.46161   0.00135318 
+  736          779.16644    771.03014   0.001358696 
+  729          778.00496    769.60188   0.001371742 
+  762          776.9163     768.17682   0.001312336 
+  739          775.90884    766.75496   0.00135318 
+  708          774.99389    765.33629   0.001412429 
+  760          774.1862     763.9208    0.001315789 
+  730          773.50534    762.50849   0.001369863 
+  742          772.97713    761.09935   0.001347709 
+  781          772.63574    759.69338   0.00128041 
+  738          772.52749    758.29056   0.001355014 
+  723          772.71573    756.8909    0.001383126 
+  750          773.28871    755.49438   0.001333333 
+  745          774.37321    754.10101   0.001342282 
+  787          776.15654    752.71076   0.001270648 
+  782          778.93077    751.32364   0.001278772 
+  816          783.15145    749.93965   0.00122549 
+  803          789.59709    748.55877   0.00124533 
+  763          799.56479    747.18099   0.001310616 
+  832          815.09896    745.80632   0.001201923 
+  851          838.61569    744.43475   0.001175088 
+  842          870.1497     743.06626   0.001187648 
+  955          908.38317    741.70086   0.00104712 
+  1005         961.54505    740.33853   0.000995025 
+  1126         1030.99891   738.97927   0.000888099 
+  1217         1097.51258   737.62308   0.000821693 
+  1261         1147.77617   736.26995   0.000793021 
+  1085         1147.03417   734.91987   0.000921659 
+  996          1088.28658   733.57284   0.001004016 
+  872          1011.63789   732.22885   0.001146789 
+  736          931.26771    730.88789   0.001358696 
+  811          867.17504    729.54996   0.001233046 
+  750          824.59141    728.21505   0.001333333 
+  760          797.28477    726.88316   0.001315789 
+  745          779.24009    725.55427   0.001342282 
+  790          766.69717    724.22839   0.001265823 
+  763          757.51155    722.90551   0.001310616 
+  763          750.62816    721.58562   0.001310616 
+  806          745.02172    720.26871   0.001240695 
+  787          740.41548    718.95478   0.001270648 
+  720          736.60963    717.64383   0.001388889 
+  785          733.25624    716.33584   0.001273885 
+  691          730.3056     715.03082   0.001447178 
+  685          727.66648    713.72874   0.001459854 
+  785          725.27319    712.42962   0.001273885 
+  734          723.07714    711.13344   0.001362398 
+  669          721.04276    709.8402    0.001494768 
+  761          719.14325    708.54989   0.00131406 
+  725          717.35844    707.26251   0.00137931 
+  707          715.67339    705.97804   0.001414427 
+  685          714.07715    704.69649   0.001459854 
+  662          712.56203    703.41785   0.001510574 
+  703          711.12338    702.1421    0.001422475 
+  671          709.75928    700.86925   0.001490313 
+  683          708.47059    699.5993    0.001464129 
+  669          707.26148    698.33222   0.001494768 
+  619          706.13986    697.06803   0.001615509 
+  691          705.11894    695.8067    0.001447178 
+  691          704.21925    694.54824   0.001447178 
+  692          703.47217    693.29265   0.001445087 
+  668          702.92663    692.0399    0.001497006 
+  645          702.66136    690.79001   0.001550388 
+  655          702.80777    689.54295   0.001526718 
+  703          703.59329    688.29874   0.001422475 
+  672          705.40686    687.05735   0.001488095 
+  696          708.86372    685.8188    0.001436782 
+  734          714.62273    684.58306   0.001362398 
+  676          722.233      683.35013   0.00147929 
+  775          729.71038    682.12001   0.001290323 
+  716          738.7403     680.8927    0.001396648 
+  779          751.55527    679.66818   0.001283697 
+  734          761.90655    678.44645   0.001362398 
+  725          759.59109    677.22751   0.00137931 
+  705          748.96159    676.01134   0.00141844 
+  652          734.6817     674.79795   0.001533742 
+  744          718.9953     673.58733   0.001344086 
+  696          706.83787    672.37947   0.001436782 
+  648          698.91276    671.17436   0.00154321 
+  653          693.96175    669.97201   0.001531394 
+  677          690.92622    668.7724    0.001477105 
+  623          689.20402    667.57553   0.001605136 
+  626          688.52661    666.38139   0.001597444 
+  661          688.86162    665.18999   0.001512859 
+  686          690.38569    664.0013    0.001457726 
+  700          693.5383     662.81533   0.001428571 
+  679          699.1598     661.63208   0.001472754 
+  646          708.68577    660.45153   0.001547988 
+  711          724.07416    659.27367   0.00140647 
+  682          745.85348    658.09852   0.001466276 
+  739          769.31022    656.92605   0.00135318 
+  803          794.06184    655.75626   0.00124533 
+  845          828.8777     654.58915   0.001183432 
+  848          864.24045    653.42472   0.001179245 
+  909          869.40782    652.26295   0.00110011 
+  872          845.12404    651.10384   0.001146789 
+  819          810.5751     649.94739   0.001221001 
+  743          768.32745    648.79359   0.001345895 
+  700          731.81827    647.64243   0.001428571 
+  679          706.99189    646.49391   0.001472754 
+  656          691.07542    645.34802   0.00152439 
+  706          680.67226    644.20477   0.001416431 
+  694          673.56659    643.06413   0.001440922 
+  648          668.48767    641.92611   0.00154321 
+  643          664.72815    640.79071   0.00155521 
+  661          661.89002    639.65791   0.001512859 
+  656          659.74564    638.52771   0.00152439 
+  623          658.16821    637.4001    0.001605136 
+  640          657.09762    636.27509   0.0015625 
+  675          656.52842    635.15266   0.001481481 
+  647          656.50885    634.03281   0.001545595 
+  642          657.15601    632.91553   0.001557632 
+  675          658.69664    631.80082   0.001481481 
+  667          661.52058    630.68867   0.00149925 
+  667          666.30419    629.57908   0.00149925 
+  658          674.06334    628.47205   0.001519757 
+  682          685.6927     627.36756   0.001466276 
+  689          700.14599    626.26561   0.001451379 
+  760          716.20587    625.16619   0.001315789 
+  791          738.44255    624.06931   0.001264223 
+  837          766.69271    622.97496   0.001194743 
+  898          788.24314    621.88312   0.001113586 
+  874          799.14144    620.7938    0.001144165 
+  924          811.13691    619.70699   0.001082251 
+  938          826.8728     618.62268   0.001066098 
+  1005         843.82779    617.54087   0.000995025 
+  1043         860.93089    616.46155   0.000958773 
+  991          879.55652    615.38473   0.001009082 
+  881          881.25851    614.31038   0.001135074 
+  824          849.61011    613.23852   0.001213592 
+  744          808.35624    612.16913   0.001344086 
+  675          764.13801    611.1022    0.001481481 
+  665          722.27326    610.03774   0.001503759 
+  668          691.89225    608.97573   0.001497006 
+  636          672.18279    607.91618   0.001572327 
+  678          659.42753    606.85907   0.001474926 
+  639          650.82929    605.80441   0.001564945 
+  623          644.67774    604.75218   0.001605136 
+  649          639.95294    603.70238   0.001540832 
+  661          636.03253    602.65501   0.001512859 
+  617          632.52761    601.61006   0.001620746 
+  627          629.21329    600.56752   0.001594896 
+  590          625.98874    599.5274    0.001694915 
+  636          622.83882    598.48968   0.001572327 
+  633          619.79521    597.45436   0.001579779 
+  640          616.90313    596.42144   0.0015625 
+  620          614.19821    595.39091   0.001612903 
+  593          611.69752    594.36276   0.001686341 
+  572          609.40062    593.33699   0.001748252 
+  613          607.29499    592.3136    0.001631321 
+  559          605.36221    591.29258   0.001788909 
+  587          603.58247    590.27392   0.001703578 
+  625          601.93689    589.25762   0.0016    
+  572          600.40903    588.24368   0.001748252 
+  591          598.9853     587.23208   0.001692047 
+  571          597.65497    586.22284   0.001751313 
+  610          596.41013    585.21593   0.001639344 
+  586          595.24565    584.21135   0.001706485 
+  649          594.15858    583.20911   0.001540832 
+  571          593.15014    582.20919   0.001751313 
+  593          592.22412    581.21159   0.001686341 
+  586          591.38792    580.21631   0.001706485 
+  596          590.65465    579.22333   0.001677852 
+  577          590.0448     578.23266   0.001733102 
+  636          589.58984    577.24429   0.001572327 
+  564          589.33868    576.25822   0.00177305 
+  580          589.36974    575.27443   0.001724138 
+  611          589.81308    574.29293   0.001636661 
+  579          590.89238    573.31371   0.001727116 
+  597          592.98887    572.33677   0.001675042 
+  590          596.71343    571.3621    0.001694915 
+  567          602.78913    570.38969   0.001763668 
+  599          611.05665    569.41954   0.001669449 
+  623          619.87473    568.45165   0.001605136 
+  662          630.61563    567.48601   0.001510574 
+  697          644.15589    566.52262   0.00143472 
+  680          651.02026    565.56147   0.001470588 
+  685          645.44592    564.60255   0.001459854 
+  663          636.25194    563.64587   0.001508296 
+  664          625.30428    562.69141   0.001506024 
+  612          613.99803    561.73918   0.001633987 
+  626          606.08215    560.78916   0.001597444 
+  611          602.43668    559.84136   0.001636661 
+  634          602.04226    558.89576   0.001577287 
+  669          600.65345    557.95237   0.001494768 
+  615          596.06937    557.01117   0.001626016 
+  569          590.85677    556.07217   0.001757469 
+  599          585.19356    555.13535   0.001669449 
+  638          579.50828    554.20072   0.001567398 
+  582          575.09944    553.26827   0.001718213 
+  656          572.01238    552.33799   0.00152439 
+  635          569.84142    551.40989   0.001574803 
+  698          568.26196    550.48395   0.001432665 
+  625          567.07474    549.56016   0.0016    
+  677          566.17026    548.63854   0.001477105 
+  632          565.48665    547.71906   0.001582278 
+  651          564.98518    546.80173   0.001536098 
+  697          564.64579    545.88655   0.00143472 
+  712          564.46008    544.9735    0.001404494 
+  701          564.39968    544.06258   0.001426534 
+  644          564.4363     543.15379   0.001552795 
+  620          564.58566    542.24712   0.001612903 
+  637          564.85918    541.34257   0.001569859 
+  599          565.26641    540.44014   0.001669449 
+  610          565.83303    539.53981   0.001639344 
+  587          566.57699    538.64159   0.001703578 
+  636          567.50664    537.74547   0.001572327 
+  604          568.62533    536.85144   0.001655629 
+  640          569.9376     535.9595    0.0015625 
+  628          571.4626     535.06965   0.001592357 
+  647          573.2536     534.18189   0.001545595 
+  710          575.4228     533.29619   0.001408451 
+  680          578.16598    532.41258   0.001470588 
+  634          581.79769    531.53102   0.001577287 
+  612          586.80787    530.65154   0.001633987 
+  621          593.94773    529.77411   0.001610306 
+  596          604.27684    528.89873   0.001677852 
+  620          618.70007    528.02541   0.001612903 
+  636          636.44029    527.15413   0.001572327 
+  689          657.08989    526.28489   0.001451379 
+  677          684.00738    525.41769   0.001477105 
+  722          712.43193    524.55252   0.001385042 
+  808          731.93361    523.68938   0.001237624 
+  745          752.39443    522.82826   0.001342282 
+  826          787.88649    521.96915   0.001210654 
+  891          851.38722    521.11207   0.001122334 
+  1033         973.51422    520.25699   0.000968054 
+  1196         1178.02717   519.40392   0.00083612 
+  1511         1436.07352   518.55284   0.000661813 
+  1973         1856.95665   517.70377   0.000506842 
+  2599         2435.6123    516.85668   0.000384763 
+  3189         2856.7904    516.01159   0.000313578 
+  3376         2927.15764   515.16847   0.000296209 
+  2815         2505.88817   514.32734   0.00035524 
+  2164         2118.10683   513.48818   0.000462107 
+  1674         1663.53824   512.65099   0.000597372 
+  1147         1220.86564   511.81576   0.00087184 
+  803          956.96054    510.9825    0.00124533 
+  661          814.04756    510.15119   0.001512859 
+  634          732.15042    509.32184   0.001577287 
+  621          680.7695     508.49443   0.001610306 
+  584          646.21936    507.66897   0.001712329 
+  602          621.84251    506.84544   0.00166113 
+  580          604.67871    506.02385   0.001724138 
+  571          591.28245    505.2042    0.001751313 
+  534          581.00496    504.38647   0.001872659 
+  564          573.3373     503.57066   0.00177305 
+  537          567.06407    502.75677   0.001862197 
+  588          562.1316     501.94479   0.00170068 
+  572          558.26471    501.13473   0.001748252 
+  573          555.25468    500.32656   0.001745201 
+  565          552.93139    499.5203    0.001769912 
+  562          551.1538     498.71594   0.001779359 
+  585          549.81275    497.91347   0.001709402 
+  594          548.85288    497.11288   0.001683502 
+  545          548.29329    496.31419   0.001834862 
+  585          548.24986    495.51737   0.001709402 
+  538          548.9655     494.72242   0.001858736 
+  589          550.89197    493.92935   0.001697793 
+  533          554.95363    493.13815   0.001876173 
+  621          563.29822    492.3488    0.001610306 
+  571          580.25624    491.56132   0.001751313 
+  580          607.86354    490.77569   0.001724138 
+  652          639.71702    489.99191   0.001533742 
+  722          705.57492    489.20998   0.001385042 
+  806          783.07722    488.42989   0.001240695 
+  876          833.26545    487.65164   0.001141553 
+  876          805.57052    486.87523   0.001141553 
+  777          747.3764     486.10064   0.001287001 
+  738          714.17232    485.32788   0.001355014 
+  679          656.02772    484.55694   0.001472754 
+  670          616.37197    483.78782   0.001492537 
+  636          603.58162    483.02051   0.001572327 
+  630          606.22414    482.25501   0.001587302 
+  686          619.817      481.49131   0.001457726 
+  723          645.2532     480.72942   0.001383126 
+  704          685.19092    479.96933   0.001420455 
+  763          737.45823    479.21102   0.001310616 
+  814          795.82017    478.45451   0.001228501 
+  987          868.17508    477.69978   0.001013171 
+  956          938.44355    476.94683   0.001046025 
+  917          954.05425    476.19566   0.001090513 
+  887          937.7923     475.44626   0.001127396 
+  881          932.59207    474.69863   0.001135074 
+  812          936.32039    473.95277   0.001231527 
+  901          965.41522    473.20867   0.001109878 
+  990          1027.74788   472.46632   0.001010101 
+  1180         1129.69787   471.72573   0.000847458 
+  1340         1259.1437    470.98688   0.000746269 
+  1458         1324.50232   470.24978   0.000685871 
+  1493         1317.67068   469.51442   0.000669792 
+  1273         1295.05572   468.7808    0.000785546 
+  1154         1207.38823   468.04891   0.000866551 
+  995          1083.99389   467.31875   0.001005025 
+  920          987.79449    466.59032   0.001086957 
+  852          912.95042    465.86361   0.001173709 
+  835          861.21721    465.13861   0.001197605 
+  845          841.79307    464.41533   0.001183432 
+  888          841.00054    463.69375   0.001126126 
+  872          825.86443    462.97389   0.001146789 
+  847          802.30818    462.25572   0.001180638 
+  839          788.41477    461.53925   0.001191895 
+  826          780.25253    460.82448   0.001210654 
+  772          784.46752    460.1114    0.001295337 
+  799          806.72143    459.4       0.001251564 
+  909          848.98236    458.69028   0.00110011 
+  899          911.66997    457.98225   0.001112347 
+  874          974.16761    457.27589   0.001144165 
+  1012         1042.44734   456.5712    0.000988142 
+  1185         1171.94788   455.86817   0.000843882 
+  1438         1427.93083   455.16681   0.00069541 
+  1875         1888.88393   454.46711   0.000533333 
+  2538         2489.1574    453.76906   0.000394011 
+  3905         3518.28921   453.07267   0.000256082 
+  5742         4979.6256    452.37792   0.000174155 
+  7202         5923.39883   451.68482   0.00013885 
+  5982         5570.09768   450.99336   0.000167168 
+  4635         4509.41468   450.30354   0.00021575 
+  3996         3814.92911   449.61535   0.00025025 
+  2730         2777.3062    448.92878   0.0003663 
+  1595         1788.48883   448.24385   0.000626959 
+  1152         1257.61081   447.56053   0.000868056 
+  947          990.2659     446.87883   0.001055966 
+  826          841.82523    446.19875   0.001210654 
+  738          749.27409    445.52028   0.001355014 
+  720          686.8539     444.84341   0.001388889 
+  692          642.49016    444.16815   0.001445087 
+  644          609.68211    443.49448   0.001552795 
+  578          584.63649    442.82241   0.001730104 
+  596          565.01461    442.15194   0.001677852 
+  541          549.30414    441.48305   0.001848429 
+  565          536.4907     440.81575   0.001769912 
+  580          525.8736     440.15002   0.001724138 
+  583          516.95489    439.48588   0.001715266 
+  642          509.37152    438.82331   0.001557632 
+  576          502.85498    438.1623    0.001736111 
+  590          497.2027     437.50287   0.001694915 
+  585          492.25885    436.84499   0.001709402 
+  629          487.90278    436.18868   0.001589825 
+  586          484.03983    435.53392   0.001706485 
+  578          480.59445    434.88071   0.001730104 
+  593          477.50643    434.22906   0.001686341 
+  599          474.72837    433.57894   0.001669449 
+  600          472.2185     432.93037   0.001666667 
+  600          469.94596    432.28333   0.001666667 
+  561          467.88441    431.63783   0.001782531 
+  578          466.01376    430.99386   0.001730104 
+  512          464.31461    430.35141   0.001953125 
+  504          462.77412    429.71049   0.001984127 
+  504          461.3815     429.07109   0.001984127 
+  517          460.12881    428.4332    0.001934236 
+  488          459.00954    427.79683   0.00204918 
+  450          458.0204     427.16196   0.002222222 
+  494          457.15999    426.5286    0.002024291 
+  408          456.42885    425.89675   0.00245098 
+  474          455.8304     425.26639   0.002109705 
+  461          455.36902    424.63752   0.002169197 
+  404          455.05353    424.01015   0.002475248 
+  462          454.89414    423.38427   0.002164502 
+  479          454.90588    422.75986   0.002087683 
+  456          455.10681    422.13695   0.002192982 
+  451          455.52063    421.5155    0.002217295 
+  436          456.17638    420.89553   0.002293578 
+  450          457.10879    420.27704   0.002222222 
+  481          458.36199    419.66001   0.002079002 
+  452          459.98794    419.04444   0.002212389 
+  437          462.04872    418.43033   0.00228833 
+  496          464.61445    417.81768   0.002016129 
+  491          467.76204    417.20648   0.00203666 
+  475          471.56856    416.59674   0.002105263 
+  495          476.09747    415.98844   0.002020202 
+  514          481.37639    415.38158   0.001945525 
+  492          487.36913    414.77616   0.00203252 
+  548          493.94543    414.17218   0.001824818 
+  594          500.87581    413.56963   0.001683502 
+  582          507.87805    412.96851   0.001718213 
+  605          514.71156    412.36882   0.001652893 
+  559          521.2802     411.77055   0.001788909 
+  578          527.6689     411.1737    0.001730104 
+  630          534.09462    410.57826   0.001587302 
+  612          540.85131    409.98424   0.001633987 
+  618          548.28359    409.39163   0.001618123 
+  647          556.97546    408.80042   0.001545595 
+  703          567.9339     408.21061   0.001422475 
+  681          582.0788     407.62221   0.001468429 
+  705          598.27769    407.0352    0.00141844 
+  731          616.03489    406.44958   0.001367989 
+  689          636.16227    405.86536   0.001451379 
+  673          644.98676    405.28252   0.001485884 
+  609          636.21584    404.70106   0.001642036 
+  628          626.14068    404.12098   0.001592357 
+  598          617.42557    403.54228   0.001672241 
+  599          600.28289    402.96495   0.001669449 
+  621          573.01631    402.38899   0.001610306 
+  600          547.655      401.8144    0.001666667 
+  578          528.08407    401.24117   0.001730104 
+  532          509.72583    400.6693    0.001879699 
+  509          495.11827    400.09878   0.001964637 
+  479          487.34435    399.52962   0.002087683 
+  457          486.73886    398.96181   0.002188184 
+  489          493.16814    398.39535   0.00204499 
+  526          505.83031    397.83023   0.001901141 
+  551          524.04688    397.26645   0.001814882 
+  581          544.97819    396.70401   0.00172117 
+  564          559.79067    396.14291   0.00177305 
+  597          564.54012    395.58313   0.001675042 
+  552          555.40581    395.02468   0.001811594 
+  505          534.58306    394.46756   0.001980198 
+  491          512.29282    393.91176   0.00203666 
+  419          489.81461    393.35727   0.002386635 
+  423          468.29138    392.80411   0.002364066 
+  416          451.913      392.25225   0.002403846 
+  432          440.79035    391.7017    0.002314815 
+  429          433.27923    391.15246   0.002331002 
+  391          428.03237    390.60452   0.002557545 
+  389          424.20658    390.05788   0.002570694 
+  418          421.31172    389.51254   0.002392344 
+  404          419.06104    388.96849   0.002475248 
+  427          417.28314    388.42573   0.00234192 
+  403          415.8722     387.88426   0.00248139 
+  395          414.76159    387.34407   0.002531646 
+  382          413.90975    386.80516   0.002617801 
+  404          413.29209    386.26753   0.002475248 
+  382          412.8958     385.73117   0.002617801 
+  406          412.71673    385.19608   0.002463054 
+  392          412.75863    384.66227   0.00255102 
+  399          413.03534    384.12972   0.002506266 
+  401          414.16609    383.59843   0.002493766 
+  362          415.04197    383.0684    0.002762431 
+  372          416.36507    382.53963   0.002688172 
+  394          418.34677    382.01211   0.002538071 
+  404          421.64947    381.48584   0.002475248 
+  433          426.29759    380.96081   0.002309469 
+  423          433.45278    380.43704   0.002364066 
+  434          443.68417    379.9145    0.002304147 
+  438          455.95507    379.3932    0.002283105 
+  491          469.43145    378.87314   0.00203666 
+  446          482.22612    378.3543    0.002242152 
+  502          484.32659    377.8367    0.001992032 
+  519          475.91164    377.32032   0.001926782 
+  417          467.12163    376.80517   0.002398082 
+  423          457.14994    376.29124   0.002364066 
+  430          444.77717    375.77852   0.002325581 
+  424          434.43565    375.26702   0.002358491 
+  385          427.81018    374.75673   0.002597403 
+  468          424.36059    374.24765   0.002136752 
+  393          423.16502    373.73977   0.002544529 
+  397          423.30678    373.2331    0.002518892 
+  441          424.34553    372.72762   0.002267574 
+  418          424.22048    372.22334   0.002392344 
+  409          421.15169    371.72026   0.002444988 
+  407          417.4918     371.21837   0.002457002 
+  381          414.21791    370.71766   0.002624672 
+  376          410.40546    370.21814   0.002659574 
+  401          406.79105    369.7198    0.002493766 
+  407          404.13522    369.22264   0.002457002 
+  415          402.34716    368.72666   0.002409639 
+  361          401.15585    368.23185   0.002770083 
+  405          400.36046    367.73821   0.002469136 
+  383          399.83805    367.24574   0.002610966 
+  402          399.51634    366.75443   0.002487562 
+  396          399.35376    366.26429   0.002525253 
+  387          399.32617    365.7753    0.002583979 
+  371          399.41989    365.28747   0.002695418 
+  394          399.62881    364.8008    0.002538071 
+  414          399.95322    364.31527   0.002415459 
+  367          400.39991    363.8309    0.002724796 
+  383          400.98444    363.34766   0.002610966 
+  376          401.73352    362.86557   0.002659574 
+  358          402.6815     362.38462   0.002793296 
+  412          403.84288    361.90481   0.002427184 
+  439          405.21857    361.42613   0.002277904 
+  408          406.8422     360.94858   0.00245098 
+  396          408.59332    360.47216   0.002525253 
+  392          410.36731    359.99686   0.00255102 
+  421          412.39707    359.52269   0.002375297 
+  422          414.64649    359.04964   0.002369668 
+  383          416.7469     358.5777    0.002610966 
+  429          418.6304     358.10688   0.002331002 
+  399          420.20689    357.63717   0.002506266 
+  430          421.50609    357.16857   0.002325581 
+  397          422.70202    356.70107   0.002518892 
+  427          424.27304    356.23468   0.00234192 
+  414          426.48517    355.76939   0.002415459 
+  424          429.31121    355.3052    0.002358491 
+  455          432.67994    354.8421    0.002197802 
+  457          436.54967    354.38009   0.002188184 
+  469          440.90303    353.91918   0.002132196 
+  429          445.74961    353.45935   0.002331002 
+  438          451.1086     353.0006    0.002283105 
+  464          457.02716    352.54294   0.002155172 
+  455          463.58094    352.08636   0.002197802 
+  439          470.88142    351.63085   0.002277904 
+  453          479.07372    351.17642   0.002207506 
+  530          488.33901    350.72305   0.001886792 
+  477          498.89369    350.27076   0.002096436 
+  489          510.99159    349.81953   0.00204499 
+  530          524.93562    349.36936   0.001886792 
+  482          541.09043    348.92026   0.002074689 
+  517          559.90611    348.47221   0.001934236 
+  577          581.9654     348.02522   0.001733102 
+  541          608.03802    347.57928   0.001848429 
+  603          639.15573    347.13439   0.001658375 
+  594          676.7318     346.69054   0.001683502 
+  675          722.71673    346.24775   0.001481481 
+  714          779.84476    345.80599   0.00140056 
+  753          852.07024    345.36527   0.001328021 
+  799          945.26771    344.92559   0.001251564 
+  986          1068.47446   344.48695   0.001014199 
+  1187         1236.28695   344.04933   0.00084246 
+  1471         1473.61996   343.61275   0.00067981 
+  1837         1826.75466   343.17719   0.000544366 
+  2428         2393.70675   342.74265   0.000411862 
+  3280         3403.81783   342.30914   0.000304878 
+  5154         5344.9767    341.87665   0.000194024 
+  8099         8765.97059   341.44517   0.000123472 
+  13116        12568.44943  341.0147    0.000076243 
+  21325        17646.59032  340.58525   0.000046893 
+  26562        22766.44985  340.1568    0.000037648 
+  21135        18861.92348  339.72937   0.000047315 
+  15227        14420.6292   339.30293   0.000065673 
+  14287        13703.05059  338.8775    0.000069994 
+  11204        10602.31981  338.45306   0.000089254 
+  5832         6299.82988   338.02962   0.000171468 
+  3179         3835.25228   337.60717   0.000314564 
+  2092         2606.19878   337.18572   0.000478011 
+  1760         1947.24275   336.76525   0.000568182 
+  1402         1549.20532   336.34577   0.000713267 
+  1230         1287.11765   335.92727   0.000813008 
+  1055         1104.63478   335.50976   0.000947867 
+  990          972.17437    335.09322   0.001010101 
+  935          872.86184    334.67766   0.001069519 
+  810          796.59958    334.26307   0.001234568 
+  780          736.89431    333.84946   0.001282051 
+  717          689.3488     333.43681   0.0013947 
+  711          651.05325    333.02513   0.00140647 
+  648          620.01018    332.61441   0.00154321 
+  616          594.75242    332.20465   0.001623377 
+  591          574.21547    331.79586   0.001692047 
+  590          557.63358    331.38802   0.001694915 
+  562          544.47574    330.98113   0.001779359 
+  568          534.38101    330.57519   0.001760563 
+  549          527.08769    330.17021   0.001821494 
+  557          522.12512    329.76617   0.001795332 
+  517          518.80063    329.36308   0.001934236 
+  473          516.60965    328.96092   0.002114165 
+  471          515.98241    328.55971   0.002123142 
+  482          516.7842     328.15944   0.002074689 
+  517          518.5952     327.7601    0.001934236 
+  483          521.55032    327.36169   0.002070393 
+  545          526.01204    326.96421   0.001834862 
+  540          532.26577    326.56766   0.001851852 
+  602          540.58911    326.17204   0.00166113 
+  557          551.28107    325.77734   0.001795332 
+  602          564.62962    325.38356   0.00166113 
+  588          580.9238     324.9907    0.00170068 
+  626          600.36106    324.59875   0.001597444 
+  572          621.72153    324.20772   0.001748252 
+  643          637.85299    323.8176    0.00155521 
+  653          638.89297    323.42839   0.001531394 
+  656          629.72122    323.04009   0.00152439 
+  623          618.25068    322.65269   0.001605136 
+  644          601.86411    322.26619   0.001552795 
+  612          579.3198     321.8806    0.001633987 
+  600          555.57851    321.4959    0.001666667 
+  563          533.29963    321.11209   0.001776199 
+  535          512.73966    320.72918   0.001869159 
+  468          493.76953    320.34716   0.002136752 
+  489          476.40127    319.96603   0.00204499 
+  495          460.69758    319.58578   0.002020202 
+  480          446.6565     319.20642   0.002083333 
+  420          434.23088    318.82794   0.002380952 
+  410          423.33765    318.45034   0.002439024 
+  426          413.83823    318.07361   0.002347418 
+  429          405.56442    317.69777   0.002331002 
+  393          398.34962    317.32279   0.002544529 
+  389          392.04078    316.94868   0.002570694 
+  439          386.50478    316.57545   0.002277904 
+  406          381.6219     316.20307   0.002463054 
+  380          377.29751    315.83157   0.002631579 
+  392          373.44982    315.46092   0.00255102 
+  389          370.01183    315.09113   0.002570694 
+  408          366.92932    314.7222    0.00245098 
+  367          364.15416    314.35413   0.002724796 
+  369          361.64967    313.9869    0.002710027 
+  345          359.3853     313.62053   0.002898551 
+  389          357.33693    313.25501   0.002570694 
+  332          355.48273    312.89033   0.003012048 
+  372          353.80853    312.5265    0.002688172 
+  401          352.30315    312.1635    0.002493766 
+  362          350.95897    311.80135   0.002762431 
+  361          349.77388    311.44004   0.002770083 
+  335          348.74859    311.07956   0.002985075 
+  358          347.8912     310.71991   0.002793296 
+  360          347.21419    310.36109   0.002777778 
+  343          346.74627    310.00311   0.002915452 
+  394          346.88147    309.64595   0.002538071 
+  392          346.97103    309.28961   0.00255102 
+  410          347.384      308.9341    0.002439024 
+  382          348.42929    308.57941   0.002617801 
+  402          350.54188    308.22553   0.002487562 
+  375          353.66024    307.87247   0.002666667 
+  364          358.83008    307.52023   0.002747253 
+  353          367.38864    307.16879   0.002832861 
+  411          381.27069    306.81817   0.00243309 
+  397          401.77754    306.46836   0.002518892 
+  431          423.50651    306.11935   0.002320186 
+  440          430.24762    305.77114   0.002272727 
+  439          420.78133    305.42373   0.002277904 
+  413          411.63244    305.07713   0.002421308 
+  444          404.42996    304.73132   0.002252252 
+  390          391.50912    304.3863    0.002564103 
+  405          376.44614    304.04208   0.002469136 
+  397          365.06762    303.69865   0.002518892 
+  392          357.76649    303.35601   0.00255102 
+  369          353.23495    303.01416   0.002710027 
+  354          350.40307    302.67309   0.002824859 
+  331          348.68771    302.3328    0.003021148 
+  359          347.91315    301.9933    0.002785515 
+  376          348.17467    301.65457   0.002659574 
+  344          349.44637    301.31662   0.002906977 
+  377          350.45827    300.97945   0.00265252 
+  346          348.97224    300.64304   0.002890173 
+  388          345.90132    300.30741   0.00257732 
+  354          343.39434    299.97255   0.002824859 
+  373          341.04374    299.63845   0.002680965 
+  349          337.96498    299.30512   0.00286533 
+  338          334.96839    298.97255   0.00295858 
+  365          332.7041     298.64074   0.002739726 
+  358          331.12005    298.30969   0.002793296 
+  338          330.03166    297.9794    0.00295858 
+  365          329.29998    297.64986   0.002739726 
+  355          328.85327    297.32107   0.002816901 
+  350          328.66827    296.99304   0.002857143 
+  356          328.77383    296.66575   0.002808989 
+  356          329.24778    296.33921   0.002808989 
+  353          330.19792    296.01342   0.002832861 
+  318          331.58948    295.68837   0.003144654 
+  367          332.76905    295.36405   0.002724796 
+  336          332.91445    295.04048   0.00297619 
+  342          332.66079    294.71765   0.002923977 
+  326          332.80405    294.39555   0.003067485 
+  293          333.08265    294.07418   0.003412969 
+  346          333.28364    293.75355   0.002890173 
+  349          333.91859    293.43364   0.00286533 
+  317          335.42344    293.11446   0.003154574 
+  358          338.10375    292.79601   0.002793296 
+  352          342.3616     292.47828   0.002840909 
+  376          348.47662    292.16128   0.002659574 
+  350          355.88292    291.84499   0.002857143 
+  409          365.09837    291.52942   0.002444988 
+  370          382.06827    291.21457   0.002702703 
+  427          408.25965    290.90043   0.00234192 
+  473          437.26355    290.587     0.002114165 
+  477          469.33118    290.27429   0.002096436 
+  467          447.67981    289.96228   0.002141328 
+  430          419.27421    289.65098   0.002325581 
+  381          414.95634    289.34038   0.002624672 
+  404          412.30597    289.03049   0.002475248 
+  424          387.29424    288.7213    0.002358491 
+  374          369.62957    288.4128    0.002673797 
+  405          361.99292    288.10501   0.002469136 
+  369          359.56709    287.79791   0.002710027 
+  412          359.4599     287.4915    0.002427184 
+  419          360.60089    287.18579   0.002386635 
+  361          362.91401    286.88077   0.002770083 
+  428          366.46742    286.57643   0.002336449 
+  364          371.37813    286.27278   0.002747253 
+  379          377.90803    285.96982   0.002638522 
+  390          386.57402    285.66754   0.002564103 
+  418          398.71872    285.36594   0.002392344 
+  409          417.40461    285.06502   0.002444988 
+  473          447.82497    284.76477   0.002114165 
+  494          493.11612    284.46521   0.002024291 
+  500          544.61206    284.16631   0.002     
+  575          598.02204    283.86809   0.00173913 
+  655          606.07355    283.57054   0.001526718 
+  619          577.24641    283.27366   0.001615509 
+  599          567.3755     282.97744   0.001669449 
+  604          573.48699    282.68189   0.001655629 
+  568          560.84262    282.387     0.001760563 
+  616          547.92079    282.09277   0.001623377 
+  564          554.70157    281.79921   0.00177305 
+  622          579.72418    281.5063    0.001607717 
+  624          618.33039    281.21405   0.001602564 
+  668          660.02384    280.92245   0.001497006 
+  668          696.36312    280.6315    0.001497006 
+  715          738.80479    280.34121   0.001398601 
+  771          799.48429    280.05156   0.001297017 
+  867          879.50887    279.76257   0.001153403 
+  1041         983.95403    279.47421   0.000960615 
+  1168         1131.92012   279.18651   0.000856164 
+  1388         1350.95056   278.89944   0.000720461 
+  1686         1685.97832   278.61302   0.00059312 
+  2363         2229.82536   278.32723   0.000423191 
+  3306         3198.21471   278.04208   0.00030248 
+  5270         5061.44168   277.75757   0.000189753 
+  8548         8372.56482   277.47369   0.000116986 
+  13591        12350.8506   277.19045   0.000073578 
+  19853        17055.62508  276.90783   0.00005037 
+  20015        17738.38265  276.62584   0.000049963 
+  13930        13426.9915   276.34448   0.000071788 
+  11100        11146.19156  276.06375   0.00009009 
+  11436        11088.76857  275.78364   0.000087443 
+  8912         8817.21599   275.50415   0.000112208 
+  4935         5317.5076    275.22528   0.000202634 
+  2724         3248.62542   274.94703   0.000367107 
+  1896         2205.77148   274.6694    0.000527426 
+  1373         1648.23112   274.39238   0.000728332 
+  1161         1315.29258   274.11598   0.000861326 
+  952          1099.5062    273.84019   0.00105042 
+  892          949.8383     273.56501   0.001121076 
+  785          837.65495    273.29044   0.001273885 
+  715          751.90914    273.01648   0.001398601 
+  638          687.69012    272.74312   0.001567398 
+  617          636.72542    272.47037   0.001620746 
+  547          591.28723    272.19822   0.001828154 
+  533          551.76207    271.92667   0.001876173 
+  507          519.97283    271.65572   0.001972387 
+  442          494.24033    271.38536   0.002262443 
+  413          472.33411    271.11561   0.002421308 
+  420          454.29081    270.84644   0.002380952 
+  410          440.58966    270.57787   0.002439024 
+  391          430.89686    270.3099    0.002557545 
+  403          423.50472    270.04251   0.00248139 
+  397          415.92903    269.77571   0.002518892 
+  397          407.98865    269.50949   0.002518892 
+  400          400.03991    269.24387   0.0025    
+  375          392.70526    268.97882   0.002666667 
+  390          386.5908     268.71436   0.002564103 
+  343          381.71393    268.45047   0.002915452 
+  381          376.22625    268.18717   0.002624672 
+  360          368.66502    267.92444   0.002777778 
+  345          360.97985    267.66229   0.002898551 
+  369          354.85472    267.40071   0.002710027 
+  317          349.39837    267.13971   0.003154574 
+  316          343.44439    266.87927   0.003164557 
+  314          337.63764    266.61941   0.003184713 
+  309          332.65138    266.36011   0.003236246 
+  311          328.47346    266.10138   0.003215434 
+  341          324.92514    265.84322   0.002932551 
+  312          321.86132    265.58562   0.003205128 
+  309          319.18057    265.32858   0.003236246 
+  317          316.8056     265.0721    0.003154574 
+  300          314.67031    264.81618   0.003333333 
+  333          312.71241    264.56081   0.003003003 
+  305          310.87776    264.30601   0.003278689 
+  297          309.12448    264.05175   0.003367003 
+  301          307.42957    263.79805   0.003322259 
+  292          305.78547    263.54491   0.003424658 
+  301          304.19692    263.29231   0.003322259 
+  340          302.67347    263.04026   0.002941176 
+  272          301.22328    262.78875   0.003676471 
+  303          299.85488    262.53779   0.00330033 
+  293          298.58817    262.28738   0.003412969 
+  313          297.43918    262.03751   0.003194888 
+  296          296.40997    261.78818   0.003378378 
+  297          295.50344    261.53939   0.003367003 
+  291          294.72665    261.29114   0.003436426 
+  292          294.08776    261.04342   0.003424658 
+  278          293.59318    260.79624   0.003597122 
+  286          293.25658    260.54959   0.003496503 
+  256          293.08946    260.30348   0.00390625 
+  307          293.05992    260.05789   0.003257329 
+  287          293.09374    259.81284   0.003484321 
+  278          293.30955    259.56831   0.003597122 
+  278          293.96484    259.32431   0.003597122 
+  301          294.96629    259.08084   0.003322259 
+  275          295.46643    258.83789   0.003636364 
+  302          294.9591     258.59546   0.003311258 
+  298          294.44724    258.35356   0.003355705 
+  320          294.6884     258.11217   0.003125  
+  246          295.51364    257.8713    0.004065041 
+  267          296.91395    257.63095   0.003745318 
+  324          299.83588    257.39111   0.00308642 
+  319          305.51211    257.15179   0.003134796 
+  373          315.15665    256.91298   0.002680965 
+  381          328.73713    256.67468   0.002624672 
+  413          340.50026    256.43689   0.002421308 
+  413          341.20883    256.19961   0.002421308 
+  408          334.61255    255.96283   0.00245098 
+  391          329.18472    255.72657   0.002557545 
+  387          324.9264     255.4908    0.002583979 
+  413          317.3848     255.25554   0.002421308 
+  337          307.75459    255.02078   0.002967359 
+  340          299.45487    254.78652   0.002941176 
+  358          293.45342    254.55276   0.002793296 
+  278          289.53995    254.3195    0.003597122 
+  314          287.19291    254.08674   0.003184713 
+  258          286.07697    253.85446   0.003875969 
+  299          286.25481    253.62269   0.003344482 
+  287          288.20449    253.3914    0.003484321 
+  288          291.58337    253.16061   0.003472222 
+  297          295.70166    252.9303    0.003367003 
+  291          296.79196    252.70048   0.003436426 
+  280          292.62634    252.47115   0.003571429 
+  267          290.95051    252.24231   0.003745318 
+  266          291.89101    252.01395   0.003759398 
+  273          292.32432    251.78607   0.003663004 
+  278          290.71351    251.55868   0.003597122 
+  299          290.98479    251.33176   0.003344482 
+  305          293.66121    251.10533   0.003278689 
+  324          299.01814    250.87937   0.00308642 
+  332          308.59549    250.65389   0.003012048 
+  322          325.38067    250.42888   0.00310559 
+  359          356.0359     250.20435   0.002785515 
+  429          398.95547    249.98029   0.002331002 
+  423          443.99404    249.7567    0.002364066 
+  465          463.97323    249.53358   0.002150538 
+  420          433.89913    249.31093   0.002380952 
+  427          410.70901    249.08874   0.00234192 
+  387          405.02753    248.86703   0.002583979 
+  383          394.71458    248.64578   0.002610966 
+  384          362.02067    248.42499   0.002604167 
+  367          333.6156     248.20466   0.002724796 
+  314          316.35856    247.9848    0.003184713 
+  272          305.46386    247.76539   0.003676471 
+  319          298.53197    247.54645   0.003134796 
+  317          294.26932    247.32796   0.003154574 
+  310          291.72953    247.10993   0.003225806 
+  297          290.3206     246.89235   0.003367003 
+  337          289.70439    246.67523   0.002967359 
+  294          289.68371    246.45856   0.003401361 
+  323          290.09894    246.24234   0.003095975 
+  325          290.73069    246.02657   0.003076923 
+  316          291.47111    245.81125   0.003164557 
+  301          292.45935    245.59637   0.003322259 
+  286          293.78192    245.38195   0.003496503 
+  282          295.38152    245.16797   0.003546099 
+  290          297.21844    244.95443   0.003448276 
+  347          299.38736    244.74133   0.002881844 
+  315          301.99587    244.52868   0.003174603 
+  325          305.14411    244.31647   0.003076923 
+  356          308.97254    244.10469   0.002808989 
+  342          313.73043    243.89336   0.002923977 
+  315          319.78915    243.68246   0.003174603 
+  351          327.36763    243.472     0.002849003 
+  356          335.52086    243.26197   0.002808989 
+  377          342.11051    243.05237   0.00265252 
+  367          348.06862    242.84321   0.002724796 
+  357          357.20851    242.63448   0.00280112 
+  377          372.54908    242.42617   0.00265252 
+  401          397.06213    242.2183    0.002493766 
+  442          432.08633    242.01085   0.002262443 
+  400          454.56438    241.80383   0.0025    
+  451          443.64231    241.59724   0.002217295 
+  428          436.41662    241.39107   0.002336449 
+  464          447.47428    241.18532   0.002155172 
+  454          462.97946    240.97999   0.002202643 
+  443          465.65468    240.77508   0.002257336 
+  466          470.37941    240.5706    0.002145923 
+  482          485.75547    240.36653   0.002074689 
+  521          511.06889    240.16288   0.001919386 
+  590          545.79733    239.95964   0.001694915 
+  615          590.54167    239.75682   0.001626016 
+  691          647.36013    239.55441   0.001447178 
+  721          721.38853    239.35242   0.001386963 
+  903          820.9432     239.15084   0.00110742 
+  1023         958.38866    238.94966   0.000977517 
+  1182         1154.70457   238.7489    0.000846024 
+  1484         1449.93197   238.54855   0.000673854 
+  1960         1928.91602   238.3486    0.000510204 
+  2895         2786.03227   238.14906   0.000345423 
+  4762         4441.03704   237.94992   0.000209996 
+  7782         7441.56767   237.75119   0.000128502 
+  12353        11257.92894  237.55285   0.000080952 
+  16536        14798.0105   237.35493   0.000060474 
+  14658        13412.05837  237.1574    0.000068222 
+  9830         9836.58549   236.96027   0.000101729 
+  8432         8670.22552   236.76354   0.000118596 
+  8985         8954.67248   236.5672    0.000111297 
+  7941         7739.49494   236.37127   0.000125929 
+  4447         4843.37055   236.17572   0.000224871 
+  2552         2939.15077   235.98058   0.00039185 
+  1577         1960.80026   235.78582   0.000634115 
+  1247         1443.2945    235.59146   0.000801925 
+  944          1137.93674   235.39748   0.001059322 
+  791          939.71941    235.2039    0.001264223 
+  737          802.86401    235.01071   0.001356852 
+  591          704.32344    234.8179    0.001692047 
+  592          631.24959    234.62548   0.001689189 
+  562          576.13637    234.43345   0.001779359 
+  474          534.6474     234.2418    0.002109705 
+  498          504.92326    234.05053   0.002008032 
+  473          487.68918    233.85965   0.002114165 
+  434          484.52179    233.66914   0.002304147 
+  459          490.06861    233.47902   0.002178649 
+  421          493.54604    233.28928   0.002375297 
+  403          466.30986    233.09992   0.00248139 
+  449          440.3444     232.91093   0.002227171 
+  398          428.15889    232.72232   0.002512563 
+  423          419.0024     232.53408   0.002364066 
+  338          396.50832    232.34622   0.00295858 
+  366          370.62534    232.15874   0.00273224 
+  314          352.65939    231.97162   0.003184713 
+  325          338.79354    231.78488   0.003076923 
+  296          327.18069    231.5985    0.003378378 
+  288          317.96133    231.4125    0.003472222 
+  295          310.77855    231.22686   0.003389831 
+  271          305.08344    231.04159   0.003690037 
+  274          300.45165    230.85669   0.003649635 
+  262          296.59676    230.67216   0.003816794 
+  287          293.32225    230.48798   0.003484321 
+  264          290.47923    230.30417   0.003787879 
+  275          288.34368    230.12073   0.003636364 
+  292          286.03406    229.93764   0.003424658 
+  269          283.87426    229.75491   0.003717472 
+  272          281.8288     229.57255   0.003676471 
+  278          279.88968    229.39054   0.003597122 
+  261          278.2677     229.20889   0.003831418 
+  225          276.5973     229.0276    0.004444444 
+  268          275.12152    228.84666   0.003731343 
+  271          273.91156    228.66608   0.003690037 
+  264          273.07543    228.48585   0.003787879 
+  244          272.7692     228.30597   0.004098361 
+  252          273.20693    228.12645   0.003968254 
+  208          274.52137    227.94727   0.004807692 
+  219          276.16299    227.76845   0.00456621 
+  262          276.44897    227.58998   0.003816794 
+  271          274.99973    227.41185   0.003690037 
+  277          273.43456    227.23407   0.003610108 
+  273          272.29564    227.05663   0.003663004 
+  284          270.92884    226.87955   0.003521127 
+  244          268.80655    226.7028    0.004098361 
+  252          266.50707    226.5264    0.003968254 
+  245          264.49537    226.35034   0.004081633 
+  268          262.81574    226.17463   0.003731343 
+  276          261.50549    225.99925   0.003623188 
+  266          260.57725    225.82422   0.003759398 
+  255          260.0433     225.64952   0.003921569 
+  251          259.94557    225.47516   0.003984064 
+  261          260.36775    225.30114   0.003831418 
+  223          261.36766    225.12745   0.004484305 
+  252          262.77606    224.9541    0.003968254 
+  233          264.28063    224.78108   0.004291845 
+  260          266.13824    224.6084    0.003846154 
+  284          269.25045    224.43605   0.003521127 
+  263          274.51143    224.26403   0.003802281 
+  299          283.49597    224.09234   0.003344482 
+  300          299.93292    223.92098   0.003333333 
+  310          330.26048    223.74995   0.003225806 
+  348          376.03973    223.57925   0.002873563 
+  383          401.52204    223.40888   0.002610966 
+  391          380.77804    223.23883   0.002557545 
+  415          366.4666     223.06911   0.002409639 
+  391          374.71947    222.89971   0.002557545 
+  375          382.04431    222.73064   0.002666667 
+  358          359.87843    222.56189   0.002793296 
+  338          330.84828    222.39346   0.00295858 
+  338          314.48084    222.22535   0.00295858 
+  300          305.46607    222.05757   0.003333333 
+  285          297.34525    221.8901    0.003508772 
+  304          291.30211    221.72295   0.003289474 
+  299          289.01564    221.55612   0.003344482 
+  292          287.84404    221.38961   0.003424658 
+  328          284.18227    221.22341   0.00304878 
+  290          279.68364    221.05753   0.003448276 
+  284          276.08205    220.89196   0.003521127 
+  284          272.68734    220.7267    0.003521127 
+  227          268.35086    220.56176   0.004405286 
+  251          263.45084    220.39713   0.003984064 
+  264          259.24826    220.23281   0.003787879 
+  249          255.68589    220.06881   0.004016064 
+  242          252.7997     219.90511   0.004132231 
+  260          250.77692    219.74172   0.003846154 
+  234          249.49801    219.57864   0.004273504 
+  240          248.76925    219.41586   0.004166667 
+  202          248.45413    219.25339   0.004950495 
+  227          248.47318    219.09123   0.004405286 
+  251          248.75205    218.92937   0.003984064 
+  230          249.14807    218.76782   0.004347826 
+  239          249.56035    218.60657   0.0041841 
+  233          250.11439    218.44562   0.004291845 
+  227          250.95378    218.28497   0.004405286 
+  266          252.1253     218.12462   0.003759398 
+  244          253.63873    217.96458   0.004098361 
+  223          255.66561    217.80483   0.004484305 
+  268          258.50284    217.64538   0.003731343 
+  251          262.31971    217.48623   0.003984064 
+  260          266.49427    217.32737   0.003846154 
+  243          269.14258    217.16881   0.004115226 
+  276          269.90467    217.01055   0.003623188 
+  232          270.87014    216.85258   0.004310345 
+  250          273.11738    216.6949    0.004     
+  262          276.02246    216.53752   0.003816794 
+  252          278.649      216.38043   0.003968254 
+  314          281.55536    216.22363   0.003184713 
+  283          285.72187    216.06712   0.003533569 
+  270          291.59252    215.9109    0.003703704 
+  293          299.51054    215.75497   0.003412969 
+  293          310.02473    215.59932   0.003412969 
+  350          323.30903    215.44397   0.002857143 
+  308          340.26649    215.2889    0.003246753 
+  311          356.61667    215.13412   0.003215434 
+  332          365.89891    214.97962   0.003012048 
+  360          370.59664    214.82541   0.002777778 
+  367          376.64542    214.67148   0.002724796 
+  355          385.06803    214.51784   0.002816901 
+  396          392.43788    214.36448   0.002525253 
+  384          396.65961    214.2114    0.002604167 
+  396          400.41005    214.0586    0.002525253 
+  399          405.90218    213.90608   0.002506266 
+  420          413.3664     213.75384   0.002380952 
+  393          422.40408    213.60188   0.002544529 
+  417          432.46653    213.45019   0.002398082 
+  459          442.9202     213.29879   0.002178649 
+  461          453.13078    213.14766   0.002169197 
+  519          462.61457    212.9968    0.001926782 
+  512          471.31312    212.84623   0.001953125 
+  494          479.58769    212.69592   0.002024291 
+  460          488.1288     212.54589   0.002173913 
+  474          497.93717    212.39613   0.002109705 
+  456          509.59497    212.24665   0.002192982 
+  458          520.62104    212.09744   0.002183406 
+  555          523.50763    211.94849   0.001801802 
+  526          514.87333    211.79982   0.001901141 
+  443          506.434      211.65142   0.002257336 
+  480          498.65624    211.50329   0.002083333 
+  463          488.35289    211.35542   0.002159827 
+  436          470.54065    211.20782   0.002293578 
+  412          449.20857    211.06049   0.002427184 
+  392          428.54877    210.91343   0.00255102 
+  418          408.5655     210.76663   0.002392344 
+  370          389.28073    210.62009   0.002702703 
+  378          371.05487    210.47382   0.002645503 
+  355          354.26849    210.32781   0.002816901 
+  335          339.1616     210.18207   0.002985075 
+  309          325.80422    210.03659   0.003236246 
+  297          314.14896    209.89137   0.003367003 
+  300          304.07885    209.74641   0.003333333 
+  281          295.45606    209.60171   0.003558719 
+  256          288.15623    209.45726   0.00390625 
+  274          282.10125    209.31308   0.003649635 
+  260          277.28509    209.16916   0.003846154 
+  285          273.7926     209.02549   0.003508772 
+  279          271.72856    208.88208   0.003584229 
+  282          270.77025    208.73893   0.003546099 
+  246          269.2449     208.59603   0.004065041 
+  264          265.52549    208.45339   0.003787879 
+  242          261.05498    208.311     0.004132231 
+  243          257.64591    208.16886   0.004115226 
+  246          255.27904    208.02698   0.004065041 
+  218          252.71757    207.88535   0.004587156 
+  243          249.4384     207.74397   0.004115226 
+  239          246.30572    207.60285   0.0041841 
+  219          243.83425    207.46197   0.00456621 
+  219          241.99737    207.32134   0.00456621 
+  220          240.66325    207.18096   0.004545455 
+  227          239.7091     207.04083   0.004405286 
+  241          239.07683    206.90095   0.004149378 
+  263          238.72828    206.76132   0.003802281 
+  254          238.63938    206.62193   0.003937008 
+  220          238.79281    206.48279   0.004545455 
+  246          239.18106    206.34389   0.004065041 
+  212          239.79809    206.20524   0.004716981 
+  211          240.67906    206.06683   0.004739336 
+  226          241.86919    205.92867   0.004424779 
+  242          243.2349     205.79075   0.004132231 
+  223          243.97159    205.65307   0.004484305 
+  219          243.1403     205.51564   0.00456621 
+  216          241.43201    205.37844   0.00462963 
+  212          239.99097    205.24149   0.004716981 
+  211          239.0313     205.10477   0.004739336 
+  242          238.05516    204.9683    0.004132231 
+  226          236.79432    204.83206   0.004424779 
+  232          235.79971    204.69606   0.004310345 
+  209          235.36581    204.5603    0.004784689 
+  218          234.98882    204.42478   0.004587156 
+  217          234.31856    204.28949   0.004608295 
+  238          234.10894    204.15444   0.004201681 
+  219          235.1478     204.01963   0.00456621 
+  229          237.54064    203.88505   0.004366812 
+  241          240.26267    203.7507    0.004149378 
+  222          241.21926    203.61659   0.004504505 
+  236          240.03667    203.48271   0.004237288 
+  239          238.47349    203.34906   0.0041841 
+  221          237.5348     203.21564   0.004524887 
+  231          237.47434    203.08246   0.004329004 
+  239          237.66026    202.94951   0.0041841 
+  243          237.81125    202.81678   0.004115226 
+  246          237.275      202.68429   0.004065041 
+  218          235.08392    202.55203   0.004587156 
+  220          232.53262    202.41999   0.004545455 
+  218          231.10058    202.28818   0.004587156 
+  240          230.8283     202.1566    0.004166667 
+  237          230.81712    202.02525   0.004219409 
+  257          230.5612     201.89412   0.003891051 
+  226          230.78188    201.76322   0.004424779 
+  241          232.23926    201.63254   0.004149378 
+  238          235.49246    201.50209   0.004201681 
+  271          241.4932     201.37186   0.003690037 
+  246          252.14956    201.24186   0.004065041 
+  273          270.57766    201.11208   0.003663004 
+  328          299.66215    200.98252   0.00304878 
+  317          328.59669    200.85318   0.003154574 
+  339          324.41884    200.72407   0.002949853 
+  329          303.09507    200.59518   0.003039514 
+  324          290.72744    200.4665    0.00308642 
+  331          290.69499    200.33805   0.003021148 
+  328          292.49165    200.20982   0.00304878 
+  319          279.66053    200.0818    0.003134796 
+  300          263.50725    199.954     0.003333333 
+  278          252.27446    199.82642   0.003597122 
+  265          245.89969    199.69906   0.003773585 
+  250          242.6978     199.57192   0.004     
+  275          240.29605    199.44499   0.003636364 
+  253          237.74795    199.31828   0.003952569 
+  269          235.4718     199.19178   0.003717472 
+  252          233.95966    199.0655    0.003968254 
+  240          233.1958     198.93943   0.004166667 
+  249          232.58706    198.81357   0.004016064 
+  253          232.08218    198.68793   0.003952569 
+  259          231.97404    198.5625    0.003861004 
+  234          232.21688    198.43729   0.004273504 
+  219          232.08871    198.31228   0.00456621 
+  226          231.31058    198.18749   0.004424779 
+  213          230.64917    198.06291   0.004694836 
+  232          230.53774    197.93853   0.004310345 
+  210          230.7407     197.81437   0.004761905 
+  192          230.69325    197.69042   0.005208333 
+  204          230.29427    197.56667   0.004901961 
+  223          229.92209    197.44314   0.004484305 
+  203          229.76182    197.31981   0.004926108 
+  218          229.80921    197.19669   0.004587156 
+  214          230.04306    197.07377   0.004672897 
+  203          230.45481    196.95107   0.004926108 
+  228          231.0606     196.82856   0.004385965 
+  202          231.90416    196.70627   0.004950495 
+  235          233.0536     196.58418   0.004255319 
+  196          234.60945    196.46229   0.005102041 
+  228          236.68435    196.34061   0.004385965 
+  246          239.2777     196.21913   0.004065041 
+  226          241.88888    196.09785   0.004424779 
+  219          243.6375     195.97678   0.00456621 
+  241          244.74149    195.85591   0.004149378 
+  251          246.12328    195.73524   0.003984064 
+  249          248.05838    195.61477   0.004016064 
+  255          250.16797    195.4945    0.003921569 
+  244          251.93234    195.37444   0.004098361 
+  217          253.47881    195.25457   0.004608295 
+  251          255.24621    195.1349    0.003984064 
+  218          257.4019     195.01543   0.004587156 
+  244          259.97906    194.89617   0.004098361 
+  268          262.99816    194.77709   0.003731343 
+  260          266.51508    194.65822   0.003846154 
+  261          270.61359    194.53954   0.003831418 
+  253          275.40565    194.42106   0.003952569 
+  272          281.02525    194.30278   0.003676471 
+  279          287.63376    194.18469   0.003584229 
+  246          295.42705    194.0668    0.004065041 
+  300          304.65874    193.9491    0.003333333 
+  292          315.66961    193.8316    0.003424658 
+  326          328.92895    193.71429   0.003067485 
+  339          345.09412    193.59718   0.002949853 
+  347          365.06604    193.48026   0.002881844 
+  369          389.90027    193.36353   0.002710027 
+  403          420.13286    193.24699   0.00248139 
+  442          454.79691    193.13065   0.002262443 
+  481          494.37727    193.0145    0.002079002 
+  540          544.6116     192.89854   0.001851852 
+  601          612.83911    192.78277   0.001663894 
+  630          707.06217    192.66719   0.001587302 
+  703          839.20412    192.5518    0.001422475 
+  901          1031.64722   192.4366    0.001109878 
+  1199         1332.7138    192.32159   0.000834028 
+  1659         1846.49183   192.20676   0.000602773 
+  2525         2821.69775   192.09213   0.00039604 
+  4064         4776.00061   191.97768   0.000246063 
+  6720         8258.63574   191.86343   0.00014881 
+  9481         11063.88769  191.74935   0.000105474 
+  9801         8772.80484   191.63547   0.00010203 
+  6877         5811.96817   191.52177   0.000145412 
+  4840         4836.99271   191.40826   0.000206612 
+  4744         5594.07491   191.29493   0.000210793 
+  5588         6382.602     191.18179   0.000178955 
+  4980         4779.74655   191.06883   0.000200803 
+  3264         2897.65778   190.95606   0.000306373 
+  1997         1824.15415   190.84347   0.000500751 
+  1217         1269.78541   190.73107   0.000821693 
+  897          964.54893    190.61884   0.001114827 
+  688          777.7267     190.5068    0.001453488 
+  617          653.5409     190.39495   0.001620746 
+  563          566.34338    190.28327   0.001776199 
+  506          502.63493    190.17178   0.001976285 
+  400          454.63215    190.06047   0.0025    
+  390          417.58574    189.94934   0.002564103 
+  372          388.47211    189.83838   0.002688172 
+  343          365.29821    189.72761   0.002915452 
+  302          346.74283    189.61702   0.003311258 
+  347          331.94779    189.50661   0.002881844 
+  335          320.42057    189.39638   0.002985075 
+  336          312.00953    189.28632   0.00297619 
+  319          306.9389     189.17645   0.003134796 
+  305          305.78675    189.06675   0.003278689 
+  357          309.06378    188.95723   0.00280112 
+  326          315.05063    188.84789   0.003067485 
+  293          316.64578    188.73872   0.003412969 
+  275          308.95542    188.62973   0.003636364 
+  290          299.00498    188.52091   0.003448276 
+  307          294.01945    188.41228   0.003257329 
+  268          295.06591    188.30381   0.003731343 
+  277          298.83935    188.19552   0.003610108 
+  299          302.15775    188.08741   0.003344482 
+  289          304.54356    187.97947   0.003460208 
+  280          300.49576    187.8717    0.003571429 
+  277          287.80751    187.76411   0.003610108 
+  288          274.87891    187.65669   0.003472222 
+  256          267.224      187.54945   0.00390625 
+  235          263.68718    187.44237   0.004255319 
+  260          258.89504    187.33547   0.003846154 
+  229          249.9346     187.22874   0.004366812 
+  248          240.2078     187.12218   0.004032258 
+  262          232.43777    187.0158    0.003816794 
+  241          226.76249    186.90958   0.004149378 
+  232          222.60246    186.80354   0.004310345 
+  222          219.44612    186.69766   0.004504505 
+  196          216.95295    186.59195   0.005102041 
+  204          214.91125    186.48642   0.004901961 
+  211          213.19109    186.38105   0.004739336 
+  197          211.71077    186.27585   0.005076142 
+  200          210.4151     186.17082   0.005     
+  192          209.27088    186.06596   0.005208333 
+  189          208.25048    185.96127   0.005291005 
+  197          207.33575    185.85674   0.005076142 
+  223          206.51216    185.75238   0.004484305 
+  213          205.7714     185.64819   0.004694836 
+  196          205.10546    185.54416   0.005102041 
+  193          204.51435    185.4403    0.005181347 
+  210          203.98552    185.3366    0.004761905 
+  212          203.52243    185.23308   0.004716981 
+  219          203.12567    185.12971   0.00456621 
+  196          202.79824    185.02651   0.005102041 
+  217          202.54694    184.92348   0.004608295 
+  203          202.38645    184.82061   0.004926108 
+  218          202.33044    184.7179    0.004587156 
+  199          202.39307    184.61536   0.005025126 
+  193          202.52998    184.51298   0.005181347 
+  183          202.55397    184.41077   0.005464481 
+  211          202.38061    184.30871   0.004739336 
+  174          202.17843    184.20682   0.005747126 
+  197          202.1359     184.10509   0.005076142 
+  172          202.29876    184.00353   0.005813953 
+  215          202.60483    183.90212   0.004651163 
+  203          203.01698    183.80088   0.004926108 
+  187          203.64443    183.69979   0.005347594 
+  188          204.68727    183.59887   0.005319149 
+  198          206.35802    183.49811   0.005050505 
+  200          208.96205    183.3975    0.005     
+  221          213.0072     183.29706   0.004524887 
+  200          219.29231    183.19678   0.005     
+  232          228.80853    183.09665   0.004310345 
+  237          241.68761    182.99669   0.004219409 
+  254          253.66492    182.89688   0.003937008 
+  234          255.73375    182.79723   0.004273504 
+  221          248.09348    182.69774   0.004524887 
+  197          240.46572    182.59841   0.005076142 
+  207          237.66231    182.49923   0.004830918 
+  233          238.20594    182.40021   0.004291845 
+  212          236.78453    182.30135   0.004716981 
+  231          231.22172    182.20265   0.004329004 
+  222          225.51423    182.1041    0.004504505 
+  227          222.38983    182.0057    0.004405286 
+  220          222.00106    181.90747   0.004545455 
+  196          223.5032     181.80938   0.005102041 
+  213          224.1235     181.71146   0.004694836 
+  202          221.52451    181.61368   0.004950495 
+  193          217.81028    181.51607   0.005181347 
+  221          215.4673     181.4186    0.004524887 
+  206          214.92424    181.3213    0.004854369 
+  231          215.00883    181.22414   0.004329004 
+  233          214.10195    181.12714   0.004291845 
+  218          212.77033    181.03029   0.004587156 
+  212          212.56383    180.93359   0.004716981 
+  252          214.04861    180.83705   0.003968254 
+  261          216.8827     180.74066   0.003831418 
+  253          220.16786    180.64442   0.003952569 
+  260          224.18685    180.54834   0.003846154 
+  286          230.7765     180.4524    0.003496503 
+  261          240.87558    180.35662   0.003831418 
+  276          252.17049    180.26099   0.003623188 
+  259          258.51873    180.16551   0.003861004 
+  252          257.39483    180.07018   0.003968254 
+  243          255.40361    179.975     0.004115226 
+  274          258.80914    179.87997   0.003649635 
+  299          268.60768    179.78509   0.003344482 
+  282          281.18943    179.69035   0.003546099 
+  285          290.87287    179.59577   0.003508772 
+  286          297.25142    179.50134   0.003496503 
+  289          303.35739    179.40706   0.003460208 
+  300          313.22559    179.31292   0.003333333 
+  304          336.8799     179.21894   0.003289474 
+  333          386.31148    179.1251    0.003003003 
+  442          473.72106    179.03141   0.002262443 
+  449          587.29458    178.93787   0.002227171 
+  552          617.50604    178.84447   0.001811594 
+  477          522.10859    178.75122   0.002096436 
+  435          436.21479    178.65812   0.002298851 
+  397          408.06436    178.56517   0.002518892 
+  381          427.01512    178.47236   0.002624672 
+  373          442.89934    178.3797    0.002680965 
+  340          395.56391    178.28718   0.002941176 
+  304          332.61722    178.19481   0.003289474 
+  295          291.06084    178.10259   0.003389831 
+  228          267.49564    178.01051   0.004385965 
+  260          255.36391    177.91857   0.003846154 
+  232          251.35633    177.82678   0.004310345 
+  241          255.04357    177.73514   0.004149378 
+  267          269.47271    177.64364   0.003745318 
+  288          303.01236    177.55228   0.003472222 
+  371          365.95851    177.46107   0.002695418 
+  408          423.93504    177.37      0.00245098 
+  382          388.6342     177.27907   0.002617801 
+  416          331.02476    177.18829   0.002403846 
+  352          311.00438    177.09765   0.002840909 
+  382          327.48998    177.00716   0.002617801 
+  380          363.01471    176.9168    0.002631579 
+  367          358.921      176.82659   0.002724796 
+  343          311.75575    176.73652   0.002915452 
+  278          274.33404    176.64659   0.003597122 
+  268          253.99276    176.55681   0.003731343 
+  245          245.28515    176.46716   0.004081633 
+  256          239.89858    176.37766   0.00390625 
+  226          231.52093    176.28829   0.004424779 
+  222          221.24586    176.19907   0.004504505 
+  211          213.03245    176.10999   0.004739336 
+  177          208.1147     176.02105   0.005649718 
+  211          204.79319    175.93225   0.004739336 
+  190          202.79702    175.84359   0.005263158 
+  192          201.38594    175.75507   0.005208333 
+  168          200.23575    175.66669   0.005952381 
+  199          199.57121    175.57845   0.005025126 
+  187          199.58397    175.49034   0.005347594 
+  188          200.30187    175.40238   0.005319149 
+  196          201.69677    175.31455   0.005102041 
+  207          203.85878    175.22687   0.004830918 
+  196          207.30495    175.13932   0.005102041 
+  201          212.91827    175.05191   0.004975124 
+  215          221.92047    174.96464   0.004651163 
+  227          235.95413    174.8775    0.004405286 
+  216          256.17286    174.7905    0.00462963 
+  289          278.99772    174.70364   0.003460208 
+  326          290.61542    174.61692   0.003067485 
+  285          281.64457    174.53034   0.003508772 
+  263          265.1565     174.44389   0.003802281 
+  252          254.76561    174.35757   0.003968254 
+  240          252.64315    174.2714    0.004166667 
+  254          252.7912     174.18536   0.003937008 
+  219          245.91437    174.09945   0.00456621 
+  233          232.31277    174.01369   0.004291845 
+  180          219.27463    173.92805   0.005555556 
+  183          209.77461    173.84256   0.005464481 
+  198          203.40994    173.75719   0.005050505 
+  192          199.20674    173.67197   0.005208333 
+  175          196.41695    173.58687   0.005714286 
+  191          194.55858    173.50192   0.005235602 
+  203          193.34111    173.41709   0.004926108 
+  180          192.58964    173.33241   0.005555556 
+  199          192.20345    173.24785   0.005025126 
+  192          192.12958    173.16343   0.005208333 
+  192          192.34835    173.07914   0.005208333 
+  177          192.8353     172.99499   0.005649718 
+  210          193.41       172.91097   0.004761905 
+  180          193.56255    172.82708   0.005555556 
+  184          193.01311    172.74333   0.005434783 
+  188          192.25368    172.65971   0.005319149 
+  203          191.76188    172.57622   0.004926108 
+  198          191.6536     172.49286   0.005050505 
+  187          191.80539    172.40964   0.005347594 
+  203          192.00837    172.32655   0.004926108 
+  211          192.35636    172.24359   0.004739336 
+  197          192.90382    172.16076   0.005076142 
+  209          192.97256    172.07806   0.004784689 
+  205          192.05037    171.9955    0.004878049 
+  246          190.87298    171.91306   0.004065041 
+  231          190.20809    171.83076   0.004329004 
+  226          190.20733    171.74859   0.004424779 
+  246          190.59966    171.66655   0.004065041 
+  284          190.9296     171.58464   0.003521127 
+  254          191.26433    171.50286   0.003937008 
+  284          192.02549    171.42121   0.003521127 
+  304          193.02959    171.33969   0.003289474 
+  285          193.68606    171.2583    0.003508772 
+  262          194.30511    171.17704   0.003816794 
+  263          195.7835     171.09591   0.003802281 
+  259          198.70705    171.01491   0.003861004 
+  275          203.44395    170.93404   0.003636364 
+  272          209.39196    170.8533    0.003676471 
+  248          213.56242    170.77269   0.004032258 
+  264          212.50332    170.6922    0.003787879 
+  250          208.11299    170.61185   0.004     
+  233          204.66043    170.53162   0.004291845 
+  211          203.76957    170.45152   0.004739336 
+  214          204.78625    170.37155   0.004672897 
+  206          205.44249    170.29171   0.004854369 
+  194          204.25999    170.21199   0.005154639 
+  199          202.28517    170.13241   0.005025126 
+  218          200.52686    170.05295   0.004587156 
+  192          199.4234     169.97362   0.005208333 
+  204          198.7969     169.89441   0.004901961 
+  234          198.60481    169.81534   0.004273504 
+  199          199.37138    169.73638   0.005025126 
+  221          201.33802    169.65756   0.004524887 
+  227          204.79747    169.57886   0.004405286 
+  190          210.14438    169.50029   0.005263158 
+  210          216.53825    169.42185   0.004761905 
+  234          220.4505     169.34353   0.004273504 
+  259          218.45029    169.26534   0.003861004 
+  249          213.47243    169.18728   0.004016064 
+  227          209.99652    169.10934   0.004405286 
+  210          209.28196    169.03152   0.004761905 
+  201          210.20133    168.95383   0.004975124 
+  217          209.99205    168.87627   0.004608295 
+  225          207.39744    168.79883   0.004444444 
+  194          204.3425     168.72152   0.005154639 
+  207          202.33665    168.64433   0.004830918 
+  218          201.54561    168.56727   0.004587156 
+  209          201.74649    168.49033   0.004784689 
+  202          202.75657    168.41352   0.004950495 
+  220          204.48791    168.33683   0.004545455 
+  230          206.8714     168.26026   0.004347826 
+  245          209.65923    168.18382   0.004081633 
+  229          212.41326    168.1075    0.004366812 
+  237          215.18393    168.03131   0.004219409 
+  221          218.51554    167.95524   0.004524887 
+  241          222.74549    167.87929   0.004149378 
+  249          227.9437     167.80347   0.004016064 
+  247          233.9885     167.72777   0.004048583 
+  272          240.72848    167.6522    0.003676471 
+  264          248.31832    167.57674   0.003787879 
+  246          257.00222    167.50141   0.004065041 
+  303          266.84151    167.42621   0.00330033 
+  286          277.77759    167.35112   0.003496503 
+  289          289.73998    167.27616   0.003460208 
+  296          302.65636    167.20132   0.003378378 
+  287          316.03609    167.1266    0.003484321 
+  297          327.8535     167.05201   0.003367003 
+  329          335.20015    166.97753   0.003039514 
+  355          338.01018    166.90318   0.002816901 
+  347          339.14412    166.82895   0.002881844 
+  348          340.72929    166.75485   0.002873563 
+  291          340.75244    166.68086   0.003436426 
+  329          336.53546    166.60699   0.003039514 
+  347          328.95656    166.53325   0.002881844 
+  298          319.85742    166.45963   0.003355705 
+  341          310.87655    166.38613   0.002932551 
+  292          303.34152    166.31275   0.003424658 
+  279          296.21893    166.23949   0.003584229 
+  272          288.67222    166.16635   0.003676471 
+  237          281.39942    166.09333   0.004219409 
+  253          274.08827    166.02043   0.003952569 
+  270          266.82559    165.94765   0.003703704 
+  283          260.0037     165.875     0.003533569 
+  242          253.73293    165.80246   0.004132231 
+  227          247.88924    165.73004   0.004405286 
+  248          242.33435    165.65775   0.004032258 
+  208          237.06271    165.58557   0.004807692 
+  248          231.93424    165.51351   0.004032258 
+  233          227.07993    165.44157   0.004291845 
+  246          222.58307    165.36975   0.004065041 
+  196          218.51986    165.29805   0.005102041 
+  233          214.94304    165.22647   0.004291845 
+  236          211.87858    165.15501   0.004237288 
+  215          209.33751    165.08367   0.004651163 
+  207          207.34276    165.01244   0.004830918 
+  216          205.95378    164.94134   0.00462963 
+  202          205.22695    164.87035   0.004950495 
+  211          205.06489    164.79948   0.004739336 
+  218          204.95093    164.72873   0.004587156 
+  215          204.31934    164.6581    0.004651163 
+  205          203.56067    164.58759   0.004878049 
+  197          203.08115    164.5172    0.005076142 
+  225          202.59934    164.44692   0.004444444 
+  218          202.04609    164.37676   0.004587156 
+  218          201.58654    164.30672   0.004587156 
+  210          201.24228    164.23679   0.004761905 
+  252          201.24823    164.16699   0.003968254 
+  238          201.73178    164.0973    0.004201681 
+  217          202.28666    164.02773   0.004608295 
+  245          203.71356    163.95827   0.004081633 
+  237          206.26637    163.88894   0.004219409 
+  257          210.67544    163.81972   0.003891051 
+  284          218.3485     163.75061   0.003521127 
+  281          232.58216    163.68163   0.003558719 
+  286          261.59006    163.61276   0.003496503 
+  315          317.50233    163.544     0.003174603 
+  342          385.10792    163.47537   0.002923977 
+  350          368.8779     163.40685   0.002857143 
+  330          307.12513    163.33844   0.003030303 
+  356          275.54638    163.27016   0.002808989 
+  289          273.89956    163.20199   0.003460208 
+  318          294.13094    163.13393   0.003144654 
+  314          316.66495    163.06599   0.003184713 
+  266          294.00803    162.99817   0.003759398 
+  260          256.35514    162.93046   0.003846154 
+  257          234.7275     162.86287   0.003891051 
+  246          224.60231    162.79539   0.004065041 
+  260          218.81046    162.72803   0.003846154 
+  222          213.8992     162.66078   0.004504505 
+  245          209.97994    162.59365   0.004081633 
+  244          207.46725    162.52664   0.004098361 
+  236          205.94462    162.45974   0.004237288 
+  200          204.78376    162.39295   0.005     
+  201          203.94928    162.32628   0.004975124 
+  225          203.76379    162.25973   0.004444444 
+  213          204.41185    162.19328   0.004694836 
+  215          205.99432    162.12696   0.004651163 
+  256          208.62083    162.06075   0.00390625 
+  241          212.63784    161.99465   0.004149378 
+  249          219.13169    161.92867   0.004016064 
+  254          230.10266    161.8628    0.003937008 
+  248          248.27799    161.79704   0.004032258 
+  274          275.72117    161.7314    0.003649635 
+  312          305.96841    161.66587   0.003205128 
+  328          308.82185    161.60046   0.00304878 
+  297          281.84609    161.53516   0.003367003 
+  288          260.28147    161.46998   0.003472222 
+  281          253.75308    161.4049    0.003558719 
+  246          259.66053    161.33995   0.004065041 
+  260          271.28516    161.2751    0.003846154 
+  290          271.66248    161.21037   0.003448276 
+  251          259.76673    161.14575   0.003984064 
+  279          251.35224    161.08125   0.003584229 
+  259          246.62541    161.01686   0.003861004 
+  223          240.58275    160.95258   0.004484305 
+  243          233.95266    160.88841   0.004115226 
+  243          229.67562    160.82436   0.004115226 
+  247          228.56973    160.76042   0.004048583 
+  213          229.82637    160.69659   0.004694836 
+  258          231.38364    160.63288   0.003875969 
+  219          231.58939    160.56927   0.00456621 
+  250          231.91706    160.50578   0.004     
+  227          235.12934    160.44241   0.004405286 
+  247          243.40469    160.37914   0.004048583 
+  257          257.17167    160.31599   0.003891051 
+  280          267.14889    160.25295   0.003571429 
+  273          260.78154    160.19002   0.003663004 
+  252          250.34095    160.1272    0.003968254 
+  259          245.73791    160.06449   0.003861004 
+  258          247.3286     160.0019    0.003875969 
+  234          253.75229    159.93942   0.004273504 
+  304          259.61073    159.87705   0.003289474 
+  259          257.90388    159.81479   0.003861004 
+  267          254.19586    159.75264   0.003745318 
+  252          253.34345    159.69061   0.003968254 
+  269          255.07896    159.62868   0.003717472 
+  269          258.32215    159.56687   0.003717472 
+  261          262.41564    159.50517   0.003831418 
+  285          267.33272    159.44358   0.003508772 
+  263          273.15679    159.3821    0.003802281 
+  280          279.77501    159.32073   0.003571429 
+  274          287.09367    159.25947   0.003649635 
+  284          295.21154    159.19833   0.003521127 
+  334          304.28394    159.13729   0.002994012 
+  314          314.57154    159.07636   0.003184713 
+  312          326.32225    159.01555   0.003205128 
+  344          339.68041    158.95484   0.002906977 
+  372          354.85255    158.89425   0.002688172 
+  418          372.2434     158.83376   0.002392344 
+  405          392.35941    158.77339   0.002469136 
+  433          415.77415    158.71313   0.002309469 
+  428          443.20631    158.65297   0.002336449 
+  474          475.50901    158.59293   0.002109705 
+  560          513.53602    158.533     0.001785714 
+  639          558.39616    158.47317   0.001564945 
+  714          612.37907    158.41346   0.00140056 
+  789          678.92774    158.35386   0.001267427 
+  855          762.4365     158.29436   0.001169591 
+  962          868.91659    158.23498   0.001039501 
+  930          1007.26195   158.1757    0.001075269 
+  1080         1191.21752   158.11654   0.000925926 
+  1282         1443.41155   158.05748   0.000780031 
+  1577         1802.65316   157.99853   0.000634115 
+  2111         2340.12641   157.9397    0.000473709 
+  2920         3200.61702   157.88097   0.000342466 
+  4387         4709.58102   157.82235   0.000227946 
+  7142         7569.41209   157.76384   0.000140017 
+  12014        12931.50528  157.70544   0.000083236 
+  18270        20579.10162  157.64715   0.000054735 
+  21303        22427.64608  157.58896   0.000046942 
+  16619        15771.92422  157.53089   0.000060172 
+  10785        10302.71646  157.47292   0.000092721 
+  8073         8183.67924   157.41506   0.00012387 
+  8379         8829.49208   157.35732   0.000119346 
+  9888         11577.93633  157.29968   0.000101133 
+  11213        12673.48324  157.24214   0.000089182 
+  9161         9139.55595   157.18472   0.000109158 
+  5706         5587.50377   157.12741   0.000175254 
+  3441         3534.67136   157.0702    0.000290613 
+  2199         2436.77086   157.0131    0.000454752 
+  1582         1818.77536   156.95611   0.000632111 
+  1319         1442.2329    156.89923   0.00075815 
+  1022         1201.11545   156.84245   0.000978474 
+  958          1029.18889   156.78579   0.001043841 
+  801          878.29553    156.72923   0.001248439 
+  723          758.39357    156.67278   0.001383126 
+  640          670.44781    156.61644   0.0015625 
+  597          606.31655    156.5602    0.001675042 
+  592          560.682      156.50407   0.001689189 
+  521          524.75198    156.44805   0.001919386 
+  444          482.75468    156.39214   0.002252252 
+  486          442.64128    156.33633   0.002057613 
+  401          411.14544    156.28064   0.002493766 
+  399          386.22602    156.22505   0.002506266 
+  352          365.7261     156.16956   0.002840909 
+  369          348.3815     156.11419   0.002710027 
+  345          333.46673    156.05892   0.002898551 
+  325          320.51242    156.00375   0.003076923 
+  346          309.17678    155.9487    0.002890173 
+  304          299.20732    155.89375   0.003289474 
+  326          290.41739    155.83891   0.003067485 
+  303          282.66396    155.78418   0.00330033 
+  258          275.82247    155.72955   0.003875969 
+  272          269.78884    155.67503   0.003676471 
+  244          264.47552    155.62061   0.004098361 
+  259          259.79932    155.5663    0.003861004 
+  271          255.68564    155.5121    0.003690037 
+  254          252.06727    155.45801   0.003937008 
+  272          248.89148    155.40402   0.003676471 
+  259          246.15099    155.35014   0.003861004 
+  254          243.92549    155.29636   0.003937008 
+  252          242.40373    155.24269   0.003968254 
+  226          241.70025    155.18913   0.004424779 
+  265          240.83947    155.13567   0.003773585 
+  237          238.07101    155.08232   0.004219409 
+  225          234.6428     155.02907   0.004444444 
+  240          231.92559    154.97593   0.004166667 
+  253          229.98093    154.9229    0.003952569 
+  224          228.7461     154.86997   0.004464286 
+  212          227.85931    154.81715   0.004716981 
+  212          226.27082    154.76443   0.004716981 
+  226          224.05637    154.71182   0.004424779 
+  223          222.06316    154.65931   0.004484305 
+  232          220.45117    154.60691   0.004310345 
+  215          219.19468    154.55462   0.004651163 
+  237          218.26662    154.50243   0.004219409 
+  247          217.61598    154.45034   0.004048583 
+  224          217.17575    154.39836   0.004464286 
+  230          216.86888    154.34649   0.004347826 
+  235          216.6315     154.29472   0.004255319 
+  220          216.41206    154.24306   0.004545455 
+  254          216.17772    154.1915    0.003937008 
+  238          215.93606    154.14004   0.004201681 
+  264          215.74226    154.08869   0.003787879 
+  247          215.60468    154.03745   0.004048583 
+  261          215.26327    153.98631   0.003831418 
+  265          214.15734    153.93528   0.003773585 
+  246          212.4145     153.88435   0.004065041 
+  249          210.85474    153.83352   0.004016064 
+  261          210.03807    153.7828    0.003831418 
+  268          210.03829    153.73218   0.003731343 
+  249          210.16125    153.68167   0.004016064 
+  267          208.83298    153.63126   0.003745318 
+  233          205.67812    153.58096   0.004291845 
+  235          202.24897    153.53076   0.004255319 
+  229          199.70593    153.48067   0.004366812 
+  210          198.2686     153.43068   0.004761905 
+  222          197.6784     153.38079   0.004504505 
+  220          197.28358    153.33101   0.004545455 
+  197          196.628      153.28133   0.005076142 
+  258          196.22856    153.23176   0.003875969 
+  198          196.85847    153.18229   0.005050505 
+  226          198.95968    153.13292   0.004424779 
+  202          202.56247    153.08366   0.004950495 
+  209          206.64414    153.0345    0.004784689 
+  221          209.07473    152.98544   0.004524887 
+  232          209.49005    152.93649   0.004310345 
+  219          209.065      152.88764   0.00456621 
+  192          207.5149     152.8389    0.005208333 
+  231          205.34049    152.79026   0.004329004 
+  198          204.00389    152.74172   0.005050505 
+  241          203.34313    152.69328   0.004149378 
+  210          202.53413    152.64495   0.004761905 
+  204          201.83462    152.59672   0.004901961 
+  204          201.25703    152.5486    0.004901961 
+  224          200.57958    152.50058   0.004464286 
+  195          200.38435    152.45266   0.005128205 
+  219          200.68879    152.40484   0.00456621 
+  194          200.48282    152.35713   0.005154639 
+  190          199.59929    152.30952   0.005263158 
+  203          199.03119    152.26201   0.004926108 
+  195          199.39979    152.21461   0.005128205 
+  215          200.78274    152.16731   0.004651163 
+  198          202.9865     152.12011   0.005050505 
+  199          205.53516    152.07301   0.005025126 
+  195          208.13342    152.02602   0.005128205 
+  225          211.26865    151.97913   0.004444444 
+  208          215.48634    151.93234   0.004807692 
+  223          220.83657    151.88565   0.004484305 
+  209          227.30101    151.83907   0.004784689 
+  229          234.96596    151.79259   0.004366812 
+  228          242.79331    151.74621   0.004385965 
+  280          248.74302    151.69993   0.003571429 
+  259          253.55854    151.65376   0.003861004 
+  278          260.30545    151.60768   0.003597122 
+  279          270.94771    151.56171   0.003584229 
+  287          285.96228    151.51585   0.003484321 
+  304          304.66784    151.47008   0.003289474 
+  299          326.51957    151.42441   0.003344482 
+  326          354.43079    151.37885   0.003067485 
+  352          395.55032    151.33339   0.002840909 
+  407          458.81074    151.28803   0.002457002 
+  564          560.92066    151.24277   0.00177305 
+  666          736.70391    151.19761   0.001501502 
+  998          1062.01422   151.15256   0.001002004 
+  1522         1672.89205   151.10761   0.00065703 
+  2257         2640.2291    151.06275   0.000443066 
+  2778         3223.56509   151.018     0.000359971 
+  2264         2531.33932   150.97335   0.000441696 
+  1539         1686.99408   150.92881   0.000649773 
+  1215         1256.70208   150.88436   0.000823045 
+  1166         1181.78418   150.84001   0.000857633 
+  1298         1409.67035   150.79577   0.000770416 
+  1537         1796.88388   150.75163   0.000650618 
+  1417         1728.09715   150.70758   0.000705716 
+  1107         1211.414     150.66364   0.000903342 
+  799          812.76322    150.6198    0.001251564 
+  522          589.93588    150.57606   0.001915709 
+  457          465.66419    150.53242   0.002188184 
+  329          389.85779    150.48889   0.003039514 
+  290          340.13988    150.44545   0.003448276 
+  259          306.28917    150.40211   0.003861004 
+  293          282.85459    150.35888   0.003412969 
+  262          266.16839    150.31574   0.003816794 
+  251          252.95001    150.27271   0.003984064 
+  232          241.07129    150.22977   0.004310345 
+  225          230.55532    150.18694   0.004444444 
+  227          221.82639    150.1442    0.004405286 
+  187          214.79891    150.10157   0.005347594 
+  238          209.21182    150.05904   0.004201681 
+  201          204.81126    150.0166    0.004975124 
+  204          201.40632    149.97427   0.004901961 
+  216          198.88738    149.93204   0.00462963 
+  184          197.2178     149.8899    0.005434783 
+  186          196.35843    149.84787   0.005376344 
+  197          195.99791    149.80594   0.005076142 
+  203          195.29963    149.7641    0.004926108 
+  187          193.71186    149.72237   0.005347594 
+  203          191.9154     149.68074   0.004926108 
+  203          190.74897    149.6392    0.004926108 
+  208          190.52167    149.59777   0.004807692 
+  180          191.26885    149.55643   0.005555556 
+  192          192.83744    149.5152    0.005208333 
+  200          194.96871    149.47406   0.005     
+  216          197.97447    149.43302   0.00462963 
+  198          203.03651    149.39209   0.005050505 
+  182          211.92895    149.35125   0.005494505 
+  257          227.67593    149.31051   0.003891051 
+  225          255.86428    149.26987   0.004444444 
+  250          304.93024    149.22933   0.004     
+  293          376.19372    149.18889   0.003412969 
+  324          422.244      149.14854   0.00308642 
+  345          382.85134    149.1083    0.002898551 
+  351          318.11501    149.06816   0.002849003 
+  279          278.80702    149.02811   0.003584229 
+  263          267.37296    148.98816   0.003802281 
+  259          279.32836    148.94832   0.003861004 
+  265          304.84751    148.90857   0.003773585 
+  321          308.19174    148.86891   0.003115265 
+  242          273.4218     148.82936   0.004132231 
+  239          237.19442    148.78991   0.0041841 
+  228          213.99329    148.75055   0.004385965 
+  220          200.65014    148.7113    0.004545455 
+  204          192.90215    148.67214   0.004901961 
+  256          188.08507    148.63308   0.00390625 
+  197          185.01348    148.59411   0.005076142 
+  207          183.34823    148.55525   0.004830918 
+  219          182.99103    148.51649   0.00456621 
+  196          183.61144    148.47782   0.005102041 
+  192          184.12552    148.43925   0.005208333 
+  201          183.30636    148.40078   0.004975124 
+  200          181.62091    148.3624    0.005     
+  214          180.39297    148.32413   0.004672897 
+  174          180.2353     148.28595   0.005747126 
+  209          181.22201    148.24787   0.004784689 
+  173          183.10441    148.20988   0.005780347 
+  184          184.75634    148.172     0.005434783 
+  170          184.54264    148.13421   0.005882353 
+  181          182.62594    148.09652   0.005524862 
+  172          180.76901    148.05893   0.005813953 
+  206          180.03862    148.02143   0.004854369 
+  210          180.58763    147.98404   0.004761905 
+  180          182.07581    147.94674   0.005555556 
+  196          183.30404    147.90953   0.005102041 
+  196          182.73488    147.87243   0.005102041 
+  199          180.74304    147.83542   0.005025126 
+  201          178.91608    147.7985    0.004975124 
+  190          178.01073    147.76169   0.005263158 
+  170          178.02959    147.72497   0.005882353 
+  198          178.57877    147.68835   0.005050505 
+  187          178.9054     147.65183   0.005347594 
+  190          178.59126    147.6154    0.005263158 
+  190          178.11647    147.57907   0.005263158 
+  179          178.02396    147.54283   0.005586592 
+  173          178.2996     147.50669   0.005780347 
+  222          178.60716    147.47065   0.004504505 
+  204          178.80353    147.43471   0.004901961 
+  185          179.02871    147.39886   0.005405405 
+  208          179.45186    147.36311   0.004807692 
+  155          180.19389    147.32745   0.006451613 
+  217          181.26216    147.29189   0.004608295 
+  201          182.54796    147.25643   0.004975124 
+  213          183.91254    147.22106   0.004694836 
+  199          185.39235    147.18579   0.005025126 
+  218          187.15843    147.15061   0.004587156 
+  193          189.33426    147.11554   0.005181347 
+  208          192.00184    147.08055   0.004807692 
+  242          195.2301     147.04566   0.004132231 
+  224          198.98482    147.01087   0.004464286 
+  244          202.93283    146.97618   0.004098361 
+  199          206.64896    146.94158   0.005025126 
+  249          210.3945     146.90707   0.004016064 
+  237          214.85682    146.87266   0.004219409 
+  225          220.48854    146.83835   0.004444444 
+  261          227.55289    146.80413   0.003831418 
+  241          236.25753    146.77      0.004149378 
+  266          246.61245    146.73598   0.003759398 
+  281          258.28606    146.70204   0.003558719 
+  317          270.85569    146.66821   0.003154574 
+  354          284.88033    146.63446   0.002824859 
+  319          302.32904    146.60082   0.003134796 
+  358          325.33601    146.56726   0.002793296 
+  337          355.94685    146.53381   0.002967359 
+  378          396.47245    146.50044   0.002645503 
+  436          449.27015    146.46717   0.002293578 
+  509          517.85894    146.434     0.001964637 
+  610          612.63581    146.40092   0.001639344 
+  726          756.49504    146.36794   0.00137741 
+  1042         993.22249    146.33505   0.000959693 
+  1429         1414.33877   146.30225   0.00069979 
+  2211         2199.24407   146.26955   0.000452284 
+  3433         3586.60661   146.23694   0.00029129 
+  4783         5246.80385   146.20443   0.000209074 
+  4650         5185.75404   146.17201   0.000215054 
+  3556         3592.63921   146.13969   0.000281215 
+  2432         2405.28587   146.10746   0.000411184 
+  1817         1889.33772   146.07532   0.000550358 
+  1908         1891.49397   146.04328   0.000524109 
+  2160         2359.37468   146.01133   0.000462963 
+  2635         3029.36919   145.97948   0.000379507 
+  2568         2857.30064   145.94772   0.000389408 
+  1890         1960.4673    145.91605   0.000529101 
+  1175         1272.73577   145.88448   0.000851064 
+  857          884.15108    145.853     0.001166861 
+  620          668.40772    145.82161   0.001612903 
+  510          539.45944    145.79032   0.001960784 
+  435          455.86117    145.75912   0.002298851 
+  415          398.08602    145.72801   0.002409639 
+  367          355.87461    145.697     0.002724796 
+  343          324.07908    145.66608   0.002915452 
+  318          299.7336     145.63525   0.003144654 
+  245          280.69031    145.60452   0.004081633 
+  287          265.61626    145.57388   0.003484321 
+  252          253.67045    145.54333   0.003968254 
+  233          243.94181    145.51288   0.004291845 
+  221          235.62479    145.48252   0.004524887 
+  257          228.32685    145.45225   0.003891051 
+  211          221.79217    145.42207   0.004739336 
+  255          215.89245    145.39198   0.003921569 
+  250          210.5991     145.36199   0.004     
+  207          205.98626    145.33209   0.004830918 
+  218          202.18631    145.30229   0.004587156 
+  198          199.14972    145.27257   0.005050505 
+  230          196.6674     145.24295   0.004347826 
+  204          194.50816    145.21342   0.004901961 
+  205          192.58189    145.18398   0.004878049 
+  179          190.8145     145.15463   0.005586592 
+  194          189.03393    145.12538   0.005154639 
+  221          187.18043    145.09622   0.004524887 
+  186          185.44909    145.06715   0.005376344 
+  194          184.00793    145.03817   0.005154639 
+  190          182.88435    145.00928   0.005263158 
+  203          182.05421    144.98048   0.004926108 
+  198          181.47157    144.95178   0.005050505 
+  178          181.04748    144.92317   0.005617978 
+  203          180.77582    144.89465   0.004926108 
+  202          180.82149    144.86622   0.004950495 
+  220          181.36261    144.83788   0.004545455 
+  193          182.33157    144.80963   0.005181347 
+  213          183.5069     144.78147   0.004694836 
+  191          185.415      144.75341   0.005235602 
+  210          189.82791    144.72543   0.004761905 
+  179          198.08992    144.69755   0.005586592 
+  235          204.04035    144.66976   0.004255319 
+  200          197.63125    144.64205   0.005     
+  214          189.39254    144.61444   0.004672897 
+  196          185.26093    144.58692   0.005102041 
+  184          184.36245    144.55949   0.005434783 
+  195          186.0768     144.53215   0.005128205 
+  204          189.96997    144.5049    0.004901961 
+  202          192.80315    144.47774   0.004950495 
+  198          188.79624    144.45067   0.005050505 
+  209          182.78213    144.42369   0.004784689 
+  190          179.04826    144.3968    0.005263158 
+  167          177.27212    144.37      0.005988024 
+  179          176.63669    144.3433    0.005586592 
+  199          176.44546    144.31668   0.005025126 
+  189          176.09967    144.29015   0.005291005 
+  181          175.48004    144.26371   0.005524862 
+  177          174.89582    144.23736   0.005649718 
+  176          174.56624    144.2111    0.005681818 
+  169          174.53894    144.18493   0.00591716 
+  171          174.81795    144.15884   0.005847953 
+  200          175.44622    144.13285   0.005     
+  192          176.50088    144.10695   0.005208333 
+  201          177.41318    144.08114   0.004975124 
+  184          179.33662    144.05541   0.005434783 
+  187          180.96683    144.02977   0.005347594 
+  186          181.45644    144.00423   0.005376344 
+  181          181.06452    143.97877   0.005524862 
+  184          180.8064     143.9534    0.005434783 
+  192          180.95301    143.92812   0.005208333 
+  203          182.31823    143.90293   0.004926108 
+  181          184.60115    143.87783   0.005524862 
+  201          187.64444    143.85281   0.004975124 
+  232          191.14762    143.82788   0.004310345 
+  191          195.16316    143.80305   0.005235602 
+  193          200.13691    143.7783    0.005181347 
+  212          206.59945    143.75363   0.004716981 
+  186          214.34754    143.72906   0.005376344 
+  240          220.49159    143.70457   0.004166667 
+  243          221.31443    143.68018   0.004115226 
+  210          218.08458    143.65587   0.004761905 
+  200          215.07046    143.63164   0.005     
+  211          214.42528    143.60751   0.004739336 
+  240          216.21902    143.58346   0.004166667 
+  215          219.93316    143.5595    0.004651163 
+  225          224.45113    143.53563   0.004444444 
+  234          227.96793    143.51185   0.004273504 
+  220          230.49509    143.48815   0.004545455 
+  248          234.03755    143.46454   0.004032258 
+  257          239.13085    143.44102   0.003891051 
+  248          243.7036     143.41758   0.004032258 
+  271          246.39755    143.39423   0.003690037 
+  277          249.27138    143.37097   0.003610108 
+  280          254.90155    143.34779   0.003571429 
+  326          264.57219    143.32471   0.003067485 
+  330          278.65282    143.3017    0.003030303 
+  322          296.10301    143.27879   0.00310559 
+  344          313.80839    143.25596   0.002906977 
+  355          330.86943    143.23322   0.002816901 
+  399          352.67099    143.21056   0.002506266 
+  376          379.99565    143.18799   0.002659574 
+  417          406.0896     143.16551   0.002398082 
+  449          436.89334    143.14311   0.002227171 
+  478          467.29062    143.1208    0.00209205 
+  479          500.86238    143.09857   0.002087683 
+  530          552.20379    143.07643   0.001886792 
+  641          631.79602    143.05437   0.001560062 
+  727          751.18803    143.03241   0.001375516 
+  919          926.3728     143.01052   0.001088139 
+  1172         1200.7905    142.98872   0.000853242 
+  1718         1666.89691   142.96701   0.000582072 
+  2589         2511.50649   142.94538   0.00038625 
+  3940         4041.55947   142.92384   0.000253807 
+  5781         6277.26345   142.90238   0.00017298 
+  6455         7314.0287    142.88101   0.000154919 
+  5372         5604.80082   142.85972   0.00018615 
+  3559         3671.92549   142.83852   0.000280978 
+  2554         2611.09117   142.8174    0.000391543 
+  2284         2263.30653   142.79637   0.000437828 
+  2361         2491.44469   142.77542   0.000423549 
+  2886         3270.09343   142.75456   0.0003465 
+  3413         4056.94201   142.73378   0.000292997 
+  3064         3536.27253   142.71308   0.000326371 
+  2244         2359.61277   142.69247   0.000445633 
+  1502         1531.46558   142.67194   0.000665779 
+  1007         1062.81237   142.6515    0.000993049 
+  799          798.91073    142.63114   0.001251564 
+  592          640.40694    142.61086   0.001689189 
+  559          537.69422    142.59067   0.001788909 
+  462          467.2117     142.57056   0.002164502 
+  406          417.00691    142.55054   0.002463054 
+  400          380.29342    142.5306    0.0025    
+  367          352.76768    142.51074   0.002724796 
+  361          331.18998    142.49097   0.002770083 
+  344          313.14074    142.47127   0.002906977 
+  337          297.91259    142.45167   0.002967359 
+  289          285.7536     142.43214   0.003460208 
+  294          276.45432    142.4127    0.003401361 
+  308          269.40777    142.39334   0.003246753 
+  275          264.41199    142.37406   0.003636364 
+  245          261.58498    142.35487   0.004081633 
+  274          260.29767    142.33576   0.003649635 
+  268          258.63093    142.31673   0.003731343 
+  248          254.01009    142.29778   0.004032258 
+  258          246.34238    142.27892   0.003875969 
+  232          238.27077    142.26014   0.004310345 
+  283          231.60234    142.24144   0.003533569 
+  240          226.8941     142.22282   0.004166667 
+  231          224.18025    142.20428   0.004329004 
+  217          222.91334    142.18583   0.004608295 
+  232          221.7152     142.16745   0.004310345 
+  261          219.53449    142.14916   0.003831418 
+  241          217.33124    142.13095   0.004149378 
+  235          216.66881    142.11283   0.004255319 
+  224          218.11767    142.09478   0.004464286 
+  251          221.22269    142.07681   0.003984064 
+  242          224.43835    142.05893   0.004132231 
+  222          224.98067    142.04113   0.004504505 
+  234          221.90772    142.0234    0.004273504 
+  253          218.16668    142.00576   0.003952569 
+  254          216.57845    141.9882    0.003937008 
+  230          218.04008    141.97072   0.004347826 
+  228          222.2737     141.95332   0.004385965 
+  218          227.74582    141.936     0.004587156 
+  228          230.9736     141.91876   0.004385965 
+  236          228.98095    141.9016    0.004237288 
+  217          223.77603    141.88453   0.004608295 
+  210          219.34294    141.86753   0.004761905 
+  210          217.66245    141.85061   0.004761905 
+  200          219.05323    141.83377   0.005     
+  219          222.19721    141.81701   0.00456621 
+  230          223.46063    141.80033   0.004347826 
+  191          220.80265    141.78373   0.005235602 
+  231          215.74604    141.76721   0.004329004 
+  198          210.04251    141.75077   0.005050505 
+  217          204.21842    141.73441   0.004608295 
+  203          199.28836    141.71813   0.004926108 
+  220          196.11037    141.70192   0.004545455 
+  190          193.99627    141.6858    0.005263158 
+  198          191.58269    141.66975   0.005050505 
+  174          189.10499    141.65379   0.005747126 
+  173          187.40912    141.6379    0.005780347 
+  193          186.65229    141.62209   0.005181347 
+  188          186.95122    141.60636   0.005319149 
+  186          188.27367    141.5907    0.005376344 
+  211          188.42635    141.57513   0.004739336 
+  188          184.45751    141.55963   0.005319149 
+  168          178.83248    141.54421   0.005952381 
+  175          174.85601    141.52887   0.005714286 
+  170          173.07477    141.51361   0.005882353 
+  179          173.22728    141.49843   0.005586592 
+  218          174.88008    141.48332   0.004587156 
+  185          176.93745    141.46829   0.005405405 
+  164          177.44076    141.45334   0.006097561 
+  195          176.07984    141.43846   0.005128205 
+  172          175.37719    141.42366   0.005813953 
+  210          176.53237    141.40894   0.004761905 
+  188          178.35026    141.3943    0.005319149 
+  150          178.44618    141.37973   0.006666667 
+  168          175.62453    141.36524   0.005952381 
+  174          171.58298    141.35083   0.005747126 
+  154          168.07096    141.33649   0.006493506 
+  156          165.81161    141.32223   0.006410256 
+  171          164.90844    141.30804   0.005847953 
+  199          164.98183    141.29393   0.005025126 
+  187          165.14524    141.2799    0.005347594 
+  162          164.08804    141.26595   0.00617284 
+  166          161.79526    141.25206   0.006024096 
+  164          159.35615    141.23826   0.006097561 
+  163          157.42562    141.22453   0.006134969 
+  145          156.0848     141.21088   0.006896552 
+  159          155.23885    141.1973    0.006289308 
+  159          154.80218    141.1838    0.006289308 
+  153          154.7356     141.17037   0.006535948 
+  180          155.0395     141.15702   0.005555556 
+  158          155.74766    141.14374   0.006329114 
+  171          156.83849    141.13054   0.005847953 
+  175          157.93766    141.11741   0.005714286 
+  149          158.19717    141.10436   0.006711409 
+  161          157.27411    141.09138   0.00621118 
+  177          155.91891    141.07848   0.005649718 
+  156          154.86355    141.06565   0.006410256 
+  144          154.32182    141.05289   0.006944444 
+  151          154.19362    141.04021   0.006622517 
+  175          154.35004    141.0276    0.005714286 
+  170          154.52228    141.01507   0.005882353 
+  160          154.29901    141.00261   0.00625   
+  184          153.64208    140.99023   0.005434783 
+  151          152.94038    140.97792   0.006622517 
+  169          152.39075    140.96568   0.00591716 
+  166          151.90291    140.95351   0.006024096 
+  138          151.41361    140.94142   0.007246377 
+  163          150.97487    140.9294    0.006134969 
+  176          150.66704    140.91746   0.005681818 
+  172          150.51133    140.90558   0.005813953 
+  164          150.49738    140.89378   0.006097561 
+  157          150.5988     140.88205   0.006369427 
+  130          150.76466    140.8704    0.007692308 
+  182          150.93785    140.85882   0.005494505 
+  156          151.15063    140.84731   0.006410256 
+  127          151.48579    140.83587   0.007874016 
+  157          151.99826    140.8245    0.006369427 
+  145          152.7052     140.81321   0.006896552 
+  141          153.60866    140.80199   0.007092199 
+  157          154.76205    140.79084   0.006369427 
+  146          156.35991    140.77976   0.006849315 
+  175          158.69356    140.76875   0.005714286 
+  187          161.99768    140.75782   0.005347594 
+  170          166.10108    140.74695   0.005882353 
+  199          169.79236    140.73616   0.005025126 
+  169          171.35575    140.72543   0.00591716 
+  187          171.06809    140.71478   0.005347594 
+  205          170.72476    140.7042    0.004878049 
+  175          170.90561    140.69369   0.005714286 
+  162          170.87671    140.68325   0.00617284 
+  171          170.39949    140.67288   0.005847953 
+  164          170.1396     140.66259   0.006097561 
+  189          170.01058    140.65236   0.005291005 
+  147          169.34781    140.6422    0.006802721 
+  168          168.53327    140.63211   0.005952381 
+  193          168.48356    140.62209   0.005181347 
+  171          169.32071    140.61214   0.005847953 
+  164          170.52166    140.60226   0.006097561 
+  180          171.73474    140.59245   0.005555556 
+  182          172.63657    140.58271   0.005494505 
+  159          172.88502    140.57304   0.006289308 
+  165          173.13136    140.56344   0.006060606 
+  180          174.13036    140.55391   0.005555556 
+  191          175.33615    140.54444   0.005235602 
+  161          175.71657    140.53505   0.00621118 
+  169          175.7017     140.52572   0.00591716 
+  190          176.49074    140.51646   0.005263158 
+  197          178.5052     140.50727   0.005076142 
+  184          181.91717    140.49815   0.005434783 
+  187          187.71093    140.4891    0.005347594 
+  200          197.55944    140.48011   0.005     
+  190          213.58084    140.4712    0.005263158 
+  214          239.01359    140.46235   0.004672897 
+  239          276.87787    140.45356   0.0041841 
+  259          315.09376    140.44485   0.003861004 
+  223          314.41799    140.4362    0.004484305 
+  255          277.52237    140.42762   0.003921569 
+  234          244.6901     140.41911   0.004273504 
+  223          228.01171    140.41066   0.004484305 
+  198          225.52339    140.40228   0.005050505 
+  233          235.04053    140.39397   0.004291845 
+  232          254.2685     140.38573   0.004310345 
+  254          272.76854    140.37755   0.003937008 
+  246          268.74963    140.36944   0.004065041 
+  230          245.56703    140.36139   0.004347826 
+  212          225.64284    140.35341   0.004716981 
+  238          215.65683    140.3455    0.004201681 
+  222          214.22712    140.33765   0.004504505 
+  221          219.11175    140.32987   0.004524887 
+  198          227.89681    140.32215   0.005050505 
+  217          239.36605    140.3145    0.004608295 
+  261          256.72846    140.30691   0.003831418 
+  289          287.41366    140.29939   0.003460208 
+  276          334.12589    140.29194   0.003623188 
+  348          369.41987    140.28455   0.002873563 
+  296          350.66552    140.27722   0.003378378 
+  313          307.10995    140.26996   0.003194888 
+  277          278.41766    140.26277   0.003610108 
+  257          270.93329    140.25563   0.003891051 
+  262          284.21702    140.24857   0.003816794 
+  298          319.79485    140.24156   0.003355705 
+  310          370.47812    140.23463   0.003225806 
+  315          393.86715    140.22775   0.003174603 
+  318          355.23747    140.22094   0.003144654 
+  266          296.69019    140.21419   0.003759398 
+  232          254.37616    140.20751   0.004310345 
+  228          231.13883    140.20089   0.004385965 
+  231          222.50961    140.19433   0.004329004 
+  204          225.27998    140.18784   0.004901961 
+  215          234.59413    140.18141   0.004651163 
+  211          235.64628    140.17504   0.004739336 
+  196          219.52656    140.16874   0.005102041 
+  196          200.12262    140.1625    0.005102041 
+  202          186.01059    140.15632   0.004950495 
+  186          177.00688    140.1502    0.005376344 
+  182          171.38102    140.14415   0.005494505 
+  188          167.73152    140.13815   0.005319149 
+  163          165.17704    140.13222   0.006134969 
+  193          163.36919    140.12635   0.005181347 
+  168          162.24193    140.12055   0.005952381 
+  163          161.80289    140.1148    0.006134969 
+  152          161.95291    140.10912   0.006578947 
+  208          162.72413    140.1035    0.004807692 
+  177          164.06712    140.09794   0.005649718 
+  163          165.90802    140.09244   0.006134969 
+  170          168.23718    140.087     0.005882353 
+  172          171.72639    140.08162   0.005813953 
+  186          176.36947    140.0763    0.005376344 
+  175          181.94536    140.07105   0.005714286 
+  189          187.96179    140.06585   0.005291005 
+  178          194.54155    140.06071   0.005617978 
+  180          204.89057    140.05564   0.005555556 
+  181          223.09529    140.05062   0.005524862 
+  196          236.71537    140.04567   0.005102041 
+  195          223.31307    140.04077   0.005128205 
+  191          203.56041    140.03594   0.005235602 
+  165          192.6002     140.03116   0.006060606 
+  195          188.64609    140.02644   0.005128205 
+  192          188.6589     140.02178   0.005208333 
+  190          192.26894    140.01718   0.005263158 
+  192          200.99126    140.01264   0.005208333 
+  179          210.64692    140.00816   0.005586592 
+  198          207.67959    140.00374   0.005050505 
+  192          198.26174    139.99938   0.005208333 
+  175          193.4956     139.99507   0.005714286 
+  213          194.59937    139.99082   0.004694836 
+  217          201.74322    139.98663   0.004608295 
+  217          217.28773    139.9825    0.004608295 
+  261          247.01641    139.97843   0.003831418 
+  315          300.24349    139.97442   0.003174603 
+  365          378.13591    139.97046   0.002739726 
+  418          424.27422    139.96656   0.002392344 
+  386          375.18104    139.96271   0.002590674 
+  306          304.83253    139.95893   0.003267974 
+  272          261.63888    139.9552    0.003676471 
+  256          242.67175    139.95153   0.00390625 
+  228          241.78079    139.94791   0.004385965 
+  275          258.66637    139.94435   0.003636364 
+  293          294.69535    139.94085   0.003412969 
+  291          331.36453    139.93741   0.003436426 
+  308          324.47279    139.93402   0.003246753 
+  238          290.02064    139.93068   0.004201681 
+  229          259.0581     139.92741   0.004366812 
+  201          236.13939    139.92419   0.004975124 
+  219          220.88476    139.92102   0.00456621 
+  191          212.0846     139.91791   0.005235602 
+  186          208.7892     139.91486   0.005376344 
+  170          209.98125    139.91186   0.005882353 
+  207          212.95763    139.90891   0.004830918 
+  196          213.84561    139.90602   0.005102041 
+  204          211.51037    139.90319   0.004901961 
+  182          209.51111    139.90041   0.005494505 
+  187          212.18126    139.89768   0.005347594 
+  187          215.44456    139.89501   0.005347594 
+  165          207.07991    139.8924    0.006060606 
+  168          194.98341    139.88983   0.005952381 
+  180          187.44239    139.88733   0.005555556 
+  194          183.20005    139.88487   0.005154639 
+  206          180.99036    139.88247   0.004854369 
+  193          181.57338    139.88012   0.005181347 
+  189          186.22223    139.87783   0.005291005 
+  170          194.26085    139.87559   0.005882353 
+  182          199.03278    139.8734    0.005494505 
+  194          198.10784    139.87127   0.005154639 
+  191          194.13907    139.86919   0.005235602 
+  175          187.36802    139.86716   0.005714286 
+  172          180.25869    139.86518   0.005813953 
+  183          174.85196    139.86326   0.005464481 
+  206          171.46954    139.86139   0.004854369 
+  182          169.92896    139.85957   0.005494505 
+  186          170.04425    139.8578    0.005376344 
+  151          171.04631    139.85609   0.006622517 
+  145          171.14562    139.85443   0.006896552 
+  152          168.96559    139.85281   0.006578947 
+  170          165.38018    139.85125   0.005882353 
+  166          161.9353     139.84975   0.006024096 
+  170          159.17541    139.84829   0.005882353 
+  164          157.03022    139.84688   0.006097561 
+  140          155.3904     139.84553   0.007142857 
+  161          154.17969    139.84422   0.00621118 
+  176          153.31303    139.84297   0.005681818 
+  164          152.71414    139.84176   0.006097561 
+  165          152.31923    139.84061   0.006060606 
+  171          152.09272    139.83951   0.005847953 
+  142          152.02237    139.83845   0.007042254 
+  174          152.11489    139.83745   0.005747126 
+  154          152.38366    139.8365    0.006493506 
+  161          152.83742    139.83559   0.00621118 
+  142          153.4405     139.83474   0.007042254 
+  138          154.10799    139.83394   0.007246377 
+  155          154.82187    139.83318   0.006451613 
+  130          155.6779     139.83247   0.007692308 
+  143          156.66863    139.83182   0.006993007 
+  162          157.55019    139.83121   0.00617284 
+  176          158.23373    139.83065   0.005681818 
+  142          159.09767    139.83013   0.007042254 
+  175          160.57225    139.82967   0.005714286 
+  168          162.78131    139.82926   0.005952381 
+  166          165.38774    139.82889   0.006024096 
+  166          167.45478    139.82857   0.006024096 
+  170          168.14857    139.8283    0.005882353 
+  147          167.91069    139.82807   0.006802721 
+  144          167.76708    139.8279    0.006944444 
+  165          168.37752    139.82777   0.006060606 
+  166          170.06397    139.82769   0.006024096 
+  168          172.98197    139.82765   0.005952381 
+  171          177.14284    139.82766   0.005847953 
+  208          182.06958    139.82772   0.004807692 
+  164          186.79951    139.82783   0.006097561 
+  165          190.41089    139.82798   0.006060606 
+  176          191.34853    139.82818   0.005681818 
+  171          188.7972     139.82842   0.005847953 
+  201          184.45569    139.82871   0.004975124 
+  178          180.61963    139.82905   0.005617978 
+  143          178.26945    139.82943   0.006993007 
+  175          177.42506    139.82986   0.005714286 
+  175          177.71614    139.83033   0.005714286 
+  161          178.6748     139.83085   0.00621118 
+  165          179.52031    139.83141   0.006060606 
+  171          179.12899    139.83202   0.005847953 
+  166          177.29106    139.83268   0.006024096 
+  164          175.15041    139.83337   0.006097561 
+  170          173.63147    139.83412   0.005882353 
+  191          173.01863    139.8349    0.005235602 
+  150          173.30997    139.83574   0.006666667 
+  172          174.44418    139.83661   0.005813953 
+  176          176.28364    139.83753   0.005681818 
+  164          178.4618     139.8385    0.006097561 
+  185          180.50448    139.8395    0.005405405 
+  207          182.45799    139.84055   0.004830918 
+  148          184.86461    139.84165   0.006756757 
+  201          187.99362    139.84279   0.004975124 
+  164          191.45337    139.84397   0.006097561 
+  177          194.33657    139.84519   0.005649718 
+  173          196.10749    139.84646   0.005780347 
+  158          196.99651    139.84777   0.006329114 
+  181          197.83246    139.84912   0.005524862 
+  194          198.39735    139.85051   0.005154639 
+  174          199.12748    139.85195   0.005747126 
+  177          200.7397     139.85343   0.005649718 
+  199          203.54693    139.85495   0.005025126 
+  183          207.27608    139.85651   0.005464481 
+  203          211.09381    139.85812   0.004926108 
+  195          214.79391    139.85976   0.005128205 
+  193          218.86103    139.86145   0.005181347 
+  203          224.31255    139.86318   0.004926108 
+  215          233.06956    139.86495   0.004651163 
+  233          249.57868    139.86676   0.004291845 
+  248          281.18679    139.86861   0.004032258 
+  311          335.48108    139.8705    0.003215434 
+  333          398.05368    139.87243   0.003003003 
+  358          400.07649    139.87441   0.002793296 
+  315          338.00545    139.87642   0.003174603 
+  239          281.80359    139.87847   0.0041841 
+  273          248.78427    139.88057   0.003663004 
+  230          233.01345    139.8827    0.004347826 
+  213          230.16418    139.88487   0.004694836 
+  210          240.17998    139.88708   0.004761905 
+  251          263.89975    139.88933   0.003984064 
+  274          286.57061    139.89163   0.003649635 
+  255          272.80834    139.89396   0.003921569 
+  224          236.70029    139.89632   0.004464286 
+  204          208.51719    139.89873   0.004901961 
+  179          191.29772    139.90118   0.005586592 
+  181          181.01046    139.90366   0.005524862 
+  173          174.5693     139.90619   0.005780347 
+  163          170.25501    139.90875   0.006134969 
+  160          167.16897    139.91135   0.00625   
+  164          164.84476    139.91398   0.006097561 
+  198          163.1041     139.91666   0.005050505 
+  155          161.92335    139.91937   0.006451613 
+  144          161.31528    139.92212   0.006944444 
+  150          161.31065    139.92491   0.006666667 
+  177          161.91483    139.92773   0.005649718 
+  175          162.9251     139.9306    0.005714286 
+  170          163.68246    139.93349   0.005882353 
+  144          163.43104    139.93643   0.006944444 
+  149          162.44649    139.9394    0.006711409 
+  176          161.70499    139.94241   0.005681818 
+  141          161.09546    139.94546   0.007092199 
+  168          159.53157    139.94854   0.005952381 
+  159          157.98322    139.95165   0.006289308 
+  159          157.28858    139.95481   0.006289308 
+  163          157.24094    139.958     0.006134969 
+  149          157.30791    139.96122   0.006711409 
+  189          157.07767    139.96448   0.005291005 
+  137          156.74155    139.96777   0.00729927 
+  156          156.70508    139.9711    0.006410256 
+  175          156.71071    139.97447   0.005714286 
+  149          156.2994     139.97787   0.006711409 
+  191          156.16081    139.98131   0.005235602 
+  164          156.62619    139.98478   0.006097561 
+  149          157.24023    139.98828   0.006711409 
+  154          157.21148    139.99182   0.006493506 
+  154          156.25713    139.99539   0.006493506 
+  168          154.88539    139.999     0.005952381 
+  157          153.65504    140.00264   0.006369427 
+  157          152.77551    140.00631   0.006369427 
+  133          152.26927    140.01002   0.007518797 
+  167          152.13209    140.01376   0.005988024 
+  131          152.2906     140.01754   0.007633588 
+  164          152.48635    140.02134   0.006097561 
+  163          152.34051    140.02518   0.006134969 
+  149          151.75273    140.02906   0.006711409 
+  154          150.99981    140.03296   0.006493506 
+  163          150.36248    140.0369    0.006134969 
+  163          149.952      140.04088   0.006134969 
+  162          149.7697     140.04488   0.00617284 
+  157          149.76528    140.04892   0.006369427 
+  144          149.8318     140.05298   0.006944444 
+  143          149.83121    140.05708   0.006993007 
+  152          149.73773    140.06122   0.006578947 
+  137          149.6577     140.06538   0.00729927 
+  164          149.683      140.06957   0.006097561 
+  152          149.84574    140.0738    0.006578947 
+  129          150.15221    140.07806   0.007751938 
+  133          150.60291    140.08235   0.007518797 
+  152          151.26579    140.08667   0.006578947 
+  166          151.88963    140.09102   0.006024096 
+  155          152.42751    140.0954    0.006451613 
+  154          152.83319    140.09981   0.006493506 
+  158          153.21666    140.10425   0.006329114 
+  148          153.69529    140.10872   0.006756757 
+  146          154.3254     140.11322   0.006849315 
+  173          155.13196    140.11775   0.005780347 
+  160          156.15385    140.12232   0.00625   
+  165          157.49015    140.12691   0.006060606 
+  153          159.2958     140.13153   0.006535948 
+  174          161.84296    140.13618   0.005747126 
+  171          165.48127    140.14086   0.005847953 
+  180          171.07743    140.14557   0.005555556 
+  195          179.94156    140.1503    0.005128205 
+  201          193.48621    140.15507   0.004975124 
+  199          210.2615     140.15986   0.005025126 
+  208          219.13659    140.16469   0.004807692 
+  190          210.15304    140.16954   0.005263158 
+  175          194.71178    140.17442   0.005714286 
+  187          183.37611    140.17933   0.005347594 
+  162          177.32274    140.18426   0.00617284 
+  158          175.47414    140.18923   0.006329114 
+  186          177.24118    140.19422   0.005376344 
+  169          182.65232    140.19924   0.00591716 
+  175          190.93177    140.20429   0.005714286 
+  172          196.91083    140.20936   0.005813953 
+  195          194.88209    140.21446   0.005128205 
+  167          189.59759    140.21959   0.005988024 
+  167          185.93112    140.22475   0.005988024 
+  210          183.17269    140.22993   0.004761905 
+  172          180.0148     140.23514   0.005813953 
+  157          176.81341    140.24037   0.006369427 
+  170          174.14946    140.24563   0.005882353 
+  173          172.10464    140.25092   0.005780347 
+  155          170.90375    140.25623   0.006451613 
+  174          170.90067    140.26157   0.005747126 
+  194          172.17345    140.26694   0.005154639 
+  181          174.29342    140.27233   0.005524862 
+  184          176.32333    140.27775   0.005434783 
+  181          177.73739    140.28319   0.005524862 
+  161          179.27665    140.28866   0.00621118 
+  186          181.87636    140.29415   0.005376344 
+  163          185.39507    140.29967   0.006134969 
+  166          188.44778    140.30521   0.006024096 
+  196          189.67475    140.31078   0.005102041 
+  179          189.82878    140.31637   0.005586592 
+  164          190.85075    140.32198   0.006097561 
+  175          194.39728    140.32762   0.005714286 
+  205          202.90449    140.33329   0.004878049 
+  211          220.43286    140.33898   0.004739336 
+  248          251.22884    140.34469   0.004032258 
+  321          288.50022    140.35043   0.003115265 
+  289          295.60385    140.35619   0.003460208 
+  260          263.30415    140.36197   0.003846154 
+  222          229.94332    140.36778   0.004504505 
+  212          209.30511    140.37361   0.004716981 
+  193          199.11465    140.37946   0.005181347 
+  191          196.45649    140.38534   0.005235602 
+  194          200.25825    140.39124   0.005154639 
+  220          210.84467    140.39716   0.004545455 
+  214          226.41392    140.40311   0.004672897 
+  231          231.65572    140.40907   0.004329004 
+  209          215.06486    140.41506   0.004784689 
+  193          194.66775    140.42108   0.005181347 
+  179          180.96143    140.42711   0.005586592 
+  171          173.13785    140.43317   0.005847953 
+  168          168.91439    140.43924   0.005952381 
+  164          166.59544    140.44534   0.006097561 
+  169          165.10443    140.45147   0.00591716 
+  169          164.00489    140.45761   0.00591716 
+  152          163.13108    140.46377   0.006578947 
+  157          162.55399    140.46996   0.006369427 
+  175          162.5818     140.47616   0.005714286 
+  185          163.32761    140.48239   0.005405405 
+  150          164.5399     140.48864   0.006666667 
+  158          165.68527    140.49491   0.006329114 
+  167          166.39469    140.5012    0.005988024 
+  167          167.07639    140.50751   0.005988024 
+  160          168.63953    140.51384   0.00625   
+  179          171.80275    140.52019   0.005586592 
+  178          176.80052    140.52656   0.005617978 
+  187          183.07732    140.53295   0.005347594 
+  170          189.00654    140.53936   0.005882353 
+  166          192.40588    140.54579   0.006024096 
+  163          191.49983    140.55224   0.006134969 
+  189          186.55691    140.55871   0.005291005 
+  183          180.24065    140.5652    0.005464481 
+  164          175.03149    140.57171   0.006097561 
+  180          171.91095    140.57824   0.005555556 
+  183          170.89452    140.58478   0.005464481 
+  147          171.51871    140.59135   0.006802721 
+  161          172.82899    140.59793   0.00621118 
+  158          173.53711    140.60454   0.006329114 
+  152          172.54653    140.61116   0.006578947 
+  163          169.6061     140.6178    0.006134969 
+  169          165.74147    140.62445   0.00591716 
+  145          162.21039    140.63113   0.006896552 
+  149          159.53223    140.63782   0.006711409 
+  174          157.68149    140.64454   0.005747126 
+  139          156.47607    140.65127   0.007194245 
+  160          155.74119    140.65801   0.00625   
+  149          155.31479    140.66478   0.006711409 
+  146          155.05951    140.67156   0.006849315 
+  179          154.93243    140.67836   0.005586592 
+  150          154.99391    140.68518   0.006666667 
+  142          155.33074    140.69201   0.007042254 
+  161          156.01436    140.69886   0.00621118 
+  157          157.15869    140.70573   0.006369427 
+  146          158.7588     140.71261   0.006849315 
+  162          160.90152    140.71951   0.00617284 
+  174          163.4258     140.72643   0.005747126 
+  146          165.80034    140.73337   0.006849315 
+  169          167.48678    140.74032   0.00591716 
+  184          168.57174    140.74728   0.005434783 
+  152          169.42268    140.75427   0.006578947 
+  161          170.02439    140.76127   0.00621118 
+  173          170.4775     140.76828   0.005780347 
+  177          171.55577    140.77531   0.005649718 
+  186          174.23522    140.78236   0.005376344 
+  178          179.33325    140.78942   0.005617978 
+  202          187.87885    140.79649   0.004950495 
+  178          201.25204    140.80359   0.005617978 
+  196          220.4373     140.81069   0.005102041 
+  201          240.30732    140.81782   0.004975124 
+  208          244.55453    140.82495   0.004807692 
+  218          230.19978    140.83211   0.004587156 
+  188          213.52825    140.83927   0.005319149 
+  200          201.62915    140.84645   0.005     
+  177          193.61896    140.85365   0.005649718 
+  174          188.77997    140.86086   0.005747126 
+  213          187.71241    140.86809   0.004694836 
+  171          191.15572    140.87532   0.005847953 
+  190          198.4576     140.88258   0.005263158 
+  202          203.81903    140.88985   0.004950495 
+  182          199.60904    140.89713   0.005494505 
+  172          190.10952    140.90442   0.005813953 
+  208          182.07193    140.91173   0.004807692 
+  172          176.24422    140.91905   0.005813953 
+  179          171.71683    140.92639   0.005586592 
+  174          168.20818    140.93374   0.005747126 
+  171          165.70133    140.9411    0.005847953 
+  167          164.06072    140.94847   0.005988024 
+  183          163.09359    140.95586   0.005464481 
+  165          162.6315     140.96326   0.006060606 
+  173          162.55292    140.97068   0.005780347 
+  170          162.76341    140.97811   0.005882353 
+  161          163.19559    140.98555   0.00621118 
+  155          163.83506    140.993     0.006451613 
+  173          164.70856    141.00046   0.005780347 
+  183          165.85084    141.00794   0.005464481 
+  212          167.30172    141.01543   0.004716981 
+  187          169.11364    141.02293   0.005347594 
+  169          171.35607    141.03045   0.00591716 
+  160          174.11116    141.03797   0.00625   
+  166          177.42617    141.04551   0.006024096 
+  196          181.22369    141.05306   0.005102041 
+  180          185.30302    141.06062   0.005555556 
+  156          189.70461    141.06819   0.006410256 
+  213          194.89361    141.07578   0.004694836 
+  222          201.42307    141.08337   0.004504505 
+  201          209.77222    141.09098   0.004975124 
+  224          220.69237    141.0986    0.004464286 
+  223          235.52631    141.10623   0.004484305 
+  256          256.3455     141.11387   0.00390625 
+  295          286.44334    141.12152   0.003389831 
+  328          331.38985    141.12918   0.00304878 
+  420          400.41655    141.13686   0.002380952 
+  552          511.21028    141.14454   0.001811594 
+  736          698.80051    141.15223   0.001358696 
+  1060         998.9354     141.15994   0.000943396 
+  1253         1337.19473   141.16765   0.000798085 
+  1260         1380.96591   141.17538   0.000793651 
+  986          1076.26632   141.18312   0.001014199 
+  739          769.88651    141.19086   0.00135318 
+  603          580.75384    141.19862   0.001658375 
+  508          484.56209    141.20639   0.001968504 
+  493          451.24022    141.21416   0.002028398 
+  508          469.38112    141.22195   0.001968504 
+  574          546.34817    141.22974   0.00174216 
+  669          688.60405    141.23755   0.001494768 
+  749          824.87904    141.24536   0.001335113 
+  706          780.62811    141.25319   0.001416431 
+  558          602.44897    141.26102   0.001792115 
+  391          450.96417    141.26887   0.002557545 
+  376          355.83488    141.27672   0.002659574 
+  298          298.70329    141.28458   0.003355705 
+  278          263.08217    141.29245   0.003597122 
+  220          239.498      141.30033   0.004545455 
+  195          222.99555    141.30822   0.005128205 
+  187          211.04495    141.31612   0.005347594 
+  180          202.16508    141.32402   0.005555556 
+  176          195.3653     141.33194   0.005681818 
+  184          190.14811    141.33986   0.005434783 
+  198          186.14766    141.34779   0.005050505 
+  189          182.766      141.35574   0.005291005 
+  182          179.43481    141.36368   0.005494505 
+  191          176.09319    141.37164   0.005235602 
+  168          172.95269    141.37961   0.005952381 
+  179          170.14443    141.38758   0.005586592 
+  170          167.7632     141.39556   0.005882353 
+  186          165.85154    141.40355   0.005376344 
+  163          164.3773     141.41155   0.006134969 
+  152          163.27529    141.41956   0.006578947 
+  154          162.44987    141.42757   0.006493506 
+  187          161.76881    141.43559   0.005347594 
+  164          161.14394    141.44362   0.006097561 
+  198          160.6182     141.45166   0.005050505 
+  158          160.27888    141.45971   0.006329114 
+  144          160.15314    141.46776   0.006944444 
+  168          160.19784    141.47582   0.005952381 
+  177          160.33699    141.48388   0.005649718 
+  145          160.5222     141.49196   0.006896552 
+  172          160.76568    141.50004   0.005813953 
+  194          161.10152    141.50813   0.005154639 
+  180          161.60223    141.51622   0.005555556 
+  158          162.40446    141.52433   0.006329114 
+  153          163.66721    141.53244   0.006535948 
+  167          165.57458    141.54055   0.005988024 
+  152          168.3902     141.54868   0.006578947 
+  146          172.51983    141.55681   0.006849315 
+  186          178.57146    141.56494   0.005376344 
+  180          187.38406    141.57309   0.005555556 
+  200          199.6713     141.58124   0.005     
+  182          213.54984    141.5894    0.005494505 
+  198          220.77086    141.59756   0.005050505 
+  169          215.87495    141.60573   0.00591716 
+  186          205.46877    141.61391   0.005376344 
+  180          195.61675    141.62209   0.005555556 
+  178          188.1655     141.63028   0.005617978 
+  190          183.62311    141.63847   0.005263158 
+  169          182.07586    141.64668   0.00591716 
+  159          183.50533    141.65488   0.006289308 
+  163          187.8861     141.6631    0.006134969 
+  160          194.06399    141.67132   0.00625   
+  178          197.83072    141.67954   0.005617978 
+  152          196.45818    141.68778   0.006578947 
+  182          193.27142    141.69601   0.005494505 
+  197          191.11557    141.70426   0.005076142 
+  182          190.01318    141.71251   0.005494505 
+  202          188.38127    141.72076   0.004950495 
+  175          184.91297    141.72902   0.005714286 
+  196          180.35279    141.73729   0.005102041 
+  158          176.29336    141.74556   0.006329114 
+  170          173.55349    141.75384   0.005882353 
+  189          172.22713    141.76213   0.005291005 
+  168          172.18245    141.77042   0.005952381 
+  192          173.36079    141.77871   0.005208333 
+  200          175.74301    141.78701   0.005     
+  168          179.01338    141.79532   0.005952381 
+  195          182.35094    141.80363   0.005128205 
+  194          185.00655    141.81194   0.005154639 
+  154          186.93141    141.82026   0.006493506 
+  185          188.01113    141.82859   0.005405405 
+  145          187.46134    141.83692   0.006896552 
+  177          184.95542    141.84526   0.005649718 
+  172          181.66448    141.8536    0.005813953 
+  209          179.02122    141.86195   0.004784689 
+  179          177.55197    141.8703    0.005586592 
+  191          177.00583    141.87866   0.005235602 
+  178          176.97946    141.88702   0.005617978 
+  183          177.4124     141.89539   0.005464481 
+  182          178.31983    141.90376   0.005494505 
+  182          179.34429    141.91214   0.005494505 
+  151          179.83043    141.92052   0.006622517 
+  183          179.42652    141.92891   0.005464481 
+  182          178.62477    141.9373    0.005494505 
+  202          178.18104    141.9457    0.004950495 
+  184          178.41913    141.9541    0.005434783 
+  189          179.24663    141.96251   0.005291005 
+  197          180.46687    141.97092   0.005076142 
+  196          182.07563    141.97934   0.005102041 
+  231          184.23949    141.98776   0.004329004 
+  192          187.11518    141.99619   0.005208333 
+  226          190.82426    142.00462   0.004424779 
+  203          195.50887    142.01305   0.004926108 
+  196          201.36028    142.02149   0.005102041 
+  207          208.64182    142.02994   0.004830918 
+  232          217.6666     142.03838   0.004310345 
+  250          228.76356    142.04684   0.004     
+  241          242.36398    142.0553    0.004149378 
+  259          259.43492    142.06376   0.003861004 
+  280          281.87877    142.07223   0.003571429 
+  316          312.63973    142.0807    0.003164557 
+  385          356.26852    142.08918   0.002597403 
+  463          420.58375    142.09766   0.002159827 
+  535          519.92295    142.10614   0.001869159 
+  740          680.4151     142.11463   0.001351351 
+  1059         945.07835    142.12313   0.000944287 
+  1429         1363.07036   142.13163   0.00069979 
+  1767         1871.53784   142.14013   0.000565931 
+  1831         2050.82832   142.14864   0.00054615 
+  1567         1669.88943   142.15715   0.000638162 
+  1118         1188.91144   142.16567   0.000894454 
+  886          864.19694    142.17419   0.001128668 
+  697          684.15201    142.18272   0.00143472 
+  633          601.89281    142.19125   0.001579779 
+  642          591.83869    142.19978   0.001557632 
+  754          652.39243    142.20832   0.00132626 
+  860          798.63362    142.21687   0.001162791 
+  979          1023.60171   142.22542   0.00102145 
+  1110         1171.69304   142.23397   0.000900901 
+  953          1033.18064   142.24253   0.001049318 
+  725          767.25943    142.25109   0.00137931 
+  560          561.88965    142.25966   0.001785714 
+  429          433.77526    142.26823   0.002331002 
+  362          356.21168    142.2768    0.002762431 
+  307          307.62291    142.28538   0.003257329 
+  260          275.25096    142.29397   0.003846154 
+  233          252.28281    142.30256   0.004291845 
+  246          235.27664    142.31115   0.004065041 
+  231          222.41585    142.31975   0.004329004 
+  235          212.56774    142.32836   0.004255319 
+  226          204.95291    142.33696   0.004424779 
+  212          199.05084    142.34558   0.004716981 
+  201          194.50244    142.35419   0.004975124 
+  173          191.07261    142.36282   0.005780347 
+  231          188.57966    142.37144   0.004329004 
+  214          186.83039    142.38007   0.004672897 
+  203          185.61478    142.38871   0.004926108 
+  184          184.70064    142.39735   0.005434783 
+  170          183.69259    142.406     0.005882353 
+  212          182.20706    142.41465   0.004716981 
+  211          180.40633    142.4233    0.004739336 
+  173          178.85861    142.43196   0.005780347 
+  171          177.69454    142.44063   0.005847953 
+  167          176.90356    142.4493    0.005988024 
+  202          176.45179    142.45798   0.004950495 
+  168          176.54714    142.46666   0.005952381 
+  168          177.49361    142.47534   0.005952381 
+  190          179.56353    142.48403   0.005263158 
+  189          182.99233    142.49273   0.005291005 
+  180          187.88697    142.50143   0.005555556 
+  177          193.98161    142.51013   0.005649718 
+  212          202.14551    142.51884   0.004716981 
+  183          215.25393    142.52756   0.005464481 
+  217          233.36133    142.53628   0.004608295 
+  209          247.36916    142.54501   0.004784689 
+  249          243.36787    142.55374   0.004016064 
+  219          226.77307    142.56248   0.00456621 
+  257          212.04496    142.57122   0.003891051 
+  213          204.06074    142.57997   0.004694836 
+  191          202.48858    142.58872   0.005235602 
+  208          206.04063    142.59748   0.004807692 
+  199          212.41758    142.60625   0.005025126 
+  215          217.92373    142.61502   0.004651163 
+  202          220.92998    142.6238    0.004950495 
+  235          223.13268    142.63258   0.004255319 
+  214          220.84666    142.64137   0.004672897 
+  193          211.07984    142.65016   0.005181347 
+  195          199.85028    142.65896   0.005128205 
+  205          191.503      142.66777   0.004878049 
+  178          186.34464    142.67658   0.005617978 
+  197          183.91152    142.6854    0.005076142 
+  185          183.6239     142.69422   0.005405405 
+  180          183.91674    142.70305   0.005555556 
+  212          182.3418     142.71189   0.004716981 
+  192          178.98041    142.72073   0.005208333 
+  172          175.89633    142.72958   0.005813953 
+  184          174.04642    142.73844   0.005434783 
+  195          173.40142    142.7473    0.005128205 
+  166          173.58246    142.75617   0.006024096 
+  182          174.16692    142.76505   0.005494505 
+  182          174.89548    142.77393   0.005494505 
+  162          175.58837    142.78282   0.00617284 
+  188          176.01701    142.79172   0.005319149 
+  177          176.15405    142.80062   0.005649718 
+  175          176.08202    142.80953   0.005714286 
+  190          175.57704    142.81845   0.005263158 
+  175          174.51578    142.82737   0.005714286 
+  176          173.32324    142.8363    0.005681818 
+  187          172.52453    142.84524   0.005347594 
+  169          172.32465    142.85419   0.00591716 
+  200          172.65919    142.86314   0.005     
+  163          173.35299    142.8721    0.006134969 
+  199          174.19504    142.88107   0.005025126 
+  179          175.02958    142.89005   0.005586592 
+  196          175.87594    142.89903   0.005102041 
+  191          176.74097    142.90803   0.005235602 
+  191          177.48339    142.91703   0.005235602 
+  205          178.07903    142.92604   0.004878049 
+  186          178.65943    142.93505   0.005376344 
+  220          179.28725    142.94408   0.004545455 
+  196          180.02068    142.95311   0.005102041 
+  209          181.00198    142.96215   0.004784689 
+  206          182.36308    142.97121   0.004854369 
+  196          184.16219    142.98026   0.005102041 
+  222          186.42834    142.98933   0.004504505 
+  215          189.18791    142.99841   0.004651163 
+  215          192.4805     143.00749   0.004651163 
+  247          196.3627     143.01659   0.004048583 
+  238          200.88958    143.02569   0.004201681 
+  229          206.10783    143.03481   0.004366812 
+  215          212.11193    143.04393   0.004651163 
+  265          219.14717    143.05306   0.003773585 
+  245          227.60457    143.0622    0.004081633 
+  262          237.98956    143.07135   0.003816794 
+  270          250.96597    143.08051   0.003703704 
+  296          267.49272    143.08968   0.003378378 
+  311          289.02038    143.09886   0.003215434 
+  347          317.7387     143.10806   0.002881844 
+  367          356.67927    143.11726   0.002724796 
+  410          408.83869    143.12647   0.002439024 
+  478          473.22793    143.13569   0.00209205 
+  570          545.04989    143.14492   0.001754386 
+  673          636.85728    143.15416   0.001485884 
+  864          785.4866     143.16342   0.001157407 
+  1176         1040.7799    143.17268   0.00085034 
+  1591         1469.97885   143.18196   0.000628536 
+  2277         2124.23272   143.19125   0.000439174 
+  2707         2811.85291   143.20054   0.000369413 
+  2660         2885.03584   143.20985   0.00037594 
+  2154         2267.63005   143.21917   0.000464253 
+  1581         1620.25316   143.22851   0.000632511 
+  1202         1198.00127   143.23785   0.000831947 
+  1007         960.31867    143.24721   0.000993049 
+  904          847.31486    143.25658   0.001106195 
+  929          831.96824    143.26596   0.001076426 
+  945          908.65358    143.27535   0.001058201 
+  1218         1084.65359   143.28476   0.000821018 
+  1352         1368.7377    143.29418   0.000739645 
+  1443         1647.85084   143.30361   0.000693001 
+  1467         1597.1411    143.31305   0.000681663 
+  1239         1237.50699   143.32251   0.000807103 
+  940          892.79602    143.33198   0.00106383 
+  672          663.38773    143.34146   0.001488095 
+  612          523.69813    143.35096   0.001633987 
+  512          439.84656    143.36047   0.001953125 
+  373          389.42495    143.37      0.002680965 
+  351          357.10374    143.37954   0.002849003 
+  341          329.5133     143.38909   0.002932551 
+  315          301.64415    143.39865   0.003174603 
+  302          277.64907    143.40824   0.003311258 
+  300          259.76411    143.41783   0.003333333 
+  278          247.22261    143.42744   0.003597122 
+  229          238.55068    143.43707   0.004366812 
+  257          232.49181    143.44671   0.003891051 
+  243          227.41128    143.45637   0.004115226 
+  236          222.12616    143.46604   0.004237288 
+  230          216.62444    143.47572   0.004347826 
+  212          211.48416    143.48543   0.004716981 
+  193          206.85488    143.49515   0.005181347 
+  213          202.64579    143.50488   0.004694836 
+  210          199.03914    143.51463   0.004761905 
+  203          196.35411    143.5244    0.004926108 
+  204          194.7182     143.53418   0.004901961 
+  197          194.19504    143.54398   0.005076142 
+  190          194.47956    143.5538    0.005263158 
+  176          194.98216    143.56363   0.005681818 
+  186          194.97261    143.57349   0.005376344 
+  209          194.12347    143.58335   0.004784689 
+  206          192.68764    143.59324   0.004854369 
+  187          191.15398    143.60315   0.005347594 
+  195          189.8639     143.61307   0.005128205 
+  181          188.95556    143.62301   0.005524862 
+  186          188.51912    143.63297   0.005376344 
+  191          188.91589    143.64295   0.005235602 
+  199          190.79306    143.65294   0.005025126 
+  186          194.49699    143.66296   0.005376344 
+  212          198.37609    143.673     0.004716981 
+  177          197.87605    143.68305   0.005649718 
+  202          193.0425     143.69312   0.004950495 
+  174          187.91701    143.70322   0.005747126 
+  177          184.0866     143.71333   0.005649718 
+  178          181.64273    143.72346   0.005617978 
+  154          180.28238    143.73362   0.006493506 
+  161          179.69746    143.74379   0.00621118 
+  188          179.84499    143.75399   0.005319149 
+  192          180.96951    143.76421   0.005208333 
+  172          183.30409    143.77444   0.005813953 
+  163          186.28183    143.7847    0.006134969 
+  184          187.67089    143.79498   0.005434783 
+  191          186.67411    143.80529   0.005235602 
+  181          184.62894    143.81561   0.005524862 
+  155          181.9105     143.82596   0.006451613 
+  183          178.85244    143.83633   0.005464481 
+  177          176.06965    143.84672   0.005649718 
+  194          173.93001    143.85714   0.005154639 
+  180          172.49977    143.86757   0.005555556 
+  172          171.73393    143.87804   0.005813953 
+  187          171.59264    143.88852   0.005347594 
+  180          172.06844    143.89903   0.005555556 
+  167          173.14732    143.90956   0.005988024 
+  179          174.69688    143.92012   0.005586592 
+  160          176.33237    143.93071   0.00625   
+  193          177.48894    143.94131   0.005181347 
+  161          177.75474    143.95194   0.00621118 
+  185          177.16783    143.9626    0.005405405 
+  163          176.31122    143.97329   0.006134969 
+  185          175.92351    143.98399   0.005405405 
+  184          176.409      143.99473   0.005434783 
+  157          177.68563    144.00549   0.006369427 
+  167          179.11958    144.01628   0.005988024 
+  165          179.72635    144.02709   0.006060606 
+  160          179.051      144.03793   0.00625   
+  175          177.66243    144.0488    0.005714286 
+  203          176.369      144.0597    0.004926108 
+  186          175.45969    144.07062   0.005376344 
+  150          174.83074    144.08157   0.006666667 
+  167          174.49442    144.09255   0.005988024 
+  193          174.69449    144.10356   0.005181347 
+  184          175.64496    144.1146    0.005434783 
+  167          177.35707    144.12567   0.005988024 
+  200          179.53039    144.13676   0.005     
+  210          181.51481    144.14789   0.004761905 
+  206          182.71808    144.15904   0.004854369 
+  202          183.13463    144.17023   0.004950495 
+  204          183.09705    144.18145   0.004901961 
+  217          182.89645    144.19269   0.004608295 
+  216          182.86609    144.20397   0.00462963 
+  172          183.32418    144.21528   0.005813953 
+  187          184.44063    144.22662   0.005347594 
+  199          186.2779     144.23799   0.005025126 
+  214          188.85995    144.2494    0.004672897 
+  196          192.13478    144.26083   0.005102041 
+  216          195.95285    144.2723    0.00462963 
+  229          200.23811    144.28381   0.004366812 
+  230          205.1658     144.29534   0.004347826 
+  237          211.10339    144.30691   0.004219409 
+  233          218.49133    144.31851   0.004291845 
+  242          227.92154    144.33015   0.004132231 
+  252          240.19308    144.34182   0.003968254 
+  278          256.30527    144.35353   0.003597122 
+  291          277.62136    144.36527   0.003436426 
+  322          306.251      144.37705   0.00310559 
+  363          346.01185    144.38886   0.002754821 
+  413          404.68891    144.40071   0.002421308 
+  579          496.81405    144.41259   0.001727116 
+  751          646.46908    144.42451   0.001331558 
+  955          885.84239    144.43647   0.00104712 
+  1227         1220.8889    144.44847   0.000814996 
+  1441         1499.99488   144.4605    0.000693963 
+  1292         1433.01933   144.47257   0.000773994 
+  1144         1110.90967   144.48468   0.000874126 
+  847          818.11003    144.49683   0.001180638 
+  722          630.46942    144.50901   0.001385042 
+  581          525.68614    144.52124   0.00172117 
+  510          477.49929    144.5335    0.001960784 
+  515          472.18152    144.54581   0.001941748 
+  542          506.59522    144.55815   0.001845018 
+  612          582.568      144.57054   0.001633987 
+  764          704.20136    144.58296   0.001308901 
+  808          850.15401    144.59543   0.001237624 
+  785          896.99275    144.60794   0.001273885 
+  726          764.47332    144.62049   0.00137741 
+  583          584.16419    144.63308   0.001715266 
+  431          449.86172    144.64571   0.002320186 
+  364          364.80592    144.65839   0.002747253 
+  331          312.87248    144.67111   0.003021148 
+  323          281.56348    144.68388   0.003095975 
+  309          263.13202    144.69668   0.003236246 
+  305          251.61074    144.70954   0.003278689 
+  264          240.54952    144.72243   0.003787879 
+  256          227.36871    144.73537   0.00390625 
+  232          215.07867    144.74836   0.004310345 
+  250          205.91678    144.76139   0.004     
+  199          200.07386    144.77447   0.005025126 
+  207          196.85169    144.7876    0.004830918 
+  210          194.04969    144.80077   0.004761905 
+  205          189.18603    144.81399   0.004878049 
+  176          183.66592    144.82726   0.005681818 
+  195          179.23747    144.84057   0.005128205 
+  212          176.0064     144.85393   0.004716981 
+  167          173.6641     144.86734   0.005988024 
+  165          171.95592    144.8808    0.006060606 
+  203          170.75045    144.89431   0.004926108 
+  192          170.03892    144.90787   0.005208333 
+  210          169.79427    144.92148   0.004761905 
+  178          170.37598    144.93514   0.005617978 
+  166          171.41374    144.94885   0.006024096 
+  170          171.67603    144.96261   0.005882353 
+  158          170.49346    144.97643   0.006329114 
+  160          168.97895    144.99029   0.00625   
+  201          167.83802    145.00421   0.004975124 
+  184          167.17158    145.01818   0.005434783 
+  176          166.96397    145.03221   0.005681818 
+  154          167.18067    145.04629   0.006493506 
+  157          167.69318    145.06042   0.006369427 
+  143          168.12304    145.07461   0.006993007 
+  167          168.12895    145.08885   0.005988024 
+  180          167.44612    145.10315   0.005555556 
+  175          166.38172    145.1175    0.005714286 
+  171          165.35714    145.13191   0.005847953 
+  184          164.56941    145.14637   0.005434783 
+  153          164.07886    145.1609    0.006535948 
+  156          163.94212    145.17548   0.006410256 
+  167          164.22013    145.19012   0.005988024 
+  174          164.98094    145.20481   0.005747126 
+  177          166.27559    145.21957   0.005649718 
+  178          168.07062    145.23438   0.005617978 
+  187          170.14754    145.24925   0.005347594 
+  176          172.01273    145.26419   0.005681818 
+  165          172.97686    145.27918   0.006060606 
+  167          172.54555    145.29424   0.005988024 
+  160          170.98225    145.30935   0.00625   
+  165          169.19508    145.32453   0.006060606 
+  165          167.99158    145.33977   0.006060606 
+  177          167.76842    145.35507   0.005649718 
+  158          168.56719    145.37044   0.006329114 
+  161          169.87861    145.38587   0.00621118 
+  162          170.50391    145.40136   0.00617284 
+  172          169.94955    145.41692   0.005813953 
+  161          169.22405    145.43254   0.00621118 
+  160          169.04712    145.44823   0.00625   
+  166          169.19501    145.46399   0.006024096 
+  160          169.08463    145.47981   0.00625   
+  177          168.40782    145.49569   0.005649718 
+  165          167.32871    145.51165   0.006060606 
+  174          166.25387    145.52767   0.005747126 
+  152          165.51669    145.54376   0.006578947 
+  151          165.22024    145.55992   0.006622517 
+  181          165.11606    145.57615   0.005524862 
+  167          164.61552    145.59244   0.005988024 
+  166          163.58806    145.60881   0.006024096 
+  164          162.62095    145.62525   0.006097561 
+  180          162.12959    145.64176   0.005555556 
+  171          162.16733    145.65834   0.005847953 
+  163          162.62825    145.67499   0.006134969 
+  179          163.37209    145.69172   0.005586592 
+  144          164.35903    145.70852   0.006944444 
+  167          165.69706    145.72539   0.005988024 
+  158          167.4698     145.74234   0.006329114 
+  168          169.49142    145.75936   0.005952381 
+  165          171.17278    145.77645   0.006060606 
+  177          171.7905     145.79362   0.005649718 
+  148          171.0706     145.81087   0.006756757 
+  189          169.27518    145.82819   0.005291005 
+  183          166.95639    145.84559   0.005464481 
+  149          164.73134    145.86307   0.006711409 
+  158          162.993      145.88063   0.006329114 
+  160          161.86784    145.89826   0.00625   
+  155          161.34733    145.91598   0.006451613 
+  174          161.38969    145.93377   0.005747126 
+  158          161.92823    145.95165   0.006329114 
+  150          162.80083    145.9696    0.006666667 
+  168          163.67885    145.98764   0.005952381 
+  179          164.17728    146.00576   0.005586592 
+  167          164.14369    146.02396   0.005988024 
+  150          163.7026     146.04224   0.006666667 
+  171          163.12764    146.06061   0.005847953 
+  176          162.711      146.07906   0.005681818 
+  175          162.58756    146.09759   0.005714286 
+  167          162.67639    146.11621   0.005988024 
+  163          162.78135    146.13492   0.006134969 
+  176          162.81715    146.15371   0.005681818 
+  157          162.89028    146.17259   0.006369427 
+  159          163.1307     146.19155   0.006289308 
+  170          163.60049    146.21061   0.005882353 
+  178          164.3209     146.22975   0.005617978 
+  156          165.24012    146.24898   0.006410256 
+  141          166.17674    146.2683    0.007092199 
+  170          166.72875    146.28771   0.005882353 
+  167          166.69078    146.30721   0.005988024 
+  169          165.67857    146.32681   0.00591716 
+  167          164.3757     146.34649   0.005988024 
+  150          163.15644    146.36627   0.006666667 
+  193          162.1558     146.38614   0.005181347 
+  173          161.43591    146.4061    0.005780347 
+  141          161.02164    146.42616   0.007092199 
+  161          160.89775    146.44631   0.00621118 
+  180          161.04624    146.46656   0.005555556 
+  165          161.42398    146.4869    0.006060606 
+  160          161.94546    146.50734   0.00625   
+  173          162.44441    146.52788   0.005780347 
+  171          162.70487    146.54851   0.005847953 
+  159          162.71297    146.56925   0.006289308 
+  176          162.6786     146.59008   0.005681818 
+  167          162.70649    146.61101   0.005988024 
+  148          162.73245    146.63204   0.006756757 
+  141          162.32879    146.65318   0.007092199 
+  168          161.62005    146.67441   0.005952381 
+  148          160.81855    146.69575   0.006756757 
+  144          160.13798    146.71719   0.006944444 
+  202          159.71277    146.73873   0.004950495 
+  156          159.60001    146.76037   0.006410256 
+  167          159.80617    146.78212   0.005988024 
+  151          160.30203    146.80398   0.006622517 
+  182          161.01374    146.82594   0.005494505 
+  150          161.81301    146.84801   0.006666667 
+  165          162.54111    146.87018   0.006060606 
+  151          163.0418     146.89247   0.006622517 
+  147          163.24273    146.91486   0.006802721 
+  145          163.17889    146.93736   0.006896552 
+  151          162.87072    146.95997   0.006622517 
+  162          162.30573    146.98269   0.00617284 
+  141          161.58313    147.00552   0.007092199 
+  151          160.90312    147.02846   0.006622517 
+  160          160.43096    147.05152   0.00625   
+  162          160.24167    147.07468   0.00617284 
+  165          160.32647    147.09796   0.006060606 
+  156          160.62022    147.12136   0.006410256 
+  166          161.04103    147.14487   0.006024096 
+  143          161.53736    147.1685    0.006993007 
+  183          162.09373    147.19224   0.005464481 
+  150          162.637      147.2161    0.006666667 
+  159          162.92596    147.24008   0.006289308 
+  152          162.70286    147.26417   0.006578947 
+  162          162.00562    147.28839   0.00617284 
+  157          161.13009    147.31272   0.006369427 
+  161          160.34382    147.33717   0.00621118 
+  152          159.76697    147.36175   0.006578947 
+  158          159.24875    147.38645   0.006329114 
+  156          159.11934    147.41127   0.006410256 
+  158          159.1741     147.43621   0.006329114 
+  161          159.38078    147.46128   0.00621118 
+  155          159.70094    147.48647   0.006451613 
+  164          160.07085    147.51179   0.006097561 
+  156          160.38969    147.53723   0.006410256 
+  157          160.56511    147.5628    0.006369427 
+  160          160.60218    147.5885    0.00625   
+  142          160.59846    147.61432   0.007042254 
+  152          160.60189    147.64028   0.006578947 
+  166          160.52813    147.66636   0.006024096 
+  161          160.63267    147.69257   0.00621118 
+  187          160.92462    147.71892   0.005347594 
+  160          161.4474     147.7454    0.00625   
+  159          162.22126    147.77201   0.006289308 
+  179          163.24813    147.79875   0.005586592 
+  160          164.47399    147.82563   0.00625   
+  159          165.72798    147.85264   0.006289308 
+  188          166.73155    147.87979   0.005319149 
+  155          167.30525    147.90707   0.006451613 
+  160          167.59386    147.93449   0.00625   
+  162          167.93535    147.96205   0.00617284 
+  176          168.58917    147.98975   0.005681818 
+  158          169.69778    148.01758   0.006329114 
+  170          171.33679    148.04556   0.005882353 
+  172          173.4433     148.07368   0.005813953 
+  173          175.75773    148.10194   0.005780347 
+  176          177.68652    148.13034   0.005681818 
+  184          179.05705    148.15888   0.005434783 
+  167          179.9256     148.18757   0.005988024 
+  159          179.56547    148.21641   0.006289308 
+  166          178.02304    148.24539   0.006024096 
+  173          176.21605    148.27451   0.005780347 
+  189          174.79332    148.30379   0.005291005 
+  179          173.98912    148.33321   0.005586592 
+  163          173.82728    148.36278   0.006134969 
+  184          174.26784    148.39249   0.005434783 
+  187          175.23741    148.42236   0.005347594 
+  192          176.62151    148.45238   0.005208333 
+  178          178.17027    148.48256   0.005617978 
+  204          179.4974     148.51288   0.004901961 
+  204          180.56461    148.54336   0.004901961 
+  181          181.25774    148.57399   0.005524862 
+  188          181.40363    148.60478   0.005319149 
+  204          181.43778    148.63573   0.004901961 
+  206          181.91208    148.66683   0.004854369 
+  215          183.06215    148.69809   0.004651163 
+  177          184.89902    148.7295    0.005649718 
+  207          187.27727    148.76108   0.004830918 
+  220          189.83722    148.79282   0.004545455 
+  200          192.05171    148.82472   0.005     
+  199          193.63525    148.85678   0.005025126 
+  188          194.86182    148.889     0.005319149 
+  206          196.25352    148.92138   0.004854369 
+  204          198.1629     148.95394   0.004901961 
+  201          200.77796    148.98665   0.004975124 
+  223          204.23964    149.01953   0.004484305 
+  242          208.67054    149.05258   0.004132231 
+  219          214.15133    149.0858    0.00456621 
+  229          220.67044    149.11919   0.004366812 
+  240          228.13143    149.15274   0.004166667 
+  233          236.49069    149.18647   0.004291845 
+  274          245.93461    149.22036   0.003649635 
+  275          256.91235    149.25443   0.003636364 
+  289          270.23152    149.28868   0.003460208 
+  320          287.18739    149.32309   0.003125  
+  320          309.55727    149.35768   0.003125  
+  387          339.78639    149.39245   0.002583979 
+  389          381.6203     149.42739   0.002570694 
+  465          441.30515    149.46252   0.002150538 
+  599          529.64468    149.49782   0.001669449 
+  799          664.84518    149.5333    0.001251564 
+  1036         875.62293    149.56896   0.000965251 
+  1283         1196.97309   149.6048    0.000779423 
+  1721         1625.58404   149.64082   0.000581058 
+  1972         1979.30241   149.67703   0.000507099 
+  1771         1927.79254   149.71342   0.000564653 
+  1496         1536.42432   149.74999   0.000668449 
+  1227         1139.38255   149.78675   0.000814996 
+  920          862.17651    149.8237    0.001086957 
+  786          691.21875    149.86083   0.001272265 
+  664          593.33451    149.89816   0.001506024 
+  586          545.62118    149.93567   0.001706485 
+  604          537.45861    149.97337   0.001655629 
+  662          568.6932     150.01127   0.001510574 
+  769          648.37784    150.04936   0.00130039 
+  853          790.50253    150.08764   0.001172333 
+  1043         988.81054    150.12611   0.000958773 
+  1111         1144.38031   150.16478   0.00090009 
+  958          1094.02664   150.20365   0.001043841 
+  885          883.3603     150.24272   0.001129944 
+  670          676.73475    150.28198   0.001492537 
+  537          530.40661    150.32144   0.001862197 
+  482          435.2409     150.3611    0.002074689 
+  383          373.55674    150.40096   0.002610966 
+  367          332.45629    150.44103   0.002724796 
+  363          303.92601    150.48129   0.002754821 
+  291          283.29399    150.52176   0.003436426 
+  281          267.82413    150.56244   0.003558719 
+  293          255.85288    150.60332   0.003412969 
+  273          246.36471    150.64441   0.003663004 
+  245          238.76067    150.68571   0.004081633 
+  241          232.64973    150.72722   0.004149378 
+  237          227.70324    150.76893   0.004219409 
+  235          223.60799    150.81086   0.004255319 
+  221          220.04078    150.853     0.004524887 
+  224          216.68241    150.89535   0.004464286 
+  216          213.36189    150.93792   0.00462963 
+  205          210.13199    150.9807    0.004878049 
+  204          207.12951    151.0237    0.004901961 
+  221          204.43799    151.06691   0.004524887 
+  214          202.07623    151.11035   0.004672897 
+  207          200.03378    151.154     0.004830918 
+  221          198.29524    151.19787   0.004524887 
+  178          196.84559    151.24196   0.005617978 
+  212          195.66446    151.28628   0.004716981 
+  194          194.71862    151.33082   0.005154639 
+  189          193.96069    151.37558   0.005291005 
+  191          193.31976    151.42057   0.005235602 
+  190          192.70548    151.46579   0.005263158 
+  189          192.07381    151.51123   0.005291005 
+  191          191.4813     151.5569    0.005235602 
+  180          191.02359    151.60281   0.005555556 
+  196          190.75638    151.64894   0.005102041 
+  173          190.6838     151.6953    0.005780347 
+  192          190.7789     151.7419    0.005208333 
+  196          190.9998     151.78873   0.005102041 
+  186          191.30745    151.8358    0.005376344 
+  181          191.67985    151.8831    0.005524862 
+  217          192.1108     151.93064   0.004608295 
+  224          192.6025     151.97842   0.004464286 
+  182          193.16821    152.02644   0.005494505 
+  208          193.83735    152.0747    0.004807692 
+  208          194.66268    152.1232    0.004807692 
+  184          195.65101    152.17194   0.005434783 
+  202          197.11978    152.22093   0.004950495 
+  216          199.24086    152.27016   0.00462963 
+  207          202.42533    152.31964   0.004830918 
+  189          207.22021    152.36937   0.005291005 
+  179          213.79351    152.41934   0.005586592 
+  217          219.92268    152.46957   0.004608295 
+  197          220.68898    152.52004   0.005076142 
+  221          216.49574    152.57077   0.004524887 
+  202          211.83307    152.62175   0.004950495 
+  194          207.94792    152.67298   0.005154639 
+  219          204.3479     152.72447   0.00456621 
+  217          200.80181    152.77622   0.004608295 
+  190          197.63225    152.82822   0.005263158 
+  189          195.0676     152.88048   0.005291005 
+  200          193.26765    152.933     0.005     
+  204          192.35665    152.98579   0.004901961 
+  192          192.51362    153.03883   0.005208333 
+  196          193.88829    153.09214   0.005102041 
+  198          195.91086    153.14571   0.005050505 
+  194          196.29962    153.19955   0.005154639 
+  189          193.82722    153.25366   0.005291005 
+  211          190.56785    153.30803   0.004739336 
+  178          187.79788    153.36268   0.005617978 
+  194          185.37653    153.41759   0.005154639 
+  174          183.06874    153.47278   0.005747126 
+  187          180.90397    153.52823   0.005347594 
+  177          179.01159    153.58397   0.005649718 
+  191          177.47109    153.63997   0.005235602 
+  210          176.28167    153.69626   0.004761905 
+  200          175.3786     153.75282   0.005     
+  183          174.65786    153.80966   0.005464481 
+  180          174.03337    153.86679   0.005555556 
+  226          173.50771    153.92419   0.004424779 
+  186          173.15977    153.98187   0.005376344 
+  190          173.07351    154.03984   0.005263158 
+  177          173.28019    154.0981    0.005649718 
+  172          173.72525    154.15664   0.005813953 
+  192          174.21369    154.21547   0.005208333 
+  175          174.41919    154.27459   0.005714286 
+  189          174.09573    154.334     0.005291005 
+  171          173.32965    154.3937    0.005847953 
+  178          172.43891    154.45369   0.005617978 
+  145          171.6833     154.51397   0.006896552 
+  163          171.14995    154.57456   0.006134969 
+  159          170.82379    154.63543   0.006289308 
+  202          170.65467    154.69661   0.004950495 
+  163          170.61623    154.75808   0.006134969 
+  176          170.69452    154.81986   0.005681818 
+  179          170.89343    154.88194   0.005586592 
+  186          171.23299    154.94431   0.005376344 
+  178          171.70588    155.007     0.005617978 
+  182          172.22414    155.06999   0.005494505 
+  169          172.65271    155.13328   0.00591716 
+  187          172.95095    155.19689   0.005347594 
+  169          173.24982    155.2608    0.00591716 
+  174          173.74539    155.32503   0.005747126 
+  193          174.60106    155.38956   0.005181347 
+  174          175.93919    155.45441   0.005747126 
+  174          177.89649    155.51958   0.005747126 
+  193          180.67507    155.58506   0.005181347 
+  194          184.61042    155.65085   0.005154639 
+  194          190.29193    155.71697   0.005154639 
+  226          198.74812    155.78341   0.004424779 
+  213          211.63264    155.85016   0.004694836 
+  227          231.06949    155.91724   0.004405286 
+  259          257.58043    155.98465   0.003861004 
+  254          282.84705    156.05238   0.003937008 
+  249          287.1497     156.12044   0.004016064 
+  287          267.33137    156.18882   0.003484321 
+  240          242.85066    156.25754   0.004166667 
+  234          225.23111    156.32658   0.004273504 
+  213          215.43103    156.39596   0.004694836 
+  233          211.93858    156.46567   0.004291845 
+  205          213.70984    156.53572   0.004878049 
+  218          220.60067    156.6061    0.004587156 
+  233          233.06406    156.67682   0.004291845 
+  253          250.97218    156.74788   0.003952569 
+  228          270.78974    156.81928   0.004385965 
+  272          284.38211    156.89102   0.003676471 
+  262          287.55299    156.96311   0.003816794 
+  266          282.14442    157.03554   0.003759398 
+  242          266.15434    157.10831   0.004132231 
+  235          243.70403    157.18144   0.004255319 
+  228          224.17057    157.25491   0.004385965 
+  202          210.76338    157.32873   0.004950495 
+  215          202.62232    157.40291   0.004651163 
+  233          198.42382    157.47744   0.004291845 
+  184          197.34719    157.55232   0.005434783 
+  178          199.07645    157.62756   0.005617978 
+  219          203.51129    157.70316   0.00456621 
+  195          209.99114    157.77912   0.005128205 
+  225          215.741      157.85544   0.004444444 
+  192          216.01991    157.93212   0.005208333 
+  215          209.80425    158.00916   0.004651163 
+  175          201.34528    158.08657   0.005714286 
+  186          193.99752    158.16434   0.005376344 
+  186          188.43627    158.24248   0.005376344 
+  177          184.28868    158.321     0.005649718 
+  205          181.15973    158.39988   0.004878049 
+  213          178.82157    158.47913   0.004694836 
+  175          177.12494    158.55876   0.005714286 
+  178          175.94612    158.63877   0.005617978 
+  173          175.17943    158.71915   0.005780347 
+  155          174.7318     158.79991   0.006451613 
+  187          174.5174     158.88105   0.005347594 
+  164          174.45934    158.96257   0.006097561 
+  197          174.499      159.04447   0.005076142 
+  173          174.60484    159.12676   0.005780347 
+  154          174.77365    159.20944   0.006493506 
+  155          175.00653    159.2925    0.006451613 
+  158          175.28177    159.37595   0.006329114 
+  167          175.57645    159.45979   0.005988024 
+  155          175.90295    159.54402   0.006451613 
+  155          176.2762     159.62865   0.006451613 
+  162          176.6325     159.71367   0.00617284 
+  149          176.80735    159.79909   0.006711409 
+  152          176.65824    159.88491   0.006578947 
+  152          176.22502    159.97113   0.006578947 
+  170          175.68276    160.05774   0.005882353 
+  154          175.17387    160.14477   0.006493506 
+  171          174.74868    160.23219   0.005847953 
+  154          174.41735    160.32002   0.006493506 
+  147          174.19854    160.40826   0.006802721 
+  176          174.11857    160.49691   0.005681818 
+  177          174.19708    160.58597   0.005649718 
+  160          174.43727    160.67545   0.00625   
+  144          174.82263    160.76533   0.006944444 
+  181          175.30279    160.85563   0.005524862 
+  154          175.76208    160.94635   0.006493506 
+  161          176.01659    161.03749   0.00621118 
+  162          175.91591    161.12905   0.00617284 
+  179          175.48453    161.22103   0.005586592 
+  158          174.89826    161.31344   0.006329114 
+  168          174.32392    161.40627   0.005952381 
+  194          173.83701    161.49953   0.005154639 
+  134          173.45175    161.59321   0.007462687 
+  170          173.16234    161.68733   0.005882353 
+  182          172.96185    161.78188   0.005494505 
+  169          172.84607    161.87686   0.00591716 
+  171          172.81544    161.97228   0.005847953 
+  205          172.8694     162.06813   0.004878049 
+  150          172.99679    162.16443   0.006666667 
+  186          173.16775    162.26116   0.005376344 
+  156          173.33435    162.35833   0.006410256 
+  150          173.45339    162.45595   0.006666667 
+  155          173.52066    162.55402   0.006451613 
+  166          173.57453    162.65253   0.006024096 
+  176          173.66214    162.75149   0.005681818 
+  181          173.80715    162.8509    0.005524862 
+  189          174.00555    162.95076   0.005291005 
+  184          174.23163    163.05108   0.005434783 
+  154          174.45516    163.15185   0.006493506 
+  182          174.66652    163.25308   0.005494505 
+  156          174.88444    163.35477   0.006410256 
+  162          175.13555    163.45691   0.00617284 
+  115          175.43691    163.55952   0.008695652 
+  164          175.79394    163.6626    0.006097561 
+  193          176.2051     163.76614   0.005181347 
+  174          176.66551    163.87015   0.005747126 
+  169          177.16636    163.97463   0.00591716 
+  169          177.69954    164.07958   0.00591716 
+  153          178.27506    164.185     0.006535948 
+  163          178.92779    164.29089   0.006134969 
+  161          179.69977    164.39727   0.00621118 
+  182          180.62063    164.50412   0.005494505 
+  153          181.69747    164.61145   0.006535948 
+  177          182.90358    164.71926   0.005649718 
+  174          184.14538    164.82756   0.005747126 
+  168          185.23483    164.93634   0.005952381 
+  162          185.96324    165.04561   0.00617284 
+  156          186.28305    165.15536   0.006410256 
+  174          186.37804    165.26561   0.005747126 
+  171          186.50694    165.37635   0.005847953 
+  188          186.84969    165.48758   0.005319149 
+  177          187.48665    165.59931   0.005649718 
+  184          188.44229    165.71154   0.005434783 
+  185          189.7041     165.82427   0.005405405 
+  189          191.21543    165.9375    0.005291005 
+  152          192.89926    166.05123   0.006578947 
+  182          194.71405    166.16547   0.005494505 
+  184          196.67139    166.28021   0.005434783 
+  185          198.83025    166.39547   0.005405405 
+  185          201.32263    166.51123   0.005405405 
+  183          204.32001    166.62751   0.005464481 
+  166          207.9348     166.7443    0.006024096 
+  188          212.01147    166.86161   0.005319149 
+  232          215.70933    166.97943   0.004310345 
+  183          217.81371    167.09778   0.005464481 
+  218          218.6813     167.21665   0.004587156 
+  189          220.41281    167.33604   0.005291005 
+  215          224.92529    167.45596   0.004651163 
+  264          233.6669     167.5764    0.003787879 
+  233          248.32754    167.69737   0.004291845 
+  300          271.02681    167.81888   0.003333333 
+  270          302.42752    167.94092   0.003703704 
+  370          334.6153     168.06349   0.002702703 
+  315          345.72262    168.1866    0.003174603 
+  297          325.46111    168.31025   0.003367003 
+  270          293.46694    168.43444   0.003703704 
+  238          267.17743    168.55918   0.004201681 
+  250          249.73376    168.68446   0.004     
+  232          238.65878    168.81028   0.004310345 
+  204          231.22362    168.93666   0.004901961 
+  199          226.2952     169.06358   0.005025126 
+  197          223.74874    169.19106   0.005076142 
+  237          223.60627    169.31909   0.004219409 
+  199          226.20473    169.44768   0.005025126 
+  231          232.41947    169.57683   0.004329004 
+  235          243.3239     169.70653   0.004255319 
+  250          258.44163    169.8368    0.004     
+  248          271.40894    169.96764   0.004032258 
+  239          270.82528    170.09904   0.0041841 
+  208          256.69513    170.23101   0.004807692 
+  242          240.21088    170.36355   0.004132231 
+  219          227.39091    170.49666   0.00456621 
+  207          218.4699     170.63035   0.004830918 
+  208          212.30503    170.76461   0.004807692 
+  210          207.98842    170.89945   0.004761905 
+  182          204.93185    171.03487   0.005494505 
+  210          202.70333    171.17087   0.004761905 
+  179          200.97887    171.30746   0.005586592 
+  161          199.57332    171.44464   0.00621118 
+  198          198.41697    171.5824    0.005050505 
+  169          197.50602    171.72076   0.00591716 
+  189          196.86868    171.8597    0.005291005 
+  184          196.52711    171.99925   0.005434783 
+  188          196.45598    172.13938   0.005319149 
+  175          196.57111    172.28012   0.005714286 
+  211          196.74799    172.42146   0.004739336 
+  190          196.87165    172.5634    0.005263158 
+  190          196.89094    172.70595   0.005263158 
+  178          196.82836    172.8491    0.005617978 
+  206          196.73027    172.99286   0.004854369 
+  215          196.60865    173.13724   0.004651163 
+  203          196.46112    173.28223   0.004926108 
+  164          196.32306    173.42783   0.006097561 
+  178          196.24571    173.57405   0.005617978 
+  182          196.25654    173.72089   0.005494505 
+  187          196.37446    173.86835   0.005347594 
+  194          196.62667    174.01644   0.005154639 
+  185          197.0196     174.16515   0.005405405 
+  184          197.50333    174.3145    0.005434783 
+  196          197.98295    174.46447   0.005102041 
+  186          198.39209    174.61507   0.005376344 
+  202          198.76177    174.76631   0.004950495 
+  209          199.19084    174.91819   0.004784689 
+  187          199.7601     175.0707    0.005347594 
+  178          200.4843     175.22386   0.005617978 
+  229          201.31643    175.37766   0.004366812 
+  190          202.17431    175.5321    0.005263158 
+  195          202.96376    175.6872    0.005128205 
+  192          203.59947    175.84294   0.005208333 
+  196          204.07443    175.99934   0.005102041 
+  196          204.48875    176.15639   0.005102041 
+  186          204.97236    176.31409   0.005376344 
+  201          205.60454    176.47246   0.004975124 
+  203          206.39459    176.63148   0.004926108 
+  198          207.31091    176.79117   0.005050505 
+  197          208.33043    176.95153   0.005076142 
+  213          209.4727     177.11255   0.004694836 
+  183          210.78722    177.27424   0.005464481 
+  197          212.3271     177.43661   0.005076142 
+  202          214.1335     177.59964   0.004950495 
+  212          216.23365    177.76336   0.004716981 
+  235          218.618      177.92775   0.004255319 
+  197          221.20018    178.09283   0.005076142 
+  220          223.77334    178.25859   0.004545455 
+  226          226.03093    178.42503   0.004424779 
+  205          227.71474    178.59217   0.004878049 
+  202          228.8238     178.75999   0.004950495 
+  203          229.59866    178.9285    0.004926108 
+  220          230.24135    179.09771   0.004545455 
+  226          230.75529    179.26762   0.004424779 
+  267          231.0867     179.43823   0.003745318 
+  210          231.30758    179.60953   0.004761905 
+  226          231.59325    179.78155   0.004424779 
+  236          232.10815    179.95427   0.004237288 
+  202          232.85222    180.12769   0.004950495 
+  223          234.09985    180.30183   0.004484305 
+  231          235.76178    180.47668   0.004329004 
+  202          237.81536    180.65225   0.004950495 
+  234          240.17876    180.82854   0.004273504 
+  238          242.69675    181.00554   0.004201681 
+  236          245.20541    181.18327   0.004237288 
+  237          247.66431    181.36172   0.004219409 
+  265          250.21013    181.5409    0.003773585 
+  272          253.03142    181.72082   0.003676471 
+  235          256.24429    181.90146   0.004255319 
+  252          259.9404     182.08284   0.003968254 
+  314          264.32666    182.26495   0.003184713 
+  282          269.74511    182.4478    0.003546099 
+  310          276.82949    182.6314    0.003225806 
+  310          285.8571     182.81574   0.003225806 
+  311          296.03869    183.00083   0.003215434 
+  353          304.29753    183.18666   0.002832861 
+  321          306.98361    183.37325   0.003115265 
+  318          304.7547     183.56059   0.003144654 
+  362          301.59281    183.74869   0.002762431 
+  320          300.06869    183.93754   0.003125  
+  337          300.68613    184.12716   0.002967359 
+  348          303.17607    184.31754   0.002873563 
+  374          307.24987    184.50869   0.002673797 
+  388          312.77572    184.7006    0.00257732 
+  339          319.74182    184.89329   0.002949853 
+  354          328.21792    185.08675   0.002824859 
+  386          338.37332    185.28099   0.002590674 
+  351          350.49885    185.476     0.002849003 
+  425          364.95443    185.67179   0.002352941 
+  389          381.87281    185.86837   0.002570694 
+  439          400.52638    186.06574   0.002277904 
+  416          419.33437    186.26389   0.002403846 
+  448          437.99015    186.46283   0.002232143 
+  510          458.75513    186.66257   0.001960784 
+  518          484.28772    186.8631    0.001930502 
+  557          516.36059    187.06444   0.001795332 
+  597          556.43796    187.26657   0.001675042 
+  656          606.41676    187.4695    0.00152439 
+  751          669.08093    187.67325   0.001331558 
+  910          748.18642    187.8778    0.001098901 
+  930          848.24485    188.08316   0.001075269 
+  1147         975.78716    188.28934   0.00087184 
+  1272         1143.91724   188.49633   0.000786164 
+  1661         1376.34455   188.70414   0.000602047 
+  1935         1707.70015   188.91277   0.000516796 
+  2593         2189.27082   189.12223   0.000385654 
+  3382         2897.92084   189.33251   0.000295683 
+  4465         3914.20132   189.54362   0.000223964 
+  5717         5201.08541   189.75557   0.000174917 
+  6475         6315.17714   189.96835   0.00015444 
+  6492         6439.74142   190.18196   0.000154036 
+  5388         5468.31609   190.39642   0.000185598 
+  4457         4188.07122   190.61172   0.000224366 
+  3632         3140.64594   190.82786   0.00027533 
+  2899         2413.2701    191.04485   0.000344947 
+  2372         1938.6289    191.26269   0.000421585 
+  2008         1639.80306   191.48138   0.000498008 
+  1828         1463.10649   191.70093   0.000547046 
+  1642         1379.09469   191.92134   0.000609013 
+  1681         1377.55641   192.14261   0.000594884 
+  1764         1462.89733   192.36474   0.000566893 
+  1923         1654.91682   192.58774   0.000520021 
+  2329         1989.01771   192.8116    0.000429369 
+  2727         2494.45023   193.03634   0.000366703 
+  3227         3107.98111   193.26196   0.000309885 
+  3458         3527.24566   193.48844   0.000289184 
+  3285         3376.00254   193.71581   0.000304414 
+  2851         2769.91358   193.94406   0.000350754 
+  2342         2116.72494   194.1732    0.000426985 
+  1846         1609.41441   194.40323   0.000541712 
+  1453         1254.87425   194.63414   0.000688231 
+  1248         1012.56816   194.86595   0.000801282 
+  1027         845.13742    195.09865   0.00097371 
+  894          726.37458    195.33225   0.001118568 
+  779          639.3246     195.56676   0.001283697 
+  662          573.35806    195.80217   0.001510574 
+  606          521.97726    196.03848   0.001650165 
+  541          481.12841    196.27571   0.001848429 
+  529          448.24448    196.51385   0.001890359 
+  465          421.57571    196.7529    0.002150538 
+  458          399.83453    196.99287   0.002183406 
+  455          382.02944    197.23376   0.002197802 
+  407          367.35081    197.47558   0.002457002 
+  354          355.11693    197.71832   0.002824859 
+  349          344.81797    197.96199   0.00286533 
+  350          336.22715    198.2066    0.002857143 
+  339          329.41809    198.45214   0.002949853 
+  318          324.60722    198.69861   0.003144654 
+  306          321.70418    198.94603   0.003267974 
+  332          319.27213    199.19439   0.003012048 
+  302          314.41456    199.4437    0.003311258 
+  337          306.51413    199.69395   0.002967359 
+  289          298.09356    199.94516   0.003460208 
+  281          290.87102    200.19733   0.003558719 
+  307          285.13285    200.45045   0.003257329 
+  286          280.6995     200.70453   0.003496503 
+  271          277.34747    200.95957   0.003690037 
+  267          274.91631    201.21559   0.003745318 
+  306          273.31615    201.47257   0.003267974 
+  275          272.49562    201.73052   0.003636364 
+  286          272.45866    201.98945   0.003496503 
+  256          273.35159    202.24936   0.00390625 
+  272          275.54672    202.51024   0.003676471 
+  234          279.60855    202.77212   0.004273504 
+  295          285.96593    203.03497   0.003389831 
+  255          293.95748    203.29882   0.003921569 
+  302          300.66168    203.56366   0.003311258 
+  279          302.02743    203.8295    0.003584229 
+  280          296.33327    204.09633   0.003571429 
+  227          286.29774    204.36417   0.004405286 
+  280          276.14549    204.63301   0.003571429 
+  230          268.02825    204.90286   0.004347826 
+  274          262.2192     205.17372   0.003649635 
+  285          258.36264    205.44559   0.003508772 
+  243          256.08967    205.71848   0.004115226 
+  246          255.16778    205.99239   0.004065041 
+  218          255.49717    206.26732   0.004587156 
+  254          257.10373    206.54328   0.003937008 
+  225          260.15242    206.82027   0.004444444 
+  226          264.9623     207.09828   0.004424779 
+  232          271.93207    207.37734   0.004310345 
+  214          281.1193     207.65743   0.004672897 
+#--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--#
+
+# start Validation Reply Form
+_vrf_PLAT741_NEW10minmill_phase_1 # for all atoms in 1_quartz
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT741_NEW10minmill_phase_3 # for all atoms in 3_pyrrhotite
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT741_NEW10minmill_phase_4 # for all atoms in 4_rutile
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT741_NEW10minmill_phase_2 # for all atoms in 2_albite
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT155_NEW10minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT141_NEW10minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT142_NEW10minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT143_NEW10minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT144_NEW10minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT145_NEW10minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT146_NEW10minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT151_NEW10minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+# end Validation Reply Form

--- a/data/hamish/vb5042sup1.cif
+++ b/data/hamish/vb5042sup1.cif
@@ -1,0 +1,8050 @@
+
+data_QPAPBMXGreaseSuspendedSamplePrep_publ
+_audit_creation_method  "created in GSAS-II"
+_audit_creation_date  2021-08-04T17:25
+_audit_author_name  "McDougall, Hamish"
+_audit_update_record
+   "2021-08-04T17:25  Initial software-generated CIF"
+_pd_block_id
+;
+2021-08-04T17:25|QPAPBMXGreaseSuspendedSamplePrep|McDougallHamish|Overall
+;
+# GSAS-II edited template follows Publication_Template
+#=============================================================================
+# this information describes the project, paper etc. for the CIF             #
+# Acta Cryst. Section C papers and editorial correspondence is generated     #
+# from the information in this section                                       #
+#                                                                            #
+#   (from)   CIF submission form for Rietveld refinements (Acta Cryst. C)    #
+#                                                 Version 14 December 1998   #
+#=============================================================================
+# 1. SUBMISSION DETAILS
+
+_publ_contact_author_name            "Suzanne Neville; Vanessa Peterson; Christophe Didier"   # Name of author for correspondence
+_publ_contact_author_address             # Address of author for correspondence
+; ?
+;
+_publ_contact_author_email           "s.neville@unsw.edu.au; vanessa.peterson@ansto.gov.au; drchristophedidier@gmail.com"
+_publ_contact_author_fax             ?
+_publ_contact_author_phone           ?
+
+_publ_contact_letter
+; ?
+;
+   
+_publ_requested_journal              ?
+_publ_requested_coeditor_name        ?
+_publ_requested_category             ?   # Acta C: one of CI/CM/CO/FI/FM/FO
+
+#==============================================================================
+
+# 2. PROCESSING SUMMARY (IUCr Office Use Only)
+
+_journal_data_validation_number      ?
+
+_journal_date_recd_electronic        ?
+_journal_date_to_coeditor            ?
+_journal_date_from_coeditor          ?
+_journal_date_accepted               ?
+_journal_date_printers_first         ?
+_journal_date_printers_final         ?
+_journal_date_proofs_out             ?
+_journal_date_proofs_in              ?
+_journal_coeditor_name               ?
+_journal_coeditor_code               ?
+_journal_coeditor_notes
+; ?
+;
+_journal_techeditor_code             ?
+_journal_techeditor_notes
+; ?
+;
+_journal_coden_ASTM                  ?
+_journal_name_full                   ?
+_journal_year                        ?
+_journal_volume                      ?
+_journal_issue                       ?
+_journal_page_first                  ?
+_journal_page_last                   ?
+_journal_paper_category              ?
+_journal_suppl_publ_number           ?
+_journal_suppl_publ_pages            ?
+
+#==============================================================================
+
+# 3. TITLE AND AUTHOR LIST
+
+_publ_section_title
+; ?
+;
+_publ_section_title_footnote
+; ?
+;         
+ 
+# The loop structure below should contain the names and addresses of all 
+# authors, in the required order of publication. Repeat as necessary.
+
+loop_
+	_publ_author_name
+        _publ_author_footnote
+	_publ_author_address
+ ?                                   #<--'Last name, first name' 
+; ?
+;
+; ?
+;
+
+#==============================================================================
+
+# 4. TEXT
+
+_publ_section_synopsis
+;  ?
+;
+_publ_section_abstract                         
+; ?
+;          
+_publ_section_comment                          
+; ?
+;
+_publ_section_exptl_prep      # Details of the preparation of the sample(s)
+                              # should be given here. 
+; ?
+;
+_publ_section_exptl_refinement                  
+; ?
+;
+_publ_section_references
+; ?
+;
+_publ_section_figure_captions
+; ?
+;
+_publ_section_acknowledgements
+; ?
+;
+
+#=============================================================================
+# 5. OVERALL REFINEMENT & COMPUTING DETAILS
+
+_refine_special_details
+; ?
+;
+_pd_proc_ls_special_details
+; ?
+;
+
+# The following items are used to identify the programs used.
+_computing_molecular_graphics     ?
+_computing_publication_material   ?
+
+_refine_ls_weighting_scheme       ?        
+_refine_ls_weighting_details      ?
+_refine_ls_hydrogen_treatment     ?        
+_refine_ls_extinction_method      ?        
+_refine_ls_extinction_coef        ?         
+_refine_ls_number_constraints     ?        
+
+_refine_ls_restrained_S_all       ?        
+_refine_ls_restrained_S_obs       ?
+
+#==============================================================================
+# 6. SAMPLE PREPARATION DATA
+
+# (In the unusual case where multiple samples are used in a single
+#  Rietveld study, this information should be moved into the phase
+#  blocks)
+
+# The following three fields describe the preparation of the material.
+# The cooling rate is in K/min.  The pressure at which the sample was  
+# prepared is in kPa.  The temperature of preparation is in K.
+               
+_pd_prep_cool_rate                N/A        
+_pd_prep_pressure                 101.3        
+_pd_prep_temperature              298         
+
+_pd_char_colour                   ?       # use ICDD colour descriptions
+
+data_QPAPBMXGreaseSuspendedSamplePrep_overall
+_pd_proc_info_datetime  2021-08-04T17:25
+_pd_calc_method  "Rietveld Refinement"
+_computing_structure_refinement
+   "GSAS-II (Toby & Von Dreele, J. Appl. Cryst. 46, 544-549, 2013)"
+_refine_ls_number_parameters  30
+_refine_ls_goodness_of_fit_all  1.783
+_refine_ls_shift/su_max  1.3150
+
+# OVERALL WEIGHTED R-FACTOR
+_refine_ls_wR_factor_obs  0.11424
+_refine_ls_matrix_type  full
+# POINTERS TO PHASE AND HISTOGRAM BLOCKS
+loop_   _pd_phase_block_id
+;
+2021-08-04T17:25|QPAPBMXGreaseSuspendedSamplePrep|phase_2|McDougallHamish
+;
+;
+2021-08-04T17:25|QPAPBMXGreaseSuspendedSamplePrep|phase_0|McDougallHamish
+;
+;
+2021-08-04T17:25|QPAPBMXGreaseSuspendedSamplePrep|phase_3|McDougallHamish
+;
+;
+2021-08-04T17:25|QPAPBMXGreaseSuspendedSamplePrep|phase_4|McDougallHamish
+;
+;
+2021-08-04T17:25|QPAPBMXGreaseSuspendedSamplePrep|phase_1|McDougallHamish
+;
+_pd_block_diffractogram_id
+;
+2021-08-04T17:25|QPAPBMXGreaseSuspendedSamplePrep|McDougallHamish|PANalytical,Co-EmpyreanII_hist_0
+;
+
+data_QPAPBMXGreaseSuspendedSamplePrep_phase_2
+# Information for phase 2
+_pd_block_id
+;
+2021-08-04T17:25|QPAPBMXGreaseSuspendedSamplePrep|phase_2|McDougallHamish
+;
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Albite NaAlSi3O8 - 68913 follows
+_pd_phase_name  "Albite NaAlSi3O8 - 68913"
+_cell_length_a  8.138925
+_cell_length_b  12.799307
+_cell_length_c  7.160071
+_cell_angle_alpha  94.2255
+_cell_angle_beta   116.5999
+_cell_angle_gamma  87.8097
+_cell_volume  665.111
+_exptl_crystal_density_diffrn  2.6187
+_symmetry_cell_setting  triclinic
+_symmetry_space_group_name_H-M  "C -1"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -x,-y,-z
+     3  1/2+x,1/2+y,z
+     4  1/2-x,1/2-y,-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Al1    Al3+ 0.00887     0.16846     0.20805     1.000      Uani 0.007      4   
+Si1    Si4+ 0.00375     0.82051     0.23737     1.000      Uani 0.006      4   
+Si2    Si4+ 0.69162     0.11021     0.31466     1.000      Uani 0.006      4   
+Si3    Si4+ 0.68129     0.88190     0.36076     1.000      Uani 0.006      4   
+Na1    Na1+ 0.26799     0.98865     0.14650     1.000      Uani 0.031      4   
+O1     O2-  0.00490     0.13103     0.96660     1.000      Uani 0.012      4   
+O2     O2-  0.59176     0.99756     0.28040     1.000      Uani 0.008      4   
+O3     O2-  0.81230     0.10966     0.19010     1.000      Uani 0.014      4   
+O4     O2-  0.82000     0.85101     0.25870     1.000      Uani 0.018      4   
+O5     O2-  0.01288     0.30238     0.27060     1.000      Uani 0.011      4   
+O6     O2-  0.02329     0.69368     0.22910     1.000      Uani 0.011      4   
+O7     O2-  0.20780     0.10896     0.38900     1.000      Uani 0.011      4   
+O8     O2-  0.18400     0.86817     0.43620     1.000      Uani 0.012      4   
+
+loop_
+   _atom_site_aniso_label
+   _atom_site_aniso_U_11
+   _atom_site_aniso_U_22
+   _atom_site_aniso_U_33
+   _atom_site_aniso_U_12
+   _atom_site_aniso_U_13
+   _atom_site_aniso_U_23
+Al1    0.0074      0.0068      0.0061      -0.0009     0.0031      0.0004      
+Si1    0.0068      0.0065      0.0055      0.0011      0.0030      0.0008      
+Si2    0.0061      0.0055      0.0073      -0.0002     0.0025      0.0004      
+Si3    0.0060      0.0055      0.0074      0.0006      0.0028      0.0009      
+Na1    0.0136      0.0471      0.0315      -0.0050     0.0084      -0.0219     
+O1     0.0164      0.0122      0.0074      -0.0002     0.0067      0.0014      
+O2     0.0074      0.0056      0.0119      0.0003      0.0033      0.0020      
+O3     0.0117      0.0130      0.0162      -0.0040     0.0093      -0.0017     
+O4     0.0134      0.0179      0.0216      0.0046      0.0129      0.0020      
+O5     0.0103      0.0076      0.0150      -0.0020     0.0052      -0.0009     
+O6     0.0101      0.0071      0.0145      0.0022      0.0034      0.0012      
+O7     0.0120      0.0129      0.0080      0.0024      0.0013      0.0015      
+O8     0.0140      0.0140      0.0084      -0.0026     -0.0002     -0.0006     
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Al   4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Na   4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  O    32     ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si   12     ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Al Na O8 Si3"
+_chemical_formula_weight  262.22
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Al1    O1     1.74597      1_555    1_554 yes
+  Al1    O3     1.74245      1_555    1_455 yes
+  Al1    O5     1.73718      1_555    1_555 yes
+  Al1    O7     1.74718      1_555    1_555 yes
+  Si1    O1     1.6002       1_555    2_566 yes
+  Si1    O4     1.60108      1_555    1_455 yes
+  Si1    O6     1.62436      1_555    1_555 yes
+  Si1    O8     1.61901      1_555    1_555 yes
+  Si2    O2     1.63051      1_555    1_545 yes
+  Si2    O3     1.59474      1_555    1_555 yes
+  Si2    O6     1.62068      1_555    3_545 yes
+  Si2    O8     1.61711      1_555    2_666 yes
+  Si3    O2     1.64959      1_555    1_555 yes
+  Si3    O4     1.62079      1_555    1_555 yes
+  Si3    O5     1.59651      1_555    3_555 yes
+  Si3    O7     1.60239      1_555    2_666 yes
+  Na1    O1     2.67262      1_555    1_564 yes
+  Na1    O1     2.53018      1_555    2_566 yes
+  Na1    O2     2.37077      1_555    1_555 yes
+  Na1    O3     2.45447      1_555    2_665 yes
+  Na1    O7     2.43641      1_555    1_565 yes
+  O1     Al1    1.74597      1_555    1_556 yes
+  O1     Si1    1.6002       1_555    2_566 yes
+  O1     Na1    2.67262      1_555    1_546 yes
+  O1     Na1    2.53018      1_555    2_566 yes
+  O2     Si2    1.63051      1_555    1_565 yes
+  O2     Si3    1.64959      1_555    1_555 yes
+  O2     Na1    2.37077      1_555    1_555 yes
+  O3     Al1    1.74245      1_555    1_655 yes
+  O3     Si2    1.59474      1_555    1_555 yes
+  O3     Na1    2.45447      1_555    2_665 yes
+  O4     Si1    1.60108      1_555    1_655 yes
+  O4     Si3    1.62079      1_555    1_555 yes
+  O5     Al1    1.73718      1_555    1_555 yes
+  O5     Si3    1.59651      1_555    3_445 yes
+  O6     Si1    1.62436      1_555    1_555 yes
+  O6     Si2    1.62068      1_555    3_455 yes
+  O7     Al1    1.74718      1_555    1_555 yes
+  O7     Si3    1.60239      1_555    2_666 yes
+  O7     Na1    2.43641      1_555    1_545 yes
+  O8     Si1    1.61901      1_555    1_555 yes
+  O8     Si2    1.61711      1_555    2_666 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Al1    O3     102.839       1_554  1_555    1_455 yes
+  O1     Al1    O5     116.078       1_554  1_555    1_555 yes
+  O3     Al1    O5     112.16        1_455  1_555    1_555 yes
+  O1     Al1    O7     103.947       1_554  1_555    1_555 yes
+  O3     Al1    O7     111.136       1_455  1_555    1_555 yes
+  O5     Al1    O7     110.225       1_555  1_555    1_555 yes
+  O1     Si1    O4     109.382       2_566  1_555    1_455 yes
+  O1     Si1    O6     112.467       2_566  1_555    1_555 yes
+  O4     Si1    O6     108.286       1_455  1_555    1_555 yes
+  O1     Si1    O8     107.201       2_566  1_555    1_555 yes
+  O4     Si1    O8     111.41        1_455  1_555    1_555 yes
+  O6     Si1    O8     108.124       1_555  1_555    1_555 yes
+  O2     Si2    O3     111.07        1_545  1_555    1_555 yes
+  O2     Si2    O6     104.318       1_545  1_555    3_545 yes
+  O3     Si2    O6     112.142       1_555  1_555    3_545 yes
+  O2     Si2    O8     106.953       1_545  1_555    2_666 yes
+  O3     Si2    O8     111.607       1_555  1_555    2_666 yes
+  O6     Si2    O8     110.392       3_545  1_555    2_666 yes
+  O2     Si3    O4     107.348       1_555  1_555    1_555 yes
+  O2     Si3    O5     105.916       1_555  1_555    3_555 yes
+  O4     Si3    O5     110.171       1_555  1_555    3_555 yes
+  O2     Si3    O7     108.553       1_555  1_555    2_666 yes
+  O4     Si3    O7     110.204       1_555  1_555    2_666 yes
+  O5     Si3    O7     114.325       3_555  1_555    2_666 yes
+  Al1    O1     Si1    141.36        1_556  1_555    2_566 yes
+  Si2    O2     Si3    130.051       1_565  1_555    1_555 yes
+  Si2    O2     Na1    120.258       1_565  1_555    1_555 yes
+  Si3    O2     Na1    108.874       1_555  1_555    1_555 yes
+  Al1    O3     Si2    139.443       1_655  1_555    1_555 yes
+  Si1    O4     Si3    161.159       1_655  1_555    1_555 yes
+  Al1    O5     Si3    129.66        1_555  1_555    3_445 yes
+  Si1    O6     Si2    135.75        1_555  1_555    3_455 yes
+  Al1    O7     Si3    133.908       1_555  1_555    2_666 yes
+  Si1    O8     Si2    151.752       1_555  1_555    2_666 yes
+_pd_proc_ls_pref_orient_corr  none
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.206(13), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_QPAPBMXGreaseSuspendedSamplePrep_phase_0
+# Information for phase 0
+_pd_block_id
+;
+2021-08-04T17:25|QPAPBMXGreaseSuspendedSamplePrep|phase_0|McDougallHamish
+;
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Pyrite FeS2 - 3919 follows
+_pd_phase_name  "Pyrite FeS2 - 3919"
+_cell_length_a  5.41928(5)
+_cell_length_b  5.41928(5)
+_cell_length_c  5.41928(5)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  90
+_cell_volume  159.157(4)
+_exptl_crystal_density_diffrn  5.0066
+_symmetry_cell_setting  cubic
+_symmetry_space_group_name_H-M  "P a -3"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  z,x,y
+     3  y,z,x
+     4  1/2+x,y,1/2-z
+     5  1/2-z,1/2+x,y
+     6  y,1/2-z,1/2+x
+     7  -z,1/2+x,1/2-y
+     8  1/2-y,-z,1/2+x
+     9  1/2+y,1/2-z,-x
+    10  -x,1/2+y,1/2-z
+    11  1/2-z,-x,1/2+y
+    12  1/2+x,1/2-y,-z
+    13  -x,-y,-z
+    14  -z,-x,-y
+    15  -y,-z,-x
+    16  1/2-x,-y,1/2+z
+    17  1/2+z,1/2-x,-y
+    18  -y,1/2+z,1/2-x
+    19  z,1/2-x,1/2+y
+    20  1/2+y,z,1/2-x
+    21  1/2-y,1/2+z,x
+    22  x,1/2-y,1/2+z
+    23  1/2+z,x,1/2-y
+    24  1/2-x,1/2+y,z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Fe1    Fe   0.00000     0.00000     0.00000     1.000      Uiso 0.0115(7)  4   
+S2     S    0.38435(13) 0.38435     0.38435     1.000      Uiso 0.0087(6)  8   
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Fe   4      11.7695    7.3573     3.5222     2.3045     4.7611     0.3072     15.3535    76.8805    1.0369     0.945
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S    8      6.9053     5.2034     1.4379     1.5863     1.4679     22.2151    0.2536     56.172     0.8669     0.2847
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Fe S2"
+_chemical_formula_weight  119.97
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Fe1    S2     2.26363(20)   1_555    4_455 yes
+  Fe1    S2     2.26363(20)   1_555    5_545 yes
+  Fe1    S2     2.26363(20)   1_555    6_554 yes
+  Fe1    S2     2.26363(20)   1_555    7_545 yes
+  Fe1    S2     2.26363(20)   1_555    8_554 yes
+  Fe1    S2     2.2636(7)    1_555    9_455 yes
+  S2     Fe1    2.26363(20)   1_555    4_555 yes
+  S2     Fe1    2.26363(20)   1_555    5_555 yes
+  S2     Fe1    2.2636(7)    1_555    6_555 yes
+  S2     S2     2.1712(8)    1_555   13_666 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.379(4), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_QPAPBMXGreaseSuspendedSamplePrep_phase_3
+# Information for phase 3
+_pd_block_id
+;
+2021-08-04T17:25|QPAPBMXGreaseSuspendedSamplePrep|phase_3|McDougallHamish
+;
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Pyrrhotite 4M Fe7S8 - 0723 follows
+_pd_phase_name  "Pyrrhotite 4M Fe7S8 - 0723"
+_cell_length_a  11.937(11)
+_cell_length_b  6.8622(15)
+_cell_length_c  12.812(13)
+_cell_angle_alpha  90
+_cell_angle_beta   117.247(23)
+_cell_angle_gamma  90
+_cell_volume  932.99(21)
+_exptl_crystal_density_diffrn  4.6090
+_symmetry_cell_setting  monoclinic
+_symmetry_space_group_name_H-M  "C 2/c"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -x,y,1/2-z
+     3  -x,-y,-z
+     4  x,-y,1/2+z
+     5  1/2+x,1/2+y,z
+     6  1/2-x,1/2+y,1/2-z
+     7  1/2-x,1/2-y,-z
+     8  1/2+x,1/2-y,1/2+z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+S1     S    0.01800     0.38330     0.11960     1.000      Uiso 0.010      8   
+S2     S    0.02910     0.11420     0.63900     1.000      Uiso 0.010      8   
+Fe3    Fe   0.10860     0.10250     0.49980     1.000      Uiso 0.010      8   
+S4     S    0.23410     0.13550     0.38260     1.000      Uiso 0.010      8   
+Fe5    Fe   0.24180     0.36600     0.24680     1.000      Uiso 0.010      8   
+S6     S    0.26790     0.13400     0.12360     1.000      Uiso 0.010      8   
+Fe7    Fe   0.38720     0.15000     0.01260     1.000      Uiso 0.010      8   
+Fe8    Fe   0.00000     0.14720     0.25000     1.000      Uiso 0.010      4   
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Fe   28     11.7695    7.3573     3.5222     2.3045     4.7611     0.3072     15.3535    76.8805    1.0369     0.945
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S    32     6.9053     5.2034     1.4379     1.5863     1.4679     22.2151    0.2536     56.172     0.8669     0.2847
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Fe7 S8"
+_chemical_formula_weight  647.41
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  S1     Fe3    2.494        1_555    2_555 yes
+  S1     Fe5    2.41247      1_555    1_555 yes
+  S1     Fe7    2.38885      1_555    5_455 yes
+  S1     Fe7    2.44056      1_555    7_555 yes
+  S1     Fe8    2.40643      1_555    1_555 yes
+  S2     Fe3    2.37426      1_555    1_555 yes
+  S2     Fe3    2.32355      1_555    3_556 yes
+  S2     Fe5    2.44416      1_555    7_556 yes
+  S2     Fe7    2.36604      1_555    8_456 yes
+  S2     Fe8    2.41103      1_555    3_556 yes
+  Fe3    S1     2.494        1_555    2_555 yes
+  Fe3    S2     2.37426      1_555    1_555 yes
+  Fe3    S2     2.32355      1_555    3_556 yes
+  Fe3    S6     2.45024      1_555    4_556 yes
+  S4     Fe5    2.38408      1_555    1_555 yes
+  Fe5    S1     2.41247      1_555    1_555 yes
+  Fe5    S2     2.44416      1_555    7_556 yes
+  Fe5    S4     2.38408      1_555    1_555 yes
+  Fe5    S6     2.36079      1_555    1_555 yes
+  S6     Fe3    2.45024      1_555    4_555 yes
+  S6     Fe5    2.36079      1_555    1_555 yes
+  S6     Fe7    2.43241      1_555    1_555 yes
+  S6     Fe7    2.38986      1_555    7_555 yes
+  Fe7    S1     2.38885      1_555    5_545 yes
+  Fe7    S1     2.44056      1_555    7_555 yes
+  Fe7    S2     2.36604      1_555    8_555 yes
+  Fe7    S6     2.43241      1_555    1_555 yes
+  Fe7    S6     2.38986      1_555    7_555 yes
+  Fe8    S1     2.40643      1_555    1_555 yes
+  Fe8    S1     2.40643      1_555    2_555 yes
+  Fe8    S2     2.41103      1_555    3_556 yes
+  Fe8    S2     2.41103      1_555    4_555 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.061(4), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_QPAPBMXGreaseSuspendedSamplePrep_phase_4
+# Information for phase 4
+_pd_block_id
+;
+2021-08-04T17:25|QPAPBMXGreaseSuspendedSamplePrep|phase_4|McDougallHamish
+;
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Rutile TiO2 follows
+_pd_phase_name  "Rutile TiO2"
+_cell_length_a  4.5970(29)
+_cell_length_b  4.5970(29)
+_cell_length_c  2.9629(26)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  90
+_cell_volume  62.61(6)
+_exptl_crystal_density_diffrn  4.2379
+_symmetry_cell_setting  tetragonal
+_symmetry_space_group_name_H-M  "P 42/m n m"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  1/2-y,1/2+x,1/2+z
+     3  -x,-y,z
+     4  1/2+y,1/2-x,1/2+z
+     5  1/2-x,1/2+y,1/2+z
+     6  -y,-x,z
+     7  1/2+x,1/2-y,1/2+z
+     8  y,x,z
+     9  -x,-y,-z
+    10  1/2+y,1/2-x,1/2-z
+    11  x,y,-z
+    12  1/2-y,1/2+x,1/2-z
+    13  1/2+x,1/2-y,1/2-z
+    14  y,x,-z
+    15  1/2-x,1/2+y,1/2-z
+    16  -y,-x,-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Ti1    Ti4+ 0.00000     0.00000     0.00000     1.000      Uani 0.006      2   
+O1     O2-  0.30493     0.30493     0.00000     1.000      Uani 0.006      4   
+
+loop_
+   _atom_site_aniso_label
+   _atom_site_aniso_U_11
+   _atom_site_aniso_U_22
+   _atom_site_aniso_U_33
+   _atom_site_aniso_U_12
+   _atom_site_aniso_U_13
+   _atom_site_aniso_U_23
+Ti1    0.0070      0.0070      0.0047      -0.0002     0.0000      0.0000      
+O1     0.0060      0.0060      0.0045      -0.0019     0.0000      0.0000      
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  O    4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Ti   2      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  2
+_chemical_formula_sum  "O2 Ti"
+_chemical_formula_weight  79.9
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Ti1    O1     1.98239      1_555    1_555 yes
+  Ti1    O1     1.95011      1_555    2_544 yes
+  Ti1    O1     1.95011      1_555    2_545 yes
+  Ti1    O1     1.98239      1_555    3_555 yes
+  Ti1    O1     1.95011      1_555    4_454 yes
+  Ti1    O1     1.95011      1_555    4_455 yes
+  O1     Ti1    1.98239      1_555    1_555 yes
+  O1     Ti1    1.95011      1_555    2_554 yes
+  O1     Ti1    1.95011      1_555    2_555 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Ti1    O1     90            1_555  1_555    2_544 yes
+  O1     Ti1    O1     90            1_555  1_555    2_545 yes
+  O1     Ti1    O1     98.87         2_544  1_555    2_545 yes
+  O1     Ti1    O1     180           1_555  1_555    3_555 yes
+  O1     Ti1    O1     90            2_544  1_555    3_555 yes
+  O1     Ti1    O1     90            2_545  1_555    3_555 yes
+  O1     Ti1    O1     90            1_555  1_555    4_454 yes
+  O1     Ti1    O1     81.13         2_544  1_555    4_454 yes
+  O1     Ti1    O1     180           2_545  1_555    4_454 yes
+  O1     Ti1    O1     90            3_555  1_555    4_454 yes
+  O1     Ti1    O1     90            1_555  1_555    4_455 yes
+  O1     Ti1    O1     180           2_544  1_555    4_455 yes
+  O1     Ti1    O1     81.13         2_545  1_555    4_455 yes
+  O1     Ti1    O1     90            3_555  1_555    4_455 yes
+  O1     Ti1    O1     98.87         4_454  1_555    4_455 yes
+  Ti1    O1     Ti1    130.565       1_555  1_555    2_554 yes
+  Ti1    O1     Ti1    130.565       1_555  1_555    2_555 yes
+  Ti1    O1     Ti1    98.87         2_554  1_555    2_555 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.100, 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_QPAPBMXGreaseSuspendedSamplePrep_phase_1
+# Information for phase 1
+_pd_block_id
+;
+2021-08-04T17:25|QPAPBMXGreaseSuspendedSamplePrep|phase_1|McDougallHamish
+;
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Silica SiO2 follows
+_pd_phase_name  "Silica SiO2"
+_cell_length_a  4.9149(5)
+_cell_length_b  4.9149(5)
+_cell_length_c  5.4057(4)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  120
+_cell_volume  113.086(10)
+_exptl_crystal_density_diffrn  2.6468
+_symmetry_cell_setting  trigonal
+_symmetry_space_group_name_H-M  "P 32 2 1"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -y,x-y,2/3+z
+     3  y-x,-x,1/3+z
+     4  y,x,-z
+     5  -x,y-x,2/3-z
+     6  x-y,-y,1/3-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Si1    Si4+ 0.47000     0.00000     0.66670     1.000      Uiso 0.010      3   
+O1     O2-  0.41460     0.26780     0.78543     1.000      Uiso 0.010      6   
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  O    6      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si   3      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  3
+_chemical_formula_sum  "O2 Si"
+_chemical_formula_weight  60.08
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Si1    O1     1.60526      1_555    1_555 yes
+  Si1    O1     1.61161      1_555    2_654 yes
+  Si1    O1     1.61135      1_555    5_656 yes
+  Si1    O1     1.6054       1_555    6_556 yes
+  O1     Si1    1.60526      1_555    1_555 yes
+  O1     Si1    1.61161      1_555    3_665 yes
+  O1     Si1    1.61135      1_555    5_666 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Si1    O1     110.256       1_555  1_555    2_654 yes
+  O1     Si1    O1     108.745       1_555  1_555    5_656 yes
+  O1     Si1    O1     109.685       2_654  1_555    5_656 yes
+  O1     Si1    O1     109.161       1_555  1_555    6_556 yes
+  O1     Si1    O1     108.725       2_654  1_555    6_556 yes
+  O1     Si1    O1     110.262       5_656  1_555    6_556 yes
+  Si1    O1     Si1    143.832       1_555  1_555    3_665 yes
+  Si1    O1     Si1    143.836       1_555  1_555    5_666 yes
+  Si1    O1     Si1    0.009         3_665  1_555    5_666 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.244(15), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_QPAPBMXGreaseSuspendedSamplePrep_pwd_0
+_pd_proc_ls_profile_function
+;
+Finger-Cox-Jephcoat function parameters U, V, W, X, Y, SH/L:
+  peak variance(Gauss) = Utan(Th)^2^+Vtan(Th)+W:
+  peak HW(Lorentz) = X/cos(Th)+Ytan(Th); SH/L = S/L+H/L
+  U, V, W in (centideg)^2^, X & Y in centideg
+    0.000, 0.000, 3.345, 2.239, -0.670, 0.034, 
+;
+# Information for histogram 0: PWDR 201103PBHMGR_PyriteSiGrease [201103PBHM].xrdml Scan 1
+_pd_block_id
+;
+2021-08-04T17:25|QPAPBMXGreaseSuspendedSamplePrep|McDougallHamish|PANalytical,Co-EmpyreanII_hist_0
+;
+# GSAS-II edited template follows Instrument_Template
+#==============================================================================
+# 9. INSTRUMENT CHARACTERIZATION
+
+_exptl_special_details
+; ?
+;
+
+# if regions of the data are excluded, the reason(s) are supplied here:
+_pd_proc_info_excluded_regions
+; ?
+;
+
+# The following item is used to identify the equipment used to record 
+# the powder pattern when the diffractogram was measured at a laboratory 
+# other than the authors' home institution, e.g. when neutron or synchrotron
+# radiation is used.
+
+_pd_instr_location
+; ?
+;
+_pd_calibration_special_details           # description of the method used
+                                          # to calibrate the instrument
+; ?
+;
+
+_diffrn_source                    Co-Ka       
+_diffrn_source_target             Co
+_diffrn_source_type               Graded_Flat
+_diffrn_measurement_device_type   Panalytical_Reflection_Transmission       
+_diffrn_detector                  PIXcel1D       
+_diffrn_detector_type             Empyrean_II       # make or model of detector
+
+_pd_meas_scan_method              ?       # options are 'step', 'cont',
+                                          # 'tof', 'fixed' or
+                                          # 'disp' (= dispersive)
+_pd_meas_special_details
+;  ?
+;
+
+# The following two items identify the program(s) used (if appropriate).
+_computing_data_collection        ?        
+_computing_data_reduction         ?                   
+
+# Describe any processing performed on the data, prior to refinement.
+# For example: a manual Lp correction or a precomputed absorption correction
+_pd_proc_info_data_reduction      ?
+
+# The following item is used for angular dispersive measurements only.
+
+_diffrn_radiation_monochromator   ?        
+
+# The following items are used to define the size of the instrument.
+# Not all distances are appropriate for all instrument types.
+
+_pd_instr_dist_src/mono           ?
+_pd_instr_dist_mono/spec          ?
+_pd_instr_dist_src/spec           ?
+_pd_instr_dist_spec/anal          ?
+_pd_instr_dist_anal/detc          ?
+_pd_instr_dist_spec/detc          ?
+
+# 10. Specimen size and mounting information
+
+# The next three fields give the specimen dimensions in mm.  The equatorial 
+# plane contains the incident and diffracted beam.
+
+_pd_spec_size_axial               ?       # perpendicular to 
+                                          # equatorial plane
+
+_pd_spec_size_equat               ?       # parallel to 
+                                          # scattering vector 
+                                          # in transmission
+
+_pd_spec_size_thick               ?       # parallel to 
+                                          # scattering vector 
+                                          # in reflection
+
+_pd_spec_mounting                         # This field should be
+                                          # used to give details of the 
+                                          # container.
+; ?
+;
+
+_pd_spec_mount_mode               ?       # options are 'reflection' 
+                                          # or 'transmission'
+    
+_pd_spec_shape                    ?       # options are 'cylinder' 
+                                          # 'flat_sheet' or 'irregular'
+
+
+loop_
+     _atom_type_symbol
+     _atom_type_scat_dispersion_real
+     _atom_type_scat_dispersion_imag
+     _atom_type_scat_dispersion_source
+  Al        0.255   0.328   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Fe       -3.332   0.490   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Na        0.167   0.167   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  O         0.063   0.044   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S         0.371   0.733   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si        0.298   0.438   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Ti       -0.063   2.321   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+_diffrn_radiation_type  K\a~1,2~
+loop_
+   _diffrn_radiation_wavelength
+   _diffrn_radiation_wavelength_wt
+   _diffrn_radiation_wavelength_id
+  1.78892         1.0             1     
+  1.79278         0.5000          2     
+
+# PHASE TABLE
+loop_
+   _pd_phase_id
+   _pd_phase_block_id
+   _pd_phase_mass_%
+  2  2021-08-04T17:25|QPAPBMXGreaseSuspendedSamplePrep|phase_2|McDougallHamish  0.1274(24)
+  0  2021-08-04T17:25|QPAPBMXGreaseSuspendedSamplePrep|phase_0|McDougallHamish  0.7533(28)
+  3  2021-08-04T17:25|QPAPBMXGreaseSuspendedSamplePrep|phase_3|McDougallHamish  0.0602(12)
+  4  2021-08-04T17:25|QPAPBMXGreaseSuspendedSamplePrep|phase_4|McDougallHamish  0.0044(5)
+  1  2021-08-04T17:25|QPAPBMXGreaseSuspendedSamplePrep|phase_1|McDougallHamish  0.0546(9)
+loop_
+   _gsas_proc_phase_R_F_factor
+   _gsas_proc_phase_R_Fsqd_factor
+   _gsas_proc_phase_id
+   _gsas_proc_phase_block_id
+    0.10687  0.39708  2  2021-08-04T17:25|QPAPBMXGreaseSuspendedSamplePrep|phase_2|McDougallHamish
+    0.02278  0.05179  0  2021-08-04T17:25|QPAPBMXGreaseSuspendedSamplePrep|phase_0|McDougallHamish
+    0.06926  0.11017  3  2021-08-04T17:25|QPAPBMXGreaseSuspendedSamplePrep|phase_3|McDougallHamish
+    0.05512  0.10491  4  2021-08-04T17:25|QPAPBMXGreaseSuspendedSamplePrep|phase_4|McDougallHamish
+    0.08988  0.19081  1  2021-08-04T17:25|QPAPBMXGreaseSuspendedSamplePrep|phase_1|McDougallHamish
+_pd_proc_ls_prof_R_factor     0.08119
+_pd_proc_ls_prof_wR_factor    0.11424
+_gsas_proc_ls_prof_R_B_factor   0.09066
+_gsas_proc_ls_prof_wR_B_factor  0.11657
+_pd_proc_ls_prof_wR_expected  0.06424
+_diffrn_radiation_probe  x-ray
+_diffrn_radiation_polarisn_ratio  0.7000
+_pd_proc_ls_background_function
+;
+Background function: "chebyschev-1" function with 7 terms:
+    181.2(5), -233.0(9), 140.3(8), -64.2(7), 23.5(7), -5.0(5), 
+    3.5(5), 
+;
+_diffrn_ambient_temperature  300
+_diffrn_ambient_pressure  100
+
+# STRUCTURE FACTOR TABLE
+loop_
+   _pd_refln_phase_id
+   _refln_index_h
+   _refln_index_k
+   _refln_index_l
+   _refln_F_squared_meas
+   _refln_F_squared_calc
+   _refln_phase_calc
+   _refln_d_spacing
+   _gsas_i100_meas
+  0  1    1    1    880.6142   862.3285   0.0     3.12882  23.64  
+  0  2    0    0    5936.7521  6060.3423  -0.0    2.70964  88.37  
+  0  2    1    0    3313.1826  3377.4384  0.0     2.42358  77.91  
+  0  2    1    1    1854.7944  1708.1513  -180.0  2.21241  71.89  
+  0  2    2    0    3375.0324  3164.7541  -0.0    1.91600  48.28  
+  0  2    2    1    33.7396    33.1676    -0.0    1.80643  0.85   
+  0  3    1    1    4835.5720  5045.6122  -0.0    1.63397  100.00 
+  0  2    2    2    2574.1005  2193.6808  0.0     1.56441  16.32  
+  0  3    0    2    2965.9778  2941.9535  -0.0    1.50304  26.20  
+  0  3    1    2    625.5014   603.7852   0.0     1.44836  10.36  
+  0  3    2    1    1625.6584  1569.2189  180.0   1.44836  26.93  
+  0  4    0    0    417.4178   425.2388   -180.0  1.35482  1.56   
+  0  3    2    2    35.3160    34.0840    -0.0    1.31437  0.51   
+  0  4    1    0    92.7173    89.4828    -0.0    1.31437  0.66   
+  0  4    1    1    46.5841    48.1452    180.0   1.27734  0.65   
+  1  1    0    0    420.7055   246.0001   180.0   4.25641  0.84   
+  1  1    0    1    655.5334   642.5993   120.0   3.34417  0.80   
+  1  1    0    -1   1576.5549  1545.4485  -120.0  3.34417  1.91   
+  1  1    1    0    336.9855   366.8305   -153.5  2.45744  0.21   
+  1  1    0    -2   128.9725   125.0260   -60.0   2.28170  0.07   
+  1  1    0    2    292.0484   283.1118   -120.0  2.28170  0.16   
+  1  1    1    1    134.7737   103.3422   90.1    2.23712  0.14   
+  1  2    0    0    261.5231   273.4863   0.0     2.12820  0.12   
+  1  2    0    -1   112.3739   82.3235    60.0    1.98026  0.05   
+  1  2    0    1    328.4764   240.6371   -60.0   1.98026  0.13   
+  1  1    1    2    565.0435   617.9827   9.8     1.81826  0.38   
+  1  0    0    3    49.8001    49.4912    0.0     1.80191  0.01   
+  1  2    0    2    75.5670    92.1401    60.0    1.67208  0.02   
+  1  2    0    -2   350.7077   427.6239   120.0   1.67208  0.10   
+  1  1    0    -3   143.5888   210.3288   180.0   1.65934  0.04   
+  1  1    0    3    7.0230     10.2873    0.0     1.65934  0.00   
+  1  2    1    0    24.4919    24.3799    -21.0   1.60877  0.01   
+  1  2    1    -1   621.0619   393.1170   95.4    1.54194  0.30   
+  1  2    1    1    422.8221   267.6360   -107.0  1.54194  0.21   
+  1  1    1    3    158.2322   149.1271   112.7   1.45313  0.07   
+  1  3    0    0    78.6188    84.2828    180.0   1.41880  0.02   
+  1  2    1    -2   358.9468   383.7375   -124.0  1.38242  0.14   
+  1  2    1    2    136.8040   146.2524   150.7   1.38242  0.06   
+  1  2    0    -3   193.4643   212.1659   -0.0    1.37519  0.04   
+  1  2    0    3    984.7400   1079.9318  0.0     1.37519  0.20   
+  1  3    0    -1   872.7549   836.5862   -120.0  1.37232  0.17   
+  1  3    0    1    8.3489     8.0029     -60.0   1.37232  0.00   
+  1  1    0    -4   125.7643   70.8900    -120.0  1.28806  0.02   
+  1  1    0    4    767.6514   432.7046   120.0   1.28806  0.14   
+  2  0    0    1    2371.7259  685.7867   180.0   6.38937  0.12   
+  2  0    2    0    1278.2068  396.4682   180.0   6.38215  0.05   
+  2  1    1    0    626.5458   238.2264   -0.0    6.33803  0.02   
+  2  1    -1   0    764.0634   287.5558   -0.0    6.30614  0.03   
+  2  1    1    -1   693.8461   406.2050   180.0   5.90981  0.02   
+  2  1    -1   -1   482.2860   415.7508   -180.0  5.59107  0.02   
+  2  0    2    -1   38.4761    16.5865    0.0     4.66552  0.00   
+  2  0    2    1    15.5665    1.8370     180.0   4.37892  0.00   
+  2  2    0    -1   28982.5537 21040.7682 -0.0    4.02860  0.43   
+  2  1    -1   1    5372.4994  3768.4641  -0.0    3.85490  0.08   
+  2  1    1    1    25626.0075 10390.7325 0.0     3.77570  0.41   
+  2  1    3    0    6601.8342  5887.8030  180.0   3.68247  0.08   
+  2  1    3    -1   3970.6851  4506.7668  0.0     3.66677  0.05   
+  2  1    -3   0    9616.0581  11684.2766 180.0   3.66371  0.12   
+  2  2    0    0    1.3493     2.5801     0.0     3.63867  0.00   
+  2  1    1    -2   4964.1875  4329.1619  0.0     3.50583  0.07   
+  2  2    2    -1   6963.5684  1650.0375  180.0   3.48036  0.08   
+  2  1    -3   -1   57.5213    12.1106    0.0     3.44114  0.00   
+  2  1    -1   -2   6381.3308  5252.5409  0.0     3.37438  0.08   
+  2  2    -2   -1   330.0901   365.4739   0.0     3.33748  0.00   
+  2  2    0    -2   28302.1491 26661.3709 -180.0  3.21590  0.29   
+  2  0    0    2    34930.4467 37077.8380 -180.0  3.19468  0.42   
+  2  0    4    0    22639.1713 25384.0136 180.0   3.19107  0.21   
+  2  2    2    0    13434.1253 13872.7626 180.0   3.16901  0.13   
+  2  2    -2   0    11649.1980 14957.3260 -180.0  3.15307  0.11   
+  2  1    -3   1    20974.8555 11184.2792 -180.0  2.96771  0.17   
+  2  2    2    -2   13411.5305 7187.7656  0.0     2.95490  0.11   
+  2  0    2    -2   6760.0343  5312.1771  0.0     2.93203  0.06   
+  2  0    4    -1   11263.6297 8593.0123  0.0     2.92994  0.09   
+  2  1    3    1    15939.2531 6898.1639  180.0   2.86181  0.14   
+  2  1    3    -2   2613.0782  1924.0931  -0.0    2.83981  0.02   
+  2  2    -2   -2   162.2316   183.4970   -0.0    2.79553  0.00   
+  2  0    2    2    161.5592   191.6866   0.0     2.78701  0.00   
+  2  0    4    1    334.7990   387.4011   -0.0    2.78521  0.00   
+  2  2    0    1    113.1057   109.6819   -0.0    2.68769  0.00   
+  2  3    1    -1   353.7622   431.0241   -180.0  2.66284  0.00   
+  2  1    -3   -2   5873.7326  6174.6196  -0.0    2.64084  0.04   
+  2  3    -1   -1   31.3741    33.5523    -180.0  2.62711  0.00   
+  2  2    4    -1   13301.8868 12552.3538 -180.0  2.55991  0.08   
+  2  3    1    -2   3037.0846  1812.2346  180.0   2.53714  0.02   
+  2  1    -1   2    690.7249   666.9600   180.0   2.51234  0.00   
+  2  2    -2   1    1745.2344  1688.6182  -180.0  2.49700  0.01   
+  2  3    -1   -2   526.0810   450.0307   180.0   2.48209  0.00   
+  2  1    1    2    109.6021   110.1448   180.0   2.46640  0.00   
+  2  2    2    1    1263.5199  1366.9989  -180.0  2.45748  0.01   
+  2  2    -4   -1   12321.6294 10461.9695 -180.0  2.44676  0.07   
+  2  1    5    -1   4206.9089  4096.3372  -0.0    2.43093  0.02   
+  2  1    5    0    55.9737    64.5696    180.0   2.41336  0.00   
+  2  2    4    0    3612.6016  3943.7501  -0.0    2.40616  0.02   
+  2  1    -5   0    2122.4826  2242.5238  180.0   2.40454  0.01   
+  2  2    -4   0    2187.8916  2083.3522  -0.0    2.39222  0.01   
+  2  3    1    0    1591.8596  1565.3631  -0.0    2.38569  0.01   
+  2  3    -1   0    1857.8763  2088.7747  -0.0    2.38057  0.01   
+  2  2    0    -3   8.7500     7.3432     180.0   2.35206  0.00   
+  2  2    4    -2   4.9406     2.9334     0.0     2.34748  0.00   
+  2  1    1    -3   146.1037   110.9384   -0.0    2.33711  0.00   
+  2  0    4    -2   1172.8981  886.6831   -180.0  2.33276  0.01   
+  2  1    -5   -1   1952.1352  1043.4163  0.0     2.31863  0.01   
+  2  3    3    -1   18818.0954 9807.0007  180.0   2.31702  0.09   
+  2  1    -1   -3   2249.9909  2293.9554  -0.0    2.27833  0.01   
+  2  2    2    -3   187.4998   155.6906   -0.0    2.26171  0.00   
+  2  3    3    -2   18.2959    15.9304    0.0     2.25027  0.00   
+  2  3    -3   -1   3207.4324  2706.8056  -180.0  2.24815  0.01   
+  2  1    -3   2    874.6291   822.9774   -0.0    2.22731  0.00   
+  2  2    -4   -2   1305.7954  1432.7781  0.0     2.19093  0.01   
+  2  0    4    2    1918.7236  2085.1188  0.0     2.18946  0.01   
+  2  1    -5   1    3885.0923  4197.6156  180.0   2.18795  0.02   
+  2  2    -2   -3   1792.2947  1854.0832  0.0     2.15599  0.01   
+  2  1    5    -2   309.7931   311.4551   -180.0  2.15295  0.00   
+  2  3    -3   -2   623.8943   515.3061   180.0   2.13987  0.00   
+  2  3    1    -3   247.1411   204.6081   0.0     2.13853  0.00   
+  2  1    3    2    192.9602   174.7022   -180.0  2.13468  0.00   
+  2  0    0    3    451.6686   454.6998   -0.0    2.12979  0.00   
+  2  0    6    0    10565.2026 11061.1686 -0.0    2.12738  0.04   
+  2  1    3    -3   661.8611   675.4873   -180.0  2.11945  0.00   
+  2  1    5    1    4635.9869  4736.6864  180.0   2.11687  0.02   
+  2  3    3    0    1458.8508  1497.2750  -180.0  2.11268  0.01   
+  2  3    -3   0    161.3219   181.2189   -180.0  2.10205  0.00   
+  2  3    -1   -3   1842.3023  2418.3608  0.0     2.09091  0.01   
+  2  2    -4   1    6786.4141  8393.2234  180.0   2.07866  0.03   
+  2  0    2    -3   275.3432   287.1519   -180.0  2.05980  0.00   
+  2  0    6    -1   82.3008    83.9647    -0.0    2.05787  0.00   
+  2  2    4    1    2484.7495  2723.6549  180.0   2.03347  0.01   
+  2  4    0    -2   2287.3734  1674.9121  -0.0    2.01430  0.01   
+  2  1    -5   -2   1399.1796  983.0910   -0.0    2.00783  0.01   
+  2  4    0    -1   4110.0688  3209.9366  -0.0    2.00082  0.01   
+  2  2    0    2    1122.0100  915.0412   0.0     1.99869  0.00   
+  2  1    -3   -3   2819.0536  2007.1870  -0.0    1.99475  0.01   
+  2  0    2    3    1715.1389  1320.7805  0.0     1.98292  0.01   
+  2  0    6    1    6273.9277  4765.5652  0.0     1.98119  0.02   
+  2  3    -1   1    2401.9429  1780.7293  0.0     1.97252  0.01   
+  2  3    3    -3   1124.4401  747.4554   -180.0  1.96994  0.00   
+  2  2    4    -3   281.7457   210.7067   -180.0  1.96372  0.00   
+  2  3    1    1    1390.8153  1050.0637  0.0     1.96357  0.01   
+  2  4    2    -2   1843.8646  1504.9735  0.0     1.94701  0.01   
+  2  2    -2   2    5730.2855  4437.4029  -0.0    1.92745  0.02   
+  2  4    2    -1   225.9099   195.3842   0.0     1.92368  0.00   
+  2  2    6    -1   28.1048    25.7062    -0.0    1.91832  0.00   
+  2  4    -2   -2   13814.3680 14629.7803 -0.0    1.89581  0.04   
+  2  4    -2   -1   80.1979    83.9500    180.0   1.89504  0.00   
+  2  2    2    2    12928.1285 11148.4273 -0.0    1.88785  0.05   
+  2  3    5    -1   3780.9729  3253.4383  -180.0  1.88777  0.01   
+  2  3    -3   -3   299.3028   242.0296   -0.0    1.86369  0.00   
+  2  3    5    -2   159.0300   152.0294   -180.0  1.86107  0.00   
+  2  4    0    -3   10398.4260 17237.0458 -180.0  1.85020  0.03   
+  2  2    -6   -1   426.9566   631.4007   -180.0  1.84615  0.00   
+  2  1    -5   2    24.9559    32.7572    -180.0  1.84484  0.00   
+  2  2    6    0    5083.8485  5974.4907  -0.0    1.84124  0.02   
+  2  2    6    -2   1675.4050  2234.4706  -180.0  1.83338  0.00   
+  2  2    -6   0    8421.3620  11189.5327 0.0     1.83185  0.02   
+  2  1    -1   3    1874.8056  2405.3085  -180.0  1.83014  0.01   
+  2  2    -4   -3   273.0833   350.1904   -0.0    1.83000  0.00   
+  2  3    -5   -1   479.4389   549.7524   -180.0  1.82598  0.00   
+  2  0    4    -3   5792.6769  6604.3122  180.0   1.82565  0.02   
+  2  0    6    -2   8239.0595  9390.0654  -180.0  1.82481  0.02   
+  2  4    0    0    15065.5075 16550.5982 -0.0    1.81933  0.04   
+  2  3    -3   1    1179.0252  1388.3670  -0.0    1.81439  0.00   
+  2  4    2    -3   1695.3896  1698.0774  -0.0    1.80673  0.00   
+  2  1    1    3    13005.9169 13208.6072 -180.0  1.80298  0.05   
+  2  3    3    1    679.7526   659.8898   -0.0    1.79371  0.00   
+  2  1    5    -3   33.0507    36.9628    180.0   1.79244  0.00   
+  2  1    7    -1   201.1032   370.4245   -180.0  1.78694  0.00   
+  2  2    0    -4   19442.0716 29316.3996 0.0     1.78509  0.06   
+  2  1    7    0    1240.0279  1189.2394  -0.0    1.77124  0.00   
+  2  1    -7   0    3063.2381  1867.8935  0.0     1.76635  0.01   
+  2  3    5    0    512.1298   192.4547   -180.0  1.76366  0.00   
+  2  3    -5   -2   1010.6300  294.6076   -180.0  1.75802  0.00   
+  2  1    5    2    4997.6510  1479.7333  -180.0  1.75788  0.02   
+  2  3    -5   0    1.3717     0.6626     -180.0  1.75337  0.00   
+  2  2    2    -4   10434.8050 5374.9726  180.0   1.75292  0.03   
+  2  4    2    0    5868.0233  3239.6883  180.0   1.75234  0.02   
+  2  4    -2   -3   2277.3769  1501.5813  -180.0  1.74875  0.01   
+  2  4    -2   0    2297.0065  1479.8081  -180.0  1.74693  0.01   
+  2  4    4    -2   50155.1279 11154.3525 -180.0  1.74018  0.13   
+  2  3    1    -4   72.4486    11.6995    0.0     1.73825  0.00   
+  2  1    1    -4   1761.8946  932.1602   180.0   1.73086  0.01   
+  2  1    -7   -1   715.0597   545.9938   -0.0    1.72344  0.00   
+  2  2    -4   2    6062.1806  5118.1822  -180.0  1.72229  0.02   
+  2  0    4    3    1883.2674  1650.1674  180.0   1.72185  0.01   
+  2  0    6    2    4443.9463  4048.7075  180.0   1.72115  0.01   
+  2  2    -6   -2   6348.6934  5855.0458  180.0   1.72057  0.02   
+  2  1    -3   3    4128.2475  3893.3583  0.0     1.71853  0.01   
+  2  4    4    -1   3206.1697  3425.5098  -0.0    1.71557  0.01   
+  2  3    -1   -4   25.9580    26.2827    -0.0    1.70464  0.00   
+  2  3    5    -3   2139.4942  1781.8537  180.0   1.70049  0.01   
+  2  1    -1   -4   1367.5788  1087.9492  180.0   1.69891  0.00   
+  2  2    -2   -4   6687.2836  6612.2591  -0.0    1.68719  0.02   
+  2  2    -6   1    113.2058   112.0146   180.0   1.68648  0.00   
+  2  1    -7   1    1094.7520  1039.6827  0.0     1.68229  0.00   
+  2  4    -4   -1   2971.3481  3117.8438  -0.0    1.67547  0.01   
+  2  1    7    -2   2878.7248  3017.8829  0.0     1.67463  0.01   
+  2  1    -5   -3   280.8585   323.7721   -180.0  1.66878  0.00   
+  2  4    -4   -2   2604.6963  3004.6747  -180.0  1.66874  0.01   
+  2  2    4    2    5544.0110  6981.7047  -180.0  1.66680  0.02   
+  2  1    3    3    494.0051   605.5747   0.0     1.65343  0.00   
+  2  3    3    -4   417.7705   474.5246   180.0   1.65095  0.00   
+  2  2    6    1    13.6829    15.1220    180.0   1.65026  0.00   
+  2  4    4    -3   84.5703    81.4112    0.0     1.64471  0.00   
+  2  1    3    -4   1329.4733  1267.8482  -180.0  1.64350  0.00   
+  2  2    6    -3   423.5616   439.5145   0.0     1.63900  0.00   
+  2  1    7    1    925.6519   960.5648   0.0     1.63668  0.00   
+  2  5    1    -2   58.4474    62.3567    -180.0  1.62137  0.00   
+  2  2    4    -4   6.8610     6.6665     0.0     1.60920  0.00   
+  2  3    -1   2    237.8659   237.2272   -180.0  1.60839  0.00   
+  2  4    0    -4   25.8073    25.5934    0.0     1.60795  0.00   
+  2  5    -1   -2   107.7592   104.7618   -0.0    1.60567  0.00   
+  2  0    0    4    1879.8688  1720.4582  -0.0    1.59734  0.01   
+  2  3    1    2    3.6586     3.3675     -180.0  1.59716  0.00   
+  2  0    8    0    4615.1210  4116.7097  -0.0    1.59554  0.01   
+  2  3    -5   -3   6110.6992  7055.7211  -180.0  1.58874  0.01   
+  2  4    2    -4   4300.5258  5769.2527  -180.0  1.58532  0.01   
+  2  4    4    0    59.2189    80.4878    180.0   1.58451  0.00   
+  2  3    -5   1    2489.9437  3546.2934  0.0     1.58189  0.01   
+  2  1    -7   -2   77.7393    106.1538   180.0   1.57755  0.00   
+  2  4    -4   0    655.9131   974.3843   180.0   1.57653  0.00   
+  2  4    0    1    1066.4365  1313.3307  0.0     1.57440  0.00   
+  2  0    2    -4   6026.0904  6841.0030  -180.0  1.57318  0.02   
+  2  5    1    -1   1655.0890  1839.1281  0.0     1.57235  0.00   
+  2  0    8    -1   4815.1993  5116.1501  -180.0  1.57157  0.01   
+  2  5    1    -3   4.5382     4.5420     0.0     1.57077  0.00   
+  2  3    -3   -4   215.2036   221.7439   -180.0  1.56860  0.00   
+  2  1    -3   -4   1299.3813  1168.5667  -180.0  1.56510  0.00   
+  2  5    -1   -1   4124.1773  3533.8617  -0.0    1.56393  0.01   
+  2  4    -4   -3   732.4938   669.0052   0.0     1.55988  0.00   
+  2  2    0    3    1878.8524  1763.7320  -180.0  1.55943  0.00   
+  2  3    5    1    6906.0204  6631.1418  -0.0    1.55915  0.02   
+  2  0    6    -3   46.3242    50.5436    180.0   1.55517  0.00   
+  2  5    -1   -3   2927.9131  3178.3511  180.0   1.55067  0.01   
+  2  5    3    -2   2706.6685  1684.7047  0.0     1.53933  0.01   
+  2  3    7    -1   391.6213   255.2823   -0.0    1.53564  0.00   
+  2  4    -2   -4   7040.0820  4569.4928  180.0   1.53438  0.02   
+  2  4    -2   1    588.1628   360.6797   -0.0    1.53233  0.00   
+  2  2    -2   3    5371.1359  3887.6768  0.0     1.53041  0.01   
+  2  1    -5   3    180.1326   114.3092   180.0   1.52901  0.00   
+  2  0    2    4    3034.4826  1999.7209  180.0   1.52694  0.01   
+  2  3    7    -2   2184.5159  1418.8476  180.0   1.52666  0.00   
+  2  0    8    1    86.3369    54.0376    0.0     1.52547  0.00   
+  2  4    2    1    85.8258    55.0493    -0.0    1.52485  0.00   
+  2  3    -3   2    1106.1493  712.9320   0.0     1.52462  0.00   
+  2  2    -6   -3   1381.5615  975.2512   180.0   1.52290  0.00   
+  2  1    -7   2    2574.6763  2097.0709  180.0   1.51590  0.01   
+  2  2    -4   -4   4396.9659  3478.4348  -180.0  1.51121  0.01   
+  2  2    8    -1   10067.2036 8940.6641  0.0     1.50758  0.02   
+  2  5    3    -3   12119.0368 11216.3189 -0.0    1.50105  0.02   
+  2  5    -3   -2   1343.3172  1283.3109  0.0     1.50000  0.00   
+  2  2    2    3    272.5218   261.5419   0.0     1.49978  0.00   
+  2  4    6    -2   1732.7662  1643.6348  -180.0  1.49778  0.00   
+  2  3    3    2    2753.2574  2828.3791  0.0     1.49643  0.01   
+  2  1    7    -3   760.7365   966.4998   -0.0    1.49239  0.00   
+  2  5    3    -1   1082.5442  1375.7326  180.0   1.49201  0.00   
+  2  3    -7   -1   3.4191     4.2383     -180.0  1.48891  0.00   
+  2  3    5    -4   810.0666   977.0519   0.0     1.48756  0.00   
+  2  2    -6   2    2310.4556  2226.8402  -180.0  1.48385  0.00   
+  2  1    5    -4   571.4830   568.7560   -0.0    1.48128  0.00   
+  2  4    4    -4   836.8946   936.4201   -0.0    1.47745  0.00   
+  2  4    6    -1   2151.3910  2425.6102  -0.0    1.47698  0.00   
+  2  5    -3   -1   1959.2884  2253.4175  180.0   1.47071  0.00   
+  2  2    8    -2   1771.8997  2039.6600  -0.0    1.47020  0.00   
+  2  0    4    -4   1414.1247  1800.0200  0.0     1.46602  0.00   
+  2  0    8    -2   2026.0794  2674.7818  0.0     1.46497  0.00   
+  2  2    8    0    13847.9117 17391.5418 180.0   1.46439  0.03   
+  2  3    7    0    1101.6290  1344.4765  -0.0    1.46170  0.00   
+  2  2    -8   -1   247.3362   277.6788   0.0     1.46041  0.00   
+  2  0    6    3    8874.3865  9734.9126  -180.0  1.45964  0.02   
+  2  2    -8   0    15008.5840 15008.2619 -180.0  1.45809  0.03   
+  2  1    5    3    91.5838    84.5203    0.0     1.45393  0.00   
+  2  3    -7   0    2014.6709  1879.8027  -0.0    1.45350  0.00   
+  2  5    -3   -3   4186.4855  3978.1354  -0.0    1.45011  0.01   
+  2  1    7    2    361.8429   339.9922   180.0   1.44810  0.00   
+  2  5    1    0    530.9883   468.9716   0.0     1.44705  0.00   
+  2  3    -7   -2   463.8845   408.4855   -180.0  1.44665  0.00   
+  2  5    -1   0    314.7059   283.3261   0.0     1.44514  0.00   
+  2  5    1    -4   428.6459   376.2186   -0.0    1.44459  0.00   
+  2  4    6    -3   4976.2274  4800.8441  180.0   1.44022  0.01   
+  2  3    7    -3   2155.9387  2067.0984  0.0     1.43881  0.00   
+  2  4    -6   -1   14562.9513 14009.4338 -0.0    1.43874  0.03   
+  2  1    -1   4    2459.4469  1748.6544  -0.0    1.43197  0.01   
+  2  2    6    2    20601.8030 14133.1721 -180.0  1.43091  0.04   
+  2  4    -6   -2   16140.0572 11520.2399 -180.0  1.42991  0.03   
+  2  2    -4   3    11209.3339 9317.7644  -0.0    1.42596  0.02   
+  2  3    1    -5   64.5608    54.6219    0.0     1.42530  0.00   
+  2  5    -1   -4   6972.0505  6194.2196  0.0     1.42440  0.01   
+  2  2    0    -5   494.9697   530.8298   -0.0    1.42009  0.00   
+  2  2    6    -4   3850.2712  4112.0229  -0.0    1.41990  0.01   
+  2  4    -4   1    2174.0867  2331.0251  -180.0  1.41784  0.00   
+  2  1    1    4    12087.1195 9767.8691  -0.0    1.41443  0.03   
+  2  2    2    -5   117.6694   102.1168   180.0   1.40805  0.00   
+  2  4    4    1    4720.8647  4250.5902  -180.0  1.40605  0.01   
+  2  1    9    -1   354.9274   313.4717   180.0   1.40550  0.00   
+  2  3    -1   -5   827.1965   559.9427   180.0   1.40229  0.00   
+  2  4    -4   -4   420.3694   334.7015   -180.0  1.39777  0.00   
+  2  5    5    -2   108.1562   121.7392   180.0   1.39651  0.00   
+  2  5    3    -4   8077.3691  10291.2963 -180.0  1.39399  0.01   
+  2  1    9    0    4725.8251  6066.4964  -180.0  1.39360  0.01   
+  2  0    4    4    470.2355   603.7543   180.0   1.39351  0.00   
+  2  0    8    2    716.3845   843.7699   -0.0    1.39261  0.00   
+  2  1    -7   -3   7.6830     8.7176     0.0     1.39217  0.00   
+  2  2    -8   -2   337.8695   389.4645   0.0     1.39162  0.00   
+  2  1    -9   0    4915.3744  5043.3215  -180.0  1.39054  0.01   
+  2  3    -5   -4   807.0536   715.7487   180.0   1.38969  0.00   
+  2  1    -5   -4   11.5956    12.1530    -0.0    1.38793  0.00   
+  2  4    6    0    6269.4891  6882.5745  0.0     1.38669  0.01   
+  2  2    -8   1    2401.7034  2594.3617  -0.0    1.38562  0.00   
+  2  3    -5   2    98.3552    107.2456   180.0   1.38282  0.00   
+  2  1    -3   4    12515.5424 11505.1596 180.0   1.38064  0.03   
+  2  3    3    -5   625.1316   601.8291   -0.0    1.38004  0.00   
+  2  5    3    0    2080.8309  2064.0651  180.0   1.37960  0.00   
+  2  4    -6   0    2871.6930  2934.9482  0.0     1.37868  0.00   
+  2  2    4    3    7881.8376  7685.0359  -0.0    1.37746  0.02   
+  2  5    -3   0    1784.4143  1849.3546  -180.0  1.37466  0.00   
+  2  4    0    -5   9715.7386  9857.0632  -0.0    1.37307  0.02   
+  2  5    5    -3   1167.2856  1000.0201  -0.0    1.37173  0.00   
+  2  1    1    -5   70.5435    51.8960    180.0   1.36910  0.00   
+  2  2    8    -3   1389.8508  899.5075   0.0     1.36808  0.00   
+  2  1    -9   -1   3236.8826  2522.4075  180.0   1.36534  0.01   
+  2  2    -2   -5   1143.4188  891.7625   -180.0  1.36532  0.00   
+  2  4    2    -5   12204.7731 11338.8231 180.0   1.36281  0.02   
+  2  2    8    1    4008.4056  3615.8412  -180.0  1.35876  0.01   
+  2  5    5    -1   1008.7472  869.9243   -180.0  1.35699  0.00   
+  2  4    -6   -3   4195.2872  4135.1598  180.0   1.35575  0.01   
+  2  3    -7   1    573.7022   580.3630   0.0     1.35509  0.00   
+  2  1    9    -2   13680.5884 16172.2051 0.0     1.35268  0.02   
+  2  1    -9   1    3156.0296  3746.0292  -0.0    1.35222  0.01   
+  2  6    0    -2   14528.5940 16989.5792 180.0   1.35173  0.02   
+  2  1    -1   -5   10234.2266 10688.1341 -0.0    1.34929  0.02   
+  2  5    -5   -2   643.2740   569.3346   180.0   1.34825  0.00   
+  2  3    5    2    241.5546   209.4399   0.0     1.34812  0.00   
+  2  3    -7   -3   1111.5759  988.1008   180.0   1.34405  0.00   
+  2  4    0    2    22123.9455 20274.1794 180.0   1.34385  0.04   
+  2  6    0    -3   478.1779   425.2904   0.0     1.34287  0.00   
+  2  5    -3   -4   29.4657    19.6105    -0.0    1.34152  0.00   
+  2  3    7    1    1023.4159  545.6813   0.0     1.33510  0.00   
+  2  1    3    4    564.9981   303.8950   180.0   1.33497  0.00   
+  2  2    4    -5   3722.8342  2139.1965  -0.0    1.33391  0.01   
+  2  6    2    -2   7524.9826  7470.8807  0.0     1.33142  0.01   
+  2  5    -5   -1   3093.8308  3084.2175  -180.0  1.33051  0.00   
+  2  3    -1   3    551.1874   551.8096   -0.0    1.33026  0.00   
+  2  1    -7   3    771.5668   847.9060   -180.0  1.32923  0.00   
+  2  1    3    -5   12953.2043 12963.7386 180.0   1.32825  0.03   
+  2  4    6    -4   1276.1944  1218.7973  0.0     1.32752  0.00   
+  2  6    2    -3   6.2057     6.0166     -0.0    1.32656  0.00   
+  2  4    -2   -5   3510.8178  3149.4557  0.0     1.32279  0.01   
+  2  1    9    1    1102.8628  1105.8107  -0.0    1.32155  0.00   
+  2  4    -2   2    2168.1980  2257.2205  0.0     1.32096  0.00   
+  2  2    -6   -4   108.8286   114.4574   0.0     1.32042  0.00   
+  2  3    1    3    3081.3435  3238.6207  0.0     1.32030  0.01   
+  2  3    -3   -5   2091.7166  2181.4186  180.0   1.32000  0.00   
+  2  0    6    -4   3842.6138  3689.8215  0.0     1.31805  0.01   
+  2  0    8    -3   4742.2823  4550.5215  -0.0    1.31760  0.01   
+  2  6    -2   -2   353.6784   330.9018   180.0   1.31355  0.00   
+  2  4    2    2    505.6905   505.4773   0.0     1.30914  0.00   
+  2  5    -5   -3   5803.6604  6222.4164  0.0     1.30818  0.01   
+  2  3    7    -4   13.2076    11.4827    -180.0  1.30628  0.00   
+  2  6    0    -1   755.9922   635.4990   -0.0    1.30296  0.00   
+  2  6    -2   -3   5699.9805  4804.0651  0.0     1.30197  0.01   
+  2  1    7    -4   1091.5810  817.9622   180.0   1.30147  0.00   
+  2  4    4    -5   1457.2270  840.0719   -180.0  1.29582  0.00   
+  2  5    -1   1    948.5228   561.3526   -180.0  1.29338  0.00   
+  2  5    5    -4   141.4215   102.0076   -0.0    1.29193  0.00   
+  2  5    1    1    291.6587   213.1141   180.0   1.29139  0.00   
+  2  5    1    -5   1968.2194  1297.9416  -180.0  1.28877  0.00   
+  2  1    -9   -2   10779.9048 7605.5427  0.0     1.28598  0.02   
+  2  3    -3   3    6151.0341  3825.8012  180.0   1.28497  0.01   
+  2  2    -6   3    158.8704   98.2873    -0.0    1.28486  0.00   
+  2  3    5    -5   3925.8300  3039.3601  -0.0    1.28354  0.01   
+  2  6    2    -1   2670.8046  2447.1852  180.0   1.28146  0.00   
+  2  4    8    -2   13485.9734 16045.7549 -0.0    1.27995  0.02   
+  2  1    -5   4    0.2301     0.2764     -0.0    1.27969  0.00   
+  2  6    0    -4   3860.3525  4645.7790  0.0     1.27955  0.01   
+  2  0    0    5    1410.5926  1505.5483  0.0     1.27787  0.00   
+  2  2    -8   -3   948.8342   973.6182   0.0     1.27738  0.00   
+  2  0    10   0    5789.9230  5627.3012  -0.0    1.27643  0.01   
+  2  1    -3   -5   1735.8713  1649.9476  -180.0  1.27603  0.00   
+  2  3    9    -1   779.8276   568.3524   180.0   1.27350  0.00   
+  2  4    -6   1    3058.0183  2161.8394  180.0   1.27195  0.00   
+  2  6    -2   -1   872.5873   605.9287   -180.0  1.27185  0.00   
+  2  3    9    -2   313.5037   209.1430   0.0     1.27155  0.00   
+  2  5    -1   -5   4937.0701  3290.1130  -0.0    1.27117  0.01   
+  2  2    -8   2    13360.6571 15705.3896 0.0     1.26967  0.02   
+  2  2    0    4    4941.7748  5973.8386  -0.0    1.26889  0.01   
+  2  6    2    -4   2342.0348  2642.9843  -180.0  1.26857  0.00   
+  2  0    2    -5   3680.5457  4143.5583  180.0   1.26856  0.01   
+  2  5    5    0    1350.4252  1539.1437  -0.0    1.26761  0.00   
+  2  0    10   -1   604.5125   723.8611   -180.0  1.26720  0.00   
+  3  1    1    0    6462.9134  5229.9972  0.0     5.76243  0.01   
+  3  1    1    -1   1680.5777  1404.4024  0.0     5.74978  0.00   
+  3  0    0    2    7005.8873  6632.0751  0.0     5.69511  0.01   
+  3  2    0    0    1488.2415  777.7143   180.0   5.30605  0.00   
+  3  2    0    -2   21140.5859 11506.7866 0.0     5.26686  0.02   
+  3  1    1    1    13970.0381 5910.1227  -180.0  4.69331  0.02   
+  3  1    1    -2   1267.6763  470.7033   -180.0  4.67287  0.00   
+  3  1    1    2    1316.9231  1806.5888  -180.0  3.62506  0.00   
+  3  1    1    -3   4939.6432  6208.1441  180.0   3.60936  0.00   
+  3  0    2    0    5124.5128  1737.5117  180.0   3.43112  0.00   
+  3  3    1    -1   1548.8615  1015.6842  -0.0    3.40730  0.00   
+  3  3    1    -2   4445.5770  3189.0727  180.0   3.39946  0.00   
+  3  0    2    1    4151.6942  5004.9132  -0.0    3.28530  0.00   
+  3  2    0    2    12142.5085 11581.7159 -0.0    3.21659  0.00   
+  3  2    0    -4   4731.1772  4994.1283  180.0   3.19043  0.00   
+  3  3    1    0    2114.0090  2137.9339  0.0     3.14421  0.00   
+  3  3    1    -3   2579.3113  2675.5752  180.0   3.12582  0.00   
+  3  4    0    -2   83591.4258 80955.5388 180.0   2.98402  0.02   
+  3  2    2    -1   97028.9591 75028.7714 -0.0    2.97457  0.04   
+  3  0    2    2    1020.4645  792.4187   0.0     2.93896  0.00   
+  3  2    2    0    2405.1621  1808.9742  0.0     2.88121  0.00   
+  3  2    2    -2   785.8946   529.2413   -0.0    2.87489  0.00   
+  3  1    1    3    4891.4384  2482.6233  -0.0    2.86050  0.00   
+  3  1    1    -4   9746.1959  5793.4416  -0.0    2.84970  0.00   
+  3  0    0    4    16370.1683 10326.0699 -0.0    2.84755  0.00   
+  3  3    1    1    2834.0667  3752.8231  -180.0  2.75673  0.00   
+  3  3    1    -4   2432.8645  3261.7566  -0.0    2.73612  0.00   
+  3  4    0    0    67320.4782 71075.1612 0.0     2.65303  0.01   
+  3  2    2    1    128590.5664 132934.8926 0.0     2.64148  0.05   
+  3  4    0    -4   131846.7560 140566.5919 180.0   2.63343  0.02   
+  3  2    2    -3   62325.3412 66230.8236 -180.0  2.63175  0.02   
+  3  0    2    3    17795.5151 14167.8457 180.0   2.54564  0.01   
+  3  3    1    2    9531.5825  9768.4331  -180.0  2.37399  0.00   
+  3  3    1    -5   6463.9401  5855.8096  -0.0    2.35557  0.00   
+  3  2    2    2    222.7777   143.7019   -180.0  2.34665  0.00   
+  3  2    2    -4   1259.8071  880.6884   180.0   2.33644  0.00   
+  3  1    1    4    4240.3919  2960.4837  -0.0    2.33289  0.00   
+  3  1    1    -5   488.2228   299.2434   -0.0    2.32535  0.00   
+  3  4    2    -2   1632.7572  1408.1184  -0.0    2.25162  0.00   
+  3  5    1    -2   2509.2187  2124.7582  180.0   2.24560  0.00   
+  3  5    1    -3   645.9889   539.5171   180.0   2.24185  0.00   
+  3  1    3    0    63.3418    52.4461    0.0     2.23606  0.00   
+  3  1    3    -1   5020.7335  4181.8084  -0.0    2.23532  0.00   
+  3  4    2    -1   968.0913   918.5295   0.0     2.21174  0.00   
+  3  4    2    -3   13087.8957 13298.3202 -0.0    2.20602  0.00   
+  3  0    2    4    902.1172   965.8131   180.0   2.19123  0.00   
+  3  5    1    -1   11723.1966 11527.2244 -0.0    2.16646  0.00   
+  3  5    1    -4   708.5232   710.1618   -180.0  2.15641  0.00   
+  3  1    3    1    1030.7403  1031.2370  -0.0    2.15523  0.00   
+  3  1    3    -2   11099.6804 10963.1875 0.0     2.15324  0.00   
+  3  2    0    4    1774.9887  1629.2256  0.0     2.13469  0.00   
+  3  2    0    -6   7062.0788  7194.2438  0.0     2.12190  0.00   
+  3  4    2    0    658.3205   728.4256   -180.0  2.09880  0.00   
+  3  4    2    -4   468.6518   548.5521   -180.0  2.08905  0.00   
+  3  4    0    2    280749.9470 285697.1154 180.0   2.06942  0.03   
+  3  2    2    3    297643.4967 292499.2164 0.0     2.06160  0.06   
+  3  2    2    -5   328434.7214 296721.1076 0.0     2.05236  0.07   
+  3  4    0    -6   335882.4134 301955.0922 -180.0  2.05086  0.03   
+  3  3    1    3    1138.5891  1080.4376  -180.0  2.04679  0.00   
+  3  3    1    -6   158.5739   154.5447   -0.0    2.03160  0.00   
+  3  5    1    0    872.2083   771.3042   180.0   2.02765  0.00   
+  3  1    3    2    18443.8294 14010.4047 -0.0    2.01626  0.00   
+  3  5    1    -5   18717.6396 14156.4238 -0.0    2.01397  0.00   
+  3  1    3    -3   1635.6096  1237.8085  -0.0    2.01355  0.00   
+  3  3    3    -1   9588.9579  7023.2908  -0.0    1.97634  0.00   
+  3  3    3    -2   257.8963   188.1445   0.0     1.97481  0.00   
+  3  6    0    -2   1156.6404  971.7452   180.0   1.96268  0.00   
+  3  1    1    5    4624.6709  4606.2730  180.0   1.95857  0.00   
+  3  6    0    -4   16856.9125 17275.4682 -180.0  1.95669  0.00   
+  3  1    1    -6   1572.1377  1558.5026  -0.0    1.95311  0.00   
+  3  4    2    1    23075.0238 20959.3815 -0.0    1.94247  0.00   
+  3  4    2    -5   81.4866    70.8854    180.0   1.93091  0.00   
+  3  3    3    0    10863.1280 9835.5595  180.0   1.92081  0.00   
+  3  3    3    -3   2978.3083  2768.8394  -0.0    1.91659  0.00   
+  3  0    0    6    1704.9756  1702.6346  -0.0    1.89837  0.00   
+  3  0    2    5    90.2296    90.0513    -180.0  1.89784  0.00   
+  3  5    1    1    2693.8016  2501.5063  -180.0  1.86077  0.00   
+  3  1    3    3    2489.3646  3420.3391  0.0     1.85027  0.00   
+  3  1    3    -4   372.0602   508.3369   -180.0  1.84734  0.00   
+  3  5    1    -6   2196.0109  2896.9866  -180.0  1.84599  0.00   
+  3  3    3    1    2992.1319  3295.1363  -0.0    1.82128  0.00   
+  3  3    3    -4   13514.1166 15068.8780 -180.0  1.81530  0.00   
+  3  2    2    4    1779.7423  2002.5242  180.0   1.81253  0.00   
+  3  2    2    -6   110.2449   110.6800   -0.0    1.80468  0.00   
+  3  3    1    4    1243.2696  1169.7925  -0.0    1.78066  0.00   
+  3  4    2    2    715.4414   569.6672   -0.0    1.77206  0.00   
+  3  6    0    0    48949.2588 33139.7797 180.0   1.76868  0.00   
+  3  3    1    -7   1084.6013  719.9125   -180.0  1.76843  0.00   
+  3  4    2    -6   3729.9871  1197.4426  -0.0    1.76037  0.00   
+  3  6    0    -6   5.3633     2.0506     0.0     1.75562  0.00   
+  3  6    2    -3   454604.2362 370234.8868 -180.0  1.72100  0.06   
+  3  0    4    0    364479.3776 348679.5186 -180.0  1.71556  0.03   
+  3  6    2    -2   426.3303   389.8073   -0.0    1.70365  0.00   
+  3  6    2    -4   1924.6030  1560.5305  180.0   1.69973  0.00   
+  3  3    3    2    4862.1527  3598.0790  -0.0    1.69681  0.00   
+  3  0    4    1    4434.4746  3256.7400  -0.0    1.69643  0.00   
+  3  5    1    2    3144.4361  2566.7981  -180.0  1.69076  0.00   
+  3  3    3    -5   12585.0084 10525.2457 0.0     1.69005  0.00   
+  3  1    1    6    788.8462   740.9601   -0.0    1.68299  0.00   
+  3  1    3    4    48.6019    44.8467    -0.0    1.68161  0.00   
+  3  1    1    -7   13278.1793 12401.2491 -180.0  1.67889  0.00   
+  3  1    3    -5   4997.4991  4674.4642  0.0     1.67878  0.00   
+  3  5    1    -7   271.3223   265.7177   -180.0  1.67652  0.00   
+  3  0    2    6    800.1583   1001.9111  0.0     1.66108  0.00   
+  3  7    1    -3   31.3809    35.5312    180.0   1.65153  0.00   
+  3  6    2    -1   773.3524   866.2621   -180.0  1.65099  0.00   
+  3  7    1    -4   512.5730   558.2160   -0.0    1.64944  0.00   
+  3  2    4    -1   2636.5033  2841.7267  180.0   1.64879  0.00   
+  3  5    3    -2   316.7110   336.8379   -180.0  1.64802  0.00   
+  3  5    3    -3   1196.8751  1233.2014  -180.0  1.64654  0.00   
+  3  6    2    -5   514.3797   505.4766   -180.0  1.64388  0.00   
+  3  0    4    2    628.0652   611.0322   -180.0  1.64265  0.00   
+  3  2    4    0    726.5140   753.0049   -0.0    1.63236  0.00   
+  3  2    4    -2   4271.1694  4458.8300  180.0   1.63121  0.00   
+  3  7    1    -2   3408.6432  3575.7790  180.0   1.61983  0.00   
+  3  5    3    -1   927.8908   966.8885   0.0     1.61596  0.00   
+  3  7    1    -5   894.1869   917.8818   -0.0    1.61395  0.00   
+  3  5    3    -4   3853.6974  3835.5929  -180.0  1.61178  0.00   
+  3  4    0    4    65753.5071 64322.9720 180.0   1.60830  0.00   
+  3  4    2    3    28.2278    27.4719    180.0   1.60687  0.00   
+  3  2    2    5    38793.9314 37088.0188 -180.0  1.60352  0.00   
+  3  2    2    -7   71757.5020 66430.6377 0.0     1.59700  0.01   
+  3  4    2    -7   2793.0948  2578.3163  -0.0    1.59598  0.00   
+  3  4    0    -8   40099.6748 36905.1679 0.0     1.59521  0.00   
+  3  2    4    1    1528.8498  1923.3657  0.0     1.58481  0.00   
+  3  2    4    -3   1453.1194  1875.0462  0.0     1.58270  0.00   
+  3  2    0    6    25061.0407 28841.3496 -0.0    1.57347  0.00   
+  3  6    2    0    291.4279   317.4777   -0.0    1.57210  0.00   
+  3  3    1    5    1821.7819  1735.4823  180.0   1.56656  0.00   
+  3  2    0    -8   5241.7432  4962.7905  -180.0  1.56629  0.00   
+  3  3    3    3    530.1518   484.0152   0.0     1.56444  0.00   
+  3  0    4    3    3214.8032  2912.9935  -0.0    1.56337  0.00   
+  3  6    2    -6   1374.8551  1247.3220  -180.0  1.56291  0.00   
+  3  7    1    -1   2163.2627  2044.2254  -0.0    1.55980  0.00   
+  3  3    3    -6   1495.0349  1491.2058  -180.0  1.55762  0.00   
+  3  3    1    -8   1831.7021  1854.6556  0.0     1.55671  0.00   
+  3  5    3    0    3673.3885  3763.1214  180.0   1.55584  0.00   
+  3  7    1    -6   3619.3497  3788.1306  -180.0  1.55106  0.00   
+  3  5    3    -5   1337.9640  1407.0908  0.0     1.54963  0.00   
+  3  5    1    3    1181.3963  786.3837   0.0     1.53172  0.00   
+  3  1    3    5    10.7405    7.4143     -180.0  1.52397  0.00   
+  3  1    3    -6   1549.8196  1153.0537  0.0     1.52139  0.00   
+  3  5    1    -8   6.6909     5.3825     0.0     1.51878  0.00   
+  3  2    4    2    5411.0894  4250.8779  180.0   1.51372  0.00   
+  3  2    4    -4   3069.7796  2485.2026  -0.0    1.51097  0.00   
+  3  6    0    2    9719.9678  8929.9401  -180.0  1.50516  0.00   
+  3  8    0    -4   16973.1907 20140.7975 0.0     1.49201  0.00   
+  3  6    0    -8   3678.8176  4382.0276  -180.0  1.49177  0.00   
+  3  4    4    -2   17822.6764 20487.7644 -0.0    1.48729  0.00   
+  3  7    1    0    497.0922   522.6657   0.0     1.48032  0.00   
+  3  6    2    1    462.5855   505.4649   180.0   1.47801  0.00   
+  3  5    3    1    1326.9603  1469.8216  180.0   1.47651  0.00   
+  3  4    4    -1   160.1640   180.5060   180.0   1.47562  0.00   
+  3  4    4    -3   1413.7876  1669.2122  180.0   1.47392  0.00   
+  3  1    1    7    7740.5102  9056.9869  -0.0    1.47309  0.00   
+  3  0    2    7    2214.0876  2492.8411  180.0   1.47022  0.00   
+  3  1    1    -8   6572.9070  7376.7327  0.0     1.46992  0.00   
+  3  7    1    -7   206.8237   232.0376   -180.0  1.46989  0.00   
+  3  0    4    4    518.9195   579.9965   180.0   1.46948  0.00   
+  3  5    3    -6   0.1612     0.1800     -180.0  1.46910  0.00   
+  3  6    2    -7   947.8391   1079.2150  180.0   1.46783  0.00   
+  3  4    2    4    320.0451   308.6587   -180.0  1.45625  0.00   
+  3  4    2    -8   333.4290   302.0947   -180.0  1.44652  0.00   
+  3  8    0    -2   57790.6913 52352.8419 0.0     1.44650  0.00   
+  3  4    4    0    43735.4530 40402.1009 -180.0  1.44061  0.00   
+  3  8    0    -6   42614.5148 39533.4246 -180.0  1.44012  0.00   
+  3  4    4    -4   59471.2714 54107.9904 0.0     1.43745  0.01   
+  3  3    3    4    5585.0019  4613.3994  -180.0  1.43552  0.00   
+  3  2    2    6    1.0759     0.7996     -180.0  1.43025  0.00   
+  3  3    3    -7   1902.2950  1446.2007  0.0     1.42909  0.00   
+  3  2    4    3    3493.3715  2695.8039  180.0   1.42841  0.00   
+  3  2    4    -5   1948.1268  1669.9616  180.0   1.42532  0.00   
+  3  2    2    -8   2077.9199  1817.1780  -0.0    1.42485  0.00   
+  3  0    0    8    288773.5638 266053.1220 -0.0    1.42378  0.01   
+  3  3    1    6    830.9072   935.4716   180.0   1.39348  0.00   
+  3  7    1    1    48.9100    50.2165    -180.0  1.39067  0.00   
+  3  5    1    4    780.6944   766.0861   0.0     1.38935  0.00   
+  3  5    3    2    429.4056   442.5311   -180.0  1.38715  0.00   
+  3  4    4    1    3501.0756  3622.6106  -0.0    1.38694  0.00   
+  3  3    1    -9   675.2394   705.1619   -0.0    1.38547  0.00   
+  3  1    3    6    3063.5512  3140.9418  0.0     1.38285  0.00   
+  3  4    4    -5   1197.3470  1223.5583  0.0     1.38272  0.00   
+  3  1    3    -7   501.1836   485.3817   -180.0  1.38058  0.00   
+  3  7    1    -8   236.5056   231.3490   0.0     1.37957  0.00   
+  3  5    3    -7   1094.6152  1074.6564  180.0   1.37926  0.00   
+  3  6    2    2    259.0662   255.4949   -180.0  1.37837  0.00   
+  3  5    1    -9   3200.8538  3156.4016  -0.0    1.37793  0.00   
+  3  0    4    5    450.5358   361.1570   -180.0  1.37042  0.00   
+  3  8    2    -4   1010.0426  739.8164   180.0   1.36825  0.00   
+  3  6    2    -8   3.9284     2.8653     0.0     1.36806  0.00   
+  3  7    3    -3   4044.5147  3200.3251  -180.0  1.36524  0.00   
+  3  7    3    -4   557.6397   462.7559   -180.0  1.36406  0.00   
+  3  1    5    0    5084.2706  4367.7824  -180.0  1.36111  0.00   
+  3  1    5    -1   66.6243    57.3337    -0.0    1.36095  0.00   
+  3  8    2    -3   2186.5929  1924.9351  180.0   1.35981  0.00   
+  3  8    2    -5   15784.9375 14166.5429 180.0   1.35715  0.00   
+  3  7    3    -2   8242.1115  6976.4729  0.0     1.34717  0.00   
+  3  7    3    -5   2945.2255  2392.0445  180.0   1.34378  0.00   
+  3  1    5    1    10077.5767 7430.2792  0.0     1.34224  0.00   
+  3  1    5    -2   4001.1469  2799.0015  180.0   1.34176  0.00   
+  3  2    4    4    391.4822   204.5762   -180.0  1.33724  0.00   
+  3  2    4    -6   6914.3176  4269.8920  180.0   1.33408  0.00   
+  3  8    2    -2   273.9036   192.4516   0.0     1.33290  0.00   
+  3  8    2    -6   123.2571   116.8054   0.0     1.32790  0.00   
+  3  8    0    0    136098.6902 126775.3192 0.0     1.32651  0.01   
+  3  4    2    5    13658.0607 12788.4716 0.0     1.32312  0.00   
+  3  4    4    2    115864.4937 113790.1896 0.0     1.32074  0.01   
+  3  8    0    -8   146918.9624 139228.4566 -0.0    1.31672  0.01   
+  3  3    3    5    1313.1904  1243.0138  -0.0    1.31606  0.00   
+  3  4    4    -6   127391.2673 120565.1659 0.0     1.31588  0.01   
+  3  0    2    8    388.8325   367.3456   180.0   1.31505  0.00   
+  3  4    2    -9   5844.2702  5515.5482  180.0   1.31460  0.00   
+  3  7    3    -1   1079.4173  1032.8378  180.0   1.31204  0.00   
+  3  3    3    -8   7382.7438  7084.1367  180.0   1.31020  0.00   
+  3  1    1    8    163.9068   156.9828   180.0   1.30853  0.00   
+  3  7    3    -6   8534.0134  7543.5146  -0.0    1.30683  0.00   
+  3  1    5    2    1981.0654  1736.1472  180.0   1.30660  0.00   
+  3  1    1    -9   828.1221   713.7481   180.0   1.30602  0.00   
+  3  1    5    -3   8522.4564  7313.8177  -0.0    1.30586  0.00   
+  3  9    1    -4   1162.8393  842.1832   0.0     1.30067  0.00   
+  3  9    1    -5   368.3164   257.1993   0.0     1.29936  0.00   
+  3  6    4    -3   3405.7139  2357.9821  -0.0    1.29919  0.00   
+  3  7    1    2    6126.8757  3971.7741  -180.0  1.29835  0.00   
+  3  3    5    -1   1058.7983  622.6553   0.0     1.29554  0.00   
+  3  5    3    3    573.0718   335.4314   180.0   1.29520  0.00   
+  3  3    5    -2   3745.8208  2190.9789  -0.0    1.29511  0.00   
+  3  6    4    -2   36.9601    25.6170    0.0     1.29167  0.00   
+  3  8    2    -1   12424.3071 8928.5418  180.0   1.29062  0.00   
+  3  6    4    -4   9939.0702  7143.6089  -0.0    1.28996  0.00   
+  3  4    0    6    26019.6460 18405.1729 180.0   1.28953  0.00   
+  3  5    3    -8   5436.3142  3481.6411  180.0   1.28734  0.00   
+  3  7    1    -9   207.7994   133.1829   180.0   1.28731  0.00   
+  3  2    2    7    24223.8930 16070.4759 -0.0    1.28650  0.00   
+  3  9    1    -3   8067.8097  5515.8132  180.0   1.28530  0.00   
+  3  8    2    -7   578.1091   429.7222   -180.0  1.28383  0.00   
+  3  2    2    -9   22438.4736 19688.6962 0.0     1.28200  0.00   
+  3  9    1    -6   205.5901   186.7579   -0.0    1.28151  0.00   
+  3  4    0    -10  20873.5692 20580.0151 -180.0  1.28052  0.00   
+  3  6    2    3    0.3719     0.3790     180.0   1.28002  0.00   
+  3  3    5    0    695.8992   721.5891   -0.0    1.27952  0.00   
+  3  3    5    -3   5949.6030  6044.6576  -0.0    1.27827  0.00   
+  3  0    4    6    153.5736   118.4522   180.0   1.27282  0.00   
+  3  6    2    -9   514.5016   464.6971   180.0   1.27012  0.00   
+  3  6    4    -1   451.3681   481.9605   -180.0  1.26827  0.00   
+  3  6    0    4    6404.1512  7251.2026  180.0   1.26511  0.00   
+  3  6    4    -5   515.5228   581.7440   -180.0  1.26503  0.00   
+  4  1    1    0    1246.0476  1271.8436  -0.0    3.25057  0.01   
+  4  1    0    1    607.2900   492.3700   -0.0    2.49041  0.01   
+  4  2    0    0    218.8020   149.3200   -0.0    2.29850  0.00   
+  4  1    1    1    349.2107   375.1577   180.0   2.18972  0.00   
+  4  2    1    0    159.4241   152.7098   0.0     2.05584  0.00   
+  4  2    1    1    1008.3678  880.3361   -0.0    1.68906  0.01   
+  4  2    2    0    1033.7742  1142.6066  -0.0    1.62528  0.00   
+  4  0    0    2    1395.3002  1420.2264  -0.0    1.48143  0.00   
+  4  3    1    0    379.9058   356.6589   -0.0    1.45370  0.00   
+  4  2    2    1    32.5900    28.2353    180.0   1.42497  0.00   
+  4  3    0    1    1244.4118  1055.1873  -0.0    1.36108  0.00   
+  4  1    1    2    618.7719   542.1781   -0.0    1.34804  0.00   
+  4  3    1    1    39.0424    32.7464    0.0     1.30508  0.00   
+  4  3    2    0    18.2288    15.0141    180.0   1.27498  0.00   
+_reflns_number_total  648
+_reflns_d_resolution_low    6.389
+_reflns_d_resolution_high   1.265
+
+# POWDER DATA TABLE
+_pd_meas_2theta_range_min  10.01687
+_pd_meas_2theta_range_max  89.99342
+_pd_meas_2theta_range_inc  0.01313
+_pd_meas_number_of_points  6092
+
+loop_
+   _pd_meas_intensity_total
+   _pd_calc_intensity_total
+   _pd_proc_intensity_bkg_calc
+   _pd_proc_ls_weight
+  973          0            0           0         
+  976          0            0           0         
+  997          0            0           0         
+  992          0            0           0         
+  982          0            0           0         
+  971          0            0           0         
+  966          0            0           0         
+  1003         0            0           0         
+  952          0            0           0         
+  1006         0            0           0         
+  955          0            0           0         
+  943          0            0           0         
+  921          0            0           0         
+  993          0            0           0         
+  992          0            0           0         
+  931          0            0           0         
+  989          0            0           0         
+  935          0            0           0         
+  980          0            0           0         
+  963          0            0           0         
+  973          0            0           0         
+  1019         0            0           0         
+  898          0            0           0         
+  935          0            0           0         
+  915          0            0           0         
+  956          0            0           0         
+  987          0            0           0         
+  994          0            0           0         
+  951          0            0           0         
+  925          0            0           0         
+  970          0            0           0         
+  961          0            0           0         
+  939          0            0           0         
+  962          0            0           0         
+  970          0            0           0         
+  964          0            0           0         
+  1027         0            0           0         
+  958          0            0           0         
+  979          0            0           0         
+  948          0            0           0         
+  976          0            0           0         
+  975          0            0           0         
+  916          0            0           0         
+  980          0            0           0         
+  932          0            0           0         
+  962          0            0           0         
+  953          0            0           0         
+  942          0            0           0         
+  956          0            0           0         
+  934          0            0           0         
+  951          0            0           0         
+  950          0            0           0         
+  916          0            0           0         
+  959          0            0           0         
+  1013         0            0           0         
+  932          0            0           0         
+  931          0            0           0         
+  947          0            0           0         
+  976          0            0           0         
+  912          0            0           0         
+  994          0            0           0         
+  928          0            0           0         
+  957          0            0           0         
+  991          0            0           0         
+  895          0            0           0         
+  884          0            0           0         
+  995          0            0           0         
+  954          0            0           0         
+  918          0            0           0         
+  913          0            0           0         
+  945          0            0           0         
+  956          0            0           0         
+  950          0            0           0         
+  917          0            0           0         
+  948          0            0           0         
+  974          0            0           0         
+  923          0            0           0         
+  895          0            0           0         
+  967          0            0           0         
+  924          0            0           0         
+  903          0            0           0         
+  927          0            0           0         
+  900          0            0           0         
+  908          0            0           0         
+  916          0            0           0         
+  934          0            0           0         
+  881          0            0           0         
+  933          0            0           0         
+  883          0            0           0         
+  891          0            0           0         
+  956          0            0           0         
+  936          0            0           0         
+  961          0            0           0         
+  892          0            0           0         
+  869          0            0           0         
+  890          0            0           0         
+  913          0            0           0         
+  892          0            0           0         
+  922          0            0           0         
+  922          0            0           0         
+  877          0            0           0         
+  886          0            0           0         
+  929          0            0           0         
+  909          0            0           0         
+  964          0            0           0         
+  933          0            0           0         
+  925          0            0           0         
+  931          0            0           0         
+  873          0            0           0         
+  908          0            0           0         
+  936          0            0           0         
+  883          0            0           0         
+  858          0            0           0         
+  929          0            0           0         
+  962          0            0           0         
+  871          0            0           0         
+  896          0            0           0         
+  955          0            0           0         
+  916          0            0           0         
+  889          0            0           0         
+  899          0            0           0         
+  877          0            0           0         
+  945          0            0           0         
+  938          0            0           0         
+  843          0            0           0         
+  869          0            0           0         
+  867          0            0           0         
+  928          0            0           0         
+  945          0            0           0         
+  913          0            0           0         
+  844          0            0           0         
+  935          0            0           0         
+  862          0            0           0         
+  897          0            0           0         
+  870          0            0           0         
+  840          0            0           0         
+  848          0            0           0         
+  925          0            0           0         
+  905          0            0           0         
+  883          0            0           0         
+  910          0            0           0         
+  926          0            0           0         
+  881          0            0           0         
+  924          0            0           0         
+  887          0            0           0         
+  910          0            0           0         
+  879          0            0           0         
+  896          0            0           0         
+  913          0            0           0         
+  898          0            0           0         
+  985          0            0           0         
+  891          0            0           0         
+  940          0            0           0         
+  853          0            0           0         
+  927          0            0           0         
+  885          0            0           0         
+  889          0            0           0         
+  897          0            0           0         
+  853          0            0           0         
+  921          0            0           0         
+  858          0            0           0         
+  894          0            0           0         
+  867          0            0           0         
+  901          0            0           0         
+  886          0            0           0         
+  890          0            0           0         
+  882          0            0           0         
+  903          0            0           0         
+  876          0            0           0         
+  868          0            0           0         
+  860          0            0           0         
+  878          0            0           0         
+  833          0            0           0         
+  876          0            0           0         
+  896          0            0           0         
+  823          0            0           0         
+  850          0            0           0         
+  880          0            0           0         
+  912          0            0           0         
+  870          0            0           0         
+  837          0            0           0         
+  866          0            0           0         
+  900          0            0           0         
+  892          0            0           0         
+  852          0            0           0         
+  893          0            0           0         
+  855          0            0           0         
+  885          0            0           0         
+  858          0            0           0         
+  853          0            0           0         
+  950          0            0           0         
+  881          0            0           0         
+  878          0            0           0         
+  826          0            0           0         
+  876          0            0           0         
+  898          0            0           0         
+  898          0            0           0         
+  831          0            0           0         
+  875          0            0           0         
+  892          0            0           0         
+  839          0            0           0         
+  873          0            0           0         
+  849          0            0           0         
+  849          0            0           0         
+  850          0            0           0         
+  878          0            0           0         
+  841          0            0           0         
+  838          0            0           0         
+  868          0            0           0         
+  871          0            0           0         
+  828          0            0           0         
+  843          0            0           0         
+  829          0            0           0         
+  848          0            0           0         
+  896          0            0           0         
+  845          0            0           0         
+  821          0            0           0         
+  857          0            0           0         
+  872          0            0           0         
+  858          0            0           0         
+  855          0            0           0         
+  833          0            0           0         
+  838          0            0           0         
+  837          0            0           0         
+  856          0            0           0         
+  779          0            0           0         
+  869          0            0           0         
+  845          0            0           0         
+  879          0            0           0         
+  843          0            0           0         
+  861          0            0           0         
+  870          0            0           0         
+  873          0            0           0         
+  826          0            0           0         
+  845          0            0           0         
+  824          0            0           0         
+  811          0            0           0         
+  876          0            0           0         
+  860          0            0           0         
+  871          0            0           0         
+  804          0            0           0         
+  848          0            0           0         
+  834          0            0           0         
+  776          0            0           0         
+  905          0            0           0         
+  898          0            0           0         
+  849          0            0           0         
+  829          0            0           0         
+  809          0            0           0         
+  758          0            0           0         
+  826          0            0           0         
+  857          0            0           0         
+  852          0            0           0         
+  859          0            0           0         
+  863          0            0           0         
+  834          0            0           0         
+  846          0            0           0         
+  801          0            0           0         
+  794          0            0           0         
+  803          0            0           0         
+  820          0            0           0         
+  852          0            0           0         
+  792          0            0           0         
+  843          0            0           0         
+  845          0            0           0         
+  870          0            0           0         
+  883          0            0           0         
+  827          0            0           0         
+  872          0            0           0         
+  854          0            0           0         
+  824          0            0           0         
+  825          0            0           0         
+  786          0            0           0         
+  774          0            0           0         
+  836          0            0           0         
+  816          0            0           0         
+  789          0            0           0         
+  818          0            0           0         
+  841          0            0           0         
+  804          0            0           0         
+  839          0            0           0         
+  820          0            0           0         
+  800          0            0           0         
+  805          0            0           0         
+  802          0            0           0         
+  786          0            0           0         
+  826          0            0           0         
+  801          0            0           0         
+  817          0            0           0         
+  727          0            0           0         
+  800          0            0           0         
+  789          0            0           0         
+  786          0            0           0         
+  766          0            0           0         
+  792          0            0           0         
+  762          0            0           0         
+  777          0            0           0         
+  790          0            0           0         
+  815          0            0           0         
+  778          0            0           0         
+  772          0            0           0         
+  833          0            0           0         
+  803          0            0           0         
+  780          0            0           0         
+  760          0            0           0         
+  742          0            0           0         
+  759          0            0           0         
+  733          0            0           0         
+  758          0            0           0         
+  788          0            0           0         
+  799          0            0           0         
+  777          0            0           0         
+  765          0            0           0         
+  821          0            0           0         
+  784          0            0           0         
+  772          0            0           0         
+  828          0            0           0         
+  785          0            0           0         
+  724          0            0           0         
+  786          0            0           0         
+  773          0            0           0         
+  799          0            0           0         
+  776          0            0           0         
+  747          0            0           0         
+  735          0            0           0         
+  744          0            0           0         
+  748          0            0           0         
+  736          0            0           0         
+  786          0            0           0         
+  759          0            0           0         
+  770          0            0           0         
+  817          0            0           0         
+  764          0            0           0         
+  770          0            0           0         
+  734          0            0           0         
+  785          0            0           0         
+  735          0            0           0         
+  750          0            0           0         
+  751          0            0           0         
+  771          0            0           0         
+  785          0            0           0         
+  737          0            0           0         
+  823          0            0           0         
+  750          0            0           0         
+  767          0            0           0         
+  739          0            0           0         
+  742          0            0           0         
+  738          0            0           0         
+  711          0            0           0         
+  740          0            0           0         
+  735          0            0           0         
+  697          0            0           0         
+  728          0            0           0         
+  763          0            0           0         
+  755          0            0           0         
+  690          0            0           0         
+  768          0            0           0         
+  743          0            0           0         
+  749          0            0           0         
+  729          0            0           0         
+  737          0            0           0         
+  724          0            0           0         
+  735          0            0           0         
+  717          0            0           0         
+  712          0            0           0         
+  719          0            0           0         
+  675          0            0           0         
+  707          0            0           0         
+  766          0            0           0         
+  670          0            0           0         
+  730          0            0           0         
+  727          0            0           0         
+  716          0            0           0         
+  742          0            0           0         
+  686          0            0           0         
+  738          0            0           0         
+  675          0            0           0         
+  646          0            0           0         
+  744          0            0           0         
+  719          0            0           0         
+  742          0            0           0         
+  687          0            0           0         
+  717          0            0           0         
+  640          0            0           0         
+  695          0            0           0         
+  699          0            0           0         
+  665          0            0           0         
+  700          0            0           0         
+  641          0            0           0         
+  730          0            0           0         
+  681          0            0           0         
+  695          0            0           0         
+  667          0            0           0         
+  744          0            0           0         
+  654          0            0           0         
+  704          0            0           0         
+  706          0            0           0         
+  659          0            0           0         
+  686          0            0           0         
+  688          0            0           0         
+  709          0            0           0         
+  751          0            0           0         
+  697          0            0           0         
+  713          0            0           0         
+  660          0            0           0         
+  658          0            0           0         
+  728          0            0           0         
+  677          0            0           0         
+  669          0            0           0         
+  648          0            0           0         
+  661          0            0           0         
+  661          650.964611   650.576995  0.00151286 
+  639          650.273773   649.874116  0.00156495 
+  651          649.58441    649.172034  0.0015361 
+  715          648.896576   648.470748  0.0013986 
+  653          648.21033    647.770259  0.00153139 
+  657          647.52574    647.070563  0.00152207 
+  686          646.842877   646.371662  0.00145773 
+  662          646.161825   645.673554  0.00151057 
+  672          645.482676   644.976239  0.0014881 
+  664          644.805531   644.279714  0.00150602 
+  666          644.130507   643.58398   0.0015015 
+  665          643.457733   642.889036  0.00150376 
+  676          642.787354   642.194881  0.00147929 
+  629          642.119537   641.501514  0.00158983 
+  709          641.454472   640.808934  0.00141044 
+  680          640.792369   640.11714   0.00147059 
+  670          640.133478   639.426132  0.00149254 
+  637          639.47808    638.735908  0.00156986 
+  655          638.826497   638.046468  0.00152672 
+  693          638.179108   637.357811  0.001443  
+  665          637.536353   636.669936  0.00150376 
+  693          636.898738   635.982843  0.001443  
+  642          636.266868   635.29653   0.00155763 
+  643          635.641458   634.610996  0.00155521 
+  715          635.023344   633.926241  0.0013986 
+  617          634.413541   633.242265  0.00162075 
+  661          633.813276   632.559065  0.00151286 
+  662          633.224013   631.876641  0.00151057 
+  644          632.647571   631.194993  0.0015528 
+  661          632.086196   630.51412   0.00151286 
+  640          631.542659   629.83402   0.0015625 
+  674          631.02049    629.154693  0.00148368 
+  609          630.524203   628.476138  0.00164204 
+  641          630.05963    627.798355  0.00156006 
+  652          629.634625   627.121342  0.00153374 
+  643          629.260107   626.445098  0.00155521 
+  655          628.951881   625.769624  0.00152672 
+  633          628.734068   625.094917  0.00157978 
+  692          628.644138   624.420977  0.00144509 
+  668          628.739461   623.747804  0.00149701 
+  724          629.104872   623.075396  0.00138122 
+  669          629.858295   622.403752  0.00149477 
+  659          631.150865   621.732873  0.00151745 
+  650          633.153362   621.062756  0.00153846 
+  652          635.998792   620.393402  0.00153374 
+  631          639.659309   619.724809  0.00158479 
+  722          643.912581   619.056976  0.00138504 
+  685          648.630013   618.389903  0.00145985 
+  723          653.895459   617.723589  0.00138313 
+  673          659.448924   617.058033  0.00148588 
+  753          664.071099   616.393235  0.00132802 
+  670          665.999258   615.729192  0.00149254 
+  726          664.497873   615.065906  0.00137741 
+  674          660.139378   614.403374  0.00148368 
+  681          653.967158   613.741596  0.00146843 
+  664          647.206218   613.080571  0.00150602 
+  676          640.997869   612.420299  0.00147929 
+  611          636.106323   611.760778  0.00163666 
+  663          632.799704   611.102008  0.0015083 
+  653          630.862225   610.443988  0.00153139 
+  655          629.709534   609.786717  0.00152672 
+  667          628.684897   609.130194  0.00149925 
+  594          627.492777   608.474418  0.0016835 
+  628          626.175506   607.81939   0.00159236 
+  623          624.868725   607.165107  0.00160514 
+  639          623.716087   606.511569  0.00156495 
+  639          622.610182   605.858776  0.00156495 
+  635          621.148045   605.206726  0.0015748 
+  626          619.123196   604.555418  0.00159744 
+  652          616.709256   603.904853  0.00153374 
+  607          614.080803   603.255028  0.00164745 
+  568          611.423119   602.605944  0.00176056 
+  615          608.985872   601.957599  0.00162602 
+  583          606.906189   601.309992  0.00171527 
+  598          605.181607   600.663124  0.00167224 
+  631          603.747589   600.016993  0.00158479 
+  597          602.529905   599.371597  0.00167504 
+  641          601.464674   598.726938  0.00156006 
+  640          600.503772   598.083012  0.0015625 
+  586          599.614097   597.439821  0.00170648 
+  583          598.774116   596.797363  0.00171527 
+  613          597.970211   596.155637  0.00163132 
+  589          597.193663   595.514642  0.00169779 
+  588          596.438617   594.874378  0.00170068 
+  601          595.700951   594.234844  0.00166389 
+  597          594.977628   593.596039  0.00167504 
+  598          594.266313   592.957963  0.00167224 
+  605          593.565187   592.320614  0.00165289 
+  576          592.872816   591.683991  0.00173611 
+  584          592.188034   591.048094  0.00171233 
+  583          591.509903   590.412923  0.00171527 
+  576          590.837658   589.778476  0.00173611 
+  627          590.170659   589.144752  0.0015949 
+  581          589.508379   588.511751  0.00172117 
+  626          588.85038    587.879472  0.00159744 
+  588          588.196287   587.247915  0.00170068 
+  589          587.545788   586.617077  0.00169779 
+  593          586.898619   585.98696   0.00168634 
+  597          586.254554   585.357561  0.00167504 
+  568          585.6134     584.72888   0.00176056 
+  581          584.974997   584.100917  0.00172117 
+  610          584.339204   583.47367   0.00163934 
+  594          583.705906   582.847138  0.0016835 
+  618          583.075005   582.221322  0.00161812 
+  610          582.446419   581.59622   0.00163934 
+  594          581.82008    580.971831  0.0016835 
+  565          581.195937   580.348155  0.00176991 
+  538          580.574001   579.72519   0.00185874 
+  563          579.954136   579.102937  0.0017762 
+  587          579.336377   578.481394  0.00170358 
+  540          578.720716   577.86056   0.00185185 
+  553          578.107156   577.240436  0.00180832 
+  583          577.495735   576.621019  0.00171527 
+  573          576.886426   576.002309  0.0017452 
+  587          576.279289   575.384306  0.00170358 
+  597          575.674369   574.767008  0.00167504 
+  549          575.071729   574.150415  0.00182149 
+  610          574.471441   573.534526  0.00163934 
+  617          573.873594   572.919341  0.00162075 
+  579          573.278295   572.304858  0.00172712 
+  560          572.685673   571.691077  0.00178571 
+  550          572.095877   571.077997  0.00181818 
+  563          571.509091   570.465618  0.0017762 
+  589          570.925584   569.853937  0.00169779 
+  574          570.345487   569.242956  0.00174216 
+  560          569.769165   568.632672  0.00178571 
+  578          569.196974   568.023086  0.0017301 
+  554          568.629349   567.414196  0.00180505 
+  576          568.066849   566.806002  0.00173611 
+  564          567.510243   566.198503  0.00177305 
+  568          566.959975   565.591698  0.00176056 
+  634          566.417229   564.985586  0.00157729 
+  514          565.883251   564.380167  0.00194553 
+  526          565.359643   563.77544   0.00190114 
+  539          564.848616   563.171404  0.00185529 
+  587          564.352825   562.568059  0.00170358 
+  570          563.876415   561.965403  0.00175439 
+  570          563.425432   561.363435  0.00175439 
+  536          563.009169   560.762156  0.00186567 
+  578          562.642119   560.161565  0.0017301 
+  565          562.346297   559.56166   0.00176991 
+  550          562.153399   558.962441  0.00181818 
+  574          562.106378   558.363906  0.00174216 
+  550          562.258295   557.766057  0.00181818 
+  521          562.662425   557.168891  0.00191939 
+  575          563.341722   556.572407  0.00173913 
+  568          564.249494   555.976606  0.00176056 
+  556          565.287996   555.381486  0.00179856 
+  583          566.463838   554.787047  0.00171527 
+  548          567.739009   554.193288  0.00182482 
+  562          568.722243   553.600208  0.00177936 
+  594          568.794103   553.007806  0.0016835 
+  540          567.756982   552.416081  0.00185185 
+  572          565.971644   551.825034  0.00174825 
+  563          563.734791   551.234663  0.0017762 
+  561          561.275785   550.644967  0.00178253 
+  586          558.938648   550.055946  0.00170648 
+  506          556.963126   549.467599  0.00197628 
+  539          555.395759   548.879925  0.00185529 
+  558          554.181853   548.292923  0.00179211 
+  544          553.241875   547.706593  0.00183824 
+  557          552.504194   547.120934  0.00179533 
+  509          551.914993   546.535945  0.00196464 
+  556          551.438805   545.951626  0.00179856 
+  558          551.055487   545.367976  0.00179211 
+  567          550.756169   544.784993  0.00176367 
+  531          550.539713   544.202678  0.00188324 
+  564          550.410326   543.621029  0.00177305 
+  543          550.376443   543.040046  0.00184162 
+  539          550.4501     542.459728  0.00185529 
+  504          550.646574   541.880075  0.00198413 
+  534          550.98452    541.301085  0.00187266 
+  516          551.485499   540.722758  0.00193798 
+  563          552.173279   540.145093  0.0017762 
+  498          553.072786   539.56809   0.00200803 
+  596          554.207032   538.991747  0.00167785 
+  537          555.591984   538.416065  0.0018622 
+  537          557.228733   537.841041  0.0018622 
+  545          559.090838   537.266676  0.00183486 
+  531          561.108911   536.692969  0.00188324 
+  538          563.158704   536.119919  0.00185874 
+  534          565.059884   535.547525  0.00187266 
+  549          566.598281   534.975787  0.00182149 
+  623          567.572054   534.404704  0.00160514 
+  563          567.841875   533.834275  0.0017762 
+  534          567.363774   533.264499  0.00187266 
+  578          566.19291    532.695376  0.0017301 
+  532          564.466354   532.126906  0.0018797 
+  554          562.373106   531.559086  0.00180505 
+  537          560.116581   530.991917  0.0018622 
+  595          557.88248    530.425398  0.00168067 
+  552          555.817904   529.859528  0.00181159 
+  532          554.022558   529.294306  0.0018797 
+  522          552.548612   528.729732  0.00191571 
+  510          551.402016   528.165805  0.00196078 
+  522          550.543731   527.602525  0.00191571 
+  502          549.891113   527.03989   0.00199203 
+  527          549.322833   526.477899  0.00189753 
+  538          548.695306   525.916553  0.00185874 
+  518          547.872361   525.355851  0.0019305 
+  508          546.758721   524.795791  0.0019685 
+  520          545.320976   524.236373  0.00192308 
+  537          543.58737    523.677596  0.0018622 
+  545          541.631452   523.11946   0.00183486 
+  523          539.549233   522.561964  0.00191205 
+  508          537.43753    522.005107  0.0019685 
+  530          535.37726    521.448888  0.00188679 
+  539          533.424448   520.893307  0.00185529 
+  507          531.610263   520.338363  0.00197239 
+  530          529.946562   519.784056  0.00188679 
+  495          528.432385   519.230384  0.0020202 
+  524          527.060151   518.677347  0.0019084 
+  522          525.81912    518.124944  0.00191571 
+  535          524.699914   517.573175  0.00186916 
+  544          523.695743   517.022039  0.00183824 
+  495          522.805076   516.471534  0.0020202 
+  492          522.034062   515.921662  0.00203252 
+  501          521.39843    515.37242   0.00199601 
+  528          520.926631   514.823807  0.00189394 
+  537          520.660023   514.275825  0.0018622 
+  509          520.649004   513.728471  0.00196464 
+  501          520.935562   513.181744  0.00199601 
+  554          521.511116   512.635645  0.00180505 
+  539          522.291311   512.090173  0.00185529 
+  514          523.216643   511.545326  0.00194553 
+  505          524.256777   511.001105  0.0019802 
+  513          525.174333   510.457508  0.00194932 
+  514          525.372344   509.914535  0.00194553 
+  525          524.480441   509.372184  0.00190476 
+  464          522.770629   508.830456  0.00215517 
+  530          520.613822   508.28935   0.00188679 
+  528          518.165003   507.748865  0.00189394 
+  504          515.678203   507.209     0.00198413 
+  486          513.442934   506.669755  0.00205761 
+  484          511.577648   506.131129  0.00206612 
+  507          510.060154   505.593121  0.00197239 
+  502          508.818311   505.05573   0.00199203 
+  499          507.776857   504.518956  0.00200401 
+  474          506.873583   503.982799  0.0021097 
+  490          506.063041   503.447257  0.00204082 
+  484          505.314714   502.91233   0.00206612 
+  513          504.60922    502.378017  0.00194932 
+  515          503.934558   501.844317  0.00194175 
+  473          503.283168   501.31123   0.00211416 
+  538          502.650036   500.778755  0.00185874 
+  466          502.031675   500.246892  0.00214592 
+  485          501.425534   499.715639  0.00206186 
+  502          500.829674   499.184996  0.00199203 
+  499          500.242605   498.654963  0.00200401 
+  530          499.663163   498.125538  0.00188679 
+  470          499.090412   497.596722  0.00212766 
+  483          498.523613   497.068512  0.00207039 
+  464          497.96217    496.540909  0.00215517 
+  473          497.405592   496.013913  0.00211416 
+  470          496.853485   495.487521  0.00212766 
+  507          496.305529   494.961734  0.00197239 
+  464          495.761459   494.436551  0.00215517 
+  518          495.221062   493.911972  0.0019305 
+  492          494.684172   493.387995  0.00203252 
+  498          494.15065    492.86462   0.00200803 
+  483          493.620396   492.341846  0.00207039 
+  487          493.093338   491.819672  0.00205339 
+  466          492.569424   491.298099  0.00214592 
+  493          492.048632   490.777125  0.0020284 
+  472          491.531271   490.256749  0.00211864 
+  540          491.016741   489.736971  0.00185185 
+  464          490.505392   489.217791  0.00215517 
+  477          489.997294   488.699207  0.00209644 
+  487          489.492529   488.181219  0.00205339 
+  508          488.991364   487.663826  0.0019685 
+  459          488.49363    487.147028  0.00217865 
+  474          487.999644   486.630824  0.0021097 
+  500          487.509602   486.115213  0.002     
+  480          487.023738   485.600194  0.00208333 
+  497          486.542319   485.085768  0.00201207 
+  497          486.065657   484.571932  0.00201207 
+  475          485.594122   484.058688  0.00210526 
+  507          485.128135   483.546033  0.00197239 
+  476          484.668188   483.033967  0.00210084 
+  480          484.214861   482.52249   0.00208333 
+  472          483.768821   482.011601  0.00211864 
+  498          483.33085    481.5013    0.00200803 
+  445          482.901879   480.991585  0.00224719 
+  474          482.482984   480.482456  0.0021097 
+  445          482.075574   479.973912  0.00224719 
+  499          481.680901   479.465953  0.00200401 
+  446          481.300869   478.958578  0.00224215 
+  470          480.937582   478.451786  0.00212766 
+  479          480.593527   477.945577  0.00208768 
+  458          480.271652   477.439951  0.00218341 
+  481          479.975446   476.934905  0.002079  
+  507          479.708827   476.43044   0.00197239 
+  452          479.476506   475.926556  0.00221239 
+  483          479.283777   475.42325   0.00207039 
+  438          479.136466   474.920524  0.00228311 
+  481          479.040744   474.418376  0.002079  
+  473          479.002549   473.916805  0.00211416 
+  448          479.027134   473.415811  0.00223214 
+  457          479.118462   472.915393  0.00218818 
+  464          479.278987   472.415551  0.00215517 
+  433          479.511058   471.916284  0.00230947 
+  512          479.819363   471.417591  0.00195312 
+  508          480.213458   470.919472  0.0019685 
+  469          480.709484   470.421926  0.0021322 
+  478          481.328263   469.924952  0.00209205 
+  473          482.090111   469.428549  0.00211416 
+  475          483.007919   468.932718  0.00210526 
+  452          484.076164   468.437457  0.00221239 
+  464          485.257156   467.942766  0.00215517 
+  435          486.469319   467.448644  0.00229885 
+  477          487.581902   466.955091  0.00209644 
+  447          488.427334   466.462105  0.00223714 
+  475          488.837245   465.969687  0.00210526 
+  475          488.688282   465.477835  0.00210526 
+  450          487.93784    464.986549  0.00222222 
+  451          486.622245   464.495829  0.00221729 
+  459          484.846349   464.005673  0.00217865 
+  445          482.75024    463.516081  0.00224719 
+  494          480.482996   463.027052  0.00202429 
+  470          478.179413   462.538587  0.00212766 
+  457          475.940755   462.050683  0.00218818 
+  454          473.833491   461.563341  0.00220264 
+  502          471.890126   461.07656   0.00199203 
+  445          470.119816   460.590339  0.00224719 
+  491          468.516646   460.104678  0.00203666 
+  443          467.066665   459.619575  0.00225734 
+  459          465.752816   459.135031  0.00217865 
+  477          464.557509   458.651045  0.00209644 
+  488          463.463822   458.167615  0.00204918 
+  470          462.456707   457.684743  0.00212766 
+  449          461.522871   457.202426  0.00222717 
+  425          460.65082    456.720664  0.00235294 
+  472          459.830852   456.239457  0.00211864 
+  455          459.054806   455.758804  0.0021978 
+  486          458.315841   455.278704  0.00205761 
+  452          457.608327   454.799156  0.00221239 
+  435          456.927599   454.320161  0.00229885 
+  454          456.269915   453.841718  0.00220264 
+  419          455.631829   453.363825  0.00238663 
+  430          455.010836   452.886482  0.00232558 
+  480          454.404718   452.409689  0.00208333 
+  454          453.811643   451.933445  0.00220264 
+  513          453.230127   451.457749  0.00194932 
+  450          452.658708   450.982601  0.00222222 
+  464          452.096341   450.508     0.00215517 
+  453          451.542064   450.033946  0.00220751 
+  421          450.99504    449.560438  0.0023753 
+  432          450.454557   449.087474  0.00231481 
+  418          449.91999    448.615056  0.00239234 
+  460          449.390792   448.143181  0.00217391 
+  466          448.866479   447.67185   0.00214592 
+  433          448.34664    447.201062  0.00230947 
+  425          447.830895   446.730816  0.00235294 
+  421          447.31892    446.261111  0.0023753 
+  391          446.810424   445.791948  0.00255754 
+  457          446.305145   445.323324  0.00218818 
+  423          445.802849   444.855241  0.00236407 
+  462          445.303335   444.387697  0.0021645 
+  470          444.810607   443.920691  0.00212766 
+  465          444.316127   443.454223  0.00215054 
+  399          443.823928   442.988292  0.00250627 
+  438          443.33387    442.522898  0.00228311 
+  414          442.845831   442.05804   0.00241546 
+  425          442.361803   441.593718  0.00235294 
+  466          441.877492   441.12993   0.00214592 
+  443          441.394899   440.666677  0.00225734 
+  403          440.913942   440.203958  0.00248139 
+  424          440.434545   439.741771  0.00235849 
+  486          439.956638   439.280117  0.00205761 
+  432          439.480159   438.818995  0.00231481 
+  423          439.00505    438.358404  0.00236407 
+  508          438.531257   437.898344  0.0019685 
+  456          438.058733   437.438813  0.00219298 
+  430          437.587433   436.979812  0.00232558 
+  396          437.117314   436.52134   0.00252525 
+  425          436.64834    436.063397  0.00235294 
+  396          436.180475   435.605981  0.00252525 
+  451          435.713687   435.149092  0.00221729 
+  426          435.247946   434.692729  0.00234742 
+  422          434.783225   434.236892  0.00236967 
+  468          434.319498   433.781581  0.00213675 
+  414          433.856742   433.326794  0.00241546 
+  442          433.394934   432.872531  0.00226244 
+  425          432.934054   432.418792  0.00235294 
+  428          432.474084   431.965575  0.00233645 
+  444          432.015006   431.512881  0.00225225 
+  416          431.556803   431.060709  0.00240385 
+  457          431.099462   430.609057  0.00218818 
+  422          430.642966   430.157926  0.00236967 
+  443          430.187305   429.707315  0.00225734 
+  450          429.732466   429.257224  0.00222222 
+  456          429.278438   428.807651  0.00219298 
+  421          428.825211   428.358596  0.0023753 
+  423          428.372774   427.910059  0.00236407 
+  436          427.92112    427.462039  0.00229358 
+  433          427.470241   427.014535  0.00230947 
+  403          427.020128   426.567547  0.00248139 
+  463          426.570776   426.121074  0.00215983 
+  460          426.122179   425.675115  0.00217391 
+  407          425.674329   425.229671  0.002457  
+  416          425.227223   424.78474   0.00240385 
+  441          424.780857   424.340322  0.00226757 
+  423          424.335226   423.896417  0.00236407 
+  431          423.890327   423.453023  0.00232019 
+  453          423.446156   423.01014   0.00220751 
+  435          423.002712   422.567768  0.00229885 
+  415          422.559992   422.125905  0.00240964 
+  417          422.117994   421.684552  0.00239808 
+  428          421.676719   421.243708  0.00233645 
+  409          421.236164   420.803372  0.00244499 
+  381          420.79633    420.363544  0.00262467 
+  386          420.357217   419.924222  0.00259067 
+  409          419.920742   419.485407  0.00244499 
+  417          419.483081   419.047098  0.00239808 
+  402          419.046145   418.609295  0.00248756 
+  452          418.609936   418.171996  0.00221239 
+  360          418.174456   417.735201  0.00277778 
+  403          417.740669   417.29891   0.00248139 
+  404          417.306663   416.863122  0.00247525 
+  397          416.873399   416.427836  0.00251889 
+  425          416.440881   415.993052  0.00235294 
+  400          416.009115   415.55877   0.0025    
+  414          415.579511   415.124988  0.00241546 
+  447          415.149274   414.691706  0.00223714 
+  391          414.723422   414.258924  0.00255754 
+  395          414.294754   413.826641  0.00253165 
+  412          413.866877   413.394856  0.00242718 
+  370          413.440504   412.96357   0.0027027 
+  417          413.014244   412.53278   0.00239808 
+  385          412.590618   412.102488  0.0025974 
+  423          412.166029   411.672691  0.00236407 
+  421          411.742294   411.24339   0.0023753 
+  379          411.319431   410.814584  0.00263852 
+  400          410.897453   410.386273  0.0025    
+  397          410.476382   409.958456  0.00251889 
+  391          410.056238   409.531131  0.00255754 
+  399          409.637044   409.1043    0.00250627 
+  406          409.218825   408.677961  0.00246305 
+  426          408.801607   408.252113  0.00234742 
+  428          408.385419   407.826757  0.00233645 
+  372          407.970293   407.401891  0.00268817 
+  408          407.556263   406.977515  0.00245098 
+  396          407.143367   406.553629  0.00252525 
+  408          406.731648   406.130231  0.00245098 
+  377          406.321152   405.707322  0.00265252 
+  400          405.911925   405.2849    0.0025    
+  417          405.504023   404.862966  0.00239808 
+  422          405.097505   404.441518  0.00236967 
+  439          404.692439   404.020556  0.0022779 
+  416          404.288895   403.60008   0.00240385 
+  374          403.886956   403.180089  0.0026738 
+  423          403.486705   402.760582  0.00236407 
+  388          403.088241   402.341558  0.00257732 
+  383          402.691673   401.923019  0.00261097 
+  398          402.29712    401.504962  0.00251256 
+  379          401.904715   401.087387  0.00263852 
+  390          401.51461    400.670293  0.0025641 
+  411          401.126962   400.253681  0.00243309 
+  421          400.741962   399.837549  0.0023753 
+  390          400.359816   399.421898  0.0025641 
+  388          399.982611   399.006725  0.00257732 
+  402          399.60691    398.592032  0.00248756 
+  358          399.234861   398.177817  0.0027933 
+  382          398.866793   397.764079  0.0026178 
+  386          398.503094   397.350819  0.00259067 
+  411          398.144201   396.938036  0.00243309 
+  429          397.791541   396.525728  0.002331  
+  371          397.443839   396.113897  0.00269542 
+  434          397.106095   395.70254   0.00230415 
+  395          396.772251   395.291658  0.00253165 
+  389          396.446613   394.881249  0.00257069 
+  396          396.130228   394.471315  0.00252525 
+  389          395.824333   394.061853  0.00257069 
+  428          395.530392   393.652863  0.00233645 
+  406          395.250159   393.244345  0.00246305 
+  345          394.98745    392.836298  0.00289855 
+  399          394.741348   392.428722  0.00250627 
+  350          394.516634   392.021616  0.00285714 
+  389          394.31701    391.61498   0.00257069 
+  408          394.146954   391.208813  0.00245098 
+  358          394.011886   390.803114  0.0027933 
+  390          393.918317   390.397884  0.0025641 
+  379          393.873912   389.99312   0.00263852 
+  400          393.887845   389.588824  0.0025    
+  416          393.970765   389.184994  0.00240385 
+  379          394.134867   388.78163   0.00263852 
+  381          394.393809   388.378731  0.00262467 
+  395          394.7623     387.976297  0.00253165 
+  383          395.254837   387.574328  0.00261097 
+  400          395.884336   387.172822  0.0025    
+  384          396.658303   386.771779  0.00260417 
+  376          397.573287   386.371199  0.00265957 
+  415          398.606918   385.97108   0.00240964 
+  383          399.708357   385.571424  0.00261097 
+  391          400.790967   385.172228  0.00255754 
+  412          401.735856   384.773493  0.00242718 
+  368          402.409981   384.375218  0.00271739 
+  384          402.699345   383.977403  0.00260417 
+  366          402.542296   383.580046  0.00273224 
+  401          401.934889   383.183148  0.00249377 
+  408          400.92978    382.786708  0.00245098 
+  387          399.609407   382.390724  0.00258398 
+  351          398.071143   381.995198  0.002849  
+  393          396.413843   381.600128  0.00254453 
+  374          394.72191    381.205514  0.0026738 
+  394          393.060065   380.811355  0.00253807 
+  388          391.469279   380.417651  0.00257732 
+  363          389.971115   380.024401  0.00275482 
+  378          388.567443   379.631605  0.0026455 
+  370          387.2452     379.239261  0.0027027 
+  401          385.998959   378.847371  0.00249377 
+  404          384.837008   378.455932  0.00247525 
+  418          383.761325   378.064945  0.00239234 
+  398          382.763681   377.674409  0.00251256 
+  360          381.838525   377.284324  0.00277778 
+  401          380.983949   376.894688  0.00249377 
+  370          380.195102   376.505503  0.0027027 
+  366          379.463967   376.116766  0.00273224 
+  381          378.781833   375.728477  0.00262467 
+  380          378.140628   375.340637  0.00263158 
+  357          377.533469   374.953244  0.00280112 
+  364          376.954682   374.566297  0.00274725 
+  393          376.399679   374.179798  0.00254453 
+  362          375.864755   373.793744  0.00276243 
+  389          375.348456   373.408135  0.00257069 
+  346          374.845428   373.022971  0.00289017 
+  354          374.355153   372.638252  0.00282486 
+  359          373.875993   372.253976  0.00278552 
+  386          373.406579   371.870144  0.00259067 
+  398          372.946474   371.486755  0.00251256 
+  342          372.493265   371.103807  0.00292398 
+  363          372.046834   370.721302  0.00275482 
+  381          371.606469   370.339238  0.00262467 
+  353          371.171552   369.957614  0.00283286 
+  402          370.741557   369.576431  0.00248756 
+  374          370.316017   369.195688  0.0026738 
+  362          369.894532   368.815383  0.00276243 
+  346          369.476753   368.435518  0.00289017 
+  357          369.062365   368.05609   0.00280112 
+  392          368.651096   367.677101  0.00255102 
+  341          368.242703   367.298548  0.00293255 
+  374          367.837431   366.920433  0.0026738 
+  398          367.434169   366.542753  0.00251256 
+  357          367.03321    366.165509  0.00280112 
+  358          366.634399   365.7887    0.0027933 
+  361          366.237599   365.412326  0.00277008 
+  392          365.842917   365.036386  0.00255102 
+  346          365.449784   364.66088   0.00289017 
+  387          365.058328   364.285807  0.00258398 
+  355          364.668464   363.911167  0.0028169 
+  377          364.280109   363.536958  0.00265252 
+  374          363.893187   363.163182  0.0026738 
+  366          363.507633   362.789836  0.00273224 
+  371          363.123387   362.416921  0.00269542 
+  353          362.740392   362.044437  0.00283286 
+  383          362.358601   361.672382  0.00261097 
+  366          361.977966   361.300756  0.00273224 
+  384          361.598524   360.929559  0.00260417 
+  368          361.220082   360.55879   0.00271739 
+  347          360.842681   360.188448  0.00288184 
+  365          360.466292   359.818534  0.00273973 
+  362          360.090885   359.449047  0.00276243 
+  389          359.716434   359.079985  0.00257069 
+  360          359.342975   358.71135   0.00277778 
+  391          358.970365   358.343139  0.00255754 
+  376          358.598643   357.975354  0.00265957 
+  368          358.227793   357.607992  0.00271739 
+  357          357.857802   357.241054  0.00280112 
+  364          357.488647   356.87454   0.00274725 
+  367          357.120318   356.508448  0.0027248 
+  315          356.752814   356.142778  0.0031746 
+  401          356.386101   355.77753   0.00249377 
+  318          356.020182   355.412704  0.00314465 
+  362          355.655049   355.048298  0.00276243 
+  373          355.290691   354.684312  0.00268097 
+  384          354.927105   354.320747  0.00260417 
+  339          354.564282   353.9576    0.00294985 
+  366          354.20222    353.594873  0.00273224 
+  369          353.841018   353.232563  0.00271003 
+  336          353.480467   352.870672  0.00297619 
+  376          353.120667   352.509198  0.00265957 
+  370          352.761618   352.148141  0.0027027 
+  350          352.403319   351.7875    0.00285714 
+  354          352.045771   351.427275  0.00282486 
+  382          351.689027   351.067466  0.0026178 
+  363          351.332986   350.708071  0.00275482 
+  307          350.977703   350.349091  0.00325733 
+  383          350.623182   349.990525  0.00261097 
+  376          350.269667   349.632373  0.00265957 
+  368          349.916684   349.274633  0.00271739 
+  339          349.564479   348.917306  0.00294985 
+  345          349.213277   348.560391  0.00289855 
+  367          348.862655   348.203888  0.0027248 
+  327          348.512839   347.847796  0.0030581 
+  355          348.163837   347.492114  0.0028169 
+  355          347.815785   347.136842  0.0028169 
+  356          347.468453   346.781981  0.00280899 
+  337          347.122085   346.427528  0.00296736 
+  338          346.776482   346.073484  0.00295858 
+  372          346.431771   345.719848  0.00268817 
+  351          346.087969   345.366621  0.002849  
+  308          345.7451     345.0138    0.00324675 
+  385          345.403187   344.661386  0.0025974 
+  346          345.062257   344.309379  0.00289017 
+  350          344.722342   343.957777  0.00285714 
+  326          344.383473   343.606581  0.00306748 
+  355          344.045693   343.255789  0.0028169 
+  331          343.709042   342.905403  0.00302115 
+  379          343.373577   342.55542   0.00263852 
+  335          343.039368   342.20584   0.00298507 
+  350          342.706508   341.856664  0.00285714 
+  362          342.375116   341.50789   0.00276243 
+  381          342.045363   341.159519  0.00262467 
+  321          341.717457   340.811549  0.00311526 
+  353          341.393374   340.46398   0.00283286 
+  350          341.069933   340.116812  0.00285714 
+  351          340.748965   339.770044  0.002849  
+  361          340.430308   339.423676  0.00277008 
+  347          340.113598   339.077707  0.00288184 
+  329          339.798368   338.732137  0.00303951 
+  352          339.484394   338.386965  0.00284091 
+  336          339.168592   338.042191  0.00297619 
+  325          338.852104   337.697815  0.00307692 
+  319          338.536597   337.353835  0.0031348 
+  364          338.222993   337.010253  0.00274725 
+  327          337.91129    336.667066  0.0030581 
+  359          337.601944   336.324274  0.00278552 
+  367          337.295907   335.981878  0.0027248 
+  323          336.993834   335.639877  0.00309598 
+  341          336.695989   335.29827   0.00293255 
+  355          336.402485   334.957056  0.0028169 
+  329          336.113423   334.616236  0.00303951 
+  320          335.828982   334.275808  0.003125  
+  325          335.549411   333.935773  0.00307692 
+  338          335.27505    333.59613   0.00295858 
+  275          335.006326   333.256878  0.00363636 
+  354          334.743755   332.918018  0.00282486 
+  322          334.48792    332.579547  0.00310559 
+  351          334.239529   332.241467  0.002849  
+  351          333.999389   331.903777  0.002849  
+  337          333.768435   331.566475  0.00296736 
+  318          333.54785    331.229563  0.00314465 
+  341          333.338711   330.893038  0.00293255 
+  336          333.142555   330.556902  0.00297619 
+  323          332.961127   330.221153  0.00309598 
+  295          332.796464   329.88579   0.00338983 
+  357          332.650981   329.550814  0.00280112 
+  335          332.527616   329.216224  0.00298507 
+  312          332.42975    328.88202   0.00320513 
+  326          332.361556   328.548201  0.00306748 
+  311          332.328157   328.214766  0.00321543 
+  357          332.335802   327.881716  0.00280112 
+  332          332.392234   327.549049  0.00301205 
+  334          332.507147   327.216765  0.00299401 
+  360          332.692805   326.884865  0.00277778 
+  369          332.964699   326.553347  0.00271003 
+  331          333.34311    326.22221   0.00302115 
+  332          333.854633   325.891456  0.00301205 
+  316          334.535078   325.561082  0.00316456 
+  356          335.434403   325.231089  0.00280899 
+  377          336.626023   324.901476  0.00265252 
+  354          338.223771   324.572243  0.00282486 
+  356          340.415153   324.243389  0.00280899 
+  337          343.512119   323.914914  0.00296736 
+  378          348.021204   323.586817  0.0026455 
+  370          354.717014   323.259098  0.0027027 
+  375          364.680584   322.931757  0.00266667 
+  408          379.246045   322.604793  0.00245098 
+  470          399.453981   322.278205  0.00212766 
+  571          425.200434   321.951993  0.00175131 
+  617          454.314299   321.626158  0.00162075 
+  570          483.884898   321.300697  0.00175439 
+  582          509.422342   320.975612  0.00171821 
+  586          521.363867   320.650901  0.00170648 
+  559          514.446433   320.326563  0.00178891 
+  523          496.490207   320.0026    0.00191205 
+  488          476.319698   319.679009  0.00204918 
+  458          454.206443   319.355791  0.00218341 
+  414          428.425445   319.032946  0.00241546 
+  361          402.446702   318.710472  0.00277008 
+  363          380.523212   318.388369  0.00275482 
+  358          363.922591   318.066638  0.0027933 
+  333          352.042866   317.745276  0.003003  
+  338          343.764236   317.424285  0.00295858 
+  341          338.005642   317.103664  0.00293255 
+  287          333.904612   316.783411  0.00348432 
+  317          330.860718   316.463528  0.00315457 
+  312          328.494633   316.144013  0.00320513 
+  326          326.580535   315.824865  0.00306748 
+  359          324.984601   315.506085  0.00278552 
+  336          323.623749   315.187672  0.00297619 
+  310          322.443003   314.869626  0.00322581 
+  350          321.403581   314.551946  0.00285714 
+  313          320.47663    314.234632  0.00319489 
+  345          319.640606   313.917682  0.00289855 
+  337          318.878898   313.601098  0.00296736 
+  301          318.178524   313.284878  0.00332226 
+  313          317.529313   312.969023  0.00319489 
+  326          316.923162   312.65353   0.00306748 
+  320          316.353494   312.338401  0.003125  
+  292          315.814994   312.023635  0.00342466 
+  321          315.303321   311.709231  0.00311526 
+  350          314.814877   311.395189  0.00285714 
+  349          314.346706   311.081508  0.00286533 
+  357          313.89635    310.768188  0.00280112 
+  328          313.46171    310.455229  0.00304878 
+  299          313.041032   310.142631  0.00334448 
+  344          312.632957   309.830391  0.00290698 
+  349          312.235962   309.518512  0.00286533 
+  344          311.848492   309.206991  0.00290698 
+  298          311.470591   308.895828  0.0033557 
+  326          311.101089   308.585024  0.00306748 
+  332          310.739649   308.274578  0.00301205 
+  360          310.385253   307.964488  0.00277778 
+  316          310.037731   307.654756  0.00316456 
+  302          309.696405   307.345379  0.00331126 
+  327          309.360987   307.036359  0.0030581 
+  360          309.031169   306.727694  0.00277778 
+  351          308.706699   306.419385  0.002849  
+  310          308.387202   306.11143   0.00322581 
+  308          308.072841   305.80383   0.00324675 
+  345          307.76324    305.496583  0.00289855 
+  344          307.458482   305.18969   0.00290698 
+  334          307.158417   304.88315   0.00299401 
+  294          306.863021   304.576962  0.00340136 
+  280          306.572107   304.271127  0.00357143 
+  328          306.286084   303.965643  0.00304878 
+  306          306.004835   303.660511  0.00326797 
+  317          305.728356   303.35573   0.00315457 
+  291          305.456976   303.0513    0.00343643 
+  325          305.190763   302.747219  0.00307692 
+  315          304.92992    302.443489  0.0031746 
+  313          304.674673   302.140108  0.00319489 
+  325          304.425313   301.837075  0.00307692 
+  302          304.189189   301.534391  0.00331126 
+  289          303.952665   301.232056  0.00346021 
+  308          303.723178   300.930067  0.00324675 
+  322          303.501232   300.628427  0.00310559 
+  298          303.28738    300.327133  0.0033557 
+  324          303.082292   300.026185  0.00308642 
+  293          302.890235   299.725584  0.00341297 
+  265          302.705045   299.425328  0.00377358 
+  255          302.53122    299.125418  0.00392157 
+  290          302.369874   298.825852  0.00344828 
+  311          302.222337   298.526631  0.00321543 
+  321          302.090066   298.227753  0.00311526 
+  302          301.974815   297.92922   0.00331126 
+  287          301.878602   297.631029  0.00348432 
+  312          301.803785   297.333182  0.00320513 
+  285          301.753092   297.035677  0.00350877 
+  307          301.729806   296.738513  0.00325733 
+  277          301.749125   296.441692  0.00361011 
+  292          301.792747   296.145211  0.00342466 
+  309          301.877509   295.849072  0.00323625 
+  327          302.016001   295.553272  0.0030581 
+  323          302.203971   295.257813  0.00309598 
+  297          302.457167   294.962694  0.003367  
+  268          302.79297    294.667913  0.00373134 
+  330          303.214616   294.373471  0.0030303 
+  298          303.749123   294.079368  0.0033557 
+  349          304.413575   293.785603  0.00286533 
+  322          305.240362   293.492175  0.00310559 
+  300          306.267809   293.199084  0.00333333 
+  308          307.545502   292.906331  0.00324675 
+  303          309.140632   292.613913  0.00330033 
+  339          311.146069   292.321832  0.00294985 
+  319          313.69718    292.030086  0.0031348 
+  342          317.003563   291.738676  0.00292398 
+  359          321.410069   291.4476    0.00278552 
+  323          327.4912     291.156859  0.00309598 
+  346          336.18569    290.866451  0.00289017 
+  345          348.911534   290.576378  0.00289855 
+  398          367.58274    290.286637  0.00251256 
+  415          394.385131   289.99723   0.00240964 
+  426          431.216378   289.708155  0.00234742 
+  488          478.277248   289.419412  0.00204918 
+  558          530.966733   289.131     0.00179211 
+  687          575.688919   288.84292   0.0014556 
+  712          594.692823   288.555171  0.00140449 
+  678          585.592263   288.267752  0.00147493 
+  635          563.595171   287.980663  0.0015748 
+  606          539.387746   287.693904  0.00165017 
+  605          510.548517   287.407475  0.00165289 
+  509          473.609011   287.121374  0.00196464 
+  479          433.779263   286.835602  0.00208768 
+  455          398.362046   286.550158  0.0021978 
+  361          370.399445   286.265042  0.00277008 
+  339          349.665886   285.980253  0.00294985 
+  318          334.783588   285.695791  0.00314465 
+  282          324.22839    285.411656  0.0035461 
+  276          316.683473   285.127847  0.00362319 
+  279          311.151999   284.844363  0.00358423 
+  296          306.946304   284.561206  0.00337838 
+  307          303.630233   284.278373  0.00325733 
+  305          300.933133   283.995865  0.00327869 
+  306          298.686526   283.713681  0.00326797 
+  283          296.780732   283.431822  0.00353357 
+  275          295.140045   283.150285  0.00363636 
+  312          293.709939   282.869072  0.00320513 
+  291          292.449526   282.588182  0.00343643 
+  324          291.327331   282.307614  0.00308642 
+  273          290.320227   282.027368  0.003663  
+  286          289.406439   281.747444  0.0034965 
+  289          288.571885   281.467841  0.00346021 
+  278          287.804349   281.188559  0.00359712 
+  287          287.093747   280.909597  0.00348432 
+  303          286.431998   280.630956  0.00330033 
+  266          285.812322   280.352634  0.0037594 
+  293          285.229769   280.074631  0.00341297 
+  290          284.678132   279.796948  0.00344828 
+  312          284.154664   279.519583  0.00320513 
+  266          283.655761   279.242536  0.0037594 
+  296          283.178537   278.965807  0.00337838 
+  293          282.720817   278.689396  0.00341297 
+  283          282.280427   278.413302  0.00353357 
+  288          281.860327   278.137524  0.00347222 
+  304          281.449561   277.862063  0.00328947 
+  269          281.051516   277.586918  0.00371747 
+  285          280.665082   277.312088  0.00350877 
+  283          280.289259   277.037574  0.00353357 
+  265          279.923191   276.763374  0.00377358 
+  284          279.566129   276.489489  0.00352113 
+  271          279.219813   276.215918  0.00369004 
+  261          278.878939   275.942661  0.00383142 
+  243          278.547894   275.669717  0.00411523 
+  278          278.221295   275.397086  0.00359712 
+  303          277.903619   275.124768  0.00330033 
+  256          277.589906   274.852762  0.00390625 
+  272          277.282254   274.581067  0.00367647 
+  263          276.98049    274.309685  0.00380228 
+  274          276.684487   274.038613  0.00364964 
+  275          276.395405   273.767853  0.00363636 
+  279          276.110729   273.497402  0.00358423 
+  279          275.832893   273.227262  0.00358423 
+  271          275.559628   272.957431  0.00369004 
+  282          275.292242   272.68791   0.0035461 
+  238          275.030926   272.418698  0.00420168 
+  280          274.775943   272.149794  0.00357143 
+  296          274.527637   271.881198  0.00337838 
+  275          274.286447   271.612911  0.00363636 
+  291          274.052908   271.344931  0.00343643 
+  283          273.827702   271.077257  0.00353357 
+  273          273.611635   270.809891  0.003663  
+  305          273.405716   270.542831  0.00327869 
+  286          273.211177   270.276077  0.0034965 
+  278          273.029533   270.009629  0.00359712 
+  311          272.862637   269.743486  0.00321543 
+  241          272.712824   269.477648  0.00414938 
+  274          272.58294    269.212114  0.00364964 
+  287          272.47662    268.946885  0.00348432 
+  300          272.398461   268.68196   0.00333333 
+  280          272.354362   268.417338  0.00357143 
+  274          272.351952   268.153019  0.00364964 
+  280          272.401377   267.889003  0.00357143 
+  261          272.516156   267.62529   0.00383142 
+  274          272.715402   267.361878  0.00364964 
+  297          273.02729    267.098768  0.003367  
+  286          273.496201   266.83596   0.0034965 
+  291          274.195451   266.573453  0.00343643 
+  283          275.247823   266.311246  0.00353357 
+  282          276.849501   266.049339  0.0035461 
+  281          279.290276   265.787733  0.00355872 
+  320          282.946599   265.526426  0.003125  
+  293          288.227657   265.265418  0.00341297 
+  291          295.440196   265.004709  0.00343643 
+  319          304.470592   264.744299  0.0031348 
+  309          314.098803   264.484186  0.00323625 
+  342          321.356949   264.224372  0.00292398 
+  313          323.23742    263.964855  0.00319489 
+  337          320.338342   263.705635  0.00296736 
+  330          315.845987   263.446711  0.0030303 
+  309          311.349439   263.188085  0.00323625 
+  312          306.046066   262.929754  0.00320513 
+  322          299.194076   262.671719  0.00310559 
+  313          291.775651   262.413979  0.00319489 
+  292          285.152649   262.156534  0.00342466 
+  304          279.889038   261.899384  0.00328947 
+  289          275.951263   261.642528  0.00346021 
+  258          273.092546   261.385966  0.00387597 
+  243          271.037591   261.129698  0.00411523 
+  266          269.546551   260.873723  0.0037594 
+  263          268.4373     260.61804   0.00380228 
+  258          267.585008   260.362651  0.00387597 
+  237          266.910745   260.107553  0.00421941 
+  265          266.366433   259.852748  0.00377358 
+  268          265.923011   259.598233  0.00373134 
+  265          265.5633     259.34401   0.00377358 
+  264          265.276248   259.090078  0.00378788 
+  248          265.055503   258.836437  0.00403226 
+  262          264.897986   258.583085  0.00381679 
+  289          264.803734   258.330023  0.00346021 
+  256          264.774953   258.077251  0.00390625 
+  272          264.816641   257.824768  0.00367647 
+  271          264.936724   257.572573  0.00369004 
+  273          265.146551   257.320667  0.003663  
+  257          265.508096   257.069049  0.00389105 
+  248          265.950312   256.817719  0.00403226 
+  246          266.548054   256.566676  0.00406504 
+  241          267.341368   256.31592   0.00414938 
+  283          268.387603   256.065451  0.00353357 
+  281          269.773422   255.815268  0.00355872 
+  282          271.661117   255.565371  0.0035461 
+  274          274.237109   255.31576   0.00364964 
+  306          277.909751   255.066434  0.00326797 
+  289          283.287769   254.817394  0.00346021 
+  325          291.242355   254.568638  0.00307692 
+  335          302.861345   254.320166  0.00298507 
+  329          319.252363   254.071978  0.00303951 
+  428          341.081198   253.824074  0.00233645 
+  474          367.457973   253.576453  0.0021097 
+  547          393.799693   253.329115  0.00182815 
+  525          410.955304   253.08206   0.00190476 
+  621          412.33273    252.835287  0.00161031 
+  712          402.490612   252.588796  0.00140449 
+  745          390.266013   252.342587  0.00134228 
+  704          378.399778   252.096659  0.00142045 
+  633          363.799379   251.851012  0.00157978 
+  561          344.932144   251.605646  0.00178253 
+  525          325.021924   251.36056   0.00190476 
+  464          307.613802   251.115754  0.00215517 
+  425          293.963429   250.871228  0.00235294 
+  382          283.85304    250.626981  0.0026178 
+  358          276.580597   250.383013  0.0027933 
+  303          271.398949   250.139323  0.00330033 
+  280          267.666683   249.895912  0.00357143 
+  271          264.902857   249.652779  0.00369004 
+  237          262.780182   249.409923  0.00421941 
+  237          261.09128    249.167345  0.00421941 
+  217          259.707922   248.925044  0.00460829 
+  284          258.550405   248.68302   0.00352113 
+  277          257.5663     248.441272  0.00361011 
+  249          256.71947    248.199799  0.00401606 
+  241          255.984212   247.958603  0.00414938 
+  259          255.340276   247.717682  0.003861  
+  231          254.773346   247.477036  0.004329  
+  260          254.272307   247.236665  0.00384615 
+  247          253.828597   246.996568  0.00404858 
+  231          253.43577    246.756745  0.004329  
+  276          253.089007   246.517196  0.00362319 
+  262          252.785174   246.27792   0.00381679 
+  204          252.521492   246.038917  0.00490196 
+  234          252.296983   245.800187  0.0042735 
+  266          252.111371   245.56173   0.0037594 
+  260          251.965343   245.323544  0.00384615 
+  263          251.860548   245.085631  0.00380228 
+  226          251.799733   244.847989  0.00442478 
+  265          251.786837   244.610618  0.00377358 
+  270          251.827254   244.373518  0.0037037 
+  225          251.930596   244.136688  0.00444444 
+  224          252.101505   243.900128  0.00446429 
+  232          252.35482    243.663839  0.00431034 
+  230          252.707092   243.427819  0.00434783 
+  220          253.180487   243.192068  0.00454545 
+  216          253.806039   242.956586  0.00462963 
+  239          254.630615   242.721372  0.0041841 
+  227          255.723037   242.486427  0.00440529 
+  255          257.200345   242.25175   0.00392157 
+  247          259.251376   242.01734   0.00404858 
+  273          262.170283   241.783198  0.003663  
+  220          266.372605   241.549323  0.00454545 
+  260          272.378611   241.315714  0.00384615 
+  297          280.715306   241.082372  0.003367  
+  304          291.712699   240.849296  0.00328947 
+  320          304.994584   240.616485  0.003125  
+  334          318.504646   240.38394   0.00299401 
+  332          328.173323   240.15166   0.00301205 
+  349          331.309409   239.919645  0.00286533 
+  355          330.479832   239.687894  0.0028169 
+  364          330.350376   239.456407  0.00274725 
+  344          333.061344   239.225184  0.00290698 
+  399          338.241402   238.994225  0.00250627 
+  382          346.098709   238.763529  0.0026178 
+  344          358.827517   238.533096  0.00290698 
+  369          377.793463   238.302925  0.00271003 
+  386          400.656613   238.073017  0.00259067 
+  383          421.237489   237.843371  0.00261097 
+  381          432.121634   237.613986  0.00262467 
+  401          429.17412    237.384862  0.00249377 
+  365          416.252339   237.156     0.00273973 
+  361          400.569129   236.927399  0.00277008 
+  311          384.703556   236.699057  0.00321543 
+  331          366.874597   236.470976  0.00302115 
+  309          345.692456   236.243155  0.00323625 
+  287          323.502982   236.015593  0.00348432 
+  287          303.817361   235.78829   0.00348432 
+  291          288.205699   235.561246  0.00343643 
+  255          276.561896   235.334461  0.00392157 
+  234          268.154575   235.107934  0.0042735 
+  228          262.16478    234.881665  0.00438596 
+  263          257.88038    234.655654  0.00380228 
+  213          254.762423   234.4299    0.00469484 
+  230          252.435834   234.204403  0.00434783 
+  235          250.660913   233.979162  0.00425532 
+  229          249.290283   233.754178  0.00436681 
+  235          248.232839   233.529451  0.00425532 
+  211          247.427274   233.304979  0.00473934 
+  214          246.826388   233.080762  0.0046729 
+  279          246.389512   232.856801  0.00358423 
+  247          246.080294   232.633094  0.00404858 
+  241          245.86756    232.409643  0.00414938 
+  210          245.727683   232.186445  0.0047619 
+  231          245.648256   231.963502  0.004329  
+  238          245.627339   231.740812  0.00420168 
+  228          245.667494   231.518376  0.00438596 
+  233          245.767568   231.296192  0.00429185 
+  238          245.915658   231.074262  0.00420168 
+  237          246.084389   230.852584  0.00421941 
+  231          246.227974   230.631158  0.004329  
+  234          246.286762   230.409984  0.0042735 
+  259          246.198771   230.189062  0.003861  
+  232          245.918289   229.968391  0.00431034 
+  242          245.429564   229.74797   0.00413223 
+  256          244.746026   229.527801  0.00390625 
+  223          243.897693   229.307882  0.0044843 
+  243          242.918624   229.088213  0.00411523 
+  228          241.843651   228.868794  0.00438596 
+  225          240.710687   228.649625  0.00444444 
+  231          239.560653   228.430704  0.004329  
+  196          238.432427   228.212033  0.00510204 
+  207          237.357293   227.99361   0.00483092 
+  224          236.354835   227.775436  0.00446429 
+  236          235.433997   227.557509  0.00423729 
+  212          234.595585   227.339831  0.00471698 
+  255          233.83528    227.122399  0.00392157 
+  257          233.146042   226.905215  0.00389105 
+  219          232.52007    226.688278  0.00456621 
+  232          231.94935    226.471587  0.00431034 
+  205          231.42648    226.255143  0.00487805 
+  194          230.944833   226.038945  0.00515464 
+  215          230.498613   225.822992  0.00465116 
+  210          230.082818   225.607284  0.0047619 
+  234          229.693293   225.391822  0.0042735 
+  224          229.326466   225.176605  0.00446429 
+  210          228.979377   224.961632  0.0047619 
+  220          228.649578   224.746903  0.00454545 
+  206          228.335045   224.532419  0.00485437 
+  225          228.034103   224.318178  0.00444444 
+  237          227.745426   224.10418   0.00421941 
+  219          227.467891   223.890425  0.00456621 
+  198          227.200615   223.676913  0.00505051 
+  213          226.942896   223.463644  0.00469484 
+  234          226.694192   223.250617  0.0042735 
+  246          226.454084   223.037832  0.00406504 
+  209          226.222314   222.825288  0.00478469 
+  224          225.998721   222.612986  0.00446429 
+  237          225.783262   222.400925  0.00421941 
+  226          225.576014   222.189105  0.00442478 
+  207          225.377182   221.977525  0.00483092 
+  219          225.187076   221.766185  0.00456621 
+  235          225.006177   221.555086  0.00425532 
+  226          224.835122   221.344225  0.00442478 
+  256          224.676265   221.133605  0.00390625 
+  257          224.527602   220.923223  0.00389105 
+  218          224.392001   220.71308   0.00458716 
+  207          224.271106   220.503176  0.00483092 
+  213          224.167027   220.29351   0.00469484 
+  239          224.08241    220.084082  0.0041841 
+  228          224.020575   219.874891  0.00438596 
+  221          223.986542   219.665938  0.00452489 
+  200          223.984261   219.457222  0.005     
+  229          224.02151    219.248743  0.00436681 
+  218          224.107643   219.0405    0.00458716 
+  250          224.255227   218.832494  0.004     
+  256          224.481751   218.624723  0.00390625 
+  211          224.812943   218.417188  0.00473934 
+  221          225.289128   218.209889  0.00452489 
+  209          225.97631    218.002825  0.00478469 
+  244          226.985121   217.795996  0.00409836 
+  220          228.493734   217.589401  0.00454545 
+  225          230.766639   217.38304   0.00444444 
+  241          234.151589   217.176914  0.00414938 
+  233          239.033848   216.971021  0.00429185 
+  228          245.714046   216.765362  0.00438596 
+  199          254.139971   216.559936  0.00502513 
+  243          263.296428   216.354743  0.00411523 
+  232          270.519114   216.149782  0.00431034 
+  289          272.742459   215.945054  0.00346021 
+  289          270.092037   215.740558  0.00346021 
+  240          265.740874   215.536294  0.00416667 
+  274          261.927917   215.332261  0.00364964 
+  247          258.364967   215.12846   0.00404858 
+  232          253.595252   214.924889  0.00431034 
+  242          247.444269   214.72155   0.00413223 
+  246          241.222195   214.51844   0.00406504 
+  250          236.029848   214.315561  0.004     
+  243          232.22555    214.112912  0.00411523 
+  228          229.786597   213.910493  0.00438596 
+  226          228.593756   213.708302  0.00442478 
+  233          228.52806    213.506341  0.00429185 
+  226          229.475884   213.304609  0.00442478 
+  227          231.247168   213.103105  0.00440529 
+  257          233.366323   212.90183   0.00389105 
+  246          234.872402   212.700782  0.00406504 
+  243          234.827627   212.499962  0.00411523 
+  295          233.412805   212.29937   0.00338983 
+  327          231.641619   212.099005  0.0030581 
+  345          230.120068   211.898867  0.00289855 
+  366          228.673141   211.698955  0.00273224 
+  391          226.834697   211.49927   0.00255754 
+  307          224.590822   211.299811  0.00325733 
+  270          222.35661    211.100578  0.0037037 
+  319          220.443343   210.90157   0.0031348 
+  297          218.928077   210.702788  0.003367  
+  309          217.769943   210.504231  0.00323625 
+  272          216.894487   210.305898  0.00367647 
+  238          216.226737   210.10779   0.00420168 
+  231          215.704507   209.909907  0.004329  
+  216          215.282259   209.712247  0.00462963 
+  221          214.929716   209.514811  0.00452489 
+  228          214.628037   209.317598  0.00438596 
+  195          214.36593    209.120609  0.00512821 
+  200          214.136674   208.923843  0.005     
+  200          213.93638    208.727299  0.005     
+  226          213.763001   208.530978  0.00442478 
+  231          213.615738   208.334878  0.004329  
+  236          213.49446    208.139001  0.00423729 
+  245          213.399103   207.943345  0.00408163 
+  230          213.328292   207.747911  0.00434783 
+  265          213.277257   207.552698  0.00377358 
+  267          213.238119   207.357705  0.00374532 
+  236          213.207137   207.162933  0.00423729 
+  239          213.188511   206.968382  0.0041841 
+  220          213.186086   206.77405   0.00454545 
+  244          213.195832   206.579938  0.00409836 
+  246          213.207075   206.386046  0.00406504 
+  242          213.209358   206.192373  0.00413223 
+  225          213.198644   205.998919  0.00444444 
+  230          213.176349   205.805684  0.00434783 
+  227          213.146699   205.612667  0.00440529 
+  220          213.115581   205.419869  0.00454545 
+  228          213.08928    205.227288  0.00438596 
+  212          213.074401   205.034925  0.00471698 
+  222          213.077857   204.84278   0.0045045 
+  190          213.107883   204.650852  0.00526316 
+  210          213.173324   204.459141  0.0047619 
+  222          213.282909   204.267646  0.0045045 
+  232          213.444073   204.076368  0.00431034 
+  210          213.662099   203.885306  0.0047619 
+  211          213.939667   203.69446   0.00473934 
+  203          214.276045   203.50383   0.00492611 
+  201          214.666962   203.313415  0.00497512 
+  216          215.105102   203.123215  0.00462963 
+  230          215.581037   202.93323   0.00434783 
+  208          216.084294   202.74346   0.00480769 
+  226          216.602767   202.553904  0.00442478 
+  226          217.120629   202.364563  0.00442478 
+  240          217.617301   202.175435  0.00416667 
+  221          218.071372   201.986521  0.00452489 
+  215          218.469057   201.79782   0.00465116 
+  203          218.812686   201.609333  0.00492611 
+  202          219.122575   201.421058  0.0049505 
+  237          219.43134    201.232996  0.00421941 
+  233          219.777292   201.045146  0.00429185 
+  202          220.202738   200.857508  0.0049505 
+  213          220.7591     200.670083  0.00469484 
+  223          221.516907   200.482869  0.0044843 
+  236          222.579618   200.295866  0.00423729 
+  237          224.102899   200.109074  0.00421941 
+  218          226.320067   199.922494  0.00458716 
+  231          229.562351   199.736124  0.004329  
+  222          234.25005    199.549964  0.0045045 
+  258          240.837303   199.364014  0.00387597 
+  286          249.664363   199.178275  0.0034965 
+  285          260.618602   198.992745  0.00350877 
+  274          272.395462   198.807424  0.00364964 
+  316          281.768398   198.622313  0.00316456 
+  273          285.32403    198.43741   0.003663  
+  290          283.636512   198.252716  0.00344828 
+  273          280.596163   198.068231  0.003663  
+  299          278.837063   197.883953  0.00334448 
+  281          278.101616   197.699884  0.00355872 
+  273          276.640606   197.516022  0.003663  
+  286          274.013874   197.332368  0.0034965 
+  325          271.773905   197.148921  0.00307692 
+  277          271.526563   196.965681  0.00361011 
+  329          274.077519   196.782647  0.00303951 
+  324          279.847959   196.59982   0.00308642 
+  356          289.372588   196.417199  0.00280899 
+  391          303.722357   196.234784  0.00255754 
+  382          325.039413   196.052575  0.0026178 
+  441          357.229355   195.870571  0.00226757 
+  481          406.56277    195.688773  0.002079  
+  529          481.546442   195.507179  0.00189036 
+  614          591.454343   195.325791  0.00162866 
+  738          742.550223   195.144607  0.00135501 
+  897          929.837473   194.963627  0.00111483 
+  1110         1119.808024  194.782851  0.0009009 
+  1296         1239.19793   194.602279  0.0007716 
+  1306         1232.629562  194.42191   0.0007657 
+  1203         1142.335157  194.241745  0.00083126 
+  1099         1049.01743   194.061783  0.00090992 
+  865          985.691921   193.882024  0.00115607 
+  847          929.598178   193.702467  0.00118064 
+  751          840.527811   193.523112  0.00133156 
+  710          718.00934    193.34396   0.00140845 
+  578          594.520896   193.16501   0.0017301 
+  458          491.9712     192.986261  0.00218341 
+  340          414.974501   192.807714  0.00294118 
+  289          360.272541   192.629368  0.00346021 
+  272          322.523605   192.451223  0.00367647 
+  225          296.574171   192.273278  0.00444444 
+  231          278.337917   192.095534  0.004329  
+  230          265.008025   191.91799   0.00434783 
+  230          254.850052   191.740646  0.00434783 
+  255          246.837302   191.563502  0.00392157 
+  228          240.357306   191.386558  0.00438596 
+  234          235.023743   191.209813  0.0042735 
+  214          230.573928   191.033266  0.0046729 
+  223          226.820589   190.856919  0.0044843 
+  218          223.626504   190.68077   0.00458716 
+  204          220.887328   190.50482   0.00490196 
+  207          218.52331    190.329068  0.00483092 
+  223          216.473232   190.153513  0.0044843 
+  192          214.688776   189.978156  0.00520833 
+  186          213.132093   189.802997  0.00537634 
+  205          211.773831   189.628035  0.00487805 
+  228          210.59066    189.45327   0.00438596 
+  213          209.564551   189.278701  0.00469484 
+  206          208.681979   189.104329  0.00485437 
+  184          207.932701   188.930153  0.00543478 
+  226          207.3094     188.756174  0.00442478 
+  183          206.80721    188.58239   0.00546448 
+  205          206.422548   188.408802  0.00487805 
+  173          206.15232    188.235409  0.00578035 
+  198          205.992265   188.062211  0.00505051 
+  193          205.934457   187.889208  0.00518135 
+  208          205.964422   187.7164    0.00480769 
+  202          206.057831   187.543786  0.0049505 
+  199          206.178537   187.371366  0.00502513 
+  192          206.281215   187.199141  0.00520833 
+  205          206.31917    187.027109  0.00487805 
+  185          206.257923   186.85527   0.00540541 
+  175          206.08455    186.683625  0.00571429 
+  213          205.808055   186.512173  0.00469484 
+  187          205.450027   186.340914  0.00534759 
+  195          205.034064   186.169847  0.00512821 
+  216          204.581878   185.998973  0.00462963 
+  194          204.115736   185.828291  0.00515464 
+  225          203.661928   185.657801  0.00444444 
+  191          203.250812   185.487503  0.0052356 
+  198          202.913262   185.317396  0.00505051 
+  198          202.677274   185.14748   0.00505051 
+  209          202.567255   184.977756  0.00478469 
+  198          202.606114   184.808222  0.00505051 
+  228          202.818099   184.638879  0.00438596 
+  182          203.232722   184.469726  0.00549451 
+  213          203.88801    184.300763  0.00469484 
+  195          204.833384   184.131991  0.00512821 
+  229          206.130376   183.963408  0.00436681 
+  214          207.85406    183.795014  0.0046729 
+  178          210.08888    183.62681   0.00561798 
+  199          212.920381   183.458795  0.00502513 
+  209          216.41324    183.290968  0.00478469 
+  208          220.564927   183.123331  0.00480769 
+  235          225.217573   182.955881  0.00425532 
+  214          229.953653   182.78862   0.0046729 
+  257          234.063      182.621547  0.00389105 
+  245          236.772496   182.454661  0.00408163 
+  276          237.71424    182.287963  0.00362319 
+  240          237.178419   182.121452  0.00416667 
+  205          235.798955   181.955128  0.00487805 
+  258          234.021425   181.788991  0.00387597 
+  219          231.90908    181.623041  0.00456621 
+  229          229.371709   181.457277  0.00436681 
+  222          226.489373   181.291699  0.0045045 
+  228          223.576149   181.126308  0.00438596 
+  188          220.996479   180.961102  0.00531915 
+  190          218.999642   180.796081  0.00526316 
+  205          217.700166   180.631246  0.00487805 
+  224          217.127032   180.466596  0.00446429 
+  216          217.280696   180.302131  0.00462963 
+  207          218.170094   180.13785   0.00483092 
+  217          219.839378   179.973754  0.00460829 
+  233          222.391971   179.809843  0.00429185 
+  200          226.037242   179.646115  0.005     
+  240          231.158258   179.482571  0.00416667 
+  234          238.407204   179.319211  0.0042735 
+  271          248.811378   179.156034  0.00369004 
+  289          263.809031   178.99304   0.00346021 
+  297          285.131498   178.830229  0.003367  
+  330          314.421531   178.667601  0.0030303 
+  332          352.381399   178.505155  0.00301205 
+  353          396.756402   178.342892  0.00283286 
+  461          438.806544   178.180811  0.0021692 
+  491          463.200675   178.018912  0.00203666 
+  549          461.581215   177.857194  0.00182149 
+  476          444.280694   177.695658  0.00210084 
+  465          427.051869   177.534303  0.00215054 
+  439          416.281103   177.373129  0.0022779 
+  394          407.822225   177.212136  0.00253807 
+  405          394.079808   177.051324  0.00246914 
+  402          374.64432    176.890692  0.00248756 
+  370          356.515044   176.73024   0.0027027 
+  352          346.146635   176.569968  0.00284091 
+  363          347.15275    176.409876  0.00275482 
+  384          362.055856   176.249964  0.00260417 
+  441          393.412894   176.090231  0.00226757 
+  504          443.715912   175.930677  0.00198413 
+  510          513.962885   175.771302  0.00196078 
+  597          599.796905   175.612106  0.00167504 
+  677          685.151216   175.453088  0.0014771 
+  736          744.568581   175.294249  0.0013587 
+  753          766.502333   175.135588  0.00132802 
+  684          762.174487   174.977104  0.00146199 
+  700          742.056689   174.818799  0.00142857 
+  563          710.399373   174.660671  0.0017762 
+  610          670.230766   174.50272   0.00163934 
+  569          620.720174   174.344946  0.00175747 
+  512          565.328317   174.187349  0.00195312 
+  415          509.049233   174.029929  0.00240964 
+  364          453.267502   173.872685  0.00274725 
+  315          401.276442   173.715618  0.0031746 
+  315          358.032653   173.558727  0.0031746 
+  273          325.766862   173.402011  0.003663  
+  282          303.766182   173.245471  0.0035461 
+  278          290.805991   173.089107  0.00359712 
+  271          285.773421   172.932917  0.00369004 
+  318          287.959343   172.776903  0.00314465 
+  302          296.843593   172.621064  0.00331126 
+  351          311.374417   172.465399  0.002849  
+  299          328.433265   172.309909  0.00334448 
+  334          341.324272   172.154593  0.00299401 
+  347          343.109551   171.999451  0.00288184 
+  349          334.760547   171.844483  0.00286533 
+  339          323.997184   171.689688  0.00294985 
+  324          316.483641   171.535067  0.00308642 
+  333          312.558271   171.380619  0.003003  
+  310          308.9232     171.226344  0.00322581 
+  274          303.386556   171.072242  0.00364964 
+  283          298.34107    170.918313  0.00353357 
+  265          297.811072   170.764556  0.00377358 
+  261          304.063317   170.610971  0.00383142 
+  268          317.042655   170.457558  0.00373134 
+  292          333.730274   170.304317  0.00342466 
+  300          347.111929   170.151248  0.00333333 
+  292          349.853535   169.99835   0.00342466 
+  266          342.709438   169.845623  0.0037594 
+  244          333.36812    169.693068  0.00409836 
+  236          327.465235   169.540683  0.00423729 
+  267          325.194617   169.388469  0.00374532 
+  248          322.905832   169.236425  0.00403226 
+  313          317.815204   169.084551  0.00319489 
+  284          311.719792   168.932848  0.00352113 
+  324          308.308352   168.781314  0.00308642 
+  334          309.98758    168.62995   0.00299401 
+  347          318.135736   168.478756  0.00288184 
+  413          334.384232   168.32773   0.00242131 
+  455          362.028728   168.176874  0.0021978 
+  512          407.888085   168.026187  0.00195312 
+  627          484.538273   167.875668  0.0015949 
+  806          611.460375   167.725318  0.00124069 
+  937          812.259186   167.575136  0.00106724 
+  1191         1102.596175  167.425122  0.00083963 
+  1505         1464.286316  167.275276  0.00066445 
+  1971         1825.119539  167.125598  0.00050736 
+  2300         2072.259636  166.976087  0.00043478 
+  2249         2078.646033  166.826744  0.00044464 
+  1976         1871.900072  166.677567  0.00050607 
+  1659         1642.114165  166.528558  0.00060277 
+  1438         1497.653013  166.379715  0.00069541 
+  1346         1422.784509  166.231039  0.00074294 
+  1345         1337.142248  166.082529  0.00074349 
+  1179         1162.624192  165.934186  0.00084818 
+  877          928.207966   165.786008  0.00114025 
+  609          711.258429   165.637996  0.00164204 
+  454          546.619709   165.49015   0.00220264 
+  368          434.820455   165.342469  0.00271739 
+  257          363.635393   165.194953  0.00389105 
+  239          318.95522    165.047603  0.0041841 
+  233          289.807528   164.900417  0.00429185 
+  221          269.427543   164.753396  0.00452489 
+  222          254.211125   164.606539  0.0045045 
+  194          242.316204   164.459846  0.00515464 
+  216          232.747941   164.313318  0.00462963 
+  218          224.903798   164.166953  0.00458716 
+  186          218.377396   164.020753  0.00537634 
+  198          212.879582   163.874715  0.00505051 
+  206          208.197177   163.728841  0.00485437 
+  194          204.171007   163.58313   0.00515464 
+  208          200.678112   163.437582  0.00480769 
+  191          197.62429    163.292197  0.0052356 
+  221          194.934837   163.146974  0.00452489 
+  198          192.55065    163.001914  0.00505051 
+  195          190.424132   162.857016  0.00512821 
+  187          188.517162   162.71228   0.00534759 
+  194          186.7981     162.567705  0.00515464 
+  164          185.241022   162.423293  0.00609756 
+  147          183.824439   162.279041  0.00680272 
+  165          182.530316   162.134951  0.00606061 
+  156          181.343424   161.991023  0.00641026 
+  159          180.251096   161.847255  0.00628931 
+  191          179.242319   161.703647  0.0052356 
+  176          178.307669   161.5602    0.00568182 
+  166          177.439259   161.416914  0.0060241 
+  182          176.630112   161.273788  0.00549451 
+  170          175.874051   161.130821  0.00588235 
+  167          175.167914   160.988015  0.00598802 
+  152          174.503193   160.845368  0.00657895 
+  157          173.877751   160.70288   0.00636943 
+  158          173.288138   160.560552  0.00632911 
+  176          172.73118    160.418383  0.00568182 
+  179          172.204081   160.276373  0.00558659 
+  149          171.704444   160.134521  0.00671141 
+  159          171.231024   159.992828  0.00628931 
+  170          170.779913   159.851293  0.00588235 
+  177          170.350398   159.709916  0.00564972 
+  170          169.940893   159.568698  0.00588235 
+  177          169.549989   159.427637  0.00564972 
+  177          169.176471   159.286733  0.00564972 
+  178          168.8192     159.145988  0.00561798 
+  155          168.477149   159.005399  0.00645161 
+  176          168.149453   158.864967  0.00568182 
+  157          167.83528    158.724693  0.00636943 
+  196          167.533885   158.584575  0.00510204 
+  152          167.244639   158.444613  0.00657895 
+  156          166.966943   158.304808  0.00641026 
+  158          166.700257   158.165159  0.00632911 
+  171          166.444147   158.025666  0.00584795 
+  159          166.198182   157.886329  0.00628931 
+  183          165.961997   157.747148  0.00546448 
+  170          165.735283   157.608122  0.00588235 
+  142          165.517763   157.469251  0.00704225 
+  138          165.309189   157.330535  0.00724638 
+  143          165.109399   157.191975  0.00699301 
+  156          164.918217   157.053569  0.00641026 
+  166          164.735804   156.915317  0.0060241 
+  158          164.561559   156.77722   0.00632911 
+  167          164.395656   156.639278  0.00598802 
+  166          164.238096   156.501489  0.0060241 
+  161          164.088935   156.363854  0.00621118 
+  173          163.948214   156.226373  0.00578035 
+  178          163.816042   156.089045  0.00561798 
+  154          163.692554   155.951871  0.00649351 
+  159          163.578073   155.81485   0.00628931 
+  163          163.472539   155.677982  0.00613497 
+  147          163.376377   155.541267  0.00680272 
+  183          163.290209   155.404704  0.00546448 
+  150          163.213768   155.268294  0.00666667 
+  158          163.147812   155.132036  0.00632911 
+  169          163.092829   154.99593   0.00591716 
+  157          163.043862   154.859976  0.00636943 
+  156          163.012619   154.724174  0.00641026 
+  157          162.99427    154.588524  0.00636943 
+  189          162.989647   154.453025  0.00529101 
+  141          162.996933   154.317677  0.0070922 
+  151          163.022846   154.182481  0.00662252 
+  156          163.065478   154.047435  0.00641026 
+  185          163.126354   153.91254   0.00540541 
+  138          163.206969   153.777796  0.00724638 
+  156          163.309062   153.643202  0.00641026 
+  178          163.434598   153.508758  0.00561798 
+  168          163.585776   153.374465  0.00595238 
+  142          163.765163   153.240321  0.00704225 
+  164          163.975688   153.106327  0.00609756 
+  154          164.220663   152.972483  0.00649351 
+  160          164.503991   152.838788  0.00625   
+  159          164.830177   152.705242  0.00628931 
+  152          165.204406   152.571845  0.00657895 
+  160          165.632967   152.438597  0.00625   
+  153          166.122857   152.305498  0.00653595 
+  150          166.682645   152.172547  0.00666667 
+  146          167.322492   152.039745  0.00684932 
+  184          168.054469   151.907091  0.00543478 
+  173          168.892762   151.774585  0.00578035 
+  163          169.854482   151.642227  0.00613497 
+  158          170.959958   151.510017  0.00632911 
+  148          172.233061   151.377954  0.00675676 
+  185          173.702107   151.246038  0.00540541 
+  176          175.400392   151.11427   0.00568182 
+  161          177.366295   150.982649  0.00621118 
+  184          179.644021   150.851174  0.00543478 
+  169          182.283145   150.719847  0.00591716 
+  185          185.336627   150.588666  0.00540541 
+  182          188.859182   150.457631  0.00549451 
+  204          192.900426   150.326742  0.00490196 
+  181          197.494221   150.196     0.00552486 
+  210          202.644318   150.065403  0.0047619 
+  213          208.303851   149.934952  0.00469484 
+  192          214.359724   149.804647  0.00520833 
+  207          220.629707   149.674487  0.00483092 
+  246          226.896679   149.544472  0.00406504 
+  210          232.972927   149.414603  0.0047619 
+  208          238.777308   149.284878  0.00480769 
+  208          244.360241   149.155298  0.00480769 
+  212          249.853245   149.025862  0.00471698 
+  263          255.363915   148.896571  0.00380228 
+  240          260.882928   148.767424  0.00416667 
+  262          266.267346   148.638422  0.00381679 
+  255          271.314414   148.509563  0.00392157 
+  236          275.918639   148.380848  0.00423729 
+  270          280.236221   148.252276  0.0037037 
+  233          284.779273   148.123848  0.00429185 
+  278          290.323211   147.995563  0.00359712 
+  243          297.566341   147.867422  0.00411523 
+  303          306.440999   147.739423  0.00330033 
+  289          314.938011   147.611567  0.00346021 
+  344          318.397418   147.483854  0.00290698 
+  367          312.803352   147.356283  0.0027248 
+  432          300.203083   147.228855  0.00231481 
+  517          286.508542   147.101568  0.00193424 
+  618          275.697835   146.974424  0.00161812 
+  592          268.242044   146.847421  0.00168919 
+  551          262.004306   146.720561  0.00181488 
+  473          254.788698   146.593841  0.00211416 
+  430          247.303165   146.467263  0.00232558 
+  445          241.970191   146.340827  0.00224719 
+  446          239.966918   146.214531  0.00224215 
+  420          240.147917   146.088376  0.00238095 
+  381          239.214562   145.962362  0.00262467 
+  327          234.239959   145.836488  0.0030581 
+  263          226.143206   145.710755  0.00380228 
+  258          218.166848   145.585162  0.00387597 
+  235          212.298409   145.459709  0.00425532 
+  238          208.394269   145.334396  0.00420168 
+  225          204.729729   145.209223  0.00444444 
+  207          199.61047    145.08419   0.00483092 
+  202          193.239972   144.959296  0.0049505 
+  200          187.027911   144.834541  0.005     
+  164          181.929538   144.709926  0.00609756 
+  187          178.210475   144.585449  0.00534759 
+  189          175.824999   144.461111  0.00529101 
+  191          174.665556   144.336912  0.0052356 
+  184          174.690096   144.212852  0.00543478 
+  183          175.999813   144.08893   0.00546448 
+  173          178.881981   143.965146  0.00578035 
+  191          183.80616    143.8415    0.0052356 
+  184          191.341933   143.717992  0.00543478 
+  201          201.948368   143.594622  0.00497512 
+  223          215.475163   143.471389  0.0044843 
+  232          230.304128   143.348294  0.00431034 
+  264          243.008313   143.225337  0.00378788 
+  268          250.079492   143.102516  0.00373134 
+  312          249.852974   142.979832  0.00320513 
+  271          243.509861   142.857286  0.00369004 
+  283          235.127116   142.734875  0.00353357 
+  260          228.008282   142.612602  0.00384615 
+  255          222.250852   142.490465  0.00392157 
+  272          216.179656   142.368464  0.00367647 
+  241          208.327757   142.246599  0.00414938 
+  200          198.489669   142.12487   0.005     
+  213          188.142455   142.003277  0.00469484 
+  205          178.95659    141.881819  0.00487805 
+  154          171.621078   141.760497  0.00649351 
+  188          166.085003   141.639311  0.00531915 
+  184          162.019589   141.518259  0.00543478 
+  147          159.052536   141.397343  0.00680272 
+  170          156.858399   141.276561  0.00588235 
+  160          155.188998   141.155914  0.00625   
+  157          153.874898   141.035402  0.00636943 
+  152          152.803329   140.915024  0.00657895 
+  148          151.906606   140.79478   0.00675676 
+  145          151.141083   140.674671  0.00689655 
+  145          150.477651   140.554695  0.00689655 
+  142          149.896067   140.434854  0.00704225 
+  131          149.381468   140.315146  0.00763359 
+  148          148.922745   140.195571  0.00675676 
+  146          148.511904   140.07613   0.00684932 
+  161          148.140816   139.956822  0.00621118 
+  133          147.805062   139.837648  0.0075188 
+  152          147.500572   139.718606  0.00657895 
+  140          147.22418    139.599697  0.00714286 
+  137          146.973487   139.480921  0.00729927 
+  154          146.746726   139.362277  0.00649351 
+  159          146.542694   139.243765  0.00628931 
+  143          146.360599   139.125386  0.00699301 
+  134          146.202705   139.007139  0.00746269 
+  134          146.064028   138.889024  0.00746269 
+  151          145.947624   138.77104   0.00662252 
+  142          145.854374   138.653188  0.00704225 
+  141          145.785455   138.535468  0.0070922 
+  142          145.742336   138.417879  0.00704225 
+  143          145.727171   138.300421  0.00699301 
+  186          145.741483   138.183094  0.00537634 
+  131          145.784197   138.065898  0.00763359 
+  143          145.853354   137.948833  0.00699301 
+  157          145.95253    137.831899  0.00636943 
+  119          146.073916   137.715095  0.00840336 
+  140          146.20994    137.598421  0.00714286 
+  146          146.351509   137.481877  0.00684932 
+  144          146.489817   137.365464  0.00694444 
+  150          146.624309   137.24918   0.00666667 
+  144          146.757439   137.133027  0.00694444 
+  142          146.898486   137.017002  0.00704225 
+  156          147.059341   136.901108  0.00641026 
+  165          147.252389   136.785342  0.00606061 
+  155          147.491247   136.669706  0.00645161 
+  140          147.79473    136.554199  0.00714286 
+  167          148.192144   136.43882   0.00598802 
+  157          148.73032    136.323571  0.00636943 
+  159          149.482306   136.20845   0.00628931 
+  146          150.563049   136.093457  0.00684932 
+  157          152.149568   135.978593  0.00636943 
+  168          154.499413   135.863857  0.00595238 
+  146          157.94676    135.749249  0.00684932 
+  183          162.860949   135.634769  0.00546448 
+  188          169.533241   135.520417  0.00531915 
+  193          177.924881   135.406193  0.00518135 
+  217          187.10674    135.292096  0.00460829 
+  241          194.549094   135.178126  0.00414938 
+  311          197.047893   135.064283  0.00321543 
+  334          194.279433   134.950568  0.00299401 
+  348          189.41541    134.836979  0.00287356 
+  304          185.47436    134.723518  0.00328947 
+  294          183.424716   134.610183  0.00340136 
+  281          182.365699   134.496974  0.00355872 
+  240          180.372986   134.383892  0.00416667 
+  272          176.444883   134.270936  0.00367647 
+  268          171.516948   134.158106  0.00373134 
+  218          166.929703   134.045402  0.00458716 
+  192          163.291692   133.932824  0.00520833 
+  193          160.639083   133.820372  0.00518135 
+  188          158.787304   133.708045  0.00531915 
+  179          157.513392   133.595844  0.00558659 
+  170          156.641524   133.483768  0.00588235 
+  133          156.080292   133.371817  0.0075188 
+  162          155.822216   133.259991  0.00617284 
+  154          155.917262   133.14829   0.00649351 
+  156          156.429763   133.036713  0.00641026 
+  189          157.375237   132.925262  0.00529101 
+  165          158.600572   132.813934  0.00606061 
+  183          159.592047   132.702731  0.00546448 
+  170          159.528417   132.591653  0.00588235 
+  156          158.068333   132.480698  0.00641026 
+  155          155.870183   132.369867  0.00645161 
+  146          153.810833   132.25916   0.00684932 
+  154          152.294072   132.148577  0.00649351 
+  154          151.216115   132.038117  0.00649351 
+  173          150.120144   131.92778   0.00578035 
+  166          148.605299   131.817567  0.0060241 
+  156          146.766882   131.707477  0.00641026 
+  154          144.961417   131.59751   0.00649351 
+  150          143.411624   131.487666  0.00666667 
+  143          142.167514   131.377944  0.00699301 
+  132          141.197941   131.268345  0.00757576 
+  120          140.449598   131.158868  0.00833333 
+  145          139.865975   131.049514  0.00689655 
+  135          139.399898   130.940282  0.00740741 
+  142          139.017024   130.831172  0.00704225 
+  138          138.692391   130.722184  0.00724638 
+  129          138.412946   130.613318  0.00775194 
+  126          138.165357   130.504573  0.00793651 
+  132          137.948064   130.39595   0.00757576 
+  126          137.753877   130.287448  0.00793651 
+  152          137.578879   130.179067  0.00657895 
+  136          137.42015    130.070808  0.00735294 
+  120          137.278068   129.96267   0.00833333 
+  134          137.148943   129.854652  0.00746269 
+  136          137.03192    129.746755  0.00735294 
+  155          136.925971   129.638979  0.00645161 
+  151          136.830305   129.531323  0.00662252 
+  148          136.744411   129.423788  0.00675676 
+  133          136.667831   129.316373  0.0075188 
+  145          136.600326   129.209078  0.00689655 
+  129          136.541984   129.101902  0.00775194 
+  136          136.492641   128.994847  0.00735294 
+  115          136.452823   128.887911  0.00869565 
+  123          136.423284   128.781095  0.00813008 
+  129          136.405386   128.674399  0.00775194 
+  140          136.401489   128.567821  0.00714286 
+  133          136.415464   128.461363  0.0075188 
+  153          136.45269    128.355024  0.00653595 
+  152          136.522116   128.248804  0.00657895 
+  153          136.632617   128.142703  0.00653595 
+  132          136.792428   128.03672   0.00757576 
+  140          137.004813   127.930856  0.00714286 
+  141          137.255256   127.82511   0.0070922 
+  133          137.494876   127.719482  0.0075188 
+  121          137.649245   127.613973  0.00826446 
+  132          137.696939   127.508582  0.00757576 
+  135          137.713778   127.403308  0.00740741 
+  143          137.797037   127.298152  0.00699301 
+  112          138.004852   127.193114  0.00892857 
+  143          138.352691   127.088194  0.00699301 
+  136          138.818695   126.983391  0.00735294 
+  118          139.530067   126.878705  0.00847458 
+  137          140.096781   126.774136  0.00729927 
+  121          140.5891     126.669685  0.00826446 
+  158          140.879015   126.56535   0.00632911 
+  146          140.88387    126.461132  0.00684932 
+  128          140.652526   126.357031  0.0078125 
+  143          140.36839    126.253046  0.00699301 
+  145          140.180249   126.149177  0.00689655 
+  130          140.187081   126.045425  0.00769231 
+  141          140.143572   125.941789  0.0070922 
+  125          140.047803   125.838269  0.008     
+  137          139.86205    125.734865  0.00729927 
+  152          139.633793   125.631576  0.00657895 
+  108          139.443952   125.528404  0.00925926 
+  120          139.337412   125.425346  0.00833333 
+  164          139.32462    125.322405  0.00609756 
+  127          139.390265   125.219578  0.00787402 
+  139          139.52421    125.116867  0.00719424 
+  136          139.71432    125.01427   0.00735294 
+  116          139.951562   124.911789  0.00862069 
+  133          140.230412   124.809422  0.0075188 
+  136          140.548331   124.70717   0.00735294 
+  127          140.904949   124.605033  0.00787402 
+  131          141.301563   124.50301   0.00763359 
+  151          141.741925   124.401101  0.00662252 
+  159          142.22575    124.299306  0.00628931 
+  140          142.757588   124.197626  0.00714286 
+  104          143.339968   124.096059  0.00961538 
+  127          143.974196   123.994607  0.00787402 
+  159          144.659348   123.893267  0.00628931 
+  138          145.390589   123.792042  0.00724638 
+  144          146.164135   123.69093   0.00694444 
+  137          146.951981   123.589931  0.00729927 
+  130          147.741416   123.489046  0.00769231 
+  159          148.514809   123.388273  0.00628931 
+  145          149.262769   123.287614  0.00689655 
+  136          149.987692   123.187067  0.00735294 
+  142          150.702479   123.086633  0.00704225 
+  129          151.424703   122.986312  0.00775194 
+  146          152.17016    122.886103  0.00684932 
+  159          152.953557   122.786006  0.00628931 
+  120          153.77801    122.686022  0.00833333 
+  157          154.657306   122.58615   0.00636943 
+  137          155.605941   122.48639   0.00729927 
+  143          156.642108   122.386742  0.00699301 
+  149          157.785208   122.287205  0.00671141 
+  148          159.053558   122.187781  0.00675676 
+  139          160.464283   122.088467  0.00719424 
+  139          162.032686   121.989266  0.00719424 
+  156          163.779297   121.890175  0.00641026 
+  156          165.705396   121.791196  0.00641026 
+  140          167.830749   121.692328  0.00714286 
+  143          170.171487   121.59357   0.00699301 
+  157          172.731785   121.494924  0.00636943 
+  147          175.524802   121.396388  0.00680272 
+  166          178.55947    121.297963  0.0060241 
+  167          181.847786   121.199648  0.00598802 
+  165          185.410712   121.101444  0.00606061 
+  161          189.284297   121.00335   0.00621118 
+  152          193.524182   120.905366  0.00657895 
+  150          198.19424    120.807492  0.00666667 
+  188          203.37999    120.709728  0.00531915 
+  172          209.176073   120.612074  0.00581395 
+  175          215.686427   120.514529  0.00571429 
+  188          223.040969   120.417094  0.00531915 
+  207          231.395241   120.319769  0.00483092 
+  200          240.944442   120.222552  0.005     
+  222          251.935076   120.125445  0.0045045 
+  261          264.669994   120.028447  0.00383142 
+  246          279.533535   119.931558  0.00406504 
+  255          297.013063   119.834778  0.00392157 
+  315          317.736887   119.738107  0.0031746 
+  341          342.543367   119.641544  0.00293255 
+  377          372.553403   119.54509   0.00265252 
+  440          409.303125   119.448744  0.00227273 
+  469          454.958397   119.352507  0.0021322 
+  490          512.726425   119.256377  0.00204082 
+  634          587.755455   119.160356  0.00157729 
+  722          689.507054   119.064443  0.00138504 
+  985          837.073526   118.968637  0.00101523 
+  1237         1068.97675   118.87294   0.00080841 
+  1657         1454.799898  118.77735   0.0006035 
+  2226         2097.066982  118.681867  0.00044924 
+  3129         3103.878579  118.586492  0.00031959 
+  4415         4519.137551  118.491224  0.0002265 
+  5843         6183.022274  118.396063  0.00017114 
+  7432         7501.921389  118.301009  0.00013455 
+  8013         7626.446118  118.206063  0.0001248 
+  7095         6606.633271  118.111223  0.00014094 
+  5604         5374.697711  118.016489  0.00017844 
+  4438         4574.960018  117.921863  0.00022533 
+  3800         4358.345046  117.827343  0.00026316 
+  4020         4523.194648  117.732929  0.00024876 
+  4279         4562.008229  117.638621  0.0002337 
+  4206         4046.394734  117.54442   0.00023776 
+  3269         3158.789788  117.450325  0.0003059 
+  2157         2289.832797  117.356335  0.00046361 
+  1338         1617.132142  117.262452  0.00074738 
+  934          1158.598868  117.168674  0.00107066 
+  692          868.944687   117.075002  0.00144509 
+  520          690.194655   116.981435  0.00192308 
+  409          575.978493   116.887974  0.00244499 
+  440          497.628675   116.794618  0.00227273 
+  362          439.976013   116.701367  0.00276243 
+  376          395.419567   116.608222  0.00265957 
+  303          359.935992   116.515181  0.00330033 
+  301          331.123078   116.422245  0.00332226 
+  325          307.39473    116.329414  0.00307692 
+  276          287.625201   116.236687  0.00362319 
+  267          270.984716   116.144065  0.00374532 
+  278          256.839706   116.051547  0.00359712 
+  288          244.682348   115.959134  0.00347222 
+  224          234.108807   115.866825  0.00446429 
+  213          224.842683   115.77462   0.00469484 
+  242          216.707194   115.682519  0.00413223 
+  206          209.560597   115.590521  0.00485437 
+  215          203.270098   115.498628  0.00465116 
+  204          197.707528   115.406838  0.00490196 
+  192          192.750047   115.315152  0.00520833 
+  168          188.298321   115.223569  0.00595238 
+  195          184.293657   115.13209   0.00512821 
+  196          180.7006     115.040713  0.00510204 
+  194          177.485497   114.94944   0.00515464 
+  176          174.613022   114.85827   0.00568182 
+  184          172.049879   114.767203  0.00543478 
+  194          169.766359   114.676238  0.00515464 
+  156          167.738178   114.585377  0.00641026 
+  167          165.944786   114.494618  0.00598802 
+  175          164.370157   114.403961  0.00571429 
+  183          163.002838   114.313407  0.00546448 
+  147          161.834445   114.222955  0.00680272 
+  156          160.86212    114.132605  0.00641026 
+  173          160.068994   114.042357  0.00578035 
+  181          159.501307   113.952211  0.00552486 
+  175          159.154212   113.862167  0.00571429 
+  162          159.048565   113.772225  0.00617284 
+  147          159.208066   113.682385  0.00680272 
+  142          159.652529   113.592646  0.00704225 
+  147          160.373064   113.503008  0.00680272 
+  158          161.3378     113.413472  0.00632911 
+  146          162.418427   113.324037  0.00684932 
+  146          163.527011   113.234703  0.00684932 
+  153          164.753873   113.14547   0.00653595 
+  159          166.29273    113.056338  0.00628931 
+  151          168.282957   112.967307  0.00662252 
+  136          170.771096   112.878376  0.00735294 
+  160          173.719559   112.789546  0.00625   
+  169          177.022092   112.700817  0.00591716 
+  154          180.570288   112.612188  0.00649351 
+  164          184.303742   112.52366   0.00609756 
+  185          188.161514   112.435231  0.00540541 
+  194          192.055666   112.346903  0.00515464 
+  189          195.926389   112.258674  0.00529101 
+  185          199.80796    112.170546  0.00540541 
+  190          203.843485   112.082517  0.00526316 
+  189          208.25039    111.994588  0.00529101 
+  206          213.263738   111.906759  0.00485437 
+  250          219.105177   111.819029  0.004     
+  227          225.974222   111.731398  0.00440529 
+  276          234.068623   111.643867  0.00362319 
+  236          243.599731   111.556435  0.00423729 
+  288          254.733607   111.469102  0.00347222 
+  304          267.488967   111.381868  0.00328947 
+  320          281.58096    111.294732  0.003125  
+  316          296.189041   111.207696  0.00316456 
+  314          309.568462   111.120758  0.00318471 
+  313          319.026307   111.033919  0.00319489 
+  298          322.802241   110.947178  0.0033557 
+  305          322.3835     110.860536  0.00327869 
+  300          320.93484    110.773992  0.00333333 
+  292          320.528838   110.687546  0.00342466 
+  317          321.542786   110.601198  0.00315457 
+  279          322.957192   110.514948  0.00358423 
+  287          322.850386   110.428796  0.00348432 
+  267          319.826727   110.342742  0.00374532 
+  261          314.107335   110.256785  0.00383142 
+  263          306.624688   110.170926  0.00380228 
+  296          298.036041   110.085165  0.00337838 
+  237          288.736951   109.999501  0.00421941 
+  276          279.038516   109.913934  0.00362319 
+  257          269.182633   109.828464  0.00389105 
+  245          259.292407   109.743092  0.00408163 
+  239          249.372446   109.657816  0.0041841 
+  213          239.382208   109.572637  0.00469484 
+  212          229.323963   109.487555  0.00471698 
+  201          219.305018   109.40257   0.00497512 
+  233          209.516154   109.317681  0.00429185 
+  201          200.174499   109.232889  0.00497512 
+  177          191.464787   109.148193  0.00564972 
+  199          183.50616    109.063594  0.00502513 
+  165          176.342712   108.97909   0.00606061 
+  158          169.966659   108.894683  0.00632911 
+  173          164.335028   108.810372  0.00578035 
+  137          159.384192   108.726157  0.00729927 
+  155          155.03905    108.642037  0.00645161 
+  140          151.224808   108.558014  0.00714286 
+  158          147.870166   108.474085  0.00632911 
+  165          144.911472   108.390253  0.00606061 
+  155          142.292596   108.306516  0.00645161 
+  132          139.965307   108.222874  0.00757576 
+  134          137.887972   108.139327  0.00746269 
+  120          136.025809   108.055876  0.00833333 
+  138          134.348921   107.972519  0.00724638 
+  132          132.83232    107.889258  0.00757576 
+  123          131.454853   107.806091  0.00813008 
+  131          130.198784   107.723019  0.00763359 
+  109          129.048947   107.640042  0.00917431 
+  117          127.992683   107.557159  0.00854701 
+  130          127.019128   107.474371  0.00769231 
+  142          126.119029   107.391678  0.00704225 
+  126          125.284591   107.309078  0.00793651 
+  133          124.508745   107.226573  0.0075188 
+  148          123.750854   107.144161  0.00675676 
+  111          123.075568   107.061844  0.00900901 
+  116          122.443466   106.979621  0.00862069 
+  141          121.850578   106.897491  0.0070922 
+  124          121.293503   106.815456  0.00806452 
+  118          120.769161   106.733513  0.00847458 
+  121          120.257609   106.651665  0.00826446 
+  107          119.791145   106.56991   0.00934579 
+  122          119.350189   106.488248  0.00819672 
+  115          118.932908   106.406679  0.00869565 
+  121          118.537676   106.325204  0.00826446 
+  128          118.163001   106.243821  0.0078125 
+  123          117.807564   106.162532  0.00813008 
+  136          117.470238   106.081335  0.00735294 
+  101          117.149994   106.000232  0.00990099 
+  146          116.845985   105.91922   0.00684932 
+  111          116.557345   105.838302  0.00900901 
+  117          116.283454   105.757476  0.00854701 
+  124          116.023762   105.676743  0.00806452 
+  114          115.777819   105.596101  0.00877193 
+  109          115.545271   105.515552  0.00917431 
+  118          115.327063   105.435095  0.00847458 
+  123          115.120644   105.354731  0.00813008 
+  115          114.92718    105.274458  0.00869565 
+  119          114.746744   105.194277  0.00840336 
+  124          114.579535   105.114188  0.00806452 
+  124          114.425903   105.03419   0.00806452 
+  121          114.28635    104.954284  0.00826446 
+  102          114.16158    104.87447   0.00980392 
+  105          114.052485   104.794747  0.00952381 
+  123          113.960861   104.715115  0.00813008 
+  124          113.887001   104.635575  0.00806452 
+  119          113.833384   104.556125  0.00840336 
+  121          113.802397   104.476767  0.00826446 
+  122          113.797057   104.3975    0.00819672 
+  104          113.821159   104.318323  0.00961538 
+  117          113.879557   104.239238  0.00854701 
+  117          113.978586   104.160243  0.00854701 
+  134          114.126065   104.081338  0.00746269 
+  123          114.33268    104.002525  0.00813008 
+  125          114.612634   103.923801  0.008     
+  124          114.985729   103.845168  0.00806452 
+  127          115.480249   103.766625  0.00787402 
+  108          116.140701   103.688173  0.00925926 
+  120          117.038876   103.60981   0.00833333 
+  122          118.2944     103.531537  0.00819672 
+  114          120.099938   103.453354  0.00877193 
+  110          122.743659   103.375261  0.00909091 
+  122          126.609554   103.297258  0.00819672 
+  122          132.133271   103.219345  0.00819672 
+  151          139.676972   103.14152   0.00662252 
+  138          149.265251   103.063786  0.00724638 
+  149          159.971097   102.98614   0.00671141 
+  169          169.0203     102.908584  0.00591716 
+  196          172.418959   102.831117  0.00510204 
+  170          168.982561   102.75374   0.00588235 
+  168          162.136407   102.676451  0.00595238 
+  163          155.928932   102.599251  0.00613497 
+  140          152.291193   102.52214   0.00714286 
+  156          151.188285   102.445118  0.00641026 
+  169          151.020164   102.368184  0.00591716 
+  170          149.324105   102.291339  0.00588235 
+  131          144.949218   102.214582  0.00763359 
+  135          139.134205   102.137914  0.00740741 
+  133          133.596589   102.061334  0.0075188 
+  114          129.185314   101.984843  0.00877193 
+  148          126.033708   101.908439  0.00675676 
+  133          123.980558   101.832124  0.0075188 
+  96           122.768175   101.755896  0.01041667 
+  103          122.124777   101.679757  0.00970874 
+  130          121.81345    101.603705  0.00769231 
+  122          121.638928   101.527741  0.00819672 
+  126          121.466895   101.451864  0.00793651 
+  141          121.230281   101.376075  0.0070922 
+  120          120.923046   101.300374  0.00833333 
+  120          120.589584   101.22476   0.00833333 
+  125          120.299338   101.149233  0.008     
+  120          120.125827   101.073793  0.00833333 
+  123          120.137403   100.99844   0.00813008 
+  130          120.387049   100.923175  0.00769231 
+  131          120.893046   100.847996  0.00763359 
+  144          121.567197   100.772904  0.00694444 
+  135          122.117548   100.697899  0.00740741 
+  171          121.99167    100.622981  0.00584795 
+  142          120.885999   100.548149  0.00704225 
+  129          119.196263   100.473404  0.00775194 
+  117          117.541463   100.398745  0.00854701 
+  133          116.288763   100.324173  0.0075188 
+  122          115.490997   100.249687  0.00819672 
+  129          114.969796   100.175287  0.00775194 
+  130          114.379997   100.100973  0.00769231 
+  116          113.451461   100.026745  0.00862069 
+  130          112.266761   99.952603   0.00769231 
+  128          111.081328   99.878547   0.0078125 
+  133          110.054219   99.804577   0.0075188 
+  104          109.225364   99.730692   0.00961538 
+  105          108.578623   99.656893   0.00952381 
+  90           108.079671   99.583179   0.01111111 
+  108          107.692559   99.509551   0.00925926 
+  116          107.386906   99.436008   0.00862069 
+  97           107.140335   99.362551   0.01030928 
+  112          106.937977   99.289179   0.00892857 
+  106          106.768411   99.215891   0.00943396 
+  118          106.63126    99.142689   0.00847458 
+  94           106.521913   99.069572   0.0106383 
+  103          106.440556   98.996539   0.00970874 
+  104          106.390228   98.923592   0.00961538 
+  96           106.376744   98.850729   0.01041667 
+  90           106.414964   98.77795    0.01111111 
+  95           106.522284   98.705257   0.01052632 
+  95           106.723483   98.632647   0.01052632 
+  105          107.045032   98.560122   0.00952381 
+  125          107.505801   98.487681   0.008     
+  109          108.096003   98.415325   0.00917431 
+  102          108.730406   98.343052   0.00980392 
+  108          109.19914    98.270864   0.00925926 
+  116          109.27428    98.19876    0.00862069 
+  104          108.964912   98.126739   0.00961538 
+  124          108.526394   98.054802   0.00806452 
+  113          108.185207   97.982949   0.00884956 
+  102          108.029118   97.91118    0.00980392 
+  90           108.039973   97.839494   0.01111111 
+  105          108.105762   97.767892   0.00952381 
+  124          108.076398   97.696373   0.00806452 
+  104          107.902956   97.624937   0.00961538 
+  99           107.682222   97.553584   0.01010101 
+  110          107.529361   97.482315   0.00909091 
+  103          107.654994   97.411129   0.00970874 
+  102          107.802016   97.340026   0.00980392 
+  107          108.147929   97.269005   0.00934579 
+  115          108.735031   97.198068   0.00869565 
+  92           109.617354   97.127213   0.01086957 
+  118          110.848308   97.056441   0.00847458 
+  127          112.449505   96.985751   0.00787402 
+  110          114.336467   96.915145   0.00909091 
+  115          116.265932   96.84462    0.00869565 
+  109          117.56156    96.774178   0.00917431 
+  106          118.047056   96.703818   0.00943396 
+  112          118.142793   96.63354    0.00892857 
+  102          118.471796   96.563345   0.00980392 
+  137          119.382358   96.493231   0.00729927 
+  122          120.909867   96.4232     0.00819672 
+  133          122.802086   96.35325    0.0075188 
+  123          124.52634    96.283382   0.00813008 
+  145          125.502069   96.213596   0.00689655 
+  129          125.50016    96.143892   0.00775194 
+  141          124.694131   96.074269   0.0070922 
+  140          123.455012   96.004727   0.00714286 
+  135          122.167566   95.935267   0.00740741 
+  124          121.087321   95.865889   0.00806452 
+  137          120.278958   95.796591   0.00729927 
+  124          119.643635   95.727375   0.00806452 
+  133          119.012296   95.65824    0.0075188 
+  133          118.269484   95.589186   0.0075188 
+  129          117.41655    95.520213   0.00775194 
+  137          116.501085   95.451321   0.00729927 
+  121          115.514362   95.38251    0.00826446 
+  105          114.444684   95.313779   0.00952381 
+  114          113.39383    95.245129   0.00877193 
+  117          112.505916   95.17656    0.00854701 
+  128          111.855117   95.108071   0.0078125 
+  98           111.441335   95.039662   0.01020408 
+  104          111.212624   94.971334   0.00961538 
+  125          111.075065   94.903086   0.008     
+  108          110.937725   94.834918   0.00925926 
+  107          110.788443   94.766831   0.00934579 
+  109          110.679168   94.698823   0.00917431 
+  117          110.65332    94.630896   0.00854701 
+  111          110.72544    94.563048   0.00900901 
+  107          110.895432   94.49528    0.00934579 
+  98           111.159617   94.427592   0.01020408 
+  88           111.515914   94.359983   0.01136364 
+  111          111.966047   94.292454   0.00900901 
+  101          112.515838   94.225005   0.00990099 
+  124          113.174624   94.157635   0.00806452 
+  126          113.951747   94.090344   0.00793651 
+  109          114.850701   94.023133   0.00917431 
+  115          115.862001   93.956001   0.00869565 
+  112          116.980377   93.888948   0.00892857 
+  130          118.256046   93.821974   0.00769231 
+  119          119.81357    93.755079   0.00840336 
+  130          121.835495   93.688263   0.00769231 
+  129          124.588111   93.621526   0.00775194 
+  110          128.482742   93.554868   0.00909091 
+  131          134.117996   93.488288   0.00763359 
+  157          142.24096    93.421787   0.00636943 
+  143          153.602502   93.355364   0.00699301 
+  160          168.567495   93.28902    0.00625   
+  169          186.217123   93.222754   0.00591716 
+  163          202.677668   93.156567   0.00613497 
+  202          210.875933   93.090458   0.0049505 
+  200          207.015366   93.024427   0.005     
+  179          196.211501   92.958474   0.00558659 
+  187          185.988151   92.892599   0.00534759 
+  167          180.302174   92.826802   0.00598802 
+  177          179.848573   92.761083   0.00564972 
+  160          182.991537   92.695442   0.00625   
+  163          185.936163   92.629879   0.00613497 
+  178          184.98328    92.564393   0.00561798 
+  168          180.707466   92.498985   0.00595238 
+  176          176.723307   92.433654   0.00568182 
+  170          175.623182   92.368401   0.00588235 
+  177          178.146099   92.303225   0.00564972 
+  202          183.561578   92.238126   0.0049505 
+  198          189.509146   92.173105   0.00505051 
+  238          192.528248   92.10816    0.00420168 
+  230          191.079254   92.043293   0.00434783 
+  261          187.323119   91.978503   0.00383142 
+  235          184.316979   91.91379    0.00425532 
+  205          183.686862   91.849154   0.00487805 
+  177          185.669849   91.784594   0.00564972 
+  213          189.454468   91.720111   0.00469484 
+  228          193.324156   91.655705   0.00438596 
+  221          195.77555    91.591375   0.00452489 
+  204          197.092387   91.527122   0.00490196 
+  213          198.75678    91.462946   0.00469484 
+  204          201.898212   91.398845   0.00490196 
+  196          207.008396   91.334821   0.00510204 
+  215          214.277467   91.270874   0.00465116 
+  218          223.840566   91.207002   0.00458716 
+  248          235.903757   91.143206   0.00403226 
+  262          250.808707   91.079487   0.00381679 
+  261          269.082308   91.015843   0.00383142 
+  279          291.457593   90.952276   0.00358423 
+  304          318.855836   90.888784   0.00328947 
+  325          352.390273   90.825367   0.00307692 
+  387          393.257003   90.762027   0.00258398 
+  434          442.935465   90.698762   0.00230415 
+  514          504.667148   90.635572   0.00194553 
+  685          586.295117   90.572458   0.00145985 
+  794          703.751744   90.50942    0.00125945 
+  1056         887.643402   90.446456   0.00094697 
+  1413         1193.093509  90.383568   0.00070771 
+  1735         1703.765445  90.320755   0.00057637 
+  2401         2514.184639  90.258017   0.00041649 
+  3425         3677.530642  90.195355   0.00029197 
+  4757         5098.52358   90.132767   0.00021022 
+  6312         6342.597983  90.070254   0.00015843 
+  7150         6648.076195  90.007815   0.00013986 
+  6331         5832.236107  89.945452   0.00015795 
+  4848         4629.031283  89.883163   0.00020627 
+  3551         3690.433795  89.820949   0.00028161 
+  2869         3255.675895  89.75881    0.00034855 
+  2773         3308.210111  89.696744   0.00036062 
+  3224         3637.600981  89.634754   0.00031017 
+  3734         3820.700729  89.572837   0.00026781 
+  3465         3480.669276  89.510995   0.0002886 
+  2759         2756.484221  89.449227   0.00036245 
+  1847         2008.712918  89.387533   0.00054142 
+  1264         1416.736479  89.325914   0.00079114 
+  737          1008.208319  89.264368   0.00135685 
+  598          748.719271   89.202896   0.00167224 
+  466          588.937675   89.141498   0.00214592 
+  412          487.858916   89.080174   0.00242718 
+  346          419.473408   89.018923   0.00289017 
+  322          369.86707    88.957747   0.00310559 
+  305          332.13714    88.896643   0.00327869 
+  309          302.762232   88.835613   0.00323625 
+  257          279.753832   88.774657   0.00389105 
+  219          261.86935    88.713774   0.00456621 
+  226          248.174926   88.652965   0.00442478 
+  198          237.746448   88.592228   0.00505051 
+  192          229.291102   88.531565   0.00520833 
+  207          221.187042   88.470975   0.00483092 
+  196          212.442658   88.410458   0.00510204 
+  187          203.173114   88.350014   0.00534759 
+  194          193.92506    88.289643   0.00515464 
+  197          185.435315   88.229344   0.00507614 
+  161          178.334155   88.169119   0.00621118 
+  167          172.665379   88.108966   0.00598802 
+  180          167.836269   88.048886   0.00555556 
+  131          163.073745   87.988878   0.00763359 
+  164          158.060834   87.928943   0.00609756 
+  165          152.89054    87.86908    0.00606061 
+  136          147.799513   87.80929    0.00735294 
+  160          143.135305   87.749572   0.00625   
+  150          139.162814   87.689926   0.00666667 
+  142          135.972814   87.630353   0.00704225 
+  128          133.554605   87.570851   0.0078125 
+  106          131.86944    87.511422   0.00943396 
+  146          130.849655   87.452064   0.00684932 
+  117          130.354706   87.392779   0.00854701 
+  133          130.051954   87.333565   0.0075188 
+  136          129.364528   87.274423   0.00735294 
+  115          127.863309   87.215353   0.00869565 
+  133          125.801165   87.156354   0.0075188 
+  124          123.808655   87.097427   0.00806452 
+  111          122.338241   87.038571   0.00900901 
+  151          121.563118   86.979787   0.00662252 
+  122          121.449739   86.921075   0.00819672 
+  148          121.749691   86.862433   0.00675676 
+  124          122.021123   86.803863   0.00806452 
+  121          121.825767   86.745364   0.00826446 
+  131          120.929554   86.686937   0.00763359 
+  130          119.467621   86.62858    0.00769231 
+  102          117.980371   86.570294   0.00980392 
+  134          117.012329   86.512079   0.00746269 
+  109          116.825481   86.453935   0.00917431 
+  109          117.395135   86.395862   0.00917431 
+  121          118.364071   86.33786    0.00826446 
+  117          118.960523   86.279928   0.00854701 
+  103          118.395266   86.222067   0.00970874 
+  98           116.721265   86.164276   0.01020408 
+  108          114.730636   86.106556   0.00925926 
+  106          113.087441   86.048907   0.00943396 
+  123          112.043168   85.991327   0.00813008 
+  105          111.558976   85.933818   0.00952381 
+  93           111.380179   85.876379   0.01075269 
+  121          111.091045   85.819011   0.00826446 
+  100          110.381713   85.761712   0.01      
+  123          109.310655   85.704483   0.00813008 
+  104          108.11651    85.647325   0.00961538 
+  89           106.958951   85.590236   0.01123596 
+  122          105.90138    85.533217   0.00819672 
+  85           104.955204   85.476268   0.01176471 
+  106          104.112956   85.419389   0.00943396 
+  101          103.349743   85.362579   0.00990099 
+  94           102.636523   85.305839   0.0106383 
+  105          101.947218   85.249168   0.00952381 
+  117          101.267956   85.192567   0.00854701 
+  96           100.596406   85.136036   0.01041667 
+  81           99.9426      85.079573   0.01234568 
+  103          99.319871    85.02318    0.00970874 
+  98           98.740972    84.966856   0.01020408 
+  115          98.215121    84.910601   0.00869565 
+  92           97.747606    84.854416   0.01086957 
+  108          97.340494    84.798299   0.00925926 
+  89           96.993809    84.742251   0.01123596 
+  106          96.706627    84.686272   0.00943396 
+  89           96.477395    84.630362   0.01123596 
+  91           96.304177    84.574521   0.01098901 
+  98           96.184248    84.518748   0.01020408 
+  98           96.11328     84.463045   0.01020408 
+  101          96.083794    84.407409   0.00990099 
+  102          96.084126    84.351842   0.00980392 
+  86           96.09703     84.296344   0.01162791 
+  84           96.100458    84.240914   0.01190476 
+  86           96.070955    84.185553   0.01162791 
+  90           95.98967     84.130259   0.01111111 
+  91           95.848488    84.075034   0.01098901 
+  99           95.652128    84.019877   0.01010101 
+  114          95.414645    83.964788   0.00877193 
+  92           95.15168     83.909768   0.01086957 
+  89           94.873443    83.854815   0.01123596 
+  87           94.582818    83.79993    0.01149425 
+  84           94.279453    83.745113   0.01190476 
+  87           93.963061    83.690363   0.01149425 
+  107          93.635561    83.635682   0.00934579 
+  85           93.302367    83.581068   0.01176471 
+  98           92.971483    83.526521   0.01020408 
+  97           92.64995     83.472042   0.01030928 
+  89           92.345432    83.417631   0.01123596 
+  101          92.061835    83.363287   0.00990099 
+  118          91.803584    83.309011   0.00847458 
+  88           91.57411     83.254801   0.01136364 
+  129          91.375164    83.200659   0.00775194 
+  97           91.206925    83.146584   0.01030928 
+  97           91.070583    83.092577   0.01030928 
+  103          90.966269    83.038636   0.00970874 
+  107          90.895667    82.984762   0.00934579 
+  91           90.862271    82.930955   0.01098901 
+  98           90.871246    82.877215   0.01020408 
+  112          90.928567    82.823542   0.00892857 
+  89           91.039722    82.769936   0.01123596 
+  95           91.207124    82.716396   0.01052632 
+  92           91.424085    82.662923   0.01086957 
+  86           91.671161    82.609517   0.01162791 
+  90           91.935711    82.556177   0.01111111 
+  97           92.247178    82.502903   0.01030928 
+  94           92.662627    82.449696   0.0106383 
+  108          93.215668    82.396556   0.00925926 
+  96           93.876371    82.343481   0.01041667 
+  89           94.503705    82.290473   0.01123596 
+  83           94.838148    82.237531   0.01204819 
+  103          94.696262    82.184655   0.00970874 
+  99           94.196359    82.131845   0.01010101 
+  92           93.618342    82.079101   0.01086957 
+  109          93.160872    82.026422   0.00917431 
+  84           92.897158    81.97381    0.01190476 
+  108          92.808782    81.921264   0.00925926 
+  96           92.79879     81.868783   0.01041667 
+  85           92.716076    81.816368   0.01176471 
+  95           92.481816    81.764019   0.01052632 
+  109          92.168847    81.711735   0.00917431 
+  99           91.903372    81.659516   0.01010101 
+  99           91.766763    81.607364   0.01010101 
+  96           91.802065    81.555276   0.01041667 
+  84           92.044341    81.503254   0.01190476 
+  108          92.545554    81.451297   0.00925926 
+  117          93.394182    81.399405   0.00854701 
+  106          94.729958    81.347579   0.00943396 
+  114          96.753311    81.295817   0.00877193 
+  122          99.709742    81.244121   0.00819672 
+  108          103.828046   81.192489   0.00925926 
+  145          109.182948   81.140923   0.00689655 
+  122          115.49306    81.089421   0.00819672 
+  148          121.917606   81.037984   0.00675676 
+  170          126.761914   80.986612   0.00588235 
+  165          127.843302   80.935305   0.00606061 
+  158          124.73818    80.884062   0.00632911 
+  166          119.689308   80.832884   0.0060241 
+  129          115.17414    80.78177    0.00775194 
+  168          112.343446   80.730721   0.00595238 
+  146          111.247754   80.679736   0.00684932 
+  149          111.255839   80.628816   0.00671141 
+  150          111.177147   80.577959   0.00666667 
+  148          109.645233   80.527167   0.00675676 
+  136          106.351454   80.47644    0.00735294 
+  116          102.156624   80.425776   0.00862069 
+  122          98.36116     80.375176   0.00819672 
+  107          95.2697      80.324641   0.00934579 
+  114          92.928047    80.274169   0.00877193 
+  109          91.227089    80.223761   0.00917431 
+  114          90.017619    80.173417   0.00877193 
+  108          89.160953    80.123137   0.00925926 
+  95           88.479719    80.07292    0.01052632 
+  101          88.033526    80.022768   0.00990099 
+  101          87.706938    79.972678   0.00990099 
+  97           87.472016    79.922653   0.01030928 
+  102          87.31319     79.87269    0.00980392 
+  106          87.222207    79.822792   0.00943396 
+  89           87.194287    79.772956   0.01123596 
+  92           87.226509    79.723184   0.01086957 
+  83           87.313973    79.673475   0.01204819 
+  81           87.445586    79.62383    0.01234568 
+  98           87.598618    79.574247   0.01020408 
+  93           87.73658     79.524728   0.01075269 
+  84           87.818737    79.475271   0.01190476 
+  93           87.822522    79.425878   0.01075269 
+  104          87.76056     79.376547   0.00961538 
+  92           87.671696    79.32728    0.01086957 
+  78           87.59666     79.278075   0.01282051 
+  88           87.560322    79.228933   0.01136364 
+  108          87.566976    79.179854   0.00925926 
+  91           87.60483     79.130837   0.01098901 
+  86           87.655443    79.081883   0.01162791 
+  91           87.70899     79.032991   0.01098901 
+  84           87.773833    78.984162   0.01190476 
+  79           87.873387    78.935396   0.01265823 
+  84           88.034642    78.886691   0.01190476 
+  100          88.282261    78.838049   0.01      
+  98           88.638948    78.78947    0.01020408 
+  84           89.130353    78.740952   0.01190476 
+  111          89.792025    78.692497   0.00900901 
+  77           90.680146    78.644103   0.01298701 
+  97           91.891324    78.595772   0.01030928 
+  87           93.596398    78.547503   0.01149425 
+  98           96.088047    78.499295   0.01020408 
+  99           99.825493    78.45115    0.01010101 
+  104          105.436974   78.403066   0.00961538 
+  138          113.627719   78.355044   0.00724638 
+  137          124.921693   78.307084   0.00729927 
+  140          139.135298   78.259185   0.00714286 
+  149          154.189605   78.211348   0.00671141 
+  179          164.838822   78.163573   0.00558659 
+  166          165.548651   78.115859   0.0060241 
+  147          157.601312   78.068206   0.00680272 
+  158          147.625145   78.020615   0.00632911 
+  111          140.436854   77.973085   0.00900901 
+  120          137.385442   77.925617   0.00833333 
+  136          137.634626   77.87821    0.00735294 
+  150          139.25633    77.830863   0.00666667 
+  144          139.451983   77.783578   0.00694444 
+  137          135.470036   77.736354   0.00729927 
+  125          127.7054     77.689191   0.008     
+  120          119.148216   77.642089   0.00833333 
+  99           111.912947   77.595048   0.01010101 
+  80           106.432786   77.548067   0.0125    
+  102          102.226646   77.501148   0.00980392 
+  85           98.737498    77.454289   0.01176471 
+  100          95.798991    77.407491   0.01      
+  105          93.433523    77.360753   0.00952381 
+  103          91.606083    77.314076   0.00970874 
+  91           90.223801    77.267459   0.01098901 
+  83           89.188151    77.220903   0.01204819 
+  95           88.41457     77.174408   0.01052632 
+  96           87.834806    77.127972   0.01041667 
+  86           87.397306    77.081597   0.01162791 
+  85           87.065482    77.035282   0.01176471 
+  89           86.815213    76.989028   0.01123596 
+  78           86.631759    76.942833   0.01282051 
+  92           86.506886    76.896699   0.01086957 
+  96           86.437015    76.850625   0.01041667 
+  91           86.420546    76.80461    0.01098901 
+  94           86.45562     76.758656   0.0106383 
+  85           86.535267    76.712761   0.01176471 
+  84           86.63828     76.666926   0.01190476 
+  82           86.724663    76.621151   0.01219512 
+  85           86.759026    76.575436   0.01176471 
+  91           86.753532    76.52978    0.01098901 
+  91           86.7527      76.484184   0.01098901 
+  94           86.790824    76.438648   0.0106383 
+  84           86.881903    76.393171   0.01190476 
+  99           87.026724    76.347753   0.01010101 
+  90           87.214259    76.302395   0.01111111 
+  91           87.42405     76.257096   0.01098901 
+  88           87.635966    76.211857   0.01136364 
+  98           87.853268    76.166676   0.01020408 
+  94           88.099649    76.121555   0.0106383 
+  105          88.397731    76.076493   0.00952381 
+  85           88.763493    76.03149    0.01176471 
+  84           89.213521    75.986546   0.01190476 
+  79           89.772083    75.941661   0.01265823 
+  89           90.476389    75.896835   0.01123596 
+  83           91.380203    75.852068   0.01204819 
+  95           92.547166    75.80736    0.01052632 
+  104          94.03585     75.76271    0.00961538 
+  96           95.863098    75.718119   0.01041667 
+  110          97.922361    75.673587   0.00909091 
+  100          99.839649    75.629114   0.01      
+  102          100.984814   75.584699   0.00980392 
+  115          101.020627   75.540342   0.00869565 
+  111          100.361903   75.496044   0.00900901 
+  92           99.68241     75.451804   0.01086957 
+  98           99.386819    75.407623   0.01020408 
+  99           99.60053     75.3635     0.01010101 
+  117          100.279196   75.319435   0.00854701 
+  118          101.222381   75.275429   0.00847458 
+  121          102.085437   75.23148    0.00826446 
+  102          102.631043   75.18759    0.00980392 
+  90           103.032165   75.143757   0.01111111 
+  114          103.713586   75.099983   0.00877193 
+  100          105.074184   75.056267   0.01      
+  102          107.458937   75.012608   0.00980392 
+  108          111.198262   74.969007   0.00925926 
+  128          116.55279    74.925465   0.0078125 
+  128          123.518183   74.881979   0.0078125 
+  143          131.359578   74.838552   0.00699301 
+  173          137.897585   74.795182   0.00578035 
+  171          140.098047   74.75187    0.00584795 
+  203          137.439372   74.708615   0.00492611 
+  181          132.763679   74.665418   0.00552486 
+  162          128.873464   74.622278   0.00617284 
+  145          127.023646   74.579195   0.00689655 
+  125          127.415443   74.53617    0.008     
+  129          129.589286   74.493202   0.00775194 
+  163          132.33098    74.450292   0.00613497 
+  124          133.823233   74.407438   0.00806452 
+  165          133.167923   74.364642   0.00606061 
+  128          131.378379   74.321902   0.0078125 
+  139          129.867521   74.27922    0.00719424 
+  142          129.336325   74.236595   0.00704225 
+  143          129.942423   74.194026   0.00699301 
+  107          131.601767   74.151515   0.00934579 
+  133          134.104048   74.10906    0.0075188 
+  134          137.149424   74.066662   0.00746269 
+  142          140.477803   74.024321   0.00704225 
+  162          144.099876   73.982036   0.00617284 
+  135          148.265796   73.939808   0.00740741 
+  152          153.230809   73.897637   0.00657895 
+  175          159.170337   73.855522   0.00571429 
+  191          166.225403   73.813463   0.0052356 
+  183          174.522203   73.771461   0.00546448 
+  195          184.178365   73.729516   0.00512821 
+  214          195.350216   73.687626   0.0046729 
+  215          208.367564   73.645793   0.00465116 
+  225          223.799108   73.604016   0.00444444 
+  235          242.389194   73.562296   0.00425532 
+  264          265.062402   73.520631   0.00378788 
+  270          293.043716   73.479023   0.0037037 
+  327          328.062448   73.43747    0.0030581 
+  392          372.738675   73.395974   0.00255102 
+  419          431.496499   73.354533   0.00238663 
+  526          512.665315   73.313148   0.00190114 
+  722          633.243203   73.271819   0.00138504 
+  990          826.360788   73.230546   0.0010101 
+  1331         1148.221457  73.189328   0.00075131 
+  1759         1674.502146  73.148167   0.0005685 
+  2427         2473.776597  73.10706    0.00041203 
+  3469         3548.00298   73.06601    0.00028827 
+  4729         4713.930587  73.025015   0.00021146 
+  5875         5451.930243  72.984075   0.00017021 
+  6202         5228.232913  72.943191   0.00016124 
+  5310         4287.547213  72.902362   0.00018832 
+  4185         3281.767368  72.861589   0.00023895 
+  2973         2582.044408  72.82087    0.00033636 
+  2540         2292.232342  72.780207   0.0003937 
+  2374         2382.115836  72.739599   0.00042123 
+  2686         2721.975543  72.699047   0.0003723 
+  3135         3041.499559  72.658549   0.00031898 
+  3235         2984.061085  72.618106   0.00030912 
+  2860         2497.920103  72.577719   0.00034965 
+  2229         1874.769359  72.537386   0.00044863 
+  1565         1335.521141  72.497108   0.00063898 
+  975          943.976158   72.456885   0.00102564 
+  613          687.463309   72.416717   0.00163132 
+  489          528.379223   72.376603   0.00204499 
+  411          429.431062   72.336545   0.00243309 
+  324          364.435827   72.29654    0.00308642 
+  280          318.398252   72.256591   0.00357143 
+  238          283.650909   72.216696   0.00420168 
+  205          256.307697   72.176855   0.00487805 
+  181          234.222847   72.137069   0.00552486 
+  175          216.067062   72.097337   0.00571429 
+  198          200.944375   72.05766    0.00505051 
+  160          188.220888   72.018037   0.00625   
+  151          177.433706   71.978468   0.00662252 
+  160          168.235154   71.938953   0.00625   
+  145          160.36658    71.899493   0.00689655 
+  139          153.629871   71.860086   0.00719424 
+  123          147.876765   71.820734   0.00813008 
+  139          143.004888   71.781436   0.00719424 
+  107          138.953093   71.742191   0.00934579 
+  150          135.700298   71.703001   0.00666667 
+  118          133.263084   71.663864   0.00847458 
+  106          131.688628   71.624781   0.00943396 
+  139          131.034417   71.585752   0.00719424 
+  127          131.315064   71.546777   0.00787402 
+  115          132.395935   71.507855   0.00869565 
+  137          133.907724   71.468987   0.00729927 
+  123          135.392282   71.430173   0.00813008 
+  116          136.481002   71.391412   0.00862069 
+  136          136.806185   71.352705   0.00735294 
+  113          136.138307   71.314051   0.00884956 
+  146          134.371856   71.27545    0.00684932 
+  127          131.380666   71.236903   0.00787402 
+  105          127.587985   71.198409   0.00952381 
+  102          123.869373   71.159968   0.00980392 
+  138          120.728955   71.12158    0.00724638 
+  133          118.184942   71.083246   0.0075188 
+  127          115.998379   71.044965   0.00787402 
+  114          113.851201   71.006736   0.00877193 
+  106          111.508822   70.968561   0.00943396 
+  74           108.742327   70.930439   0.01351351 
+  110          105.499125   70.892369   0.00909091 
+  96           102.135437   70.854353   0.01041667 
+  97           99.068138    70.816389   0.01030928 
+  106          96.483036    70.778478   0.00943396 
+  107          94.380782    70.74062    0.00934579 
+  91           92.689527    70.702814   0.01098901 
+  97           91.322632    70.665061   0.01030928 
+  88           90.201184    70.62736    0.01136364 
+  83           89.262518    70.589713   0.01204819 
+  91           88.460816    70.552117   0.01098901 
+  90           87.766128    70.514574   0.01111111 
+  82           87.157873    70.477084   0.01219512 
+  92           86.623167    70.439645   0.01086957 
+  92           86.153393    70.402259   0.01086957 
+  97           85.743087    70.364926   0.01030928 
+  98           85.388935    70.327644   0.01020408 
+  87           85.089229    70.290415   0.01149425 
+  92           84.843526    70.253238   0.01086957 
+  80           84.65239     70.216112   0.0125    
+  77           84.517127    70.179039   0.01298701 
+  81           84.439392    70.142018   0.01234568 
+  94           84.420607    70.105049   0.0106383 
+  85           84.460996    70.068131   0.01176471 
+  92           84.558255    70.031266   0.01086957 
+  75           84.705676    69.994452   0.01333333 
+  93           84.889233    69.95769    0.01075269 
+  77           85.08662     69.920979   0.01298701 
+  72           85.267211    69.88432    0.01388889 
+  89           85.401919    69.847713   0.01123596 
+  88           85.449902    69.811157   0.01136364 
+  95           85.401637    69.774653   0.01052632 
+  79           85.262719    69.738201   0.01265823 
+  79           85.056627    69.701799   0.01265823 
+  100          84.814866    69.665449   0.01      
+  62           84.565674    69.629151   0.01612903 
+  94           84.326776    69.592903   0.0106383 
+  85           84.104297    69.556707   0.01176471 
+  85           83.897249    69.520562   0.01176471 
+  84           83.706097    69.484468   0.01190476 
+  87           83.540893    69.448426   0.01149425 
+  87           83.429902    69.412434   0.01149425 
+  80           83.409381    69.376493   0.0125    
+  71           83.537674    69.340603   0.01408451 
+  71           83.878022    69.304764   0.01408451 
+  91           84.491131    69.268976   0.01098901 
+  96           85.419155    69.233239   0.01041667 
+  98           86.634777    69.197553   0.01020408 
+  95           87.970766    69.161917   0.01052632 
+  84           89.024901    69.126332   0.01190476 
+  87           89.353324    69.090797   0.01149425 
+  76           88.959729    69.055313   0.01315789 
+  76           88.287086    69.01988    0.01315789 
+  95           87.718399    68.984497   0.01052632 
+  74           87.380518    68.949165   0.01351351 
+  82           87.221209    68.913882   0.01219512 
+  102          87.12557     68.878651   0.00980392 
+  77           86.963172    68.843469   0.01298701 
+  87           86.55226     68.808338   0.01149425 
+  90           85.771486    68.773257   0.01111111 
+  74           84.748245    68.738226   0.01351351 
+  81           83.71208     68.703246   0.01234568 
+  86           82.786573    68.668315   0.01162791 
+  92           81.975134    68.633434   0.01086957 
+  94           81.227754    68.598604   0.0106383 
+  88           80.510952    68.563823   0.01136364 
+  72           79.834603    68.529092   0.01388889 
+  72           79.220945    68.494411   0.01388889 
+  71           78.682118    68.45978    0.01408451 
+  78           78.221266    68.425199   0.01282051 
+  87           77.837779    68.390667   0.01149425 
+  87           77.53054     68.356185   0.01149425 
+  77           77.301499    68.321753   0.01298701 
+  79           77.152148    68.28737    0.01265823 
+  64           77.091697    68.253036   0.015625  
+  80           77.130686    68.218753   0.0125    
+  78           77.278162    68.184518   0.01282051 
+  84           77.531496    68.150333   0.01190476 
+  63           77.855159    68.116197   0.01587302 
+  85           78.1574      68.082111   0.01176471 
+  80           78.327974    68.048074   0.0125    
+  94           78.344739    68.014086   0.0106383 
+  86           78.277203    67.980147   0.01162791 
+  77           78.205333    67.946258   0.01298701 
+  80           78.212523    67.912417   0.0125    
+  67           78.367076    67.878626   0.01492537 
+  83           78.695493    67.844883   0.01204819 
+  97           79.174167    67.811189   0.01030928 
+  84           79.7303      67.777545   0.01190476 
+  76           80.28221     67.743949   0.01315789 
+  79           80.820599    67.710402   0.01265823 
+  82           81.437263    67.676904   0.01219512 
+  81           82.295065    67.643454   0.01234568 
+  92           83.597251    67.610053   0.01086957 
+  84           85.608746    67.576701   0.01190476 
+  94           88.686581    67.543397   0.0106383 
+  108          93.299386    67.510142   0.00925926 
+  94           99.969606    67.476935   0.0106383 
+  111          109.113322   67.443777   0.00900901 
+  116          120.781665   67.410667   0.00862069 
+  115          134.084205   67.377606   0.00869565 
+  144          146.098692   67.344593   0.00694444 
+  141          152.259313   67.311628   0.0070922 
+  158          150.233847   67.278711   0.00632911 
+  112          142.012948   67.245843   0.00892857 
+  146          131.862254   67.213022   0.00684932 
+  109          123.522424   67.18025    0.00917431 
+  113          118.785834   67.147526   0.00884956 
+  118          117.7859     67.11485    0.00847458 
+  125          119.429044   67.082222   0.008     
+  114          121.354652   67.049641   0.00877193 
+  118          120.830615   67.017109   0.00847458 
+  110          116.86258    66.984624   0.00909091 
+  97           110.561749   66.952187   0.01030928 
+  101          103.857478   66.919798   0.00990099 
+  97           98.205496    66.887457   0.01030928 
+  108          94.17267     66.855163   0.00925926 
+  110          91.729309    66.822917   0.00909091 
+  80           90.584116    66.790718   0.0125    
+  75           90.435476    66.758567   0.01333333 
+  86           91.252822    66.726463   0.01162791 
+  87           92.690685    66.694407   0.01149425 
+  84           94.338912    66.662398   0.01190476 
+  101          95.161379    66.630437   0.00990099 
+  100          94.337732    66.598523   0.01      
+  109          92.262592    66.566656   0.00917431 
+  84           90.028619    66.534836   0.01190476 
+  84           88.376519    66.503064   0.01190476 
+  93           87.570415    66.471338   0.01075269 
+  96           87.626993    66.43966    0.01041667 
+  94           88.338824    66.408028   0.0106383 
+  93           88.90726     66.376444   0.01075269 
+  74           88.492268    66.344907   0.01351351 
+  81           86.800122    66.313416   0.01234568 
+  81           84.425982    66.281972   0.01234568 
+  82           82.12517     66.250576   0.01219512 
+  72           80.295051    66.219225   0.01388889 
+  81           79.021452    66.187922   0.01234568 
+  78           78.230429    66.156665   0.01282051 
+  83           77.742806    66.125455   0.01204819 
+  69           77.307498    66.094292   0.01449275 
+  94           76.741505    66.063175   0.0106383 
+  76           76.068466    66.032105   0.01315789 
+  68           75.417662    66.001081   0.01470588 
+  65           74.873392    65.970103   0.01538462 
+  75           74.458097    65.939172   0.01333333 
+  73           74.165374    65.908287   0.01369863 
+  76           73.979096    65.877449   0.01315789 
+  70           73.882089    65.846656   0.01428571 
+  77           73.857559    65.81591    0.01298701 
+  87           73.88515     65.78521    0.01149425 
+  68           73.814098    65.754556   0.01470588 
+  67           73.839832    65.723949   0.01492537 
+  62           73.820864    65.693387   0.01612903 
+  69           73.779174    65.662871   0.01449275 
+  67           73.750874    65.632401   0.01492537 
+  93           73.756641    65.601977   0.01075269 
+  78           73.801944    65.571599   0.01282051 
+  72           73.884445    65.541267   0.01388889 
+  77           73.937136    65.510981   0.01298701 
+  67           74.063866    65.48074    0.01492537 
+  67           74.187015    65.450545   0.01492537 
+  69           74.303385    65.420395   0.01449275 
+  77           74.433264    65.390291   0.01298701 
+  83           74.604559    65.360233   0.01204819 
+  86           74.842644    65.33022    0.01162791 
+  62           75.175016    65.300253   0.01612903 
+  76           75.638685    65.270331   0.01315789 
+  71           76.281469    65.240454   0.01408451 
+  65           77.15685     65.210623   0.01538462 
+  73           78.3096      65.180837   0.01369863 
+  77           79.739803    65.151096   0.01298701 
+  74           81.323017    65.121401   0.01351351 
+  77           82.695389    65.091751   0.01298701 
+  73           83.327126    65.062145   0.01369863 
+  69           83.029302    65.032585   0.01449275 
+  79           82.216733    65.00307    0.01265823 
+  70           81.428663    64.9736     0.01428571 
+  77           80.96372     64.944175   0.01298701 
+  88           80.913836    64.914795   0.01136364 
+  77           81.257702    64.885459   0.01298701 
+  76           81.878131    64.856169   0.01315789 
+  73           82.532062    64.826923   0.01369863 
+  88           82.914225    64.797722   0.01136364 
+  81           82.924601    64.768565   0.01234568 
+  94           82.766637    64.739453   0.0106383 
+  91           82.690386    64.710386   0.01098901 
+  81           82.831492    64.681364   0.01234568 
+  87           83.245374    64.652386   0.01149425 
+  74           83.961408    64.623452   0.01351351 
+  91           85.02916     64.594563   0.01098901 
+  77           86.533617    64.565718   0.01298701 
+  81           88.60515     64.536917   0.01234568 
+  90           91.409147    64.508161   0.01111111 
+  78           95.106313    64.479449   0.01282051 
+  90           99.774022    64.450782   0.01111111 
+  99           105.200573   64.422158   0.01010101 
+  104          110.530665   64.393579   0.00961538 
+  92           114.138171   64.365043   0.01086957 
+  123          114.811301   64.336552   0.00813008 
+  101          113.287585   64.308105   0.00990099 
+  83           111.406596   64.279702   0.01204819 
+  120          110.469223   64.251342   0.00833333 
+  108          111.000999   64.223027   0.00925926 
+  105          113.077556   64.194755   0.00952381 
+  111          116.485431   64.166527   0.00900901 
+  100          120.648128   64.138343   0.01      
+  93           124.623317   64.110203   0.01075269 
+  103          127.72058    64.082106   0.00970874 
+  115          130.249536   64.054053   0.00869565 
+  134          133.045574   64.026043   0.00746269 
+  103          136.640377   63.998077   0.00970874 
+  107          141.130249   63.970155   0.00934579 
+  125          146.331591   63.942276   0.008     
+  157          151.905461   63.91444    0.00636943 
+  124          157.430052   63.886648   0.00806452 
+  154          162.499848   63.858899   0.00649351 
+  146          166.843694   63.831193   0.00684932 
+  185          170.418455   63.803531   0.00540541 
+  161          173.424579   63.775911   0.00621118 
+  189          176.228957   63.748335   0.00529101 
+  192          179.237933   63.720802   0.00520833 
+  187          182.783815   63.693312   0.00534759 
+  230          187.064949   63.665865   0.00434783 
+  240          192.128375   63.638461   0.00416667 
+  246          197.928526   63.6111     0.00406504 
+  222          204.361317   63.583782   0.0045045 
+  240          211.305193   63.556507   0.00416667 
+  271          218.600652   63.529275   0.00369004 
+  259          225.988851   63.502085   0.003861  
+  238          233.047918   63.474938   0.00420168 
+  279          239.209524   63.447834   0.00358423 
+  264          243.889826   63.420772   0.00378788 
+  266          246.705482   63.393753   0.0037594 
+  255          247.652849   63.366777   0.00392157 
+  198          247.124208   63.339843   0.00505051 
+  249          245.757163   63.312952   0.00401606 
+  227          244.218213   63.286103   0.00440529 
+  194          243.06273    63.259296   0.00515464 
+  227          242.620448   63.232532   0.00440529 
+  226          242.938066   63.20581    0.00442478 
+  190          243.87736    63.17913    0.00526316 
+  228          245.299852   63.152493   0.00438596 
+  223          247.180358   63.125898   0.0044843 
+  208          249.647423   63.099345   0.00480769 
+  227          252.921766   63.072834   0.00440529 
+  219          257.225089   63.046365   0.00456621 
+  233          262.665229   63.019938   0.00429185 
+  243          269.091778   62.993553   0.00411523 
+  300          276.00211    62.96721    0.00333333 
+  308          282.575223   62.940909   0.00324675 
+  385          287.864878   62.914649   0.0025974 
+  410          291.034051   62.888432   0.00243902 
+  419          291.583461   62.862256   0.00238663 
+  362          289.449133   62.836122   0.00276243 
+  344          284.978873   62.81003    0.00290698 
+  353          278.76822    62.783979   0.00283286 
+  306          271.451687   62.75797    0.00326797 
+  293          263.520554   62.732003   0.00341297 
+  296          255.207781   62.706077   0.00337838 
+  287          246.499613   62.680192   0.00348432 
+  279          237.249871   62.654349   0.00358423 
+  326          227.328733   62.628547   0.00306748 
+  300          216.72184    62.602787   0.00333333 
+  240          205.572726   62.577068   0.00416667 
+  227          194.14933    62.55139    0.00440529 
+  172          182.780266   62.525753   0.00581395 
+  153          171.794907   62.500158   0.00653595 
+  162          161.457439   62.474604   0.00617284 
+  149          151.944225   62.44909    0.00671141 
+  141          143.33927    62.423618   0.0070922 
+  123          135.652779   62.398187   0.00813008 
+  113          128.842065   62.372797   0.00884956 
+  104          122.838233   62.347448   0.00961538 
+  106          117.560626   62.32214    0.00943396 
+  87           112.925982   62.296872   0.01149425 
+  106          108.857572   62.271645   0.00943396 
+  104          105.284603   62.24646    0.00961538 
+  97           102.145044   62.221314   0.01030928 
+  84           99.386402    62.19621    0.01190476 
+  99           96.966259    62.171146   0.01010101 
+  86           94.85196     62.146123   0.01162791 
+  88           93.024665    62.12114    0.01136364 
+  94           91.478484    62.096198   0.0106383 
+  91           90.227451    62.071296   0.01098901 
+  76           89.301299    62.046435   0.01315789 
+  101          88.739836    62.021614   0.00990099 
+  78           88.576661    61.996833   0.01282051 
+  88           88.8045      61.972093   0.01136364 
+  71           89.293143    61.947393   0.01408451 
+  85           89.665456    61.922733   0.01176471 
+  67           89.340645    61.898114   0.01492537 
+  92           88.045887    61.873534   0.01086957 
+  101          86.170143    61.848995   0.00990099 
+  58           84.299934    61.824496   0.01724138 
+  89           82.778107    61.800036   0.01123596 
+  73           81.716742    61.775617   0.01369863 
+  70           81.105551    61.751238   0.01428571 
+  83           80.847913    61.726898   0.01204819 
+  83           80.730136    61.702598   0.01204819 
+  84           80.419057    61.678339   0.01190476 
+  84           79.673466    61.654119   0.01190476 
+  72           78.589097    61.629938   0.01388889 
+  81           77.437633    61.605798   0.01234568 
+  78           76.40154     61.581697   0.01282051 
+  73           75.539548    61.557635   0.01369863 
+  85           74.849132    61.533613   0.01176471 
+  79           74.305595    61.509631   0.01265823 
+  81           73.88554     61.485688   0.01234568 
+  84           73.553572    61.461785   0.01190476 
+  77           73.29561     61.437921   0.01298701 
+  73           73.099082    61.414096   0.01369863 
+  68           72.956821    61.390311   0.01470588 
+  67           72.865933    61.366565   0.01492537 
+  77           72.826772    61.342858   0.01298701 
+  88           72.842103    61.31919    0.01136364 
+  74           72.917734    61.295562   0.01351351 
+  70           73.057426    61.271972   0.01428571 
+  82           73.268695    61.248422   0.01219512 
+  66           73.56149     61.224911   0.01515152 
+  73           73.937365    61.201438   0.01369863 
+  67           74.404774    61.178005   0.01492537 
+  78           74.967349    61.15461    0.01282051 
+  79           75.62605     61.131255   0.01265823 
+  99           76.378811    61.107938   0.01010101 
+  88           77.220145    61.08466    0.01136364 
+  89           78.143204    61.061421   0.01123596 
+  76           79.142341    61.03822    0.01315789 
+  100          80.207263    61.015058   0.01      
+  91           81.30901     60.991935   0.01098901 
+  112          82.346062    60.96885    0.00892857 
+  94           83.078892    60.945804   0.0106383 
+  80           83.209038    60.922796   0.0125    
+  96           82.687026    60.899827   0.01041667 
+  71           81.79329     60.876896   0.01408451 
+  80           80.838815    60.854003   0.0125    
+  81           79.99809     60.831149   0.01234568 
+  82           79.341412    60.808333   0.01219512 
+  88           78.884297    60.785556   0.01136364 
+  76           78.597128    60.762816   0.01315789 
+  81           78.384394    60.740115   0.01234568 
+  92           78.092313    60.717452   0.01086957 
+  99           77.63339     60.694826   0.01010101 
+  91           77.083481    60.672239   0.01098901 
+  80           76.536695    60.64969    0.0125    
+  88           75.939373    60.627179   0.01136364 
+  62           75.142657    60.604706   0.01612903 
+  84           74.134098    60.582271   0.01190476 
+  75           73.091183    60.559873   0.01333333 
+  67           72.191247    60.537513   0.01492537 
+  73           71.521555    60.515191   0.01369863 
+  74           71.104601    60.492907   0.01351351 
+  77           70.938405    60.470661   0.01298701 
+  88           71.005154    60.448452   0.01136364 
+  82           71.25983     60.42628    0.01219512 
+  87           71.636883    60.404146   0.01149425 
+  75           72.128959    60.38205    0.01333333 
+  86           72.837929    60.359991   0.01162791 
+  85           73.86396     60.33797    0.01176471 
+  82           75.146266    60.315986   0.01219512 
+  82           76.325094    60.294039   0.01219512 
+  80           76.844517    60.27213    0.0125    
+  72           76.494804    60.250258   0.01388889 
+  64           75.692516    60.228423   0.015625  
+  75           74.941428    60.206625   0.01333333 
+  76           74.406567    60.184864   0.01315789 
+  69           74.024714    60.163141   0.01449275 
+  78           73.821988    60.141454   0.01282051 
+  87           73.933629    60.119805   0.01149425 
+  78           74.385389    60.098192   0.01282051 
+  96           74.979065    60.076617   0.01041667 
+  78           75.488054    60.055078   0.01282051 
+  68           75.901613    60.033577   0.01470588 
+  73           76.215307    60.012112   0.01369863 
+  68           76.116315    59.990683   0.01470588 
+  71           75.262604    59.969292   0.01408451 
+  83           73.804534    59.947937   0.01204819 
+  72           72.239664    59.926619   0.01388889 
+  79           70.949926    59.905337   0.01265823 
+  87           70.079378    59.884092   0.01149425 
+  70           69.638301    59.862884   0.01428571 
+  91           69.561548    59.841712   0.01098901 
+  73           69.7124      59.820576   0.01369863 
+  76           69.85539     59.799477   0.01315789 
+  80           69.736582    59.778415   0.0125    
+  78           69.308887    59.757388   0.01282051 
+  66           68.756052    59.736398   0.01515152 
+  89           68.266406    59.715444   0.01123596 
+  77           67.927576    59.694526   0.01298701 
+  74           67.7603      59.673645   0.01351351 
+  77           67.760888    59.652799   0.01298701 
+  75           67.923252    59.63199    0.01333333 
+  81           68.250337    59.611217   0.01234568 
+  67           68.761991    59.590479   0.01492537 
+  60           69.500848    59.569778   0.01666667 
+  81           70.534953    59.549113   0.01234568 
+  69           71.964391    59.528483   0.01449275 
+  90           73.921709    59.507889   0.01111111 
+  80           76.560965    59.487331   0.0125    
+  75           80.014997    59.466809   0.01333333 
+  94           84.362971    59.446322   0.0106383 
+  90           89.757107    59.425872   0.01111111 
+  104          96.53005     59.405456   0.00961538 
+  102          104.734448   59.385077   0.00980392 
+  127          113.444729   59.364733   0.00787402 
+  132          120.627096   59.344424   0.00757576 
+  154          123.445977   59.324151   0.00649351 
+  135          120.116021   59.303913   0.00740741 
+  140          112.656265   59.283711   0.00714286 
+  129          104.855031   59.263544   0.00775194 
+  121          98.973757    59.243413   0.00826446 
+  105          95.70997     59.223316   0.00952381 
+  99           95.016803    59.203255   0.01010101 
+  101          96.27957     59.183229   0.00990099 
+  117          98.307912    59.163238   0.00854701 
+  108          99.483973    59.143283   0.00925926 
+  124          98.173314    59.123362   0.00806452 
+  121          94.137871    59.103476   0.00826446 
+  120          88.98504     59.083626   0.00833333 
+  103          84.341303    59.06381    0.00970874 
+  100          80.890283    59.044029   0.01      
+  79           78.676234    59.024283   0.01265823 
+  63           77.413013    59.004572   0.01587302 
+  80           76.594848    58.984895   0.0125    
+  84           75.705224    58.965254   0.01190476 
+  76           74.585862    58.945647   0.01315789 
+  76           73.459352    58.926075   0.01315789 
+  81           72.56332     58.906537   0.01234568 
+  73           71.958       58.887034   0.01369863 
+  67           71.54737     58.867565   0.01492537 
+  90           71.19343     58.848131   0.01111111 
+  66           70.856507    58.828731   0.01515152 
+  92           70.545179    58.809366   0.01086957 
+  69           70.178865    58.790035   0.01449275 
+  66           69.674328    58.770739   0.01515152 
+  66           69.106416    58.751477   0.01515152 
+  79           68.640084    58.732249   0.01265823 
+  95           68.372063    58.713055   0.01052632 
+  69           68.304253    58.693895   0.01449275 
+  90           68.379627    58.67477    0.01111111 
+  83           68.556884    58.655678   0.01204819 
+  74           68.849028    58.636621   0.01351351 
+  49           69.239066    58.617598   0.02040816 
+  84           69.578877    58.598608   0.01190476 
+  92           69.635925    58.579653   0.01086957 
+  71           69.338042    58.560731   0.01408451 
+  85           68.871617    58.541844   0.01176471 
+  65           68.464378    58.52299    0.01538462 
+  56           68.237738    58.50417    0.01785714 
+  59           68.228011    58.485383   0.01694915 
+  60           68.428145    58.46663    0.01666667 
+  61           68.80077     58.447911   0.01639344 
+  82           69.264255    58.429226   0.01219512 
+  70           69.679655    58.410574   0.01428571 
+  60           69.916213    58.391955   0.01666667 
+  68           69.963843    58.37337    0.01470588 
+  78           69.916522    58.354819   0.01282051 
+  71           69.85182     58.336301   0.01408451 
+  68           69.79451     58.317816   0.01470588 
+  66           69.741163    58.299365   0.01515152 
+  74           69.681053    58.280946   0.01351351 
+  68           69.609548    58.262561   0.01470588 
+  65           69.525149    58.24421    0.01538462 
+  67           69.436966    58.225891   0.01492537 
+  63           69.349711    58.207606   0.01587302 
+  56           69.266284    58.189353   0.01785714 
+  60           69.185293    58.171134   0.01666667 
+  77           69.102511    58.152948   0.01298701 
+  62           69.013143    58.134794   0.01612903 
+  63           68.915124    58.116674   0.01587302 
+  67           68.811056    58.098586   0.01492537 
+  56           68.712685    58.080531   0.01785714 
+  58           68.635484    58.062509   0.01724138 
+  57           68.599436    58.04452    0.01754386 
+  76           68.627768    58.026563   0.01315789 
+  86           68.745848    58.00864    0.01162791 
+  65           68.981582    57.990748   0.01538462 
+  88           69.363089    57.97289    0.01136364 
+  77           69.913146    57.955064   0.01298701 
+  59           70.633582    57.93727    0.01694915 
+  85           71.470222    57.919509   0.01176471 
+  89           72.258466    57.90178    0.01123596 
+  70           72.75389     57.884084   0.01428571 
+  73           72.861773    57.86642    0.01369863 
+  77           72.769251    57.848788   0.01298701 
+  79           72.729501    57.831189   0.01265823 
+  75           72.883968    57.813622   0.01333333 
+  81           73.27182     57.796087   0.01234568 
+  90           73.776103    57.778584   0.01111111 
+  90           74.536835    57.761113   0.01111111 
+  71           75.347973    57.743674   0.01408451 
+  70           76.0414      57.726268   0.01428571 
+  71           76.440097    57.708893   0.01408451 
+  69           76.497224    57.69155    0.01449275 
+  86           76.321313    57.67424    0.01162791 
+  74           76.048826    57.656961   0.01351351 
+  85           75.721895    57.639714   0.01176471 
+  83           75.49089     57.622498   0.01204819 
+  72           75.327658    57.605315   0.01388889 
+  72           75.23249     57.588163   0.01388889 
+  78           75.186813    57.571042   0.01282051 
+  74           75.166481    57.553954   0.01351351 
+  81           75.147618    57.536897   0.01234568 
+  67           75.116174    57.519871   0.01492537 
+  75           75.072197    57.502877   0.01333333 
+  71           75.028779    57.485915   0.01408451 
+  70           75.005662    57.468983   0.01428571 
+  87           75.02367     57.452084   0.01149425 
+  85           75.09991     57.435215   0.01176471 
+  59           75.246697    57.418378   0.01694915 
+  71           75.472184    57.401572   0.01408451 
+  64           75.780255    57.384798   0.015625  
+  72           76.174623    57.368054   0.01388889 
+  71           76.658321    57.351342   0.01408451 
+  72           77.235226    57.33466    0.01388889 
+  80           77.910752    57.31801    0.0125    
+  84           78.69311     57.301391   0.01190476 
+  75           79.596173    57.284803   0.01333333 
+  98           80.639777    57.268246   0.01020408 
+  78           81.85616     57.251719   0.01282051 
+  73           83.295386    57.235224   0.01369863 
+  82           85.026135    57.218759   0.01219512 
+  95           87.136977    57.202325   0.01052632 
+  94           89.725019    57.185922   0.0106383 
+  100          92.867856    57.169549   0.01      
+  117          96.566736    57.153207   0.00854701 
+  110          100.612005   57.136896   0.00909091 
+  133          104.413077   57.120615   0.0075188 
+  156          107.175417   57.104365   0.00641026 
+  115          108.718162   57.088145   0.00869565 
+  138          109.77103    57.071956   0.00724638 
+  168          111.200227   57.055797   0.00595238 
+  136          113.501593   57.039669   0.00735294 
+  125          116.883277   57.023571   0.008     
+  187          121.421212   57.007503   0.00534759 
+  161          127.113224   56.991465   0.00621118 
+  132          133.844962   56.975458   0.00757576 
+  147          141.340875   56.959481   0.00680272 
+  143          149.343566   56.943533   0.00699301 
+  138          158.058405   56.927616   0.00724638 
+  176          168.202602   56.911729   0.00568182 
+  196          180.608024   56.895872   0.00510204 
+  195          196.051084   56.880045   0.00512821 
+  209          215.428744   56.864248   0.00478469 
+  229          239.972043   56.848481   0.00436681 
+  266          271.59647    56.832744   0.0037594 
+  337          313.646946   56.817036   0.00296736 
+  424          372.626461   56.801358   0.00235849 
+  560          461.630891   56.78571    0.00178571 
+  740          605.320051   56.770092   0.00135135 
+  955          843.359401   56.754503   0.00104712 
+  1325         1225.546481  56.738944   0.00075472 
+  1844         1791.366241  56.723414   0.0005423 
+  2456         2527.11194   56.707914   0.00040717 
+  3240         3278.238092  56.692444   0.00030864 
+  3858         3670.530589  56.677003   0.0002592 
+  3865         3407.18604   56.661591   0.00025873 
+  3019         2722.867942  56.646208   0.00033124 
+  2243         2022.691335  56.630855   0.00044583 
+  1607         1506.433767  56.615531   0.00062228 
+  1330         1223.32713   56.600237   0.00075188 
+  1223         1163.805563  56.584971   0.00081766 
+  1364         1297.009861  56.569735   0.00073314 
+  1542         1571.284052  56.554528   0.00064851 
+  1922         1876.948763  56.53935    0.00052029 
+  2171         2007.21151   56.524201   0.00046062 
+  2078         1816.951379  56.509081   0.00048123 
+  1573         1431.081999  56.49399    0.00063573 
+  1138         1043.044564  56.478928   0.00087873 
+  745          739.056425   56.463895   0.00134228 
+  524          529.988808   56.44889    0.0019084 
+  402          397.070069   56.433915   0.00248756 
+  286          314.946977   56.418968   0.0034965 
+  268          262.808878   56.40405    0.00373134 
+  200          227.423107   56.38916    0.005     
+  178          201.619657   56.374299   0.00561798 
+  165          181.792037   56.359467   0.00606061 
+  146          166.036811   56.344663   0.00684932 
+  174          153.246655   56.329888   0.00574713 
+  154          142.703853   56.315141   0.00649351 
+  121          133.903131   56.300423   0.00826446 
+  114          126.478299   56.285733   0.00877193 
+  114          120.157004   56.271071   0.00877193 
+  117          114.733195   56.256438   0.00854701 
+  109          110.04888    56.241833   0.00917431 
+  89           105.981483   56.227256   0.01123596 
+  99           102.435553   56.212708   0.01010101 
+  82           99.334736    56.198187   0.01219512 
+  100          96.62157     56.183695   0.01      
+  92           94.249289    56.169231   0.01086957 
+  93           92.18266     56.154795   0.01075269 
+  77           90.397558    56.140386   0.01298701 
+  101          88.87898     56.126006   0.00990099 
+  93           87.624604    56.111654   0.01075269 
+  78           86.648955    56.097329   0.01282051 
+  82           85.992462    56.083032   0.01219512 
+  90           85.732364    56.068764   0.01111111 
+  83           85.996159    56.054522   0.01204819 
+  89           86.964738    56.040309   0.01123596 
+  93           88.857272    56.026123   0.01075269 
+  106          91.884214    56.011965   0.00943396 
+  89           96.137834    55.997834   0.01123596 
+  89           101.34331    55.983731   0.01123596 
+  100          106.390579   55.969656   0.01      
+  108          109.126838   55.955607   0.00925926 
+  98           107.794902   55.941587   0.01020408 
+  80           103.130544   55.927593   0.0125    
+  104          97.476034    55.913627   0.00961538 
+  97           92.598986    55.899689   0.01030928 
+  87           89.251097    55.885777   0.01149425 
+  98           87.59811     55.871893   0.01020408 
+  81           87.535022    55.858036   0.01234568 
+  73           88.734602    55.844206   0.01369863 
+  85           90.496959    55.830404   0.01176471 
+  93           91.644948    55.816628   0.01075269 
+  88           91.185154    55.802879   0.01136364 
+  76           89.402247    55.789157   0.01315789 
+  85           87.547086    55.775463   0.01176471 
+  83           86.702605    55.761795   0.01204819 
+  91           87.462567    55.748154   0.01098901 
+  88           90.081575    55.734539   0.01136364 
+  115          94.5086      55.720952   0.00869565 
+  100          100.129076   55.707391   0.01      
+  105          105.24665    55.693857   0.00952381 
+  119          107.197067   55.68035    0.00840336 
+  117          104.501713   55.666869   0.00854701 
+  116          98.666254    55.653415   0.00862069 
+  111          92.338685    55.639987   0.00900901 
+  91           87.189101    55.626586   0.01098901 
+  85           83.824782    55.613211   0.01176471 
+  96           82.319796    55.599863   0.01041667 
+  78           82.479908    55.586541   0.01282051 
+  94           83.840649    55.573245   0.0106383 
+  91           85.458731    55.559976   0.01098901 
+  83           85.888107    55.546733   0.01204819 
+  87           84.123237    55.533516   0.01149425 
+  87           80.654005    55.520325   0.01149425 
+  73           76.739263    55.507161   0.01369863 
+  75           73.224162    55.494022   0.01333333 
+  71           70.392459    55.48091    0.01408451 
+  75           68.233542    55.467823   0.01333333 
+  71           66.632578    55.454763   0.01408451 
+  67           65.452405    55.441728   0.01492537 
+  61           64.56976     55.42872    0.01639344 
+  71           63.889683    55.415737   0.01408451 
+  69           63.346438    55.40278    0.01449275 
+  62           62.897668    55.389849   0.01612903 
+  53           62.516815    55.376943   0.01886792 
+  57           62.187233    55.364063   0.01754386 
+  66           61.897484    55.351209   0.01515152 
+  76           61.639908    55.338381   0.01315789 
+  73           61.408836    55.325577   0.01369863 
+  73           61.199918    55.3128     0.01369863 
+  64           61.009755    55.300048   0.015625  
+  64           60.835666    55.287321   0.015625  
+  57           60.675527    55.27462    0.01754386 
+  64           60.527601    55.261944   0.015625  
+  71           60.390477    55.249294   0.01408451 
+  55           60.263       55.236669   0.01818182 
+  46           60.14421     55.224069   0.02173913 
+  64           60.033304    55.211494   0.015625  
+  55           59.929641    55.198944   0.01818182 
+  61           59.832658    55.18642    0.01639344 
+  68           59.741908    55.17392    0.01470588 
+  73           59.657036    55.161446   0.01369863 
+  72           59.578344    55.148996   0.01388889 
+  62           59.504392    55.136572   0.01612903 
+  60           59.435516    55.124172   0.01666667 
+  69           59.37185     55.111798   0.01449275 
+  69           59.313231    55.099448   0.01449275 
+  60           59.259534    55.087123   0.01666667 
+  63           59.211247    55.074822   0.01587302 
+  50           59.168416    55.062547   0.02      
+  59           59.131111    55.050296   0.01694915 
+  57           59.100544    55.03807    0.01754386 
+  66           59.077336    55.025868   0.01515152 
+  59           59.062888    55.013691   0.01694915 
+  61           59.059819    55.001538   0.01639344 
+  65           59.070626    54.98941    0.01538462 
+  60           59.099623    54.977306   0.01666667 
+  62           59.151658    54.965227   0.01612903 
+  67           59.2308      54.953172   0.01492537 
+  53           59.338698    54.941141   0.01886792 
+  64           59.468766    54.929135   0.015625  
+  37           59.597866    54.917153   0.02702703 
+  58           59.688578    54.905195   0.01724138 
+  65           59.722362    54.893261   0.01538462 
+  68           59.72546     54.881351   0.01470588 
+  59           59.738605    54.869465   0.01694915 
+  63           59.783661    54.857604   0.01587302 
+  63           59.859371    54.845766   0.01587302 
+  50           59.945564    54.833952   0.02      
+  53           60.013924    54.822162   0.01886792 
+  64           60.051516    54.810397   0.015625  
+  56           60.065302    54.798654   0.01785714 
+  73           60.059482    54.786936   0.01369863 
+  62           60.033461    54.775241   0.01612903 
+  51           60.001121    54.76357    0.01960784 
+  58           59.986545    54.751923   0.01724138 
+  59           60.005899    54.7403     0.01694915 
+  49           60.062536    54.728699   0.02040816 
+  63           60.149765    54.717123   0.01587302 
+  60           60.255148    54.70557    0.01666667 
+  57           60.37222     54.69404    0.01754386 
+  65           60.510396    54.682534   0.01538462 
+  51           60.687222    54.671051   0.01960784 
+  63           60.920952    54.659592   0.01587302 
+  61           61.229338    54.648156   0.01639344 
+  55           61.635965    54.636743   0.01818182 
+  64           62.173262    54.625353   0.015625  
+  67           62.893094    54.613987   0.01492537 
+  67           63.879231    54.602643   0.01492537 
+  62           65.260695    54.591323   0.01612903 
+  64           67.224339    54.580026   0.015625  
+  59           70.009554    54.568752   0.01694915 
+  75           73.878451    54.5575     0.01333333 
+  72           79.036557    54.546272   0.01388889 
+  72           85.459004    54.535067   0.01388889 
+  82           92.501643    54.523884   0.01219512 
+  79           98.352635    54.512724   0.01265823 
+  88           100.406369   54.501587   0.01136364 
+  56           97.682197    54.490473   0.01785714 
+  74           92.116488    54.479382   0.01351351 
+  62           86.337058    54.468313   0.01612903 
+  55           81.842926    54.457266   0.01818182 
+  67           79.155518    54.446243   0.01492537 
+  58           78.321861    54.435241   0.01724138 
+  73           79.157943    54.424263   0.01369863 
+  82           81.22644     54.413306   0.01219512 
+  68           83.615336    54.402373   0.01470588 
+  68           84.830693    54.391461   0.01470588 
+  56           83.679342    54.380572   0.01785714 
+  63           80.525596    54.369705   0.01587302 
+  74           76.74224     54.35886    0.01351351 
+  69           73.354001    54.348038   0.01449275 
+  55           70.777779    54.337238   0.01818182 
+  89           69.098674    54.326459   0.01123596 
+  56           68.291561    54.315703   0.01785714 
+  66           68.302653    54.304969   0.01515152 
+  61           69.072568    54.294257   0.01639344 
+  78           70.502221    54.283567   0.01282051 
+  69           72.376612    54.272899   0.01449275 
+  62           74.220314    54.262253   0.01612903 
+  68           75.213917    54.251628   0.01470588 
+  68           74.654976    54.241025   0.01470588 
+  63           72.770231    54.230445   0.01587302 
+  89           70.465128    54.219885   0.01123596 
+  70           68.456931    54.209348   0.01428571 
+  70           67.051906    54.198832   0.01428571 
+  71           66.321203    54.188338   0.01408451 
+  58           66.232916    54.177865   0.01724138 
+  58           66.686126    54.167414   0.01724138 
+  68           67.482057    54.156984   0.01470588 
+  49           68.23693     54.146576   0.02040816 
+  71           68.466213    54.136189   0.01408451 
+  79           68.00536     54.125823   0.01265823 
+  66           67.198193    54.115479   0.01515152 
+  64           66.498096    54.105156   0.015625  
+  62           66.178817    54.094854   0.01612903 
+  61           66.370825    54.084574   0.01639344 
+  67           67.15391     54.074314   0.01492537 
+  57           68.598254    54.064076   0.01754386 
+  70           70.750792    54.053859   0.01428571 
+  63           73.563402    54.043663   0.01587302 
+  73           76.86182     54.033487   0.01369863 
+  77           80.494877    54.023333   0.01298701 
+  88           84.41923     54.0132     0.01136364 
+  66           88.184391    54.003087   0.01515152 
+  75           90.548072    53.992995   0.01333333 
+  77           90.501117    53.982925   0.01298701 
+  80           88.672124    53.972874   0.0125    
+  79           86.554445    53.962845   0.01265823 
+  88           84.949887    53.952836   0.01136364 
+  71           83.789044    53.942848   0.01408451 
+  61           82.877031    53.93288    0.01639344 
+  83           82.3774      53.922933   0.01204819 
+  63           82.608369    53.913007   0.01587302 
+  83           83.685988    53.903101   0.01204819 
+  75           85.261713    53.893215   0.01333333 
+  76           86.717594    53.88335    0.01315789 
+  80           87.982249    53.873505   0.0125    
+  83           89.782376    53.86368    0.01204819 
+  73           92.786478    53.853876   0.01369863 
+  112          96.897078    53.844092   0.00892857 
+  90           101.165244   53.834328   0.01111111 
+  123          104.260847   53.824584   0.00813008 
+  93           105.248349   53.81486    0.01075269 
+  79           103.796476   53.805156   0.01265823 
+  101          100.193408   53.795473   0.00990099 
+  89           95.734737    53.785809   0.01123596 
+  84           92.007764    53.776165   0.01190476 
+  82           89.961397    53.766541   0.01219512 
+  80           89.922662    53.756937   0.0125    
+  91           91.885579    53.747353   0.01098901 
+  100          95.616207    53.737788   0.01      
+  85           100.680601   53.728244   0.01176471 
+  97           106.714737   53.718719   0.01030928 
+  104          113.856371   53.709213   0.00961538 
+  131          122.79667    53.699728   0.00763359 
+  155          134.758833   53.690261   0.00645161 
+  127          151.015731   53.680815   0.00787402 
+  141          171.520871   53.671387   0.0070922 
+  182          194.255358   53.66198    0.00549451 
+  186          215.931577   53.652591   0.00537634 
+  230          230.897911   53.643222   0.00434783 
+  209          230.581861   53.633873   0.00478469 
+  207          212.941984   53.624542   0.00483092 
+  207          187.341463   53.615231   0.00483092 
+  157          163.98922    53.605939   0.00636943 
+  147          147.69681    53.596666   0.00680272 
+  139          139.498449   53.587413   0.00719424 
+  134          138.600952   53.578178   0.00746269 
+  139          143.057876   53.568963   0.00719424 
+  131          150.279118   53.559766   0.00763359 
+  140          157.355687   53.550589   0.00714286 
+  145          159.983129   53.54143    0.00689655 
+  152          153.773151   53.53229    0.00657895 
+  130          139.76903    53.523169   0.00769231 
+  110          123.479643   53.514067   0.00909091 
+  105          109.02561    53.504984   0.00952381 
+  88           97.775224    53.495919   0.01136364 
+  79           89.653397    53.486873   0.01265823 
+  76           84.075918    53.477846   0.01315789 
+  84           80.365342    53.468837   0.01190476 
+  62           77.926389    53.459847   0.01612903 
+  72           76.291293    53.450875   0.01388889 
+  54           75.118496    53.441922   0.01851852 
+  70           74.243134    53.432987   0.01428571 
+  85           73.71424     53.424071   0.01176471 
+  67           73.719652    53.415173   0.01492537 
+  48           74.55014     53.406293   0.02083333 
+  68           76.677182    53.397432   0.01470588 
+  74           80.825085    53.388589   0.01351351 
+  95           87.883186    53.379764   0.01052632 
+  100          98.521044    53.370957   0.01      
+  126          112.375245   53.362168   0.00793651 
+  147          126.481411   53.353397   0.00680272 
+  117          133.950807   53.344645   0.00854701 
+  149          129.433978   53.33591    0.00671141 
+  112          117.348917   53.327193   0.00892857 
+  111          105.386407   53.318495   0.00900901 
+  104          97.480864    53.309814   0.00961538 
+  95           94.726287    53.301151   0.01052632 
+  89           97.072675    53.292505   0.01123596 
+  103          103.956689   53.283878   0.00970874 
+  110          114.092409   53.275268   0.00909091 
+  128          124.683283   53.266676   0.0078125 
+  140          131.200021   53.258101   0.00714286 
+  114          129.40104    53.249544   0.00877193 
+  145          119.547523   53.241005   0.00689655 
+  105          106.73176    53.232483   0.00952381 
+  88           95.336686    53.223978   0.01136364 
+  79           87.087585    53.215491   0.01265823 
+  64           82.1588      53.207021   0.015625  
+  77           80.053852    53.198569   0.01298701 
+  73           79.987164    53.190134   0.01369863 
+  88           80.901836    53.181716   0.01136364 
+  74           81.374353    53.173316   0.01351351 
+  70           80.169717    53.164932   0.01428571 
+  72           77.300541    53.156566   0.01388889 
+  81           73.753645    53.148217   0.01234568 
+  60           70.352157    53.139885   0.01666667 
+  67           67.464716    53.131569   0.01492537 
+  68           65.196898    53.123271   0.01470588 
+  77           63.512848    53.11499    0.01298701 
+  82           62.311916    53.106726   0.01219512 
+  55           61.48493     53.098478   0.01818182 
+  74           60.941489    53.090248   0.01351351 
+  72           60.617105    53.082034   0.01388889 
+  59           60.46663     53.073837   0.01694915 
+  71           60.449658    53.065656   0.01408451 
+  69           60.505376    53.057493   0.01449275 
+  45           60.533349    53.049345   0.02222222 
+  63           60.438664    53.041215   0.01587302 
+  62           60.227326    53.033101   0.01612903 
+  46           59.991054    53.025003   0.02173913 
+  72           59.809243    53.016922   0.01388889 
+  64           59.719156    53.008857   0.015625  
+  61           59.73737     53.000809   0.01639344 
+  50           59.87266     52.992777   0.02      
+  60           60.127752    52.984761   0.01666667 
+  51           60.498656    52.976762   0.01960784 
+  59           60.967846    52.968779   0.01694915 
+  54           61.502388    52.960811   0.01851852 
+  59           62.090107    52.95286    0.01694915 
+  56           62.786128    52.944926   0.01785714 
+  45           63.70516     52.937007   0.02222222 
+  53           64.988522    52.929104   0.01886792 
+  62           66.817667    52.921217   0.01612903 
+  52           69.446766    52.913346   0.01923077 
+  59           73.215162    52.905491   0.01694915 
+  57           78.530174    52.897652   0.01754386 
+  73           85.815643    52.889828   0.01369863 
+  61           95.413309    52.882021   0.01639344 
+  67           107.205534   52.874229   0.01492537 
+  65           119.779496   52.866452   0.01538462 
+  93           129.476495   52.858692   0.01075269 
+  82           131.629579   52.850947   0.01219512 
+  100          125.233212   52.843217   0.01      
+  98           114.303635   52.835503   0.01020408 
+  87           103.40155    52.827805   0.01149425 
+  75           94.917941    52.820122   0.01333333 
+  78           89.585342    52.812454   0.01282051 
+  69           87.406106    52.804802   0.01449275 
+  69           88.097174    52.797165   0.01449275 
+  85           91.081233    52.789544   0.01176471 
+  83           95.159721    52.781937   0.01204819 
+  69           98.093736    52.774346   0.01449275 
+  89           97.396909    52.76677    0.01123596 
+  92           92.681853    52.759209   0.01086957 
+  97           85.971649    52.751663   0.01030928 
+  88           79.354448    52.744132   0.01136364 
+  59           73.807656    52.736616   0.01694915 
+  58           69.524501    52.729115   0.01724138 
+  69           66.368742    52.721629   0.01449275 
+  79           64.102878    52.714158   0.01265823 
+  57           62.486409    52.706702   0.01754386 
+  63           61.321027    52.699261   0.01587302 
+  59           60.459837    52.691834   0.01694915 
+  76           59.804937    52.684422   0.01315789 
+  58           59.294467    52.677024   0.01724138 
+  60           58.889963    52.669642   0.01666667 
+  59           58.567948    52.662274   0.01694915 
+  51           58.313861    52.65492    0.01960784 
+  67           58.11869     52.647581   0.01492537 
+  67           57.977317    52.640256   0.01492537 
+  51           57.88767     52.632946   0.01960784 
+  64           57.850777    52.62565    0.015625  
+  66           57.871117    52.618369   0.01515152 
+  66           57.95728     52.611102   0.01515152 
+  51           58.121809    52.603849   0.01960784 
+  43           58.380105    52.596611   0.02325581 
+  55           58.747093    52.589386   0.01818182 
+  58           59.229801    52.582176   0.01724138 
+  63           59.810271    52.57498    0.01587302 
+  58           60.413361    52.567798   0.01724138 
+  54           60.892504    52.56063    0.01851852 
+  66           61.125115    52.553475   0.01515152 
+  57           61.154579    52.546335   0.01754386 
+  62           61.133009    52.539209   0.01612903 
+  54           61.170179    52.532097   0.01851852 
+  64           61.299897    52.524998   0.015625  
+  51           61.515598    52.517913   0.01960784 
+  78           61.800404    52.510842   0.01282051 
+  72           62.14373     52.503785   0.01388889 
+  62           62.542818    52.496742   0.01612903 
+  53           62.985611    52.489712   0.01886792 
+  65           63.428544    52.482695   0.01538462 
+  65           64.080078    52.475692   0.01538462 
+  53           64.345388    52.468703   0.01886792 
+  67           64.370976    52.461727   0.01492537 
+  46           64.013517    52.454765   0.02173913 
+  71           63.321914    52.447815   0.01408451 
+  65           62.523886    52.44088    0.01538462 
+  64           61.804774    52.433957   0.015625  
+  54           61.239029    52.427048   0.01851852 
+  67           60.836144    52.420152   0.01492537 
+  71           60.577509    52.413269   0.01408451 
+  59           60.427943    52.4064     0.01694915 
+  55           60.346408    52.399543   0.01818182 
+  64           60.286045    52.3927     0.015625  
+  69           60.298969    52.385869   0.01449275 
+  84           60.023937    52.379052   0.01190476 
+  68           59.605475    52.372247   0.01470588 
+  72           59.156166    52.365456   0.01388889 
+  84           58.776663    52.358677   0.01190476 
+  73           58.512245    52.351911   0.01369863 
+  95           58.37441     52.345158   0.01052632 
+  91           58.361996    52.338417   0.01098901 
+  87           58.470906    52.33169    0.01149425 
+  86           58.703863    52.324975   0.01162791 
+  87           59.077971    52.318272   0.01149425 
+  95           59.604962    52.311582   0.01052632 
+  83           60.246509    52.304905   0.01204819 
+  88           60.855115    52.29824    0.01136364 
+  82           61.178296    52.291588   0.01219512 
+  87           61.057089    52.284948   0.01149425 
+  85           60.622102    52.278321   0.01176471 
+  78           60.143688    52.271705   0.01282051 
+  82           59.812411    52.265102   0.01219512 
+  90           59.717779    52.258512   0.01111111 
+  70           59.906597    52.251933   0.01428571 
+  83           60.422458    52.245367   0.01204819 
+  81           61.320702    52.238813   0.01234568 
+  79           62.660744    52.232271   0.01265823 
+  110          64.472742    52.225741   0.00909091 
+  90           66.720587    52.219223   0.01111111 
+  99           69.322603    52.212717   0.01010101 
+  82           72.114758    52.206223   0.01219512 
+  82           74.593389    52.199741   0.01219512 
+  101          75.884269    52.193271   0.00990099 
+  93           75.418856    52.186813   0.01075269 
+  84           73.456365    52.180366   0.01190476 
+  83           70.806087    52.173931   0.01204819 
+  67           68.305576    52.167508   0.01492537 
+  81           66.467897    52.161097   0.01234568 
+  76           65.485615    52.154697   0.01315789 
+  80           65.380209    52.148308   0.0125    
+  69           66.085505    52.141932   0.01449275 
+  83           67.424705    52.135566   0.01204819 
+  54           69.008364    52.129213   0.01851852 
+  85           70.196636    52.12287    0.01176471 
+  96           70.400477    52.116539   0.01041667 
+  77           69.528124    52.110219   0.01298701 
+  65           68.030136    52.103911   0.01538462 
+  65           66.502043    52.097614   0.01538462 
+  57           65.268685    52.091328   0.01754386 
+  50           64.305592    52.085053   0.02      
+  62           63.434204    52.07879    0.01612903 
+  67           62.598682    52.072537   0.01492537 
+  70           61.906933    52.066296   0.01428571 
+  75           61.449485    52.060066   0.01333333 
+  53           61.212801    52.053846   0.01886792 
+  48           61.096959    52.047638   0.02083333 
+  69           61.002667    52.04144    0.01449275 
+  57           60.934146    52.035254   0.01754386 
+  66           60.969861    52.029078   0.01515152 
+  63           61.155787    52.022913   0.01587302 
+  57           61.465631    52.016759   0.01754386 
+  75           61.846961    52.010615   0.01333333 
+  66           62.333959    52.004482   0.01515152 
+  98           63.091045    51.99836    0.01020408 
+  71           64.324025    51.992248   0.01408451 
+  74           66.206046    51.986147   0.01351351 
+  92           68.839139    51.980056   0.01086957 
+  92           72.169442    51.973976   0.01086957 
+  106          75.776623    51.967906   0.00943396 
+  101          78.607246    51.961847   0.00990099 
+  129          79.309304    51.955798   0.00775194 
+  145          77.5497      51.949759   0.00689655 
+  172          74.445696    51.94373    0.00581395 
+  162          71.309391    51.937712   0.00617284 
+  164          68.842769    51.931704   0.00609756 
+  205          67.268558    51.925706   0.00487805 
+  206          66.598878    51.919719   0.00485437 
+  203          66.764042    51.913741   0.00492611 
+  201          67.63749     51.907773   0.00497512 
+  204          68.96758     51.901815   0.00490196 
+  185          70.243844    51.895868   0.00540541 
+  142          70.725492    51.88993    0.00704225 
+  139          69.995739    51.884002   0.00719424 
+  147          68.420608    51.878084   0.00680272 
+  125          66.671147    51.872175   0.008     
+  160          65.163543    51.866277   0.00625   
+  149          64.029607    51.860388   0.00671141 
+  139          63.26081     51.854509   0.00719424 
+  140          62.799285    51.848639   0.00714286 
+  121          62.583672    51.842779   0.00826446 
+  121          62.559373    51.836929   0.00826446 
+  115          62.690528    51.831088   0.00869565 
+  97           62.958958    51.825256   0.01030928 
+  106          63.359538    51.819434   0.00943396 
+  101          63.89251     51.813622   0.00990099 
+  56           64.551811    51.807819   0.01785714 
+  90           65.301578    51.802025   0.01111111 
+  73           66.046243    51.79624    0.01369863 
+  87           66.643643    51.790465   0.01149425 
+  77           67.032381    51.784699   0.01298701 
+  55           67.311433    51.778942   0.01818182 
+  64           67.630505    51.773194   0.015625  
+  70           68.083636    51.767455   0.01428571 
+  61           68.709534    51.761725   0.01639344 
+  61           69.522973    51.756004   0.01639344 
+  82           70.53022     51.750292   0.01219512 
+  49           71.735659    51.74459    0.02040816 
+  67           73.13473     51.738896   0.01492537 
+  73           74.704763    51.73321    0.01369863 
+  66           76.397156    51.727534   0.01515152 
+  76           78.182409    51.721867   0.01315789 
+  87           80.115282    51.716208   0.01149425 
+  79           82.309703    51.710558   0.01265823 
+  97           84.875422    51.704916   0.01030928 
+  85           87.903232    51.699283   0.01176471 
+  107          91.480149    51.693659   0.00934579 
+  101          95.708995    51.688043   0.00990099 
+  125          100.713065   51.682436   0.008     
+  150          106.635272   51.676837   0.00666667 
+  177          113.618459   51.671246   0.00564972 
+  177          121.774157   51.665664   0.00564972 
+  153          131.151617   51.660091   0.00653595 
+  161          141.689349   51.654525   0.00621118 
+  187          153.026053   51.648968   0.00534759 
+  156          164.320368   51.643419   0.00641026 
+  166          174.583586   51.637878   0.0060241 
+  179          183.252915   51.632346   0.00558659 
+  158          190.008668   51.626821   0.00632911 
+  191          194.335137   51.621305   0.0052356 
+  181          195.753649   51.615796   0.00552486 
+  192          194.413326   51.610296   0.00520833 
+  207          191.376625   51.604803   0.00483092 
+  215          188.174749   51.599319   0.00465116 
+  198          185.979728   51.593842   0.00505051 
+  201          185.202663   51.588373   0.00497512 
+  218          185.414355   51.582912   0.00458716 
+  190          185.648121   51.577459   0.00526316 
+  193          185.305615   51.572013   0.00518135 
+  185          184.533939   51.566575   0.00540541 
+  180          183.521877   51.561145   0.00555556 
+  197          182.083615   51.555722   0.00507614 
+  162          179.953456   51.550307   0.00617284 
+  164          177.110584   51.544899   0.00609756 
+  152          173.772733   51.539499   0.00657895 
+  164          169.931495   51.534106   0.00609756 
+  162          165.428399   51.528721   0.00617284 
+  140          159.922218   51.523343   0.00714286 
+  133          153.509762   51.517972   0.0075188 
+  158          146.558558   51.512609   0.00632911 
+  145          139.604495   51.507253   0.00689655 
+  114          133.180656   51.501904   0.00877193 
+  103          127.606907   51.496562   0.00970874 
+  119          122.966923   51.491227   0.00840336 
+  122          119.143524   51.4859     0.00819672 
+  105          116.001682   51.480579   0.00952381 
+  86           113.20132    51.475266   0.01162791 
+  96           110.351704   51.469959   0.01041667 
+  78           107.113728   51.46466    0.01282051 
+  98           103.428817   51.459367   0.01020408 
+  95           99.504133    51.454081   0.01052632 
+  81           95.583718    51.448802   0.01234568 
+  92           91.836751    51.44353    0.01086957 
+  70           88.357557    51.438264   0.01428571 
+  71           85.192316    51.433006   0.01408451 
+  70           82.350771    51.427753   0.01428571 
+  69           79.820789    51.422508   0.01449275 
+  100          77.578974    51.417269   0.01      
+  79           75.596136    51.412037   0.01265823 
+  76           73.844038    51.406811   0.01315789 
+  72           72.295777    51.401591   0.01388889 
+  70           70.926968    51.396378   0.01428571 
+  70           69.715923    51.391172   0.01428571 
+  72           68.643625    51.385972   0.01388889 
+  51           67.693842    51.380778   0.01960784 
+  71           66.852339    51.37559    0.01408451 
+  73           66.107011    51.370409   0.01369863 
+  58           65.447645    51.365234   0.01724138 
+  64           64.864867    51.360065   0.015625  
+  51           64.349368    51.354902   0.01960784 
+  63           63.891806    51.349745   0.01587302 
+  63           63.485139    51.344594   0.01587302 
+  61           63.127461    51.339449   0.01639344 
+  74           62.822117    51.334311   0.01351351 
+  63           62.574485    51.329178   0.01587302 
+  51           62.394058    51.324051   0.01960784 
+  65           62.290708    51.31893    0.01538462 
+  71           62.283877    51.313815   0.01408451 
+  57           62.395802    51.308705   0.01754386 
+  70           62.64918     51.303601   0.01428571 
+  63           63.057746    51.298503   0.01587302 
+  71           63.60452     51.293411   0.01408451 
+  58           64.200175    51.288324   0.01724138 
+  62           64.662414    51.283243   0.01612903 
+  66           64.833687    51.278168   0.01515152 
+  64           64.768822    51.273097   0.015625  
+  66           64.660163    51.268033   0.01515152 
+  57           64.604607    51.262974   0.01754386 
+  67           64.52836     51.25792    0.01492537 
+  64           64.315259    51.252871   0.015625  
+  58           63.992286    51.247828   0.01724138 
+  69           63.707412    51.242791   0.01449275 
+  63           63.568497    51.237758   0.01587302 
+  71           63.590162    51.232731   0.01408451 
+  74           63.699373    51.227708   0.01351351 
+  64           63.772309    51.222691   0.015625  
+  88           63.734981    51.217679   0.01136364 
+  68           63.632847    51.212673   0.01470588 
+  79           63.547169    51.207671   0.01265823 
+  68           63.493331    51.202674   0.01470588 
+  82           63.417836    51.197682   0.01219512 
+  63           63.282453    51.192695   0.01587302 
+  73           63.132248    51.187713   0.01369863 
+  71           63.046936    51.182735   0.01408451 
+  69           63.076321    51.177763   0.01449275 
+  65           63.237725    51.172795   0.01538462 
+  74           63.535017    51.167832   0.01351351 
+  80           63.971116    51.162873   0.0125    
+  51           64.554114    51.157919   0.01960784 
+  70           65.299954    51.15297    0.01428571 
+  70           66.232653    51.148026   0.01428571 
+  82           67.382416    51.143086   0.01219512 
+  85           68.782312    51.13815    0.01176471 
+  77           70.463584    51.133219   0.01298701 
+  78           72.44916     51.128292   0.01282051 
+  81           74.741863    51.12337    0.01234568 
+  85           77.298957    51.118452   0.01176471 
+  96           80.001351    51.113538   0.01041667 
+  90           82.620248    51.108628   0.01111111 
+  84           84.843103    51.103723   0.01190476 
+  106          86.408794    51.098822   0.00943396 
+  98           87.301914    51.093925   0.01020408 
+  91           87.816404    51.089033   0.01098901 
+  95           88.370724    51.084144   0.01052632 
+  73           89.170259    51.079259   0.01369863 
+  89           89.893044    51.074378   0.01123596 
+  87           89.742958    51.069502   0.01149425 
+  98           88.25876     51.064629   0.01020408 
+  81           85.939295    51.05976    0.01234568 
+  81           83.593031    51.054895   0.01234568 
+  82           81.622891    51.050034   0.01219512 
+  86           80.025152    51.045176   0.01162791 
+  69           78.655103    51.040323   0.01449275 
+  82           77.44052     51.035473   0.01219512 
+  74           76.441829    51.030626   0.01351351 
+  77           75.759434    51.025784   0.01298701 
+  73           75.371884    51.020945   0.01369863 
+  59           74.997822    51.016109   0.01694915 
+  70           74.199572    51.011277   0.01428571 
+  66           72.826684    51.006448   0.01515152 
+  73           71.181331    51.001623   0.01369863 
+  62           69.630664    50.996801   0.01612903 
+  71           68.196514    50.991983   0.01408451 
+  66           66.913775    50.987168   0.01515152 
+  62           65.833795    50.982356   0.01612903 
+  84           65.018202    50.977548   0.01190476 
+  68           64.477692    50.972743   0.01470588 
+  61           64.183655    50.967941   0.01639344 
+  75           64.094378    50.963142   0.01333333 
+  63           64.167046    50.958346   0.01587302 
+  76           64.359463    50.953553   0.01315789 
+  56           64.626614    50.948763   0.01785714 
+  67           64.915098    50.943977   0.01492537 
+  59           65.156539    50.939193   0.01694915 
+  75           65.289442    50.934412   0.01333333 
+  63           65.335077    50.929634   0.01587302 
+  63           65.34072     50.924859   0.01587302 
+  65           65.433771    50.920087   0.01538462 
+  76           65.707185    50.915317   0.01315789 
+  78           66.239853    50.91055    0.01282051 
+  74           67.098837    50.905786   0.01351351 
+  68           68.328472    50.901025   0.01470588 
+  74           69.915125    50.896266   0.01351351 
+  56           71.696348    50.89151    0.01785714 
+  81           73.354478    50.886756   0.01234568 
+  63           74.591933    50.882005   0.01587302 
+  76           75.375599    50.877257   0.01315789 
+  80           75.8362      50.872511   0.0125    
+  80           76.260751    50.867767   0.0125    
+  98           77.252872    50.863025   0.01020408 
+  83           79.543487    50.858286   0.01204819 
+  71           83.720043    50.85355    0.01408451 
+  81           90.081762    50.848815   0.01234568 
+  84           98.388812    50.844083   0.01190476 
+  98           107.17507    50.839353   0.01020408 
+  96           113.109473   50.834625   0.01041667 
+  87           112.810727   50.829899   0.01149425 
+  95           106.768967   50.825176   0.01052632 
+  89           98.57665     50.820454   0.01123596 
+  68           91.029782    50.815734   0.01470588 
+  76           85.283949    50.811017   0.01315789 
+  75           81.724928    50.806301   0.01333333 
+  79           80.443583    50.801587   0.01265823 
+  76           81.359701    50.796875   0.01315789 
+  93           84.249326    50.792165   0.01075269 
+  80           88.58114     50.787457   0.0125    
+  96           93.127774    50.78275    0.01041667 
+  87           95.861969    50.778045   0.01149425 
+  75           95.320691    50.773342   0.01333333 
+  73           92.371926    50.768641   0.01369863 
+  81           89.120852    50.763941   0.01234568 
+  92           86.763606    50.759242   0.01086957 
+  74           85.146256    50.754546   0.01351351 
+  80           83.343083    50.74985    0.0125    
+  60           80.764009    50.745157   0.01666667 
+  59           77.794456    50.740464   0.01694915 
+  79           75.133607    50.735773   0.01265823 
+  68           73.105054    50.731084   0.01470588 
+  83           71.637848    50.726395   0.01204819 
+  67           70.539308    50.721708   0.01492537 
+  70           69.767645    50.717023   0.01428571 
+  74           69.428154    50.712338   0.01351351 
+  74           69.576249    50.707655   0.01351351 
+  73           70.094267    50.702973   0.01369863 
+  56           70.631383    50.698292   0.01785714 
+  71           70.689898    50.693612   0.01408451 
+  49           70.041782    50.688933   0.02040816 
+  61           68.975441    50.684255   0.01639344 
+  55           67.937521    50.679578   0.01818182 
+  61           67.207535    50.674902   0.01639344 
+  70           66.912639    50.670226   0.01428571 
+  64           67.131133    50.665552   0.015625  
+  76           67.950616    50.660879   0.01315789 
+  66           69.478536    50.656206   0.01515152 
+  70           71.811093    50.651534   0.01428571 
+  68           74.94583     50.646863   0.01470588 
+  69           78.573686    50.642193   0.01449275 
+  71           81.733689    50.637523   0.01408451 
+  57           82.8958      50.632853   0.01754386 
+  68           81.379762    50.628185   0.01470588 
+  61           78.263629    50.623517   0.01639344 
+  60           75.019763    50.618849   0.01666667 
+  80           72.428132    50.614182   0.0125    
+  62           70.712516    50.609515   0.01612903 
+  75           69.868048    50.604849   0.01333333 
+  64           69.823761    50.600183   0.015625  
+  71           70.497625    50.595518   0.01408451 
+  75           71.785819    50.590852   0.01333333 
+  52           73.472257    50.586187   0.01923077 
+  66           75.052463    50.581523   0.01515152 
+  70           75.739645    50.576858   0.01428571 
+  68           75.134997    50.572194   0.01470588 
+  67           73.735418    50.567529   0.01492537 
+  55           72.280963    50.562865   0.01818182 
+  58           71.170767    50.558201   0.01724138 
+  55           70.501187    50.553537   0.01818182 
+  52           70.220014    50.548873   0.01923077 
+  64           70.197209    50.544209   0.015625  
+  71           70.275407    50.539544   0.01408451 
+  74           70.360743    50.53488    0.01351351 
+  70           70.470626    50.530216   0.01428571 
+  67           70.665038    50.525551   0.01492537 
+  75           70.982511    50.520886   0.01333333 
+  73           71.432821    50.516221   0.01369863 
+  75           72.005113    50.511555   0.01333333 
+  55           72.665457    50.50689    0.01818182 
+  70           73.35446     50.502223   0.01428571 
+  71           74.019094    50.497557   0.01408451 
+  72           74.657644    50.49289    0.01388889 
+  67           75.293653    50.488222   0.01492537 
+  93           75.927072    50.483554   0.01075269 
+  68           76.552973    50.478886   0.01470588 
+  86           77.201128    50.474217   0.01162791 
+  67           77.910853    50.469547   0.01492537 
+  69           78.706415    50.464877   0.01449275 
+  81           79.595324    50.460206   0.01234568 
+  76           80.575866    50.455534   0.01315789 
+  70           81.636643    50.450862   0.01428571 
+  78           82.755       50.446189   0.01282051 
+  81           83.909678    50.441515   0.01234568 
+  83           85.107667    50.43684    0.01204819 
+  87           86.381391    50.432165   0.01149425 
+  90           87.764535    50.427488   0.01111111 
+  72           89.280695    50.422811   0.01388889 
+  80           90.949665    50.418132   0.0125    
+  97           92.791347    50.413453   0.01030928 
+  91           94.826595    50.408772   0.01098901 
+  101          97.075094    50.40409    0.00990099 
+  105          99.55475     50.399408   0.00952381 
+  94           102.27579    50.394724   0.0106383 
+  104          105.221839   50.390039   0.00961538 
+  111          108.309457   50.385353   0.00900901 
+  111          111.409042   50.380665   0.00900901 
+  123          114.492097   50.375976   0.00813008 
+  109          117.708064   50.371286   0.00917431 
+  155          121.254548   50.366595   0.00645161 
+  153          125.27015    50.361902   0.00653595 
+  162          129.841802   50.357208   0.00617284 
+  167          135.038537   50.352512   0.00598802 
+  150          140.931045   50.347815   0.00666667 
+  182          147.603595   50.343117   0.00549451 
+  176          155.152149   50.338416   0.00568182 
+  196          163.693213   50.333715   0.00510204 
+  200          173.343454   50.329011   0.005     
+  170          184.223876   50.324306   0.00588235 
+  198          196.530344   50.3196     0.00505051 
+  219          210.595521   50.314891   0.00456621 
+  184          226.855      50.310181   0.00543478 
+  196          245.83312    50.305469   0.00510204 
+  233          268.221052   50.300755   0.00429185 
+  247          294.942403   50.29604    0.00404858 
+  292          327.201034   50.291322   0.00342466 
+  338          366.609147   50.286603   0.00295858 
+  384          415.344767   50.281882   0.00260417 
+  420          476.619023   50.277158   0.00238095 
+  523          555.515221   50.272433   0.00191205 
+  643          661.155045   50.267706   0.00155521 
+  801          811.40343    50.262976   0.00124844 
+  1098         1041.00792   50.258245   0.00091075 
+  1461         1411.323701  50.253511   0.00068446 
+  2183         2013.432576  50.248775   0.00045809 
+  3050         2950.670962  50.244037   0.00032787 
+  4253         4287.687371  50.239297   0.00023513 
+  5610         5945.68564   50.234555   0.00017825 
+  6917         7497.252914  50.22981    0.00014457 
+  7395         8081.764673  50.225063   0.00013523 
+  6775         7250.174558  50.220313   0.0001476 
+  5358         5661.810421  50.215561   0.00018664 
+  3764         4114.437726  50.210807   0.00026567 
+  2861         2943.156137  50.20605    0.00034953 
+  2253         2195.325625  50.201291   0.00044385 
+  1880         1817.233269  50.196529   0.00053191 
+  1816         1746.485518  50.191765   0.00055066 
+  2078         1949.80734   50.186998   0.00048123 
+  2491         2415.165965  50.182228   0.00040145 
+  3126         3104.389563  50.177456   0.0003199 
+  3594         3857.751253  50.172681   0.00027824 
+  3841         4289.388006  50.167903   0.00026035 
+  3584         4031.461798  50.163123   0.00027902 
+  3136         3255.511962  50.158339   0.00031888 
+  2334         2397.135277  50.153553   0.00042845 
+  1593         1692.077306  50.148764   0.00062775 
+  1193         1190.303085  50.143973   0.00083822 
+  841          862.902135   50.139178   0.00118906 
+  610          658.204343   50.13438    0.00163934 
+  522          529.150664   50.12958    0.00191571 
+  406          443.37617    50.124776   0.00246305 
+  352          382.278812   50.11997    0.00284091 
+  273          336.168559   50.11516    0.003663  
+  275          300.009169   50.110347   0.00363636 
+  278          271.00025    50.105531   0.00359712 
+  227          247.341405   50.100712   0.00440529 
+  217          227.790702   50.09589    0.00460829 
+  201          211.413028   50.091064   0.00497512 
+  164          197.463701   50.086235   0.00609756 
+  167          185.339835   50.081403   0.00598802 
+  171          174.588233   50.076568   0.00584795 
+  144          164.925685   50.071729   0.00694444 
+  149          156.214193   50.066887   0.00671141 
+  131          148.393564   50.062041   0.00763359 
+  142          141.419448   50.057192   0.00704225 
+  106          135.234489   50.05234    0.00943396 
+  107          129.770011   50.047484   0.00934579 
+  111          124.951752   50.042624   0.00900901 
+  127          120.697959   50.037761   0.00787402 
+  103          116.920689   50.032894   0.00970874 
+  96           113.520144   50.028024   0.01041667 
+  89           110.387806   50.02315    0.01123596 
+  97           107.4251     50.018272   0.01030928 
+  105          104.569838   50.013391   0.00952381 
+  93           101.813851   50.008506   0.01075269 
+  100          99.183963    50.003617   0.01      
+  93           96.714279    49.998724   0.01075269 
+  103          94.422618    49.993827   0.00970874 
+  84           92.308847    49.988927   0.01190476 
+  88           90.362069    49.984022   0.01136364 
+  91           88.56733     49.979114   0.01098901 
+  82           86.91085     49.974201   0.01219512 
+  86           85.381352    49.969285   0.01162791 
+  84           83.96933     49.964365   0.01190476 
+  81           82.665296    49.95944    0.01234568 
+  96           81.460309    49.954512   0.01041667 
+  75           80.343126    49.949579   0.01333333 
+  72           79.304797    49.944642   0.01388889 
+  86           78.339539    49.939701   0.01162791 
+  85           77.441822    49.934756   0.01176471 
+  69           76.605445    49.929807   0.01449275 
+  80           75.823692    49.924853   0.0125    
+  85           75.090533    49.919895   0.01176471 
+  76           74.402031    49.914933   0.01315789 
+  56           73.756398    49.909966   0.01785714 
+  51           73.153628    49.904995   0.01960784 
+  76           72.594507    49.900019   0.01315789 
+  75           72.079876    49.895039   0.01333333 
+  64           71.610657    49.890055   0.015625  
+  60           71.18689     49.885066   0.01666667 
+  66           70.808417    49.880072   0.01515152 
+  74           70.475       49.875074   0.01351351 
+  73           70.186643    49.870071   0.01369863 
+  66           69.943187    49.865064   0.01515152 
+  69           69.743993    49.860052   0.01449275 
+  71           69.588189    49.855035   0.01408451 
+  82           69.475085    49.850014   0.01219512 
+  49           69.40547     49.844988   0.02040816 
+  62           69.383066    49.839957   0.01612903 
+  80           69.416757    49.834921   0.0125    
+  67           69.518448    49.829881   0.01492537 
+  83           69.716358    49.824835   0.01204819 
+  81           70.037133    49.819785   0.01234568 
+  66           70.515152    49.81473    0.01515152 
+  72           71.184526    49.80967    0.01388889 
+  71           72.065184    49.804605   0.01408451 
+  85           73.138131    49.799534   0.01176471 
+  81           74.29299     49.794459   0.01234568 
+  75           75.259783    49.789379   0.01333333 
+  67           75.679563    49.784294   0.01492537 
+  68           75.504618    49.779203   0.01470588 
+  75           74.828439    49.774107   0.01333333 
+  58           74.016721    49.769007   0.01724138 
+  78           73.254336    49.763901   0.01282051 
+  65           72.637618    49.758789   0.01538462 
+  86           72.216382    49.753673   0.01162791 
+  76           72.017755    49.748551   0.01315789 
+  84           72.05478     49.743424   0.01190476 
+  67           72.323413    49.738291   0.01492537 
+  75           72.785303    49.733153   0.01333333 
+  64           73.338166    49.72801    0.015625  
+  59           73.801301    49.722861   0.01694915 
+  84           74.012336    49.717707   0.01190476 
+  80           73.977558    49.712547   0.0125    
+  80           73.852941    49.707382   0.0125    
+  89           73.651331    49.702212   0.01123596 
+  88           73.426444    49.697035   0.01136364 
+  67           73.16082     49.691853   0.01492537 
+  63           72.833304    49.686666   0.01587302 
+  66           72.437115    49.681472   0.01515152 
+  63           71.986373    49.676273   0.01587302 
+  66           71.513718    49.671069   0.01515152 
+  65           71.056963    49.665858   0.01538462 
+  78           70.652926    49.660642   0.01282051 
+  73           70.332344    49.65542    0.01369863 
+  82           70.118729    49.650193   0.01219512 
+  71           70.022777    49.644959   0.01408451 
+  81           70.041659    49.639719   0.01234568 
+  79           70.163121    49.634474   0.01265823 
+  77           70.370633    49.629223   0.01298701 
+  62           70.65151     49.623965   0.01612903 
+  64           71.003806    49.618702   0.015625  
+  61           71.440711    49.613433   0.01639344 
+  81           71.990873    49.608157   0.01234568 
+  81           72.693648    49.602876   0.01234568 
+  79           73.588813    49.597588   0.01265823 
+  76           74.704942    49.592295   0.01315789 
+  88           76.04448     49.586995   0.01136364 
+  86           77.56483     49.581689   0.01162791 
+  77           79.135367    49.576377   0.01298701 
+  78           80.517875    49.571058   0.01282051 
+  86           81.47389     49.565733   0.01162791 
+  67           81.98743     49.560402   0.01492537 
+  65           82.273025    49.555065   0.01538462 
+  91           82.551355    49.549721   0.01098901 
+  75           82.898655    49.544371   0.01333333 
+  96           83.17749     49.539015   0.01041667 
+  76           83.049473    49.533652   0.01315789 
+  109          82.260284    49.528283   0.00917431 
+  92           80.972913    49.522907   0.01086957 
+  79           79.587194    49.517525   0.01265823 
+  83           78.371012    49.512136   0.01204819 
+  81           77.369574    49.506741   0.01234568 
+  96           76.477792    49.501339   0.01041667 
+  78           75.577484    49.495931   0.01282051 
+  99           74.665212    49.490515   0.01010101 
+  72           73.8238      49.485094   0.01388889 
+  81           73.115597    49.479665   0.01234568 
+  84           72.526183    49.47423    0.01190476 
+  66           71.935735    49.468788   0.01515152 
+  74           71.150561    49.463339   0.01351351 
+  73           70.078935    49.457884   0.01369863 
+  77           68.852944    49.452422   0.01298701 
+  61           67.688235    49.446953   0.01639344 
+  55           66.737185    49.441477   0.01818182 
+  63           66.086917    49.435994   0.01587302 
+  82           65.796461    49.430504   0.01219512 
+  73           65.92229     49.425008   0.01369863 
+  65           66.513867    49.419504   0.01538462 
+  76           67.589687    49.413993   0.01315789 
+  71           69.07202     49.408476   0.01408451 
+  70           70.653428    49.402951   0.01428571 
+  84           71.689869    49.397419   0.01190476 
+  64           71.510443    49.391881   0.015625  
+  47           70.116142    49.386335   0.0212766 
+  62           68.185889    49.380782   0.01612903 
+  65           66.382256    49.375221   0.01538462 
+  59           65.043124    49.369654   0.01694915 
+  54           64.289608    49.364079   0.01851852 
+  62           64.164497    49.358498   0.01612903 
+  53           64.69113     49.352908   0.01886792 
+  64           65.882539    49.347312   0.015625  
+  73           67.713665    49.341708   0.01369863 
+  53           70.019674    49.336097   0.01886792 
+  72           72.308323    49.330479   0.01388889 
+  83           73.669718    49.324853   0.01204819 
+  60           73.315727    49.31922    0.01666667 
+  58           71.4376      49.313579   0.01724138 
+  58           68.960126    49.307931   0.01724138 
+  67           66.651335    49.302276   0.01492537 
+  70           64.857981    49.296613   0.01428571 
+  64           63.677938    49.290942   0.015625  
+  54           63.111972    49.285264   0.01851852 
+  62           63.133303    49.279578   0.01612903 
+  70           63.707476    49.273885   0.01428571 
+  56           64.775232    49.268184   0.01785714 
+  77           66.187099    49.262476   0.01298701 
+  58           67.570306    49.256759   0.01724138 
+  50           68.290032    49.251035   0.02      
+  64           67.850969    49.245304   0.015625  
+  48           66.437543    49.239564   0.02083333 
+  46           64.676326    49.233817   0.02173913 
+  62           63.050613    49.228062   0.01612903 
+  52           61.760373    49.2223     0.01923077 
+  56           60.844389    49.216529   0.01785714 
+  59           60.277499    49.210751   0.01694915 
+  45           60.016319    49.204964   0.02222222 
+  55           60.017179    49.19917    0.01818182 
+  71           60.237173    49.193368   0.01408451 
+  57           60.617256    49.187558   0.01754386 
+  58           61.044244    49.18174    0.01724138 
+  72           61.344297    49.175914   0.01388889 
+  51           61.392757    49.17008    0.01960784 
+  62           61.252955    49.164238   0.01612903 
+  50           61.097558    49.158387   0.02      
+  64           61.050622    49.152529   0.015625  
+  61           61.157597    49.146663   0.01639344 
+  54           61.405597    49.140788   0.01851852 
+  58           61.727968    49.134906   0.01724138 
+  54           62.041699    49.129015   0.01851852 
+  46           62.34271     49.123116   0.02173913 
+  54           62.726932    49.117209   0.01851852 
+  49           63.308042    49.111293   0.02040816 
+  42           64.169842    49.10537    0.02380952 
+  63           65.368874    49.099438   0.01587302 
+  59           66.930592    49.093497   0.01694915 
+  64           68.827431    49.087549   0.015625  
+  68           70.997568    49.081592   0.01470588 
+  77           73.436766    49.075626   0.01298701 
+  55           76.177856    49.069653   0.01818182 
+  70           79.020491    49.06367    0.01428571 
+  95           81.334734    49.05768    0.01052632 
+  71           82.448274    49.051681   0.01408451 
+  71           82.422473    49.045673   0.01408451 
+  85           81.948171    49.039657   0.01176471 
+  80           81.574264    49.033633   0.0125    
+  77           81.459257    49.0276     0.01298701 
+  71           81.460753    49.021558   0.01408451 
+  79           81.262464    49.015508   0.01265823 
+  80           80.786017    49.009449   0.0125    
+  102          80.348945    49.003381   0.00980392 
+  80           80.328143    48.997305   0.0125    
+  80           80.917872    48.991221   0.0125    
+  96           82.053944    48.985127   0.01041667 
+  82           83.410755    48.979025   0.01219512 
+  79           84.628809    48.972914   0.01265823 
+  84           85.704792    48.966794   0.01190476 
+  81           86.947374    48.960666   0.01234568 
+  79           88.610686    48.954529   0.01265823 
+  79           90.785515    48.948383   0.01265823 
+  90           93.460008    48.942228   0.01111111 
+  85           96.606231    48.936064   0.01176471 
+  88           100.380874   48.929891   0.01136364 
+  101          105.219513   48.92371    0.00990099 
+  128          111.683537   48.91752    0.0078125 
+  134          120.431101   48.91132    0.00746269 
+  128          132.442904   48.905112   0.0078125 
+  156          149.529196   48.898895   0.00641026 
+  173          175.218391   48.892668   0.00578035 
+  225          215.994048   48.886433   0.00444444 
+  295          282.168032   48.880189   0.00338983 
+  382          386.841783   48.873936   0.0026178 
+  498          541.262598   48.867673   0.00200803 
+  808          744.950262   48.861402   0.00123762 
+  1127         964.750417   48.855121   0.00088731 
+  1402         1108.290808  48.848831   0.00071327 
+  1445         1074.536142  48.842532   0.00069204 
+  1149         893.347817   48.836224   0.00087032 
+  791          678.627734   48.829907   0.00126422 
+  574          499.3622     48.823581   0.00174216 
+  416          373.80811    48.817245   0.00240385 
+  379          298.118724   48.8109     0.00263852 
+  305          262.5736     48.804546   0.00327869 
+  276          259.744113   48.798182   0.00362319 
+  344          287.261083   48.79181    0.00290698 
+  381          345.851546   48.785428   0.00262467 
+  459          433.698871   48.779036   0.00217865 
+  626          535.709625   48.772635   0.00159744 
+  739          608.790742   48.766225   0.00135318 
+  765          598.434953   48.759806   0.00130719 
+  666          509.379083   48.753377   0.0015015 
+  509          397.537806   48.746939   0.00196464 
+  369          301.084279   48.740491   0.00271003 
+  269          230.835671   48.734033   0.00371747 
+  224          184.494128   48.727567   0.00446429 
+  186          155.171575   48.72109    0.00537634 
+  149          135.827763   48.714605   0.00671141 
+  125          121.67774    48.708109   0.008     
+  110          110.536713   48.701605   0.00909091 
+  91           101.649179   48.69509    0.01098901 
+  76           94.638702    48.688566   0.01315789 
+  96           89.200368    48.682033   0.01041667 
+  81           85.062411    48.675489   0.01234568 
+  73           82.001027    48.668936   0.01369863 
+  82           79.833725    48.662374   0.01219512 
+  87           78.396825    48.655802   0.01149425 
+  71           77.506481    48.64922    0.01408451 
+  78           76.910198    48.642628   0.01282051 
+  68           76.245147    48.636027   0.01470588 
+  77           75.11235     48.629416   0.01298701 
+  74           73.361884    48.622795   0.01351351 
+  69           71.241518    48.616164   0.01449275 
+  56           69.127147    48.609524   0.01785714 
+  60           67.248846    48.602874   0.01666667 
+  69           65.678052    48.596214   0.01449275 
+  59           64.403792    48.589544   0.01694915 
+  72           63.384168    48.582864   0.01388889 
+  56           62.567994    48.576175   0.01785714 
+  69           61.919539    48.569475   0.01449275 
+  69           61.404055    48.562766   0.01449275 
+  66           61.003503    48.556046   0.01515152 
+  47           60.70882     48.549317   0.0212766 
+  55           60.52529     48.542578   0.01818182 
+  53           60.466216    48.535829   0.01886792 
+  48           60.550016    48.529069   0.02083333 
+  66           60.793489    48.5223     0.01515152 
+  69           61.199454    48.515521   0.01449275 
+  57           61.733029    48.508732   0.01754386 
+  71           62.254986    48.501933   0.01408451 
+  63           62.499018    48.495123   0.01587302 
+  63           62.227998    48.488304   0.01587302 
+  58           61.493145    48.481474   0.01724138 
+  58           60.57409     48.474635   0.01724138 
+  64           59.709246    48.467785   0.015625  
+  64           59.007527    48.460925   0.015625  
+  49           58.49394     48.454055   0.02040816 
+  55           58.165043    48.447175   0.01818182 
+  50           58.005014    48.440285   0.02      
+  59           58.007948    48.433384   0.01694915 
+  67           58.156434    48.426473   0.01492537 
+  60           58.422365    48.419552   0.01666667 
+  48           58.749739    48.412621   0.02083333 
+  60           59.014615    48.405679   0.01666667 
+  55           59.078064    48.398728   0.01818182 
+  50           58.914516    48.391766   0.02      
+  55           58.646928    48.384793   0.01818182 
+  47           58.413438    48.377811   0.0212766 
+  54           58.294748    48.370818   0.01851852 
+  68           58.319877    48.363814   0.01470588 
+  45           58.495827    48.356801   0.02222222 
+  55           58.833333    48.349776   0.01818182 
+  47           59.344113    48.342742   0.0212766 
+  52           60.05602     48.335697   0.01923077 
+  61           61.018272    48.328642   0.01639344 
+  63           62.319136    48.321576   0.01587302 
+  69           64.110514    48.3145     0.01449275 
+  75           66.650449    48.307414   0.01333333 
+  68           70.347331    48.300317   0.01470588 
+  86           75.788928    48.293209   0.01162791 
+  86           83.799895    48.286091   0.01162791 
+  107          94.910271    48.278963   0.00934579 
+  119          109.636587   48.271824   0.00840336 
+  159          127.35106    48.264674   0.00628931 
+  193          144.913033   48.257514   0.00518135 
+  209          155.624597   48.250344   0.00478469 
+  223          153.34003    48.243162   0.0044843 
+  211          139.83266    48.235971   0.00473934 
+  194          122.474091   48.228768   0.00515464 
+  156          106.767363   48.221555   0.00641026 
+  146          94.801427    48.214332   0.00684932 
+  141          86.866183    48.207098   0.0070922 
+  96           82.637859    48.199853   0.01041667 
+  110          81.703744    48.192597   0.00909091 
+  116          83.716575    48.185331   0.00862069 
+  115          88.354936    48.178055   0.00869565 
+  116          95.143147    48.170767   0.00862069 
+  121          102.764838   48.163469   0.00826446 
+  130          108.587152   48.15616    0.00769231 
+  146          108.997092   48.14884    0.00684932 
+  145          103.024425   48.14151    0.00689655 
+  143          93.679051    48.134169   0.00699301 
+  132          84.339081    48.126817   0.00757576 
+  117          76.61229     48.119455   0.00854701 
+  119          70.825764    48.112081   0.00840336 
+  89           66.775682    48.104697   0.01123596 
+  71           64.096125    48.097302   0.01408451 
+  87           62.416401    48.089897   0.01149425 
+  67           61.417762    48.08248    0.01492537 
+  64           60.843346    48.075053   0.015625  
+  52           60.521467    48.067614   0.01923077 
+  59           60.407176    48.060165   0.01694915 
+  65           60.548832    48.052705   0.01538462 
+  62           60.985382    48.045235   0.01612903 
+  75           61.641213    48.037753   0.01333333 
+  68           62.232074    48.03026    0.01470588 
+  71           62.314731    48.022757   0.01408451 
+  58           61.651842    48.015243   0.01724138 
+  79           60.485362    48.007717   0.01265823 
+  84           59.246787    48.000181   0.01190476 
+  64           58.216245    47.992634   0.015625  
+  72           57.496073    47.985076   0.01388889 
+  63           57.097453    47.977507   0.01587302 
+  59           56.990137    47.969927   0.01694915 
+  64           57.126817    47.962336   0.015625  
+  76           57.477488    47.954734   0.01315789 
+  75           58.06306     47.947121   0.01333333 
+  49           58.921885    47.939497   0.02040816 
+  61           60.01697     47.931862   0.01639344 
+  61           61.171114    47.924216   0.01639344 
+  72           62.120634    47.916559   0.01388889 
+  70           62.644231    47.908891   0.01428571 
+  58           62.55074     47.901212   0.01724138 
+  61           61.742139    47.893521   0.01639344 
+  56           60.447022    47.88582    0.01785714 
+  51           59.083524    47.878108   0.01960784 
+  65           57.939513    47.870384   0.01538462 
+  80           57.107526    47.86265    0.0125    
+  70           56.574062    47.854904   0.01428571 
+  55           56.315153    47.847148   0.01818182 
+  54           56.339804    47.83938    0.01851852 
+  62           56.678516    47.831601   0.01612903 
+  65           57.356781    47.823811   0.01538462 
+  68           58.368528    47.81601    0.01470588 
+  57           59.622229    47.808198   0.01754386 
+  64           60.854745    47.800374   0.015625  
+  63           61.625238    47.792539   0.01587302 
+  77           61.572401    47.784694   0.01298701 
+  57           60.731522    47.776837   0.01754386 
+  62           59.477974    47.768969   0.01612903 
+  86           58.216118    47.761089   0.01162791 
+  70           57.18587     47.753199   0.01428571 
+  65           56.465722    47.745297   0.01538462 
+  54           56.051168    47.737384   0.01851852 
+  61           55.901208    47.72946    0.01639344 
+  55           55.952311    47.721525   0.01818182 
+  63           56.11906     47.713578   0.01587302 
+  67           56.342352    47.70562    0.01492537 
+  69           56.621116    47.697651   0.01449275 
+  61           56.943682    47.689671   0.01639344 
+  62           57.21212     47.68168    0.01612903 
+  54           57.296385    47.673677   0.01851852 
+  62           57.149581    47.665663   0.01612903 
+  52           56.803937    47.657638   0.01923077 
+  68           56.318444    47.649601   0.01470588 
+  58           55.787558    47.641553   0.01724138 
+  70           55.317225    47.633494   0.01428571 
+  52           54.965842    47.625424   0.01923077 
+  60           54.734999    47.617342   0.01666667 
+  62           54.587099    47.609249   0.01612903 
+  56           54.471808    47.601145   0.01785714 
+  53           54.364156    47.593029   0.01886792 
+  69           54.280559    47.584902   0.01449275 
+  50           54.246822    47.576764   0.02      
+  55           54.274001    47.568615   0.01818182 
+  54           54.351452    47.560454   0.01851852 
+  58           54.444217    47.552281   0.01724138 
+  58           54.501326    47.544098   0.01724138 
+  53           54.496222    47.535903   0.01886792 
+  62           54.453542    47.527697   0.01612903 
+  49           54.416845    47.519479   0.02040816 
+  60           54.414478    47.51125    0.01666667 
+  60           54.457417    47.50301    0.01666667 
+  44           54.549315    47.494758   0.02272727 
+  64           54.693638    47.486495   0.015625  
+  52           54.896927    47.478221   0.01923077 
+  64           55.170332    47.469935   0.015625  
+  46           55.528791    47.461638   0.02173913 
+  51           55.987829    47.45333    0.01960784 
+  43           56.556296    47.44501    0.02325581 
+  59           57.219061    47.436679   0.01694915 
+  64           57.904756    47.428336   0.015625  
+  61           58.459695    47.419982   0.01639344 
+  64           58.719875    47.411617   0.015625  
+  50           58.679207    47.40324    0.02      
+  60           58.499194    47.394852   0.01666667 
+  63           58.342259    47.386452   0.01587302 
+  60           58.289668    47.378041   0.01666667 
+  56           58.363893    47.369619   0.01785714 
+  73           58.562765    47.361185   0.01369863 
+  58           58.877751    47.35274    0.01724138 
+  68           59.302454    47.344283   0.01470588 
+  62           59.835844    47.335815   0.01612903 
+  52           60.481398    47.327336   0.01923077 
+  74           61.238676    47.318845   0.01351351 
+  74           62.08576     47.310343   0.01351351 
+  78           62.971167    47.301829   0.01282051 
+  76           63.861974    47.293304   0.01315789 
+  67           64.814455    47.284768   0.01492537 
+  94           65.931882    47.27622    0.0106383 
+  71           67.245746    47.26766    0.01408451 
+  70           68.621449    47.25909    0.01428571 
+  67           69.745238    47.250507   0.01492537 
+  79           70.327009    47.241914   0.01265823 
+  87           70.421012    47.233309   0.01149425 
+  63           70.363777    47.224692   0.01587302 
+  95           70.453366    47.216064   0.01052632 
+  73           70.839232    47.207425   0.01369863 
+  64           71.581372    47.198774   0.015625  
+  90           72.714413    47.190112   0.01111111 
+  87           74.279124    47.181439   0.01149425 
+  59           76.335654    47.172754   0.01694915 
+  92           78.960647    47.164057   0.01086957 
+  91           82.233652    47.155349   0.01098901 
+  101          86.191897    47.14663    0.00990099 
+  109          90.74352     47.137899   0.00917431 
+  96           95.550058    47.129157   0.01041667 
+  91           100.003849   47.120404   0.01098901 
+  104          103.508483   47.111639   0.00961538 
+  122          106.05283    47.102862   0.00819672 
+  121          108.392428   47.094075   0.00826446 
+  145          111.450857   47.085275   0.00689655 
+  107          115.860847   47.076465   0.00934579 
+  137          122.020867   47.067643   0.00729927 
+  131          130.273095   47.058809   0.00763359 
+  148          141.060344   47.049964   0.00675676 
+  148          155.038022   47.041108   0.00675676 
+  167          173.261187   47.03224    0.00598802 
+  207          197.575355   47.023361   0.00483092 
+  239          231.457754   47.014471   0.0041841 
+  331          281.563881   47.005569   0.00302115 
+  415          359.835577   46.996656   0.00240964 
+  520          484.963266   46.987731   0.00192308 
+  759          680.54492    46.978795   0.00131752 
+  1030         966.576286   46.969847   0.00097087 
+  1362         1340.839066  46.960888   0.00073421 
+  1677         1739.588609  46.951918   0.0005963 
+  1779         1991.453907  46.942937   0.00056211 
+  1766         1918.177931  46.933944   0.00056625 
+  1441         1582.178349  46.924939   0.00069396 
+  1136         1189.791805  46.915923   0.00088028 
+  834          863.265713   46.906896   0.00119904 
+  704          633.691796   46.897858   0.00142045 
+  555          492.492852   46.888808   0.0018018 
+  518          419.905153   46.879747   0.0019305 
+  471          399.341277   46.870674   0.00212314 
+  457          423.61135    46.86159    0.00218818 
+  550          494.698151   46.852495   0.00181818 
+  676          617.676168   46.843388   0.00147929 
+  810          788.336042   46.83427    0.00123457 
+  909          971.391232   46.825141   0.00110011 
+  1036         1077.558765  46.816      0.00096525 
+  931          1020.698396  46.806848   0.00107411 
+  741          838.511807   46.797685   0.00134953 
+  634          633.461166   46.78851    0.00157729 
+  477          463.175527   46.779324   0.00209644 
+  378          340.887085   46.770127   0.0026455 
+  316          260.727879   46.760918   0.00316456 
+  224          210.752704   46.751699   0.00446429 
+  206          179.473198   46.742468   0.00485437 
+  188          158.447667   46.733225   0.00531915 
+  131          142.790992   46.723971   0.00763359 
+  138          130.407537   46.714706   0.00724638 
+  129          120.522011   46.70543    0.00775194 
+  127          112.611512   46.696143   0.00787402 
+  112          106.081766   46.686844   0.00892857 
+  98           100.351793   46.677534   0.01020408 
+  108          95.101383    46.668213   0.00925926 
+  96           90.352259    46.65888    0.01041667 
+  85           86.234537    46.649537   0.01176471 
+  91           82.78855     46.640182   0.01098901 
+  70           79.968088    46.630815   0.01428571 
+  72           77.682933    46.621438   0.01388889 
+  88           75.818114    46.61205    0.01136364 
+  80           74.249344    46.60265    0.0125    
+  73           72.898585    46.593239   0.01369863 
+  80           71.771744    46.583817   0.0125    
+  66           70.905866    46.574383   0.01515152 
+  72           70.294956    46.564939   0.01388889 
+  58           69.853527    46.555483   0.01724138 
+  54           69.441928    46.546017   0.01851852 
+  50           68.976973    46.536539   0.02      
+  66           68.48458     46.52705    0.01515152 
+  62           67.981449    46.517549   0.01612903 
+  64           67.392065    46.508038   0.015625  
+  63           66.619514    46.498516   0.01587302 
+  61           65.648284    46.488982   0.01639344 
+  62           64.5761      46.479438   0.01612903 
+  58           63.537669    46.469882   0.01724138 
+  50           62.467161    46.460315   0.02      
+  67           61.707014    46.450737   0.01492537 
+  58           61.107078    46.441148   0.01724138 
+  55           60.662545    46.431549   0.01818182 
+  61           60.366686    46.421938   0.01639344 
+  49           60.212374    46.412316   0.02040816 
+  56           60.188787    46.402683   0.01785714 
+  65           60.271697    46.393039   0.01538462 
+  63           60.411531    46.383384   0.01587302 
+  50           60.536379    46.373718   0.02      
+  66           60.585969    46.364041   0.01515152 
+  51           60.549477    46.354353   0.01960784 
+  57           60.472498    46.344654   0.01754386 
+  53           60.335512    46.334944   0.01886792 
+  58           60.304056    46.325223   0.01724138 
+  63           60.237807    46.315491   0.01587302 
+  60           60.043511    46.305749   0.01666667 
+  50           59.681933    46.295995   0.02      
+  42           59.205548    46.286231   0.02380952 
+  52           58.694355    46.276455   0.01923077 
+  60           58.203614    46.266669   0.01666667 
+  46           57.765198    46.256872   0.02173913 
+  47           57.399072    46.247064   0.0212766 
+  64           57.12086     46.237245   0.015625  
+  51           56.944523    46.227416   0.01960784 
+  57           56.883248    46.217576   0.01754386 
+  59           56.951558    46.207724   0.01694915 
+  43           57.158002    46.197862   0.02325581 
+  62           57.496964    46.18799    0.01612903 
+  66           57.930999    46.178106   0.01515152 
+  60           58.375216    46.168212   0.01666667 
+  45           58.696323    46.158307   0.02222222 
+  66           58.737639    46.148391   0.01515152 
+  67           58.420675    46.138465   0.01492537 
+  61           57.853141    46.128528   0.01639344 
+  59           57.241149    46.11858    0.01694915 
+  66           56.736581    46.108621   0.01515152 
+  52           56.405305    46.098652   0.01923077 
+  54           56.263059    46.088673   0.01851852 
+  59           56.298804    46.078682   0.01694915 
+  46           56.483283    46.068681   0.02173913 
+  67           56.764224    46.058669   0.01492537 
+  56           57.063799    46.048647   0.01785714 
+  68           57.288347    46.038614   0.01470588 
+  58           57.347619    46.028571   0.01724138 
+  55           57.211994    46.018517   0.01818182 
+  53           56.886174    46.008453   0.01886792 
+  67           56.390202    45.998378   0.01492537 
+  42           55.7982      45.988292   0.02380952 
+  52           55.227091    45.978196   0.01923077 
+  47           54.763975    45.96809    0.0212766 
+  50           54.445815    45.957973   0.02      
+  64           54.27976     45.947846   0.015625  
+  61           54.260068    45.937708   0.01639344 
+  51           54.375906    45.92756    0.01960784 
+  45           54.611859    45.917401   0.02222222 
+  48           54.943316    45.907232   0.02083333 
+  37           55.339363    45.897053   0.02702703 
+  61           55.768222    45.886864   0.01639344 
+  65           56.210321    45.876664   0.01538462 
+  64           56.633845    45.866453   0.015625  
+  55           56.96273     45.856233   0.01818182 
+  47           57.07359     45.846002   0.0212766 
+  59           56.849437    45.835761   0.01694915 
+  57           56.285462    45.825509   0.01754386 
+  57           55.544162    45.815248   0.01754386 
+  51           54.824111    45.804976   0.01960784 
+  64           54.239574    45.794694   0.015625  
+  42           53.825651    45.784402   0.02380952 
+  67           53.58115     45.7741     0.01492537 
+  56           53.493448    45.763787   0.01785714 
+  52           53.550022    45.753464   0.01923077 
+  45           53.737764    45.743132   0.02222222 
+  50           54.039614    45.732789   0.02      
+  50           54.420185    45.722436   0.02      
+  53           54.814998    45.712073   0.01886792 
+  49           55.138142    45.7017     0.02040816 
+  55           55.306087    45.691317   0.01818182 
+  44           55.278517    45.680924   0.02272727 
+  40           55.104818    45.670521   0.025     
+  45           54.885076    45.660109   0.02222222 
+  69           54.695471    45.649686   0.01449275 
+  48           54.577017    45.639253   0.02083333 
+  58           54.540884    45.62881    0.01724138 
+  55           54.607075    45.618358   0.01818182 
+  46           54.795092    45.607896   0.02173913 
+  54           55.128412    45.597423   0.01851852 
+  52           55.630694    45.586941   0.01923077 
+  48           56.315284    45.576449   0.02083333 
+  62           57.161645    45.565948   0.01612903 
+  53           58.074921    45.555437   0.01886792 
+  66           58.866372    45.544915   0.01515152 
+  48           59.336634    45.534385   0.02083333 
+  55           59.393343    45.523844   0.01818182 
+  60           59.051392    45.513294   0.01666667 
+  55           58.424453    45.502734   0.01818182 
+  57           57.703356    45.492165   0.01754386 
+  61           57.050155    45.481586   0.01639344 
+  56           56.540888    45.470997   0.01785714 
+  55           56.200848    45.460399   0.01818182 
+  68           56.037186    45.449791   0.01470588 
+  59           56.049614    45.439174   0.01694915 
+  54           56.236445    45.428547   0.01851852 
+  56           56.589849    45.417911   0.01785714 
+  52           57.081088    45.407265   0.01923077 
+  73           57.642586    45.39661    0.01369863 
+  51           58.185174    45.385945   0.01960784 
+  50           58.661153    45.375271   0.02      
+  56           59.089167    45.364588   0.01785714 
+  50           59.53837     45.353895   0.02      
+  61           60.121473    45.343193   0.01639344 
+  55           60.933223    45.332482   0.01818182 
+  63           61.980952    45.321761   0.01587302 
+  57           63.238468    45.311031   0.01754386 
+  61           64.799916    45.300292   0.01639344 
+  62           66.890403    45.289544   0.01612903 
+  49           69.671793    45.278787   0.02040816 
+  67           73.048673    45.26802    0.01492537 
+  71           76.602685    45.257245   0.01408451 
+  60           79.542302    45.24646    0.01666667 
+  69           80.724048    45.235666   0.01449275 
+  76           79.413142    45.224863   0.01315789 
+  79           76.221216    45.214051   0.01265823 
+  69           72.516463    45.20323    0.01449275 
+  64           69.292552    45.1924     0.015625  
+  71           66.940108    45.181561   0.01408451 
+  61           65.484397    45.170714   0.01639344 
+  54           64.803029    45.159857   0.01851852 
+  64           64.77425     45.148991   0.015625  
+  65           65.366861    45.138117   0.01538462 
+  57           66.590031    45.127234   0.01754386 
+  50           68.366449    45.116342   0.02      
+  63           70.453678    45.105441   0.01587302 
+  61           72.465647    45.094531   0.01639344 
+  73           73.932108    45.083613   0.01369863 
+  66           74.444273    45.072686   0.01515152 
+  85           74.089086    45.06175    0.01176471 
+  59           73.547598    45.050806   0.01694915 
+  64           73.523458    45.039853   0.015625  
+  88           74.348636    45.028892   0.01136364 
+  59           75.953022    45.017922   0.01694915 
+  68           77.83576     45.006943   0.01470588 
+  75           79.165226    44.995956   0.01333333 
+  66           79.44137     44.984961   0.01515152 
+  76           79.10736     44.973957   0.01315789 
+  76           79.06436     44.962945   0.01315789 
+  75           79.885917    44.951924   0.01333333 
+  73           81.571976    44.940895   0.01369863 
+  92           83.533688    44.929857   0.01086957 
+  76           84.703144    44.918812   0.01315789 
+  79           84.224117    44.907758   0.01265823 
+  80           82.360699    44.896695   0.0125    
+  77           80.174856    44.885625   0.01298701 
+  74           78.526864    44.874546   0.01351351 
+  84           77.743978    44.86346    0.01190476 
+  81           77.744614    44.852365   0.01234568 
+  79           78.146532    44.841262   0.01265823 
+  75           78.473483    44.830151   0.01333333 
+  94           78.58622     44.819032   0.0106383 
+  69           78.803242    44.807905   0.01449275 
+  81           79.522463    44.79677    0.01234568 
+  90           80.932528    44.785627   0.01111111 
+  90           82.955282    44.774476   0.01111111 
+  92           85.224733    44.763317   0.01086957 
+  98           87.214149    44.752151   0.01020408 
+  107          88.720314    44.740976   0.00934579 
+  102          90.165128    44.729794   0.00980392 
+  93           92.200113    44.718604   0.01075269 
+  100          95.25562     44.707406   0.01      
+  125          99.445269    44.696201   0.008     
+  117          104.554345   44.684988   0.00854701 
+  105          109.913511   44.673767   0.00952381 
+  130          114.310376   44.662539   0.00769231 
+  110          116.631928   44.651303   0.00909091 
+  132          117.153305   44.64006    0.00757576 
+  125          117.374182   44.628809   0.008     
+  106          118.593913   44.617551   0.00943396 
+  134          121.449474   44.606286   0.00746269 
+  115          126.200558   44.595013   0.00869565 
+  131          133.017677   44.583732   0.00763359 
+  134          142.117531   44.572444   0.00746269 
+  137          153.843395   44.561149   0.00729927 
+  171          168.717051   44.549847   0.00584795 
+  198          187.485825   44.538538   0.00505051 
+  180          211.201496   44.527221   0.00555556 
+  221          241.420868   44.515897   0.00452489 
+  293          280.796435   44.504566   0.00341297 
+  367          334.702429   44.493228   0.0027248 
+  420          414.465219   44.481883   0.00238095 
+  613          540.682543   44.470531   0.00163132 
+  762          743.004468   44.459172   0.00131234 
+  1041         1053.139226  44.447806   0.00096061 
+  1475         1489.717511  44.436433   0.00067797 
+  1920         2025.931895  44.425053   0.00052083 
+  2348         2525.872939  44.413667   0.00042589 
+  2595         2720.669625  44.402273   0.00038536 
+  2427         2463.246981  44.390873   0.00041203 
+  2095         1950.337165  44.379466   0.00047733 
+  1570         1436.535246  44.368053   0.00063694 
+  1126         1034.005515  44.356632   0.0008881 
+  879          759.160827   44.345206   0.00113766 
+  695          591.508597   44.333772   0.00143885 
+  618          502.943276   44.322332   0.00161812 
+  570          472.964386   44.310886   0.00175439 
+  590          494.183134   44.299433   0.00169492 
+  691          571.045853   44.287973   0.00144718 
+  759          713.104871   44.276508   0.00131752 
+  981          923.5948     44.265035   0.00101937 
+  1136         1179.110446  44.253557   0.00088028 
+  1362         1394.730228  44.242072   0.00073421 
+  1324         1431.995718  44.230581   0.00075529 
+  1210         1252.509767  44.219084   0.00082645 
+  1024         976.657839   44.207581   0.00097656 
+  794          718.301685   44.196071   0.00125945 
+  639          519.626254   44.184556   0.00156495 
+  492          382.451041   44.173034   0.00203252 
+  398          293.715974   44.161507   0.00251256 
+  277          237.625795   44.149973   0.00361011 
+  229          201.346564   44.138434   0.00436681 
+  195          176.529214   44.126889   0.00512821 
+  180          158.474629   44.115337   0.00555556 
+  142          144.71951    44.10378    0.00704225 
+  139          133.945131   44.092218   0.00719424 
+  133          125.379186   44.080649   0.0075188 
+  138          118.528086   44.069075   0.00724638 
+  127          113.039663   44.057495   0.00787402 
+  119          108.662609   44.04591    0.00840336 
+  128          105.217839   44.034319   0.0078125 
+  112          102.572278   44.022723   0.00892857 
+  122          100.628945   44.011121   0.00819672 
+  116          99.311899    43.999513   0.00862069 
+  107          98.532264    43.987901   0.00934579 
+  110          98.133774    43.976283   0.00909091 
+  98           97.847437    43.964659   0.01020408 
+  88           97.393082    43.953031   0.01136364 
+  103          96.783529    43.941397   0.00970874 
+  115          96.404969    43.929758   0.00869565 
+  97           96.681368    43.918113   0.01030928 
+  99           97.77451     43.906464   0.01010101 
+  114          99.409931    43.89481    0.00877193 
+  109          100.734307   43.883151   0.00917431 
+  103          100.609626   43.871486   0.00970874 
+  85           98.610339    43.859817   0.01176471 
+  76           95.481071    43.848143   0.01315789 
+  79           92.264231    43.836464   0.01265823 
+  82           89.544612    43.82478    0.01219512 
+  73           87.452077    43.813092   0.01369863 
+  67           85.868963    43.801399   0.01492537 
+  70           84.560408    43.789701   0.01428571 
+  71           83.299114    43.777999   0.01408451 
+  80           82.042955    43.766292   0.0125    
+  72           80.958595    43.75458    0.01388889 
+  74           80.242101    43.742864   0.01351351 
+  78           79.96124     43.731144   0.01282051 
+  80           79.96532     43.719419   0.0125    
+  93           79.81202     43.70769    0.01075269 
+  95           78.932416    43.695957   0.01052632 
+  91           77.138582    43.684219   0.01098901 
+  76           74.81888     43.672478   0.01315789 
+  62           72.485835    43.660732   0.01612903 
+  80           70.420509    43.648982   0.0125    
+  82           68.691424    43.637228   0.01219512 
+  76           67.248721    43.62547    0.01315789 
+  75           66.079039    43.613708   0.01333333 
+  72           65.114337    43.601942   0.01388889 
+  86           64.327037    43.590172   0.01162791 
+  69           63.711147    43.578399   0.01449275 
+  62           63.280768    43.566621   0.01612903 
+  61           63.065383    43.55484    0.01639344 
+  80           63.107995    43.543055   0.0125    
+  73           63.462719    43.531267   0.01369863 
+  74           64.19041     43.519475   0.01351351 
+  64           65.317834    43.50768    0.015625  
+  95           66.839332    43.495881   0.01052632 
+  83           68.732521    43.484079   0.01204819 
+  76           71.060776    43.472273   0.01315789 
+  78           73.972497    43.460464   0.01282051 
+  92           77.331417    43.448652   0.01086957 
+  118          80.45245     43.436836   0.00847458 
+  113          82.297824    43.425017   0.00884956 
+  116          82.456363    43.413196   0.00862069 
+  98           81.627972    43.401371   0.01020408 
+  95           80.651555    43.389543   0.01052632 
+  93           79.574523    43.377712   0.01075269 
+  101          77.851873    43.365878   0.00990099 
+  96           75.309531    43.354042   0.01041667 
+  74           72.510986    43.342202   0.01351351 
+  87           70.138027    43.33036    0.01149425 
+  80           68.521383    43.318515   0.0125    
+  64           67.694945    43.306667   0.015625  
+  65           67.624423    43.294817   0.01538462 
+  78           68.279011    43.282965   0.01282051 
+  97           69.522819    43.271109   0.01030928 
+  95           70.973727    43.259252   0.01052632 
+  75           72.076848    43.247392   0.01333333 
+  89           72.579573    43.235529   0.01123596 
+  86           72.825409    43.223665   0.01162791 
+  88           73.304388    43.211798   0.01136364 
+  80           74.140497    43.199929   0.0125    
+  80           75.12018     43.188057   0.0125    
+  96           76.114649    43.176184   0.01041667 
+  93           77.227635    43.164309   0.01075269 
+  75           78.373246    43.152431   0.01333333 
+  89           79.039457    43.140552   0.01123596 
+  105          78.814972    43.128671   0.00952381 
+  94           78.003899    43.116788   0.0106383 
+  80           77.319661    43.104904   0.0125    
+  95           77.263293    43.093018   0.01052632 
+  88           77.968641    43.08113    0.01136364 
+  88           79.262621    43.06924    0.01136364 
+  76           80.69536     43.057349   0.01315789 
+  103          81.679074    43.045457   0.00970874 
+  93           81.907795    43.033563   0.01075269 
+  75           81.570974    43.021668   0.01333333 
+  92           81.031718    43.009771   0.01086957 
+  72           80.51813     42.997873   0.01388889 
+  76           80.082944    42.985975   0.01315789 
+  81           79.606708    42.974075   0.01234568 
+  64           78.81403     42.962173   0.015625  
+  77           77.489749    42.950271   0.01298701 
+  73           75.780068    42.938368   0.01369863 
+  75           74.092187    42.926464   0.01333333 
+  69           72.753371    42.91456    0.01449275 
+  62           71.893745    42.902654   0.01612903 
+  85           71.475701    42.890748   0.01176471 
+  72           71.315947    42.878841   0.01388889 
+  77           71.132969    42.866933   0.01298701 
+  77           70.740457    42.855025   0.01298701 
+  77           70.199619    42.843117   0.01298701 
+  63           69.694793    42.831208   0.01587302 
+  64           69.344371    42.819298   0.015625  
+  59           69.132477    42.807389   0.01694915 
+  72           68.888832    42.795479   0.01388889 
+  61           68.345042    42.783569   0.01639344 
+  66           67.374006    42.771659   0.01515152 
+  67           66.186588    42.759749   0.01492537 
+  68           65.131037    42.747838   0.01470588 
+  51           64.360164    42.735928   0.01960784 
+  61           63.706089    42.724018   0.01639344 
+  58           62.834936    42.712108   0.01724138 
+  58           61.659835    42.700199   0.01724138 
+  53           60.444585    42.68829    0.01886792 
+  52           59.427495    42.676381   0.01923077 
+  49           58.606523    42.664472   0.02040816 
+  55           57.86553     42.652564   0.01818182 
+  49           57.185317    42.640657   0.02040816 
+  53           56.650769    42.62875    0.01886792 
+  57           56.28701     42.616844   0.01754386 
+  62           55.993173    42.604939   0.01612903 
+  48           55.658276    42.593034   0.02083333 
+  55           55.321762    42.581131   0.01818182 
+  60           55.147431    42.569228   0.01666667 
+  55           55.259308    42.557326   0.01818182 
+  51           55.649297    42.545426   0.01960784 
+  59           56.208692    42.533526   0.01694915 
+  70           56.905056    42.521628   0.01428571 
+  66           57.899398    42.509731   0.01515152 
+  55           59.365871    42.497835   0.01818182 
+  73           61.256964    42.485941   0.01369863 
+  63           63.16963     42.474048   0.01587302 
+  71           64.342706    42.462157   0.01408451 
+  66           64.013168    42.450267   0.01515152 
+  57           62.133438    42.438379   0.01754386 
+  57           59.447668    42.426493   0.01754386 
+  56           56.753168    42.414608   0.01785714 
+  54           54.46662     42.402726   0.01851852 
+  51           52.702898    42.390845   0.01960784 
+  46           51.4422      42.378966   0.02173913 
+  71           50.625295    42.367089   0.01408451 
+  49           50.194664    42.355215   0.02040816 
+  53           50.110825    42.343342   0.01886792 
+  54           50.353924    42.331472   0.01851852 
+  53           50.910128    42.319604   0.01886792 
+  64           51.74093     42.307739   0.015625  
+  61           52.718786    42.295876   0.01639344 
+  63           53.539897    42.284016   0.01587302 
+  54           53.770102    42.272158   0.01851852 
+  50           53.18054     42.260303   0.02      
+  60           52.001608    42.24845    0.01666667 
+  56           50.656052    42.236601   0.01785714 
+  52           49.426879    42.224754   0.01923077 
+  61           48.417671    42.21291    0.01639344 
+  50           47.634392    42.20107    0.02      
+  45           47.045852    42.189232   0.02222222 
+  50           46.610802    42.177398   0.02      
+  60           46.29179     42.165566   0.01666667 
+  44           46.057411    42.153739   0.02272727 
+  39           45.885422    42.141914   0.02564103 
+  46           45.761259    42.130093   0.02173913 
+  39           45.676342    42.118275   0.02564103 
+  45           45.625619    42.106461   0.02222222 
+  45           45.604927    42.094651   0.02222222 
+  36           45.61069     42.082844   0.02777778 
+  53           45.639266    42.071042   0.01886792 
+  49           45.696344    42.059243   0.02040816 
+  47           45.801976    42.047448   0.0212766 
+  50           45.986167    42.035657   0.02      
+  37           46.281886    42.02387    0.02702703 
+  31           46.721862    42.012087   0.03225806 
+  48           47.331657    42.000309   0.02083333 
+  37           48.11347     41.988535   0.02702703 
+  47           49.006671    41.976765   0.0212766 
+  43           49.826805    41.965      0.02325581 
+  42           50.266521    41.953239   0.02380952 
+  48           50.107305    41.941483   0.02083333 
+  47           49.448873    41.929732   0.0212766 
+  50           48.580057    41.917985   0.02      
+  47           47.726574    41.906243   0.0212766 
+  52           46.997113    41.894506   0.01923077 
+  44           46.42806     41.882774   0.02272727 
+  33           46.021342    41.871048   0.03030303 
+  53           45.7669      41.859326   0.01886792 
+  37           45.653444    41.84761    0.02702703 
+  50           45.673431    41.835898   0.02      
+  54           45.824095    41.824193   0.01851852 
+  43           46.102703    41.812492   0.02325581 
+  57           46.492809    41.800797   0.01754386 
+  54           46.936246    41.789108   0.01851852 
+  64           47.305539    41.777425   0.015625  
+  50           47.447363    41.765747   0.02      
+  49           47.314146    41.754075   0.02040816 
+  51           46.995885    41.742409   0.01960784 
+  42           46.591288    41.730749   0.02380952 
+  43           46.144255    41.719095   0.02325581 
+  45           45.69064     41.707447   0.02222222 
+  50           45.277002    41.695806   0.02      
+  44           44.934246    41.684171   0.02272727 
+  47           44.667951    41.672542   0.0212766 
+  39           44.469387    41.660919   0.02564103 
+  49           44.325889    41.649304   0.02040816 
+  36           44.226012    41.637694   0.02777778 
+  35           44.161195    41.626092   0.02857143 
+  50           44.126133    41.614496   0.02      
+  51           44.116934    41.602908   0.01960784 
+  46           44.132079    41.591326   0.02173913 
+  38           44.169431    41.579751   0.02631579 
+  49           44.222864    41.568183   0.02040816 
+  36           44.277945    41.556623   0.02777778 
+  58           44.3134      41.545069   0.01724138 
+  43           44.317574    41.533524   0.02325581 
+  51           44.303267    41.521985   0.01960784 
+  41           44.294789    41.510454   0.02439024 
+  50           44.310396    41.498931   0.02      
+  36           44.355834    41.487416   0.02777778 
+  46           44.425875    41.475908   0.02173913 
+  42           44.503105    41.464408   0.02380952 
+  57           44.563403    41.452916   0.01754386 
+  38           44.596566    41.441432   0.02631579 
+  36           44.618422    41.429956   0.02777778 
+  51           44.654174    41.418488   0.01960784 
+  55           44.720471    41.407029   0.01818182 
+  39           44.822355    41.395578   0.02564103 
+  45           44.958589    41.384135   0.02222222 
+  40           45.128646    41.372701   0.025     
+  41           45.342839    41.361276   0.02439024 
+  39           45.624755    41.349859   0.02564103 
+  38           46.00658     41.338451   0.02631579 
+  41           46.528665    41.327052   0.02439024 
+  46           47.252714    41.315662   0.02173913 
+  62           48.250441    41.304281   0.01612903 
+  50           49.608596    41.292909   0.02      
+  44           51.413877    41.281547   0.02272727 
+  47           53.727842    41.270193   0.0212766 
+  51           56.527282    41.25885    0.01960784 
+  60           59.568515    41.247515   0.01666667 
+  55           62.248462    41.23619    0.01818182 
+  59           63.782371    41.224875   0.01694915 
+  60           63.746218    41.21357    0.01666667 
+  54           62.295398    41.202274   0.01851852 
+  44           59.963146    41.190988   0.02272727 
+  47           57.429502    41.179713   0.0212766 
+  49           55.209956    41.168447   0.02040816 
+  40           53.510417    41.157192   0.025     
+  45           52.320806    41.145947   0.02222222 
+  45           51.58773     41.134712   0.02222222 
+  55           51.308703    41.123488   0.01818182 
+  46           51.51573     41.112274   0.02173913 
+  52           52.231036    41.101071   0.01923077 
+  52           53.4495      41.089879   0.01923077 
+  50           55.119331    41.078698   0.02      
+  41           57.076721    41.067527   0.02439024 
+  53           58.964168    41.056368   0.01886792 
+  61           60.304264    41.045219   0.01639344 
+  58           60.706775    41.034082   0.01724138 
+  53           59.987907    41.022956   0.01886792 
+  60           58.338229    41.011842   0.01666667 
+  57           56.305178    41.000739   0.01754386 
+  52           54.381534    40.989647   0.01923077 
+  71           52.758516    40.978567   0.01408451 
+  61           51.427306    40.967499   0.01639344 
+  58           50.362066    40.956443   0.01724138 
+  53           49.574487    40.945399   0.01886792 
+  54           49.071869    40.934367   0.01851852 
+  46           48.837595    40.923347   0.02173913 
+  49           48.847386    40.912339   0.02040816 
+  41           49.092547    40.901343   0.02439024 
+  60           49.585785    40.89036    0.01666667 
+  40           50.338032    40.87939    0.025     
+  42           51.318521    40.868432   0.02380952 
+  55           52.427613    40.857486   0.01818182 
+  61           53.54835     40.846554   0.01639344 
+  57           54.660598    40.835634   0.01754386 
+  67           55.798383    40.824728   0.01492537 
+  52           56.817916    40.813834   0.01923077 
+  54           57.333221    40.802954   0.01851852 
+  39           57.070443    40.792087   0.02564103 
+  54           56.236398    40.781233   0.01851852 
+  56           55.297018    40.770393   0.01785714 
+  64           54.550969    40.759566   0.015625  
+  50           54.015789    40.748753   0.02      
+  50           53.554286    40.737954   0.02      
+  55           53.093873    40.727169   0.01818182 
+  50           52.728316    40.716397   0.02      
+  58           52.596636    40.70564    0.01724138 
+  48           52.803033    40.694897   0.02083333 
+  48           53.405817    40.684168   0.02083333 
+  55           54.452406    40.673454   0.01818182 
+  57           55.996783    40.662754   0.01754386 
+  51           58.056184    40.652068   0.01960784 
+  57           60.744687    40.641397   0.01754386 
+  49           64.086513    40.630741   0.02040816 
+  70           68.337259    40.6201     0.01428571 
+  60           74.038888    40.609474   0.01666667 
+  82           81.761721    40.598863   0.01219512 
+  64           91.637213    40.588267   0.015625  
+  94           102.712669   40.577686   0.0106383 
+  92           112.112797   40.567121   0.01086957 
+  115          115.537632   40.556571   0.00869565 
+  87           111.06811    40.546037   0.01149425 
+  92           101.632378   40.535519   0.01086957 
+  95           91.565501    40.525016   0.01052632 
+  89           83.403482    40.514529   0.01123596 
+  82           77.931253    40.504058   0.01219512 
+  89           75.154912    40.493604   0.01123596 
+  92           74.637399    40.483165   0.01086957 
+  97           75.657534    40.472743   0.01030928 
+  70           77.215987    40.462337   0.01428571 
+  94           78.473173    40.451948   0.0106383 
+  79           79.482078    40.441575   0.01265823 
+  72           81.057541    40.431219   0.01388889 
+  100          83.83787     40.42088    0.01      
+  64           87.599288    40.410558   0.015625  
+  99           90.912572    40.400253   0.01010101 
+  76           91.576633    40.389965   0.01315789 
+  96           88.658971    40.379694   0.01041667 
+  88           83.651898    40.369441   0.01136364 
+  82           78.634132    40.359205   0.01219512 
+  67           74.684859    40.348986   0.01492537 
+  59           72.104995    40.338786   0.01694915 
+  71           70.970878    40.328603   0.01408451 
+  88           71.229353    40.318438   0.01136364 
+  75           72.534534    40.308291   0.01333333 
+  88           74.130342    40.298162   0.01136364 
+  70           75.018397    40.288052   0.01428571 
+  87           74.573481    40.27796    0.01149425 
+  76           73.064449    40.267886   0.01315789 
+  70           71.377302    40.257831   0.01428571 
+  82           70.34502     40.247794   0.01219512 
+  70           70.507317    40.237776   0.01428571 
+  64           72.273284    40.227777   0.015625  
+  79           76.097546    40.217797   0.01265823 
+  82           82.466792    40.207837   0.01219512 
+  85           91.727195    40.197895   0.01176471 
+  91           103.759418   40.187973   0.01098901 
+  89           117.355662   40.17807    0.01123596 
+  92           129.176215   40.168187   0.01086957 
+  107          134.14112    40.158323   0.00934579 
+  118          129.809304   40.14848    0.00847458 
+  116          119.355298   40.138656   0.00862069 
+  104          107.546185   40.128852   0.00961538 
+  93           97.065257    40.119068   0.01075269 
+  96           88.904361    40.109305   0.01041667 
+  73           83.466324    40.099561   0.01369863 
+  79           80.900868    40.089839   0.01265823 
+  79           81.201634    40.080136   0.01265823 
+  84           84.316031    40.070455   0.01190476 
+  67           90.113351    40.060794   0.01492537 
+  93           98.290493    40.051155   0.01075269 
+  111          108.500463   40.041536   0.00900901 
+  103          120.512751   40.031938   0.00970874 
+  111          133.251985   40.022362   0.00900901 
+  124          143.020195   40.012807   0.00806452 
+  134          144.36216    40.003274   0.00746269 
+  110          135.453711   39.993762   0.00909091 
+  148          120.488396   39.984272   0.00675676 
+  92           104.825173   39.974803   0.01086957 
+  102          91.383832    39.965357   0.00980392 
+  88           81.03224     39.955933   0.01136364 
+  75           73.713939    39.946531   0.01333333 
+  98           69.018509    39.937151   0.01020408 
+  55           66.470225    39.927794   0.01818182 
+  75           65.648566    39.918459   0.01333333 
+  51           66.183067    39.909147   0.01960784 
+  85           67.6821      39.899858   0.01176471 
+  64           69.773154    39.890592   0.015625  
+  62           72.255341    39.881348   0.01612903 
+  66           74.884137    39.872128   0.01515152 
+  79           76.72037     39.862931   0.01265823 
+  84           76.250666    39.853758   0.01190476 
+  78           72.983083    39.844608   0.01282051 
+  75           68.160134    39.835481   0.01333333 
+  80           63.301172    39.826379   0.0125    
+  67           59.176435    39.8173     0.01492537 
+  63           55.966199    39.808245   0.01587302 
+  64           53.569629    39.799214   0.015625  
+  68           51.778773    39.790208   0.01470588 
+  60           50.399949    39.781226   0.01666667 
+  64           49.321147    39.772268   0.015625  
+  65           48.486279    39.763335   0.01538462 
+  51           47.857211    39.754427   0.01960784 
+  63           47.402841    39.745544   0.01587302 
+  44           47.101847    39.736686   0.02272727 
+  47           46.943733    39.727852   0.0212766 
+  45           46.928895    39.719044   0.02222222 
+  56           47.062703    39.710261   0.01785714 
+  55           47.356955    39.701504   0.01818182 
+  54           47.820208    39.692773   0.01851852 
+  47           48.443479    39.684067   0.0212766 
+  59           49.168318    39.675387   0.01694915 
+  61           49.838727    39.666732   0.01639344 
+  41           50.21684     39.658104   0.02439024 
+  57           50.151076    39.649503   0.01754386 
+  56           49.740934    39.640927   0.01785714 
+  55           49.234018    39.632378   0.01818182 
+  49           48.838595    39.623856   0.02040816 
+  39           48.671973    39.61536    0.02564103 
+  46           48.798779    39.606892   0.02173913 
+  71           49.270856    39.59845    0.01408451 
+  42           50.142539    39.590035   0.02380952 
+  56           51.477005    39.581648   0.01785714 
+  52           53.320781    39.573288   0.01923077 
+  56           55.663718    39.564956   0.01785714 
+  64           58.319951    39.556651   0.015625  
+  54           60.789392    39.548374   0.01851852 
+  53           62.298958    39.540125   0.01886792 
+  61           62.362112    39.531904   0.01639344 
+  53           61.246658    39.523711   0.01886792 
+  63           59.632062    39.515546   0.01587302 
+  69           58.079699    39.50741    0.01449275 
+  71           56.909149    39.499302   0.01408451 
+  55           56.218474    39.491223   0.01818182 
+  66           55.956311    39.483173   0.01515152 
+  61           55.98337     39.475151   0.01639344 
+  56           56.136413    39.467159   0.01785714 
+  66           56.28989     39.459196   0.01515152 
+  68           56.411153    39.451263   0.01470588 
+  57           56.561764    39.443358   0.01754386 
+  62           56.849066    39.435484   0.01612903 
+  60           57.327257    39.427639   0.01666667 
+  54           57.898606    39.419824   0.01851852 
+  60           58.27332     39.412039   0.01666667 
+  58           58.166347    39.404284   0.01724138 
+  43           57.631542    39.39656    0.02325581 
+  61           57.024306    39.388866   0.01639344 
+  52           56.663765    39.381202   0.01923077 
+  61           56.622632    39.37357    0.01639344 
+  54           56.73937     39.365968   0.01851852 
+  58           56.747497    39.358397   0.01724138 
+  72           56.502817    39.350857   0.01388889 
+  56           56.083416    39.343348   0.01785714 
+  55           55.62943     39.335871   0.01818182 
+  56           55.229521    39.328425   0.01785714 
+  54           54.931024    39.321011   0.01851852 
+  64           54.781225    39.313628   0.015625  
+  68           54.821409    39.306278   0.01470588 
+  64           55.078671    39.298959   0.015625  
+  57           55.558433    39.291673   0.01754386 
+  50           56.271604    39.284419   0.02      
+  61           57.286658    39.277198   0.01639344 
+  71           58.761963    39.270009   0.01408451 
+  62           60.910028    39.262853   0.01612903 
+  70           63.99839     39.25573    0.01428571 
+  80           68.388496    39.24864    0.0125    
+  75           74.592653    39.241583   0.01333333 
+  67           83.445429    39.234559   0.01492537 
+  96           96.140898    39.227569   0.01041667 
+  113          113.703528   39.220613   0.00884956 
+  139          135.324451   39.21369    0.00719424 
+  154          155.73418    39.206801   0.00649351 
+  150          164.084708   39.199946   0.00666667 
+  156          153.927027   39.193126   0.00641026 
+  116          132.736473   39.186339   0.00862069 
+  119          111.138139   39.179587   0.00840336 
+  128          94.175266    39.17287    0.0078125 
+  109          82.799548    39.166188   0.00917431 
+  90           76.34252     39.15954    0.01111111 
+  72           73.769091    39.152927   0.01388889 
+  73           74.166527    39.14635    0.01369863 
+  80           76.964348    39.139808   0.0125    
+  59           81.788074    39.133301   0.01694915 
+  69           88.248046    39.12683    0.01449275 
+  78           95.858723    39.120395   0.01282051 
+  82           104.546225   39.113996   0.01219512 
+  104          114.671291   39.107632   0.00961538 
+  117          125.583271   39.101305   0.00854701 
+  128          133.386796   39.095014   0.0078125 
+  130          132.229533   39.08876    0.00769231 
+  112          121.37782    39.082543   0.00892857 
+  94           106.312015   39.076362   0.0106383 
+  78           92.050138    39.070218   0.01282051 
+  64           80.832886    39.064111   0.015625  
+  79           73.039004    39.058042   0.01265823 
+  57           68.265287    39.052009   0.01754386 
+  46           65.904177    39.046015   0.02173913 
+  56           65.452982    39.040058   0.01785714 
+  63           66.537448    39.034139   0.01587302 
+  62           68.809948    39.028258   0.01612903 
+  72           71.774931    39.022415   0.01388889 
+  58           74.788915    39.01661    0.01724138 
+  64           77.252191    39.010844   0.015625  
+  50           78.634702    39.005116   0.02      
+  53           78.481197    38.999427   0.01886792 
+  79           76.804093    38.993777   0.01265823 
+  65           74.022248    38.988166   0.01538462 
+  42           70.58636     38.982594   0.02380952 
+  71           67.001564    38.977062   0.01408451 
+  57           63.718236    38.971569   0.01754386 
+  53           60.940625    38.966116   0.01886792 
+  61           58.669719    38.960702   0.01639344 
+  63           56.867463    38.955329   0.01587302 
+  63           55.511811    38.949995   0.01587302 
+  48           54.600309    38.944702   0.02083333 
+  59           54.13301     38.93945    0.01694915 
+  68           54.105706    38.934238   0.01470588 
+  61           54.48061     38.929066   0.01639344 
+  54           55.141467    38.923936   0.01851852 
+  63           55.812312    38.918847   0.01587302 
+  70           56.08717     38.913798   0.01428571 
+  58           55.710695    38.908792   0.01724138 
+  45           54.855008    38.903826   0.02222222 
+  69           53.923495    38.898903   0.01449275 
+  62           53.223448    38.894021   0.01612903 
+  69           52.880713    38.889181   0.01449275 
+  62           52.923721    38.884384   0.01612903 
+  72           53.362445    38.879628   0.01388889 
+  56           54.255539    38.874916   0.01785714 
+  79           55.711336    38.870245   0.01265823 
+  72           57.861782    38.865618   0.01388889 
+  67           60.780369    38.861034   0.01492537 
+  76           64.374761    38.856492   0.01315789 
+  71           68.143486    38.851994   0.01408451 
+  59           71.004054    38.84754    0.01694915 
+  61           71.632222    38.843129   0.01639344 
+  50           69.60781     38.838761   0.02      
+  55           65.887139    38.834438   0.01818182 
+  52           61.812198    38.830159   0.01923077 
+  59           58.19668     38.825924   0.01694915 
+  41           55.313976    38.821733   0.02439024 
+  59           53.151041    38.817587   0.01694915 
+  46           51.622766    38.813486   0.02173913 
+  52           50.644474    38.80943    0.01923077 
+  53           50.158697    38.805418   0.01886792 
+  47           50.123796    38.801452   0.0212766 
+  38           50.53525     38.797531   0.02631579 
+  48           51.397345    38.793656   0.02083333 
+  47           52.700413    38.789827   0.0212766 
+  57           54.338863    38.786043   0.01754386 
+  64           55.998705    38.782305   0.015625  
+  55           57.075028    38.778614   0.01818182 
+  58           56.947073    38.774969   0.01724138 
+  56           55.549405    38.771371   0.01785714 
+  60           53.447968    38.767819   0.01666667 
+  66           51.27926     38.764314   0.01515152 
+  51           49.381436    38.760856   0.01960784 
+  44           47.845261    38.757446   0.02272727 
+  41           46.64355     38.754083   0.02439024 
+  57           45.715935    38.750767   0.01754386 
+  45           45.005745    38.747499   0.02222222 
+  52           44.4591      38.744279   0.01923077 
+  44           44.031245    38.741107   0.02272727 
+  57           43.687689    38.737984   0.01754386 
+  44           43.34935     38.734908   0.02272727 
+  61           43.106342    38.731881   0.01639344 
+  43           42.896209    38.728903   0.02325581 
+  53           42.713186    38.725974   0.01886792 
+  57           42.554578    38.723094   0.01754386 
+  53           42.418317    38.720264   0.01886792 
+  50           42.302983    38.717482   0.02      
+  50           42.207257    38.71475    0.02      
+  46           42.129939    38.712068   0.02173913 
+  48           42.070269    38.709436   0.02083333 
+  43           42.027798    38.706855   0.02325581 
+  37           42.00276     38.704323   0.02702703 
+  40           41.996047    38.701842   0.025     
+  53           42.009677    38.699411   0.01886792 
+  38           42.046788    38.697031   0.02631579 
+  51           42.085735    38.694703   0.01960784 
+  36           42.184892    38.692425   0.02777778 
+  46           42.324881    38.690199   0.02173913 
+  43           42.512171    38.688024   0.02325581 
+  55           42.750583    38.685901   0.01818182 
+  45           43.034407    38.68383    0.02222222 
+  48           43.339277    38.681811   0.02083333 
+  62           43.624051    38.679844   0.01612903 
+  38           43.862636    38.67793    0.02631579 
+  61           44.080627    38.676068   0.01639344 
+  50           44.335263    38.674258   0.02      
+  41           44.664481    38.672502   0.02439024 
+  57           45.047941    38.670799   0.01754386 
+  63           45.392066    38.669149   0.01587302 
+  49           45.5574      38.667553   0.02040816 
+  53           45.475862    38.66601    0.01886792 
+  61           45.227768    38.664521   0.01639344 
+  57           44.959437    38.663086   0.01754386 
+  52           44.776623    38.661706   0.01923077 
+  54           44.73395     38.660379   0.01851852 
+  43           44.858055    38.659107   0.02325581 
+  48           45.170318    38.65789    0.02083333 
+  53           45.690437    38.656728   0.01886792 
+  49           46.436809    38.655621   0.02040816 
+  46           47.420354    38.654569   0.02173913 
+  48           48.647773    38.653573   0.02083333 
+  61           50.107366    38.652632   0.01639344 
+  46           51.68497     38.651747   0.02173913 
+  50           53.083111    38.650919   0.02      
+  46           53.9087      38.650146   0.02173913 
+  57           54.020974    38.64943    0.01754386 
+  37           53.657184    38.64877    0.02702703 
+  50           53.151401    38.648167   0.02      
+  51           52.682348    38.647621   0.01960784 
+  58           52.228209    38.647132   0.01724138 
+  49           51.707208    38.6467     0.02040816 
+  60           51.154966    38.646326   0.01666667 
+  47           50.729361    38.64601    0.0212766 
+  34           50.598765    38.645751   0.02941176 
+  55           50.876924    38.645551   0.01818182 
+  47           51.628822    38.645408   0.0212766 
+  47           52.888368    38.645325   0.0212766 
+  44           54.676842    38.645299   0.02272727 
+  51           57.024969    38.645333   0.01960784 
+  59           59.92448     38.645426   0.01694915 
+  48           63.187886    38.645577   0.02083333 
+  69           66.300523    38.645788   0.01449275 
+  71           68.480633    38.646059   0.01408451 
+  64           69.036491    38.64639    0.015625  
+  57           67.972569    38.64678    0.01754386 
+  59           66.021598    38.64723    0.01694915 
+  68           63.926446    38.647741   0.01470588 
+  79           62.015699    38.648313   0.01265823 
+  67           60.384875    38.648945   0.01492537 
+  58           59.09949     38.649638   0.01724138 
+  58           58.207853    38.650392   0.01724138 
+  58           57.692629    38.651207   0.01724138 
+  60           57.489717    38.652084   0.01666667 
+  51           57.521891    38.653023   0.01960784 
+  56           57.733996    38.654023   0.01785714 
+  50           58.11261     38.655085   0.02      
+  65           58.688385    38.65621    0.01538462 
+  60           59.471489    38.657397   0.01666667 
+  60           60.358587    38.658647   0.01666667 
+  66           61.045105    38.65996    0.01515152 
+  61           61.124753    38.661335   0.01639344 
+  68           60.449645    38.662774   0.01470588 
+  75           59.30697     38.664277   0.01333333 
+  66           58.110869    38.665843   0.01515152 
+  56           57.101049    38.667473   0.01785714 
+  46           56.345421    38.669166   0.02173913 
+  56           55.853094    38.670925   0.01785714 
+  50           55.616927    38.672747   0.02      
+  47           55.615557    38.674634   0.0212766 
+  46           55.815413    38.676586   0.02173913 
+  66           56.186936    38.678603   0.01515152 
+  62           56.708113    38.680685   0.01612903 
+  62           57.365174    38.682833   0.01612903 
+  56           58.127667    38.685046   0.01785714 
+  60           58.916714    38.687325   0.01666667 
+  73           59.575871    38.68967    0.01369863 
+  68           59.960837    38.692082   0.01470588 
+  76           60.100908    38.694559   0.01315789 
+  70           60.204645    38.697104   0.01428571 
+  77           60.482232    38.699715   0.01298701 
+  70           61.054308    38.702393   0.01428571 
+  69           61.94947     38.705139   0.01449275 
+  51           63.133246    38.707952   0.01960784 
+  49           64.522553    38.710832   0.02040816 
+  66           66.031514    38.713781   0.01515152 
+  52           67.594796    38.716797   0.01923077 
+  69           69.114689    38.719882   0.01449275 
+  73           70.468334    38.723035   0.01369863 
+  61           71.597842    38.726257   0.01639344 
+  66           72.50868     38.729547   0.01515152 
+  69           73.129792    38.732907   0.01449275 
+  62           73.26982     38.736336   0.01612903 
+  72           72.781872    38.739835   0.01388889 
+  62           71.695408    38.743403   0.01612903 
+  68           70.248377    38.747041   0.01470588 
+  63           68.810736    38.75075    0.01587302 
+  62           67.6957      38.754528   0.01612903 
+  58           67.078704    38.758378   0.01724138 
+  80           67.023631    38.762298   0.0125    
+  64           67.537302    38.766288   0.015625  
+  63           68.590637    38.770351   0.01587302 
+  71           70.138811    38.774484   0.01408451 
+  87           72.110976    38.778689   0.01149425 
+  74           74.351432    38.782966   0.01351351 
+  77           76.570435    38.787315   0.01298701 
+  83           78.465784    38.791736   0.01204819 
+  81           79.879895    38.796229   0.01234568 
+  79           80.735795    38.800795   0.01265823 
+  80           80.974888    38.805434   0.0125    
+  77           80.699456    38.810146   0.01298701 
+  81           80.170822    38.814932   0.01234568 
+  89           79.634798    38.81979    0.01123596 
+  89           79.252041    38.824723   0.01123596 
+  86           79.086049    38.829729   0.01162791 
+  89           79.133439    38.83481    0.01123596 
+  80           79.359825    38.839965   0.0125    
+  67           79.737088    38.845194   0.01492537 
+  85           80.279592    38.850499   0.01176471 
+  75           81.068818    38.855878   0.01333333 
+  75           82.298879    38.861333   0.01333333 
+  82           84.318147    38.866863   0.01219512 
+  87           87.662478    38.872468   0.01149425 
+  102          93.052657    38.87815    0.00980392 
+  126          101.282872   38.883907   0.00793651 
+  117          112.882536   38.889741   0.00854701 
+  132          127.183961   38.895652   0.00757576 
+  127          140.739795   38.901639   0.00787402 
+  143          146.33873    38.907703   0.00699301 
+  132          139.169522   38.913844   0.00757576 
+  117          123.805967   38.920063   0.00854701 
+  109          107.629605   38.926359   0.00917431 
+  90           94.347471    38.932734   0.01111111 
+  96           84.647138    38.939186   0.01041667 
+  102          78.030673    38.945716   0.00980392 
+  71           73.648811    38.952325   0.01408451 
+  64           70.749698    38.959013   0.015625  
+  81           68.832591    38.96578    0.01234568 
+  74           67.680913    38.972626   0.01351351 
+  53           67.34555     38.979551   0.01886792 
+  72           68.083644    38.986556   0.01388889 
+  78           70.288431    38.993641   0.01282051 
+  80           74.309913    39.000806   0.0125    
+  77           80.179792    39.008051   0.01298701 
+  89           86.958026    39.015377   0.01123596 
+  90           91.814684    39.022783   0.01111111 
+  95           91.043694    39.030271   0.01052632 
+  97           84.544129    39.037839   0.01030928 
+  83           75.959918    39.04549    0.01204819 
+  65           68.182277    39.053221   0.01538462 
+  62           62.168728    39.061035   0.01612903 
+  53           57.903312    39.068931   0.01886792 
+  64           55.009959    39.076909   0.015625  
+  52           53.072836    39.084969   0.01923077 
+  56           51.751423    39.093113   0.01785714 
+  53           50.824554    39.101339   0.01886792 
+  45           50.166395    39.109649   0.02222222 
+  56           49.716308    39.118042   0.01785714 
+  48           49.447106    39.126519   0.02083333 
+  46           49.343668    39.13508    0.02173913 
+  45           49.391942    39.143725   0.02222222 
+  56           49.586472    39.152455   0.01785714 
+  53           49.946925    39.161269   0.01886792 
+  41           50.501745    39.170168   0.02439024 
+  32           51.222079    39.179152   0.03125   
+  53           51.949964    39.188222   0.01886792 
+  44           52.375317    39.197377   0.02272727 
+  45           52.212704    39.206617   0.02222222 
+  55           51.479297    39.215944   0.01818182 
+  40           50.469736    39.225357   0.025     
+  42           49.474434    39.234857   0.02380952 
+  52           48.64019     39.244444   0.01923077 
+  48           48.002261    39.254117   0.02083333 
+  47           47.548838    39.263878   0.0212766 
+  53           47.250912    39.273726   0.01886792 
+  52           47.080061    39.283662   0.01923077 
+  53           47.01092     39.293685   0.01886792 
+  42           47.023109    39.303797   0.02380952 
+  53           47.099269    39.313997   0.01886792 
+  43           47.235584    39.324286   0.02325581 
+  54           47.443025    39.334664   0.01851852 
+  52           47.730861    39.345131   0.01923077 
+  40           48.066073    39.355687   0.025     
+  47           48.341848    39.366333   0.0212766 
+  51           48.39117     39.377069   0.01960784 
+  54           48.111906    39.387895   0.01851852 
+  45           47.574677    39.398811   0.02222222 
+  42           46.94511     39.409818   0.02380952 
+  51           46.350289    39.420915   0.01960784 
+  51           45.84913     39.432104   0.01960784 
+  56           45.455273    39.443384   0.01785714 
+  45           45.164318    39.454755   0.02222222 
+  47           44.964167    39.466218   0.0212766 
+  51           44.843138    39.477773   0.01960784 
+  41           44.793456    39.489421   0.02439024 
+  47           44.811285    39.501161   0.0212766 
+  32           44.896511    39.512993   0.03125   
+  36           45.049853    39.524919   0.02777778 
+  62           45.266307    39.536938   0.01612903 
+  36           45.53404     39.549051   0.02777778 
+  49           45.851995    39.561257   0.02040816 
+  33           46.249492    39.573557   0.03030303 
+  51           46.767766    39.585951   0.01960784 
+  46           47.402919    39.59844    0.02173913 
+  42           48.054727    39.611024   0.02380952 
+  52           48.503571    39.623702   0.01923077 
+  47           48.527425    39.636476   0.0212766 
+  53           48.103411    39.649345   0.01886792 
+  44           47.409393    39.66231    0.02272727 
+  51           46.631135    39.675371   0.01960784 
+  56           45.881021    39.688528   0.01785714 
+  44           45.229074    39.701782   0.02272727 
+  56           44.716858    39.715132   0.01785714 
+  49           44.353468    39.72858    0.02040816 
+  39           44.128445    39.742124   0.02564103 
+  40           44.021964    39.755766   0.025     
+  43           44.011473    39.769506   0.02325581 
+  57           44.07391     39.783344   0.01754386 
+  41           44.199287    39.79728    0.02439024 
+  44           44.395457    39.811314   0.02272727 
+  54           44.674414    39.825447   0.01851852 
+  35           45.021623    39.83968    0.02857143 
+  38           45.369352    39.854011   0.02631579 
+  46           45.596644    39.868442   0.02173913 
+  48           45.599037    39.882973   0.02083333 
+  39           45.385053    39.897603   0.02564103 
+  52           45.048498    39.912334   0.01923077 
+  39           44.671292    39.927166   0.02564103 
+  45           44.302066    39.942098   0.02222222 
+  42           43.971269    39.957132   0.02380952 
+  53           43.695898    39.972266   0.01886792 
+  54           43.477805    39.987503   0.01851852 
+  45           43.310908    40.002841   0.02222222 
+  38           43.188317    40.018281   0.02631579 
+  53           43.102545    40.033823   0.01886792 
+  38           43.048807    40.049468   0.02631579 
+  44           43.024333    40.065216   0.02272727 
+  41           43.028054    40.081068   0.02439024 
+  59           43.06125     40.097022   0.01694915 
+  37           43.125633    40.11308    0.02702703 
+  38           43.222951    40.129242   0.02631579 
+  45           43.353319    40.145508   0.02222222 
+  45           43.511619    40.161879   0.02222222 
+  44           43.679427    40.178354   0.02272727 
+  34           43.818339    40.194934   0.02941176 
+  49           43.880398    40.21162    0.02040816 
+  52           43.846898    40.228411   0.01923077 
+  36           43.746929    40.245308   0.02777778 
+  51           43.626271    40.26231    0.01960784 
+  40           43.515218    40.279419   0.025     
+  59           43.426471    40.296635   0.01694915 
+  42           43.363994    40.313957   0.02380952 
+  52           43.328979    40.331387   0.01923077 
+  40           43.32208     40.348924   0.025     
+  43           43.345838    40.366568   0.02325581 
+  53           43.402874    40.38432    0.01886792 
+  48           43.496805    40.402181   0.02083333 
+  58           43.629982    40.42015    0.01724138 
+  44           43.799994    40.438227   0.02272727 
+  51           43.994226    40.456414   0.01960784 
+  56           44.183316    40.47471    0.01785714 
+  38           44.331542    40.493115   0.02631579 
+  33           44.418761    40.51163    0.03030303 
+  53           44.44895     40.530255   0.01886792 
+  50           44.443641    40.548991   0.02      
+  42           44.435875    40.567837   0.02380952 
+  53           44.454736    40.586793   0.01886792 
+  54           44.516488    40.605861   0.01851852 
+  47           44.62449     40.625041   0.0212766 
+  39           44.775478    40.644332   0.02564103 
+  46           44.962444    40.663735   0.02173913 
+  39           45.179926    40.68325    0.02564103 
+  45           45.423781    40.702878   0.02222222 
+  59           45.687308    40.722618   0.01694915 
+  37           45.963139    40.742472   0.02702703 
+  39           46.251229    40.762439   0.02564103 
+  50           46.556998    40.782519   0.02      
+  49           46.880175    40.802714   0.02040816 
+  52           47.209851    40.823022   0.01923077 
+  39           47.531966    40.843445   0.02564103 
+  41           47.846673    40.863983   0.02439024 
+  45           48.170826    40.884636   0.02222222 
+  50           48.528958    40.905404   0.02      
+  39           48.945646    40.926287   0.02564103 
+  42           49.4503      40.947286   0.02380952 
+  54           50.085114    40.968402   0.01851852 
+  49           50.910512    40.989634   0.02040816 
+  61           52.012697    41.010982   0.01639344 
+  48           53.498237    41.032448   0.02083333 
+  63           55.484506    41.05403    0.01587302 
+  68           58.071442    41.075731   0.01470588 
+  81           61.340198    41.097549   0.01234568 
+  90           65.304804    41.119485   0.01111111 
+  98           69.720902    41.141539   0.01020408 
+  95           73.673415    41.163713   0.01052632 
+  129          75.576368    41.186005   0.00775194 
+  109          74.40841     41.208416   0.00917431 
+  96           70.933676    41.230947   0.01041667 
+  109          66.792927    41.253597   0.00917431 
+  87           63.122628    41.276368   0.01149425 
+  78           60.338053    41.299259   0.01282051 
+  70           58.491904    41.322271   0.01428571 
+  82           57.493114    41.345404   0.01219512 
+  64           57.235042    41.368657   0.015625  
+  58           57.625129    41.392033   0.01724138 
+  65           58.605703    41.41553    0.01538462 
+  66           60.1144      41.439149   0.01515152 
+  58           62.016265    41.462891   0.01724138 
+  65           64.020702    41.486755   0.01538462 
+  82           65.781121    41.510743   0.01219512 
+  67           67.213094    41.534853   0.01492537 
+  64           68.523947    41.559087   0.015625  
+  96           69.726467    41.583445   0.01041667 
+  98           70.270217    41.607927   0.01020408 
+  95           69.501765    41.632534   0.01052632 
+  104          67.446081    41.657265   0.00961538 
+  96           64.706303    41.682121   0.01041667 
+  82           61.905177    41.707103   0.01219512 
+  88           59.486906    41.73221    0.01136364 
+  71           57.678747    41.757443   0.01408451 
+  63           56.539775    41.782802   0.01587302 
+  67           56.025281    41.808288   0.01492537 
+  79           56.049622    41.8339     0.01265823 
+  55           56.476262    41.85964    0.01818182 
+  73           57.100571    41.885507   0.01369863 
+  66           57.651929    41.911501   0.01515152 
+  60           57.896864    41.937624   0.01666667 
+  56           57.730188    41.963875   0.01785714 
+  55           57.208956    41.990254   0.01818182 
+  51           56.546979    42.016762   0.01960784 
+  58           55.988984    42.0434     0.01724138 
+  68           55.672727    42.070166   0.01470588 
+  60           55.603972    42.097063   0.01666667 
+  53           55.686326    42.12409    0.01886792 
+  59           55.79526     42.151247   0.01694915 
+  65           55.883629    42.178534   0.01538462 
+  60           56.007877    42.205953   0.01666667 
+  66           56.221303    42.233503   0.01515152 
+  65           56.500828    42.261184   0.01538462 
+  59           56.785887    42.288997   0.01694915 
+  59           57.103002    42.316943   0.01694915 
+  67           57.580467    42.345021   0.01492537 
+  61           58.347353    42.373232   0.01639344 
+  51           59.461247    42.401576   0.01960784 
+  58           60.965737    42.430053   0.01724138 
+  62           62.926385    42.458664   0.01612903 
+  44           65.347219    42.487409   0.02272727 
+  63           67.952409    42.516288   0.01587302 
+  56           70.087564    42.545302   0.01785714 
+  68           70.981116    42.574451   0.01470588 
+  53           70.38951     42.603735   0.01886792 
+  48           68.713008    42.633154   0.02083333 
+  73           66.524875    42.66271    0.01369863 
+  54           64.307517    42.692401   0.01851852 
+  56           62.439167    42.722229   0.01785714 
+  44           61.123391    42.752194   0.02272727 
+  60           60.407118    42.782296   0.01666667 
+  56           60.263877    42.812535   0.01785714 
+  54           60.726657    42.842912   0.01851852 
+  67           61.981263    42.873427   0.01492537 
+  64           64.365212    42.904081   0.015625  
+  66           68.314054    42.934873   0.01515152 
+  68           74.248989    42.965804   0.01470588 
+  63           82.403972    42.996874   0.01587302 
+  92           92.453754    43.028084   0.01086957 
+  104          102.492331   43.059434   0.00961538 
+  92           108.284451   43.090924   0.01086957 
+  97           106.301172   43.122554   0.01030928 
+  107          98.43095     43.154326   0.00934579 
+  92           89.145657    43.186238   0.01086957 
+  79           81.079221    43.218292   0.01265823 
+  86           74.9272      43.250488   0.01162791 
+  60           70.397782    43.282826   0.01666667 
+  56           66.948885    43.315307   0.01785714 
+  60           64.184493    43.34793    0.01666667 
+  53           61.928272    43.380696   0.01886792 
+  61           60.149459    43.413606   0.01639344 
+  59           58.921589    43.446659   0.01694915 
+  56           58.393473    43.479856   0.01785714 
+  60           58.728753    43.513198   0.01666667 
+  66           60.092909    43.546685   0.01515152 
+  58           62.597976    43.580316   0.01724138 
+  59           66.199852    43.614093   0.01694915 
+  77           70.399117    43.648015   0.01298701 
+  67           73.666694    43.682084   0.01492537 
+  60           73.868064    43.716298   0.01666667 
+  71           70.737779    43.75066    0.01408451 
+  85           66.303098    43.785168   0.01176471 
+  69           62.330961    43.819823   0.01449275 
+  64           59.4139      43.854626   0.015625  
+  53           57.463043    43.889577   0.01886792 
+  56           56.115456    43.924676   0.01785714 
+  69           55.042925    43.959924   0.01449275 
+  52           54.081375    43.995321   0.01923077 
+  51           53.203754    44.030867   0.01960784 
+  50           52.449934    44.066562   0.02      
+  62           51.882167    44.102408   0.01612903 
+  56           51.544787    44.138403   0.01785714 
+  52           51.454511    44.174549   0.01923077 
+  67           51.606394    44.210846   0.01492537 
+  46           51.97248     44.247294   0.02173913 
+  57           52.485266    44.283894   0.01754386 
+  63           53.025962    44.320645   0.01587302 
+  68           53.47831     44.357549   0.01470588 
+  52           53.825974    44.394605   0.01923077 
+  78           54.153295    44.431814   0.01282051 
+  82           54.521058    44.469177   0.01219512 
+  50           54.878551    44.506692   0.02      
+  60           55.114866    44.544362   0.01666667 
+  69           55.218146    44.582186   0.01449275 
+  75           55.345922    44.620164   0.01333333 
+  78           55.71939     44.658298   0.01282051 
+  50           56.517569    44.696586   0.02      
+  73           57.873806    44.73503    0.01369863 
+  59           59.862752    44.77363    0.01694915 
+  57           62.469898    44.812386   0.01754386 
+  46           65.471618    44.851298   0.02173913 
+  61           68.325694    44.890368   0.01639344 
+  61           70.29568     44.929595   0.01639344 
+  51           71.050566    44.968979   0.01960784 
+  56           71.024373    45.008521   0.01785714 
+  58           70.901725    45.048221   0.01724138 
+  55           70.993818    45.08808    0.01818182 
+  65           71.134493    45.128098   0.01538462 
+  63           70.929271    45.168275   0.01587302 
+  80           70.059603    45.208612   0.0125    
+  57           68.42148     45.249109   0.01754386 
+  72           66.21045     45.289766   0.01388889 
+  91           63.898761    45.330583   0.01098901 
+  69           61.950162    45.371562   0.01449275 
+  58           60.616794    45.412702   0.01724138 
+  49           59.932067    45.454003   0.02040816 
+  60           59.80777     45.495467   0.01666667 
+  64           60.129318    45.537093   0.015625  
+  50           60.795972    45.578882   0.02      
+  56           61.628422    45.620833   0.01785714 
+  60           62.292377    45.662948   0.01666667 
+  61           62.449215    45.705227   0.01639344 
+  64           62.079132    45.74767    0.015625  
+  53           61.522673    45.790277   0.01886792 
+  51           61.129764    45.833049   0.01960784 
+  39           60.975998    45.875987   0.02564103 
+  63           60.87849     45.91909    0.01587302 
+  47           60.576203    45.962358   0.0212766 
+  66           59.907875    46.005793   0.01515152 
+  51           58.87515     46.049394   0.01960784 
+  49           57.652913    46.093162   0.02040816 
+  54           56.49536     46.137098   0.01851852 
+  51           55.570993    46.181201   0.01960784 
+  58           54.914949    46.225472   0.01724138 
+  52           54.455283    46.269911   0.01923077 
+#--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--#
+
+# start Validation Reply Form
+_vrf_PLAT741_QPAPBMXGreaseSuspendedSamplePrep_phase_1 # for all atoms in 1_quartz
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT741_QPAPBMXGreaseSuspendedSamplePrep_phase_3 # for all atoms in 3_pyrrhotite
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT741_QPAPBMXGreaseSuspendedSamplePrep_phase_4 # for all atoms in 4_rutile
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT741_QPAPBMXGreaseSuspendedSamplePrep_phase_2 # for all atoms in 2_albite
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT155_QPAPBMXGreaseSuspendedSamplePrep_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+; 
+_vrf_PLAT141_QPAPBMXGreaseSuspendedSamplePrep_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT142_QPAPBMXGreaseSuspendedSamplePrep_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT143_QPAPBMXGreaseSuspendedSamplePrep_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT144_QPAPBMXGreaseSuspendedSamplePrep_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT145_QPAPBMXGreaseSuspendedSamplePrep_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT146_QPAPBMXGreaseSuspendedSamplePrep_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT151_QPAPBMXGreaseSuspendedSamplePrep_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+# end Validation Reply Form

--- a/data/hamish/vb5042sup2.cif
+++ b/data/hamish/vb5042sup2.cif
@@ -1,0 +1,8052 @@
+
+data_QPAPBMXHandGrindSamplePrep_publ
+_audit_creation_method  "created in GSAS-II"
+_audit_creation_date  2021-08-04T17:23
+_audit_author_name  "McDougall, Hamish"
+_audit_update_record
+   "2021-08-04T17:23  Initial software-generated CIF"
+_pd_block_id
+   2021-08-04T17:23|QPAPBMXHandGrindSamplePrep|McDougallHamish|Overall
+# GSAS-II edited template follows Publication_Template
+#=============================================================================
+# this information describes the project, paper etc. for the CIF             #
+# Acta Cryst. Section C papers and editorial correspondence is generated     #
+# from the information in this section                                       #
+#                                                                            #
+#   (from)   CIF submission form for Rietveld refinements (Acta Cryst. C)    #
+#                                                 Version 14 December 1998   #
+#=============================================================================
+# 1. SUBMISSION DETAILS
+
+_publ_contact_author_name            "Suzanne Neville; Vanessa Peterson; Christophe Didier"   # Name of author for correspondence
+_publ_contact_author_address             # Address of author for correspondence
+; ?
+;
+_publ_contact_author_email           "s.neville@unsw.edu.au; vanessa.peterson@ansto.gov.au; drchristophedidier@gmail.com"
+_publ_contact_author_fax             ?
+_publ_contact_author_phone           ?
+
+_publ_contact_letter
+; ?
+;
+   
+_publ_requested_journal              ?
+_publ_requested_coeditor_name        ?
+_publ_requested_category             ?   # Acta C: one of CI/CM/CO/FI/FM/FO
+
+#==============================================================================
+
+# 2. PROCESSING SUMMARY (IUCr Office Use Only)
+
+_journal_data_validation_number      ?
+
+_journal_date_recd_electronic        ?
+_journal_date_to_coeditor            ?
+_journal_date_from_coeditor          ?
+_journal_date_accepted               ?
+_journal_date_printers_first         ?
+_journal_date_printers_final         ?
+_journal_date_proofs_out             ?
+_journal_date_proofs_in              ?
+_journal_coeditor_name               ?
+_journal_coeditor_code               ?
+_journal_coeditor_notes
+; ?
+;
+_journal_techeditor_code             ?
+_journal_techeditor_notes
+; ?
+;
+_journal_coden_ASTM                  ?
+_journal_name_full                   ?
+_journal_year                        ?
+_journal_volume                      ?
+_journal_issue                       ?
+_journal_page_first                  ?
+_journal_page_last                   ?
+_journal_paper_category              ?
+_journal_suppl_publ_number           ?
+_journal_suppl_publ_pages            ?
+
+#==============================================================================
+
+# 3. TITLE AND AUTHOR LIST
+
+_publ_section_title
+; ?
+;
+_publ_section_title_footnote
+; ?
+;         
+ 
+# The loop structure below should contain the names and addresses of all 
+# authors, in the required order of publication. Repeat as necessary.
+
+loop_
+	_publ_author_name
+        _publ_author_footnote
+	_publ_author_address
+ ?                                   #<--'Last name, first name' 
+; ?
+;
+; ?
+;
+
+#==============================================================================
+
+# 4. TEXT
+
+_publ_section_synopsis
+;  ?
+;
+_publ_section_abstract                         
+; ?
+;          
+_publ_section_comment                          
+; ?
+;
+_publ_section_exptl_prep      # Details of the preparation of the sample(s)
+                              # should be given here. 
+; ?
+;
+_publ_section_exptl_refinement                  
+; ?
+;
+_publ_section_references
+; ?
+;
+_publ_section_figure_captions
+; ?
+;
+_publ_section_acknowledgements
+; ?
+;
+
+#=============================================================================
+# 5. OVERALL REFINEMENT & COMPUTING DETAILS
+
+_refine_special_details
+; ?
+;
+_pd_proc_ls_special_details
+; ?
+;
+
+# The following items are used to identify the programs used.
+_computing_molecular_graphics     ?
+_computing_publication_material   ?
+
+_refine_ls_weighting_scheme       ?        
+_refine_ls_weighting_details      ?
+_refine_ls_hydrogen_treatment     ?        
+_refine_ls_extinction_method      ?        
+_refine_ls_extinction_coef        ?         
+_refine_ls_number_constraints     ?        
+
+_refine_ls_restrained_S_all       ?        
+_refine_ls_restrained_S_obs       ?
+
+#==============================================================================
+# 6. SAMPLE PREPARATION DATA
+
+# (In the unusual case where multiple samples are used in a single
+#  Rietveld study, this information should be moved into the phase
+#  blocks)
+
+# The following three fields describe the preparation of the material.
+# The cooling rate is in K/min.  The pressure at which the sample was  
+# prepared is in kPa.  The temperature of preparation is in K.
+               
+_pd_prep_cool_rate                N/A        
+_pd_prep_pressure                 101.3        
+_pd_prep_temperature              298         
+
+_pd_char_colour                   ?       # use ICDD colour descriptions
+
+data_QPAPBMXHandGrindSamplePrep_overall
+_pd_proc_info_datetime  2021-08-04T17:23
+_pd_calc_method  "Rietveld Refinement"
+_computing_structure_refinement
+   "GSAS-II (Toby & Von Dreele, J. Appl. Cryst. 46, 544-549, 2013)"
+_refine_ls_number_parameters  29
+_refine_ls_goodness_of_fit_all  2.482
+_refine_ls_shift/su_max  4.9301
+
+# OVERALL WEIGHTED R-FACTOR
+_refine_ls_wR_factor_obs  0.14998
+_refine_ls_matrix_type  full
+# POINTERS TO PHASE AND HISTOGRAM BLOCKS
+loop_   _pd_phase_block_id
+
+   2021-08-04T17:23|QPAPBMXHandGrindSamplePrep|phase_2|McDougallHamish
+
+   2021-08-04T17:23|QPAPBMXHandGrindSamplePrep|phase_0|McDougallHamish
+
+   2021-08-04T17:23|QPAPBMXHandGrindSamplePrep|phase_3|McDougallHamish
+
+   2021-08-04T17:23|QPAPBMXHandGrindSamplePrep|phase_4|McDougallHamish
+
+   2021-08-04T17:23|QPAPBMXHandGrindSamplePrep|phase_1|McDougallHamish
+_pd_block_diffractogram_id
+;
+2021-08-04T17:23|QPAPBMXHandGrindSamplePrep|McDougallHamish|PANalytical,Co-EmpyreanII_hist_0
+;
+
+data_QPAPBMXHandGrindSamplePrep_phase_2
+# Information for phase 2
+_pd_block_id
+   2021-08-04T17:23|QPAPBMXHandGrindSamplePrep|phase_2|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Albite NaAlSi3O8 follows
+_pd_phase_name  "Albite NaAlSi3O8"
+_cell_length_a  8.141789
+_cell_length_b  12.787902
+_cell_length_c  7.158828
+_cell_angle_alpha  94.2429
+_cell_angle_beta   116.5972
+_cell_angle_gamma  87.7872
+_cell_volume  664.636
+_exptl_crystal_density_diffrn  2.6206
+_symmetry_cell_setting  triclinic
+_symmetry_space_group_name_H-M  "C -1"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -x,-y,-z
+     3  1/2+x,1/2+y,z
+     4  1/2-x,1/2-y,-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Al1    Al3+ 0.00887     0.16846     0.20805     1.000      Uani 0.007      4   
+Si1    Si4+ 0.00375     0.82051     0.23737     1.000      Uani 0.006      4   
+Si2    Si4+ 0.69162     0.11021     0.31466     1.000      Uani 0.006      4   
+Si3    Si4+ 0.68129     0.88190     0.36076     1.000      Uani 0.006      4   
+Na1    Na1+ 0.26799     0.98865     0.14650     1.000      Uani 0.031      4   
+O1     O2-  0.00490     0.13103     0.96660     1.000      Uani 0.012      4   
+O2     O2-  0.59176     0.99756     0.28040     1.000      Uani 0.008      4   
+O3     O2-  0.81230     0.10966     0.19010     1.000      Uani 0.014      4   
+O4     O2-  0.82000     0.85101     0.25870     1.000      Uani 0.018      4   
+O5     O2-  0.01288     0.30238     0.27060     1.000      Uani 0.011      4   
+O6     O2-  0.02329     0.69368     0.22910     1.000      Uani 0.011      4   
+O7     O2-  0.20780     0.10896     0.38900     1.000      Uani 0.011      4   
+O8     O2-  0.18400     0.86817     0.43620     1.000      Uani 0.012      4   
+
+loop_
+   _atom_site_aniso_label
+   _atom_site_aniso_U_11
+   _atom_site_aniso_U_22
+   _atom_site_aniso_U_33
+   _atom_site_aniso_U_12
+   _atom_site_aniso_U_13
+   _atom_site_aniso_U_23
+Al1    0.0074      0.0068      0.0061      -0.0009     0.0031      0.0004      
+Si1    0.0068      0.0065      0.0055      0.0011      0.0030      0.0008      
+Si2    0.0061      0.0055      0.0073      -0.0002     0.0025      0.0004      
+Si3    0.0060      0.0055      0.0074      0.0006      0.0028      0.0009      
+Na1    0.0136      0.0471      0.0315      -0.0050     0.0084      -0.0219     
+O1     0.0164      0.0122      0.0074      -0.0002     0.0067      0.0014      
+O2     0.0074      0.0056      0.0119      0.0003      0.0033      0.0020      
+O3     0.0117      0.0130      0.0162      -0.0040     0.0093      -0.0017     
+O4     0.0134      0.0179      0.0216      0.0046      0.0129      0.0020      
+O5     0.0103      0.0076      0.0150      -0.0020     0.0052      -0.0009     
+O6     0.0101      0.0071      0.0145      0.0022      0.0034      0.0012      
+O7     0.0120      0.0129      0.0080      0.0024      0.0013      0.0015      
+O8     0.0140      0.0140      0.0084      -0.0026     -0.0002     -0.0006     
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Al   4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Na   4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  O    32     ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si   12     ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Al Na O8 Si3"
+_chemical_formula_weight  262.22
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Al1    O1     1.74545      1_555    1_554 yes
+  Al1    O3     1.74292      1_555    1_455 yes
+  Al1    O5     1.73556      1_555    1_555 yes
+  Al1    O7     1.74706      1_555    1_555 yes
+  Si1    O1     1.59987      1_555    2_566 yes
+  Si1    O4     1.60134      1_555    1_455 yes
+  Si1    O6     1.62285      1_555    1_555 yes
+  Si1    O8     1.61909      1_555    1_555 yes
+  Si2    O2     1.62972      1_555    1_545 yes
+  Si2    O3     1.59488      1_555    1_555 yes
+  Si2    O6     1.62016      1_555    3_545 yes
+  Si2    O8     1.6169       1_555    2_666 yes
+  Si3    O2     1.64834      1_555    1_555 yes
+  Si3    O4     1.6208       1_555    1_555 yes
+  Si3    O5     1.59651      1_555    3_555 yes
+  Si3    O7     1.60217      1_555    2_666 yes
+  Na1    O1     2.67163      1_555    1_564 yes
+  Na1    O1     2.53036      1_555    2_566 yes
+  Na1    O2     2.37173      1_555    1_555 yes
+  Na1    O3     2.45337      1_555    2_665 yes
+  Na1    O7     2.43501      1_555    1_565 yes
+  O1     Al1    1.74545      1_555    1_556 yes
+  O1     Si1    1.59987      1_555    2_566 yes
+  O1     Na1    2.67163      1_555    1_546 yes
+  O1     Na1    2.53036      1_555    2_566 yes
+  O2     Si2    1.62972      1_555    1_565 yes
+  O2     Si3    1.64834      1_555    1_555 yes
+  O2     Na1    2.37173      1_555    1_555 yes
+  O3     Al1    1.74292      1_555    1_655 yes
+  O3     Si2    1.59488      1_555    1_555 yes
+  O3     Na1    2.45337      1_555    2_665 yes
+  O4     Si1    1.60134      1_555    1_655 yes
+  O4     Si3    1.6208       1_555    1_555 yes
+  O5     Al1    1.73556      1_555    1_555 yes
+  O5     Si3    1.59651      1_555    3_445 yes
+  O6     Si1    1.62285      1_555    1_555 yes
+  O6     Si2    1.62016      1_555    3_455 yes
+  O7     Al1    1.74706      1_555    1_555 yes
+  O7     Si3    1.60217      1_555    2_666 yes
+  O7     Na1    2.43501      1_555    1_545 yes
+  O8     Si1    1.61909      1_555    1_555 yes
+  O8     Si2    1.6169       1_555    2_666 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Al1    O3     102.855       1_554  1_555    1_455 yes
+  O1     Al1    O5     116.061       1_554  1_555    1_555 yes
+  O3     Al1    O5     112.147       1_455  1_555    1_555 yes
+  O1     Al1    O7     103.957       1_554  1_555    1_555 yes
+  O3     Al1    O7     111.182       1_455  1_555    1_555 yes
+  O5     Al1    O7     110.191       1_555  1_555    1_555 yes
+  O1     Si1    O4     109.397       2_566  1_555    1_455 yes
+  O1     Si1    O6     112.462       2_566  1_555    1_555 yes
+  O4     Si1    O6     108.255       1_455  1_555    1_555 yes
+  O1     Si1    O8     107.195       2_566  1_555    1_555 yes
+  O4     Si1    O8     111.458       1_455  1_555    1_555 yes
+  O6     Si1    O8     108.103       1_555  1_555    1_555 yes
+  O2     Si2    O3     111.114       1_545  1_555    1_555 yes
+  O2     Si2    O6     104.247       1_545  1_555    3_545 yes
+  O3     Si2    O6     112.16        1_555  1_555    3_545 yes
+  O2     Si2    O8     106.957       1_545  1_555    2_666 yes
+  O3     Si2    O8     111.575       1_555  1_555    2_666 yes
+  O6     Si2    O8     110.428       3_545  1_555    2_666 yes
+  O2     Si3    O4     107.334       1_555  1_555    1_555 yes
+  O2     Si3    O5     105.864       1_555  1_555    3_555 yes
+  O4     Si3    O5     110.228       1_555  1_555    3_555 yes
+  O2     Si3    O7     108.58        1_555  1_555    2_666 yes
+  O4     Si3    O7     110.176       1_555  1_555    2_666 yes
+  O5     Si3    O7     114.331       3_555  1_555    2_666 yes
+  Al1    O1     Si1    141.388       1_556  1_555    2_566 yes
+  Si2    O2     Si3    129.999       1_565  1_555    1_555 yes
+  Si2    O2     Na1    120.298       1_565  1_555    1_555 yes
+  Si3    O2     Na1    108.885       1_555  1_555    1_555 yes
+  Al1    O3     Si2    139.47        1_655  1_555    1_555 yes
+  Si1    O4     Si3    161.161       1_655  1_555    1_555 yes
+  Al1    O5     Si3    129.633       1_555  1_555    3_445 yes
+  Si1    O6     Si2    135.712       1_555  1_555    3_455 yes
+  Al1    O7     Si3    133.928       1_555  1_555    2_666 yes
+  Si1    O8     Si2    151.749       1_555  1_555    2_666 yes
+_pd_proc_ls_pref_orient_corr  none
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    1.000, 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_QPAPBMXHandGrindSamplePrep_phase_0
+# Information for phase 0
+_pd_block_id
+   2021-08-04T17:23|QPAPBMXHandGrindSamplePrep|phase_0|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Pyrite FeS2 - 3191 follows
+_pd_phase_name  "Pyrite FeS2 - 3191"
+_cell_length_a  5.41900(5)
+_cell_length_b  5.41900(5)
+_cell_length_c  5.41900(5)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  90
+_cell_volume  159.132(5)
+_exptl_crystal_density_diffrn  5.0074
+_symmetry_cell_setting  cubic
+_symmetry_space_group_name_H-M  "P a -3"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  z,x,y
+     3  y,z,x
+     4  1/2+x,y,1/2-z
+     5  1/2-z,1/2+x,y
+     6  y,1/2-z,1/2+x
+     7  -z,1/2+x,1/2-y
+     8  1/2-y,-z,1/2+x
+     9  1/2+y,1/2-z,-x
+    10  -x,1/2+y,1/2-z
+    11  1/2-z,-x,1/2+y
+    12  1/2+x,1/2-y,-z
+    13  -x,-y,-z
+    14  -z,-x,-y
+    15  -y,-z,-x
+    16  1/2-x,-y,1/2+z
+    17  1/2+z,1/2-x,-y
+    18  -y,1/2+z,1/2-x
+    19  z,1/2-x,1/2+y
+    20  1/2+y,z,1/2-x
+    21  1/2-y,1/2+z,x
+    22  x,1/2-y,1/2+z
+    23  1/2+z,x,1/2-y
+    24  1/2-x,1/2+y,z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Fe1    Fe   0.00000     0.00000     0.00000     1.000      Uiso 0.0281(10) 4   
+S2     S    0.38871(17) 0.38871     0.38871     1.000      Uiso 0.0310(8)  8   
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Fe   4      11.7695    7.3573     3.5222     2.3045     4.7611     0.3072     15.3535    76.8805    1.0369     0.945
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S    8      6.9053     5.2034     1.4379     1.5863     1.4679     22.2151    0.2536     56.172     0.8669     0.2847
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Fe S2"
+_chemical_formula_weight  119.97
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Fe1    S2     2.27253(24)   1_555    4_455 yes
+  Fe1    S2     2.27253(24)   1_555    5_545 yes
+  Fe1    S2     2.27253(24)   1_555    6_554 yes
+  Fe1    S2     2.27253(24)   1_555    7_545 yes
+  Fe1    S2     2.27253(24)   1_555    8_554 yes
+  Fe1    S2     2.2725(8)    1_555    9_455 yes
+  S2     Fe1    2.27253(24)   1_555    4_555 yes
+  S2     Fe1    2.27253(24)   1_555    5_555 yes
+  S2     Fe1    2.2725(8)    1_555    6_555 yes
+  S2     S2     2.0892(10)   1_555   13_666 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.389(5), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_QPAPBMXHandGrindSamplePrep_phase_3
+# Information for phase 3
+_pd_block_id
+   2021-08-04T17:23|QPAPBMXHandGrindSamplePrep|phase_3|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Pyrrhotite 4M Fe7S8 follows
+_pd_phase_name  "Pyrrhotite 4M Fe7S8"
+_cell_length_a  11.93(4)
+_cell_length_b  6.860(5)
+_cell_length_c  12.89(4)
+_cell_angle_alpha  90
+_cell_angle_beta   117.08(7)
+_cell_angle_gamma  90
+_cell_volume  939.0(4)
+_exptl_crystal_density_diffrn  4.5794
+_symmetry_cell_setting  monoclinic
+_symmetry_space_group_name_H-M  "C 2/c"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -x,y,1/2-z
+     3  -x,-y,-z
+     4  x,-y,1/2+z
+     5  1/2+x,1/2+y,z
+     6  1/2-x,1/2+y,1/2-z
+     7  1/2-x,1/2-y,-z
+     8  1/2+x,1/2-y,1/2+z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+S1     S    0.01800     0.38330     0.11960     1.000      Uiso 0.010      8   
+S2     S    0.02910     0.11420     0.63900     1.000      Uiso 0.010      8   
+Fe3    Fe   0.10860     0.10250     0.49980     1.000      Uiso 0.010      8   
+S4     S    0.23410     0.13550     0.38260     1.000      Uiso 0.010      8   
+Fe5    Fe   0.24180     0.36600     0.24680     1.000      Uiso 0.010      8   
+S6     S    0.26790     0.13400     0.12360     1.000      Uiso 0.010      8   
+Fe7    Fe   0.38720     0.15000     0.01260     1.000      Uiso 0.010      8   
+Fe8    Fe   0.00000     0.14720     0.25000     1.000      Uiso 0.010      4   
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Fe   28     11.7695    7.3573     3.5222     2.3045     4.7611     0.3072     15.3535    76.8805    1.0369     0.945
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S    32     6.9053     5.2034     1.4379     1.5863     1.4679     22.2151    0.2536     56.172     0.8669     0.2847
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Fe7 S8"
+_chemical_formula_weight  647.41
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  S1     Fe3    2.49857      1_555    2_555 yes
+  S1     Fe5    2.4174       1_555    1_555 yes
+  S1     Fe7    2.39247      1_555    5_455 yes
+  S1     Fe7    2.4473       1_555    7_555 yes
+  S1     Fe8    2.413        1_555    1_555 yes
+  S2     Fe3    2.3821       1_555    1_555 yes
+  S2     Fe3    2.33075      1_555    3_556 yes
+  S2     Fe5    2.44766      1_555    7_556 yes
+  S2     Fe7    2.37162      1_555    8_456 yes
+  S2     Fe8    2.41553      1_555    3_556 yes
+  Fe3    S1     2.49857      1_555    2_555 yes
+  Fe3    S2     2.3821       1_555    1_555 yes
+  Fe3    S2     2.33075      1_555    3_556 yes
+  Fe3    S6     2.45518      1_555    4_556 yes
+  S4     Fe5    2.39134      1_555    1_555 yes
+  Fe5    S1     2.4174       1_555    1_555 yes
+  Fe5    S2     2.44766      1_555    7_556 yes
+  Fe5    S4     2.39134      1_555    1_555 yes
+  Fe5    S6     2.36671      1_555    1_555 yes
+  S6     Fe3    2.45518      1_555    4_555 yes
+  S6     Fe5    2.36671      1_555    1_555 yes
+  S6     Fe7    2.43689      1_555    1_555 yes
+  S6     Fe7    2.39639      1_555    7_555 yes
+  Fe7    S1     2.39247      1_555    5_545 yes
+  Fe7    S1     2.4473       1_555    7_555 yes
+  Fe7    S2     2.37162      1_555    8_555 yes
+  Fe7    S6     2.43689      1_555    1_555 yes
+  Fe7    S6     2.39639      1_555    7_555 yes
+  Fe8    S1     2.413        1_555    1_555 yes
+  Fe8    S1     2.413        1_555    2_555 yes
+  Fe8    S2     2.41553      1_555    3_556 yes
+  Fe8    S2     2.41553      1_555    4_555 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.0230(14), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_QPAPBMXHandGrindSamplePrep_phase_4
+# Information for phase 4
+_pd_block_id
+   2021-08-04T17:23|QPAPBMXHandGrindSamplePrep|phase_4|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Rutile TiO2 follows
+_pd_phase_name  "Rutile TiO2"
+_cell_length_a  4.5962(7)
+_cell_length_b  4.5962(7)
+_cell_length_c  2.9622(7)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  90
+_cell_volume  62.576(15)
+_exptl_crystal_density_diffrn  4.2404
+_symmetry_cell_setting  tetragonal
+_symmetry_space_group_name_H-M  "P 42/m n m"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  1/2-y,1/2+x,1/2+z
+     3  -x,-y,z
+     4  1/2+y,1/2-x,1/2+z
+     5  1/2-x,1/2+y,1/2+z
+     6  -y,-x,z
+     7  1/2+x,1/2-y,1/2+z
+     8  y,x,z
+     9  -x,-y,-z
+    10  1/2+y,1/2-x,1/2-z
+    11  x,y,-z
+    12  1/2-y,1/2+x,1/2-z
+    13  1/2+x,1/2-y,1/2-z
+    14  y,x,-z
+    15  1/2-x,1/2+y,1/2-z
+    16  -y,-x,-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Ti1    Ti4+ 0.00000     0.00000     0.00000     1.000      Uani 0.006      2   
+O1     O2-  0.30493     0.30493     0.00000     1.000      Uani 0.006      4   
+
+loop_
+   _atom_site_aniso_label
+   _atom_site_aniso_U_11
+   _atom_site_aniso_U_22
+   _atom_site_aniso_U_33
+   _atom_site_aniso_U_12
+   _atom_site_aniso_U_13
+   _atom_site_aniso_U_23
+Ti1    0.0070      0.0070      0.0047      -0.0002     0.0000      0.0000      
+O1     0.0060      0.0060      0.0045      -0.0019     0.0000      0.0000      
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  O    4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Ti   2      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  2
+_chemical_formula_sum  "O2 Ti"
+_chemical_formula_weight  79.9
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Ti1    O1     1.98205      1_555    1_555 yes
+  Ti1    O1     1.9497       1_555    2_544 yes
+  Ti1    O1     1.9497       1_555    2_545 yes
+  Ti1    O1     1.98205      1_555    3_555 yes
+  Ti1    O1     1.9497       1_555    4_454 yes
+  Ti1    O1     1.9497       1_555    4_455 yes
+  O1     Ti1    1.98205      1_555    1_555 yes
+  O1     Ti1    1.9497       1_555    2_554 yes
+  O1     Ti1    1.9497       1_555    2_555 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Ti1    O1     90            1_555  1_555    2_544 yes
+  O1     Ti1    O1     90            1_555  1_555    2_545 yes
+  O1     Ti1    O1     98.866        2_544  1_555    2_545 yes
+  O1     Ti1    O1     180           1_555  1_555    3_555 yes
+  O1     Ti1    O1     90            2_544  1_555    3_555 yes
+  O1     Ti1    O1     90            2_545  1_555    3_555 yes
+  O1     Ti1    O1     90            1_555  1_555    4_454 yes
+  O1     Ti1    O1     81.134        2_544  1_555    4_454 yes
+  O1     Ti1    O1     180           2_545  1_555    4_454 yes
+  O1     Ti1    O1     90            3_555  1_555    4_454 yes
+  O1     Ti1    O1     90            1_555  1_555    4_455 yes
+  O1     Ti1    O1     180           2_544  1_555    4_455 yes
+  O1     Ti1    O1     81.134        2_545  1_555    4_455 yes
+  O1     Ti1    O1     90            3_555  1_555    4_455 yes
+  O1     Ti1    O1     98.866        4_454  1_555    4_455 yes
+  Ti1    O1     Ti1    130.567       1_555  1_555    2_554 yes
+  Ti1    O1     Ti1    130.567       1_555  1_555    2_555 yes
+  Ti1    O1     Ti1    98.866        2_554  1_555    2_555 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    1.000, 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_QPAPBMXHandGrindSamplePrep_phase_1
+# Information for phase 1
+_pd_block_id
+   2021-08-04T17:23|QPAPBMXHandGrindSamplePrep|phase_1|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Silica SiO2 follows
+_pd_phase_name  "Silica SiO2"
+_cell_length_a  4.9135(3)
+_cell_length_b  4.9135(3)
+_cell_length_c  5.40577(30)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  120
+_cell_volume  113.026(7)
+_exptl_crystal_density_diffrn  2.6482
+_symmetry_cell_setting  trigonal
+_symmetry_space_group_name_H-M  "P 32 2 1"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -y,x-y,2/3+z
+     3  y-x,-x,1/3+z
+     4  y,x,-z
+     5  -x,y-x,2/3-z
+     6  x-y,-y,1/3-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Si1    Si4+ 0.47000     0.00000     0.66670     1.000      Uani 0.006      3   
+O1     O2-  0.41460     0.26780     0.78543     1.000      Uani 0.011      6   
+
+loop_
+   _atom_site_aniso_label
+   _atom_site_aniso_U_11
+   _atom_site_aniso_U_22
+   _atom_site_aniso_U_33
+   _atom_site_aniso_U_12
+   _atom_site_aniso_U_13
+   _atom_site_aniso_U_23
+Si1    0.0073      0.0059      0.0053      0.0029      0.0003      0.0006      
+O1     0.0120      0.0105      0.0118      0.0065      -0.0029     -0.0040     
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  O    6      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si   3      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  3
+_chemical_formula_sum  "O2 Si"
+_chemical_formula_weight  60.08
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Si1    O1     1.60489      1_555    1_555 yes
+  Si1    O1     1.6114       1_555    2_654 yes
+  Si1    O1     1.61114      1_555    5_656 yes
+  Si1    O1     1.60504      1_555    6_556 yes
+  O1     Si1    1.60489      1_555    1_555 yes
+  O1     Si1    1.6114       1_555    3_665 yes
+  O1     Si1    1.61114      1_555    5_666 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Si1    O1     110.262       1_555  1_555    2_654 yes
+  O1     Si1    O1     108.732       1_555  1_555    5_656 yes
+  O1     Si1    O1     109.697       2_654  1_555    5_656 yes
+  O1     Si1    O1     109.164       1_555  1_555    6_556 yes
+  O1     Si1    O1     108.712       2_654  1_555    6_556 yes
+  O1     Si1    O1     110.268       5_656  1_555    6_556 yes
+  Si1    O1     Si1    143.832       1_555  1_555    3_665 yes
+  Si1    O1     Si1    143.836       1_555  1_555    5_666 yes
+  Si1    O1     Si1    0.009         3_665  1_555    5_666 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.263(14), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_QPAPBMXHandGrindSamplePrep_pwd_0
+_pd_proc_ls_profile_function
+;
+Finger-Cox-Jephcoat function parameters U, V, W, X, Y, SH/L:
+  peak variance(Gauss) = Utan(Th)^2^+Vtan(Th)+W:
+  peak HW(Lorentz) = X/cos(Th)+Ytan(Th); SH/L = S/L+H/L
+  U, V, W in (centideg)^2^, X & Y in centideg
+    0.000, 0.000, 3.345, 2.239, -0.670, 0.034, 
+;
+# Information for histogram 0: PWDR 201103PBHMR1_PyriteHandGrind.xrdml Scan 1
+_pd_block_id
+;
+2021-08-04T17:23|QPAPBMXHandGrindSamplePrep|McDougallHamish|PANalytical,Co-EmpyreanII_hist_0
+;
+# GSAS-II edited template follows Instrument_Template
+#==============================================================================
+# 9. INSTRUMENT CHARACTERIZATION
+
+_exptl_special_details
+; ?
+;
+
+# if regions of the data are excluded, the reason(s) are supplied here:
+_pd_proc_info_excluded_regions
+; ?
+;
+
+# The following item is used to identify the equipment used to record 
+# the powder pattern when the diffractogram was measured at a laboratory 
+# other than the authors' home institution, e.g. when neutron or synchrotron
+# radiation is used.
+
+_pd_instr_location
+; ?
+;
+_pd_calibration_special_details           # description of the method used
+                                          # to calibrate the instrument
+; ?
+;
+
+_diffrn_source                    Co-Ka       
+_diffrn_source_target             Co
+_diffrn_source_type               Graded_Flat
+_diffrn_measurement_device_type   Panalytical_Reflection_Transmission       
+_diffrn_detector                  PIXcel1D       
+_diffrn_detector_type             Empyrean_II       # make or model of detector
+
+_pd_meas_scan_method              ?       # options are 'step', 'cont',
+                                          # 'tof', 'fixed' or
+                                          # 'disp' (= dispersive)
+_pd_meas_special_details
+;  ?
+;
+
+# The following two items identify the program(s) used (if appropriate).
+_computing_data_collection        ?        
+_computing_data_reduction         ?                   
+
+# Describe any processing performed on the data, prior to refinement.
+# For example: a manual Lp correction or a precomputed absorption correction
+_pd_proc_info_data_reduction      ?
+
+# The following item is used for angular dispersive measurements only.
+
+_diffrn_radiation_monochromator   ?        
+
+# The following items are used to define the size of the instrument.
+# Not all distances are appropriate for all instrument types.
+
+_pd_instr_dist_src/mono           ?
+_pd_instr_dist_mono/spec          ?
+_pd_instr_dist_src/spec           ?
+_pd_instr_dist_spec/anal          ?
+_pd_instr_dist_anal/detc          ?
+_pd_instr_dist_spec/detc          ?
+
+# 10. Specimen size and mounting information
+
+# The next three fields give the specimen dimensions in mm.  The equatorial 
+# plane contains the incident and diffracted beam.
+
+_pd_spec_size_axial               ?       # perpendicular to 
+                                          # equatorial plane
+
+_pd_spec_size_equat               ?       # parallel to 
+                                          # scattering vector 
+                                          # in transmission
+
+_pd_spec_size_thick               ?       # parallel to 
+                                          # scattering vector 
+                                          # in reflection
+
+_pd_spec_mounting                         # This field should be
+                                          # used to give details of the 
+                                          # container.
+; ?
+;
+
+_pd_spec_mount_mode               ?       # options are 'reflection' 
+                                          # or 'transmission'
+    
+_pd_spec_shape                    ?       # options are 'cylinder' 
+                                          # 'flat_sheet' or 'irregular'
+
+
+loop_
+     _atom_type_symbol
+     _atom_type_scat_dispersion_real
+     _atom_type_scat_dispersion_imag
+     _atom_type_scat_dispersion_source
+  Al        0.255   0.328   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Fe       -3.332   0.490   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Na        0.167   0.167   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  O         0.063   0.044   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S         0.371   0.733   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si        0.298   0.438   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Ti       -0.063   2.321   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+_diffrn_radiation_type  K\a~1,2~
+loop_
+   _diffrn_radiation_wavelength
+   _diffrn_radiation_wavelength_wt
+   _diffrn_radiation_wavelength_id
+  1.78892         1.0             1     
+  1.79278         0.5000          2     
+
+# PHASE TABLE
+loop_
+   _pd_phase_id
+   _pd_phase_block_id
+   _pd_phase_mass_%
+  2  2021-08-04T17:23|QPAPBMXHandGrindSamplePrep|phase_2|McDougallHamish  0.0929(20)
+  0  2021-08-04T17:23|QPAPBMXHandGrindSamplePrep|phase_0|McDougallHamish  0.752(3)
+  3  2021-08-04T17:23|QPAPBMXHandGrindSamplePrep|phase_3|McDougallHamish  0.0708(20)
+  4  2021-08-04T17:23|QPAPBMXHandGrindSamplePrep|phase_4|McDougallHamish  0.0041(4)
+  1  2021-08-04T17:23|QPAPBMXHandGrindSamplePrep|phase_1|McDougallHamish  0.0802(11)
+loop_
+   _gsas_proc_phase_R_F_factor
+   _gsas_proc_phase_R_Fsqd_factor
+   _gsas_proc_phase_id
+   _gsas_proc_phase_block_id
+    0.15957  0.44825  2  2021-08-04T17:23|QPAPBMXHandGrindSamplePrep|phase_2|McDougallHamish
+    0.05236  0.07424  0  2021-08-04T17:23|QPAPBMXHandGrindSamplePrep|phase_0|McDougallHamish
+    0.08966  0.20282  3  2021-08-04T17:23|QPAPBMXHandGrindSamplePrep|phase_3|McDougallHamish
+    0.10514  0.25185  4  2021-08-04T17:23|QPAPBMXHandGrindSamplePrep|phase_4|McDougallHamish
+    0.12224  0.27272  1  2021-08-04T17:23|QPAPBMXHandGrindSamplePrep|phase_1|McDougallHamish
+_pd_proc_ls_prof_R_factor     0.10502
+_pd_proc_ls_prof_wR_factor    0.14998
+_gsas_proc_ls_prof_R_B_factor   0.12461
+_gsas_proc_ls_prof_wR_B_factor  0.16565
+_pd_proc_ls_prof_wR_expected  0.06059
+_diffrn_radiation_probe  x-ray
+_diffrn_radiation_polarisn_ratio  0.7000
+_pd_proc_ls_background_function
+;
+Background function: "chebyschev-1" function with 7 terms:
+    188.5(8), -242.5(13), 149.2(12), -71.5(10), 28.4(10), -6.6(8), 
+    3.0(7), 
+;
+_diffrn_ambient_temperature  300
+_diffrn_ambient_pressure  100
+
+# STRUCTURE FACTOR TABLE
+loop_
+   _pd_refln_phase_id
+   _refln_index_h
+   _refln_index_k
+   _refln_index_l
+   _refln_F_squared_meas
+   _refln_F_squared_calc
+   _refln_phase_calc
+   _refln_d_spacing
+   _gsas_i100_meas
+  0  1    1    1    757.0510   672.7758   0.0     3.12866  20.31  
+  0  2    0    0    6721.4934  6248.9158  -0.0    2.70950  100.00 
+  0  2    1    0    2521.8354  2684.7009  0.0     2.42345  59.27  
+  0  2    1    1    1412.9392  1381.6310  -180.0  2.21230  54.75  
+  0  2    2    0    2584.4971  2755.3249  -0.0    1.91591  36.97  
+  0  2    2    1    53.7371    50.0462    -0.0    1.80633  1.36   
+  0  3    1    1    3747.4061  3661.9697  -0.0    1.63389  77.51  
+  0  2    2    2    1710.5925  1693.8210  0.0     1.56433  10.85  
+  0  3    0    2    2050.6608  2176.9056  -0.0    1.50296  18.12  
+  0  3    1    2    322.3112   282.9653   0.0     1.44829  5.34   
+  0  3    2    1    1345.8224  1181.5323  180.0   1.44829  22.30  
+  0  4    0    0    513.5634   161.3838   -180.0  1.35475  1.92   
+  0  3    2    2    37.6323    47.8745    -0.0    1.31430  0.54   
+  0  4    1    0    83.4776    106.1973   -0.0    1.31430  0.60   
+  0  4    1    1    63.0337    58.1413    180.0   1.27727  0.87   
+  1  1    0    0    159.8976   242.4765   180.0   4.25525  0.69   
+  1  1    0    -1   2032.3431  1509.1214  -120.0  3.34362  5.34   
+  1  1    0    1    854.3184   634.3762   120.0   3.34362  2.24   
+  1  1    1    0    275.5435   343.6538   -155.6  2.45677  0.38   
+  1  1    0    -2   72.4226    86.1201    -60.0   2.28153  0.09   
+  1  1    0    2    251.3070   298.8374   -120.0  2.28153  0.30   
+  1  1    1    1    80.3155    96.0078    82.9    2.23662  0.18   
+  1  2    0    0    348.9038   308.9373   0.0     2.12763  0.35   
+  1  2    0    -1   83.3855    77.1778    60.0    1.97980  0.07   
+  1  2    0    1    199.6907   184.8246   -60.0   1.97980  0.17   
+  1  1    1    2    564.7279   602.6435   9.8     1.81800  0.82   
+  1  0    0    3    99.8428    94.4664    0.0     1.80192  0.02   
+  1  2    0    -2   611.5467   364.0082   120.0   1.67181  0.38   
+  1  2    0    2    137.8345   82.0426    60.0    1.67181  0.08   
+  1  1    0    -3   148.9813   203.8147   180.0   1.65928  0.09   
+  1  1    0    3    1.8869     2.5814     0.0     1.65928  0.00   
+  1  2    1    0    13.0265    14.6199    -38.9   1.60833  0.01   
+  1  2    1    -1   267.7199   356.0952   95.9    1.54155  0.28   
+  1  2    1    1    230.5283   306.6265   -109.6  1.54155  0.24   
+  1  1    1    3    172.9621   142.5308   117.5   1.45300  0.16   
+  1  3    0    0    82.1286    76.2961    180.0   1.41842  0.04   
+  1  2    1    -2   373.4253   413.6199   -123.3  1.38215  0.33   
+  1  2    1    2    115.9199   128.3973   143.4   1.38215  0.10   
+  1  2    0    -3   229.1502   292.6199   -0.0    1.37505  0.10   
+  1  2    0    3    806.6028   1030.0148  0.0     1.37505  0.35   
+  1  3    0    -1   564.1005   815.3070   -120.0  1.37197  0.24   
+  1  3    0    1    0.6985     1.0096     -60.0   1.37197  0.00   
+  1  1    0    -4   92.6785    120.2775   -120.0  1.28804  0.04   
+  1  1    0    4    305.4179   396.3690   120.0   1.28804  0.12   
+  2  0    0    1    1132.4208  685.7647   180.0   6.38835  0.21   
+  2  0    2    0    642.5380   396.4120   180.0   6.37631  0.00   
+  2  1    1    0    345.4458   238.2377   -0.0    6.33920  0.00   
+  2  1    -1   0    512.3787   287.5556   -0.0    6.30570  0.00   
+  2  1    1    -1   789.4884   406.2236   180.0   5.90977  0.01   
+  2  1    -1   -1   302.4063   415.7013   -180.0  5.58902  0.00   
+  2  0    2    -1   19.7937    16.5801    0.0     4.66336  0.00   
+  2  0    2    1    2.3022     1.8366     180.0   4.37627  0.00   
+  2  2    0    -1   53089.9501 21043.8193 -0.0    4.02974  0.13   
+  2  1    -1   1    9376.0722  3768.5551  -0.0    3.85493  0.06   
+  2  1    1    1    10791.6372 10390.7983 0.0     3.77579  0.14   
+  2  1    3    0    15323.6802 5886.5192  180.0   3.68077  0.04   
+  2  1    3    -1   12048.3803 4505.2577  0.0     3.66511  0.02   
+  2  1    -3   0    26286.8632 11680.2050 180.0   3.66110  0.05   
+  2  2    0    0    2.9185     2.5832     0.0     3.64003  0.00   
+  2  1    1    -2   6160.2173  4328.6309  0.0     3.50528  0.05   
+  2  2    2    -1   3313.1549  1650.0335  180.0   3.48090  0.01   
+  2  1    -3   -1   59.9698    12.1173    0.0     3.43836  0.00   
+  2  1    -1   -2   4449.9394  5251.8386  0.0     3.37324  0.06   
+  2  2    -2   -1   474.6157   365.3694   0.0     3.33662  0.00   
+  2  2    0    -2   29754.3180 26661.3008 -180.0  3.21586  0.08   
+  2  0    0    2    42022.7302 37073.7643 -180.0  3.19418  1.92   
+  2  0    4    0    32992.7950 25367.4849 180.0   3.18815  0.05   
+  2  2    2    0    21216.0457 13873.9510 180.0   3.16960  0.05   
+  2  2    -2   0    21254.5061 14956.5420 -180.0  3.15285  0.03   
+  2  1    -3   1    11740.7455 11180.6996 -180.0  2.96651  0.02   
+  2  2    2    -2   5785.6845  7187.5807  0.0     2.95488  0.01   
+  2  0    2    -2   13475.7326 5311.3929  0.0     2.93134  0.06   
+  2  0    4    -1   18608.9451 8588.0866  0.0     2.92784  0.03   
+  2  1    3    1    7075.1568  6896.7891  180.0   2.86082  0.03   
+  2  1    3    -2   2819.7057  1923.1952  -0.0    2.83887  0.01   
+  2  2    -2   -2   189.5101   183.4864   -0.0    2.79451  0.00   
+  2  0    2    2    121.6317   191.6420   0.0     2.78596  0.00   
+  2  0    4    1    223.6842   387.5366   -0.0    2.78296  0.00   
+  2  2    0    1    108.1675   109.7875   -0.0    2.68830  0.00   
+  2  3    1    -1   222.8414   431.0564   -180.0  2.66389  0.00   
+  2  1    -3   -2   6123.3101  6172.5327  -0.0    2.63917  0.02   
+  2  3    -1   -1   28.7115    33.5494    -180.0  2.62768  0.00   
+  2  2    4    -1   16450.4604 12549.4355 -180.0  2.55929  0.02   
+  2  3    1    -2   2200.3700  1812.0601  180.0   2.53773  0.00   
+  2  1    -1   2    1067.4526  666.9371   180.0   2.51226  0.01   
+  2  2    -2   1    1896.3802  1688.6024  -180.0  2.49702  0.00   
+  2  3    -1   -2   585.6458   449.9332   180.0   2.48219  0.00   
+  2  1    1    2    124.4022   110.2132   180.0   2.46626  0.00   
+  2  2    2    1    1059.5602  1367.0996  -180.0  2.45772  0.00   
+  2  2    -4   -1   9949.5121  10458.4667 -180.0  2.44517  0.01   
+  2  1    5    -1   4337.5148  4093.4339  -0.0    2.42932  0.00   
+  2  1    5    0    58.4124    63.9704    180.0   2.41171  0.00   
+  2  2    4    0    4102.5031  3942.6705  -0.0    2.40566  0.00   
+  2  1    -5   0    2430.0064  2235.9855  180.0   2.40247  0.00   
+  2  2    -4   0    2227.4639  2082.2215  -0.0    2.39103  0.00   
+  2  3    1    0    1928.8180  1564.7419  -0.0    2.38661  0.00   
+  2  3    -1   0    2934.0859  2088.1418  -0.0    2.38122  0.00   
+  2  2    0    -3   10.7028    7.3573     180.0   2.35170  0.00   
+  2  2    4    -2   4.7066     2.9337     0.0     2.34690  0.00   
+  2  1    1    -3   185.9498   110.8614   -0.0    2.33668  0.00   
+  2  0    4    -2   1664.9878  885.2704   -180.0  2.33168  0.00   
+  2  3    3    -1   34063.7193 9809.4418  180.0   2.31746  0.03   
+  2  1    -5   -1   3713.8596  1044.3756  0.0     2.31652  0.00   
+  2  1    -1   -3   1533.2044  2291.8461  -0.0    2.27768  0.02   
+  2  2    2    -3   173.2617   155.7072   -0.0    2.26145  0.00   
+  2  3    3    -2   21.5110    15.9276    0.0     2.25050  0.00   
+  2  3    -3   -1   3294.0135  2706.2986  -180.0  2.24772  0.00   
+  2  1    -3   2    797.5116   823.6349   -0.0    2.22680  0.00   
+  2  2    -4   -2   1279.2789  1432.3442  0.0     2.18948  0.00   
+  2  0    4    2    1841.4441  2085.0733  0.0     2.18813  0.01   
+  2  1    -5   1    3671.0340  4195.9129  180.0   2.18652  0.00   
+  2  2    -2   -3   1292.9067  1852.6924  0.0     2.15521  0.00   
+  2  1    5    -2   207.4640   312.5636   -180.0  2.15181  0.00   
+  2  3    -3   -2   392.9352   514.4958   180.0   2.13920  0.00   
+  2  3    1    -3   164.2781   204.6552   0.0     2.13861  0.00   
+  2  1    3    2    147.2534   174.3368   -180.0  2.13411  0.00   
+  2  0    0    3    479.9260   454.6694   -0.0    2.12945  0.01   
+  2  0    6    0    18390.2194 11046.7060 -0.0    2.12544  0.01   
+  2  1    3    -3   916.4124   674.5582   -180.0  2.11891  0.00   
+  2  1    5    1    4521.3943  4734.7861  180.0   2.11563  0.01   
+  2  3    3    0    1539.7385  1496.7653  -180.0  2.11307  0.00   
+  2  3    -3   0    175.5466   181.3393   -180.0  2.10190  0.00   
+  2  3    -1   -3   2899.6564  2417.9444  0.0     2.09067  0.00   
+  2  2    -4   1    13236.4244 8387.1524  180.0   2.07800  0.01   
+  2  0    2    -3   294.6493   286.9831   -180.0  2.05944  0.00   
+  2  0    6    -1   95.2160    83.9146    -0.0    2.05621  0.00   
+  2  2    4    1    3776.8667  2722.4107  180.0   2.03310  0.01   
+  2  4    0    -2   1804.3412  1675.9000  -0.0    2.01487  0.00   
+  2  1    -5   -2   1216.7208  978.1835   -0.0    2.00623  0.00   
+  2  4    0    -1   4140.1369  3213.2483  -0.0    2.00158  0.00   
+  2  2    0    2    954.6674   915.2009   0.0     1.99890  0.00   
+  2  1    -3   -3   2085.2020  2006.9959  -0.0    1.99378  0.01   
+  2  0    2    3    1154.1817  1320.4867  0.0     1.98235  0.02   
+  2  0    6    1    5238.8521  4761.0232  0.0     1.97947  0.00   
+  2  3    -1   1    1582.0882  1781.9764  0.0     1.97296  0.00   
+  2  3    3    -3   731.0263   747.3311   -180.0  1.96992  0.00   
+  2  3    1    1    1133.3991  1050.9711  0.0     1.96411  0.00   
+  2  2    4    -3   190.6037   210.4912   -180.0  1.96325  0.00   
+  2  4    2    -2   1430.0906  1505.4469  0.0     1.94762  0.00   
+  2  2    -2   2    4633.7749  4437.2487  -0.0    1.92746  0.01   
+  2  4    2    -1   196.7045   195.4576   0.0     1.92441  0.00   
+  2  2    6    -1   24.4565    25.6550    -0.0    1.91739  0.00   
+  2  4    -2   -2   14966.2422 14631.1918 -0.0    1.89589  0.01   
+  2  4    -2   -1   88.4079    83.9565    180.0   1.89533  0.00   
+  2  2    2    2    9019.8939  11148.7231 -0.0    1.88789  0.03   
+  2  3    5    -1   2655.3059  3251.7822  -180.0  1.88756  0.00   
+  2  3    -3   -3   288.4281   242.0551   -0.0    1.86301  0.00   
+  2  3    5    -2   180.0231   151.8892   -180.0  1.86081  0.00   
+  2  4    0    -3   45170.8803 17240.5285 -180.0  1.85042  0.03   
+  2  2    -6   -1   1580.9218  630.6748   -180.0  1.84465  0.00   
+  2  1    -5   2    74.3309    32.7394    -180.0  1.84401  0.00   
+  2  2    6    0    10236.2683 5972.5447  -0.0    1.84039  0.01   
+  2  2    6    -2   4060.5257  2234.2310  -180.0  1.83255  0.00   
+  2  2    -6   0    14347.8493 11181.5242 0.0     1.83055  0.01   
+  2  1    -1   3    2904.8635  2404.9621  -180.0  1.83002  0.01   
+  2  2    -4   -3   489.9467   351.0141   -0.0    1.82893  0.00   
+  2  0    4    -3   8382.3923  6601.7381  180.0   1.82508  0.01   
+  2  3    -5   -1   696.6278   548.8976   -180.0  1.82505  0.00   
+  2  0    6    -2   11816.0018 9381.3005  -180.0  1.82367  0.01   
+  2  4    0    0    17215.4512 16559.4268 -0.0    1.82001  0.01   
+  2  3    -3   1    1522.5170  1388.1866  -0.0    1.81438  0.00   
+  2  4    2    -3   1846.6913  1698.6376  -0.0    1.80705  0.00   
+  2  1    1    3    10469.5943 13206.5125 -180.0  1.80281  0.11   
+  2  3    3    1    1606.0277  659.8969   -0.0    1.79394  0.00   
+  2  1    5    -3   90.5381    36.9259    180.0   1.79173  0.00   
+  2  1    7    -1   360.4221   370.2194   -180.0  1.78560  0.00   
+  2  2    0    -4   24322.8239 29308.4798 0.0     1.78474  0.08   
+  2  1    7    0    2393.0923  1186.8843  -0.0    1.76987  0.00   
+  2  1    -7   0    5664.1134  1864.1693  0.0     1.76475  0.00   
+  2  3    5    0    691.9013   192.4465   -180.0  1.76350  0.00   
+  2  1    5    2    5940.5958  1478.0487  -180.0  1.75705  0.01   
+  2  3    -5   -2   1169.3282  293.8707   -180.0  1.75701  0.00   
+  2  4    2    0    6505.4327  3241.7093  180.0   1.75297  0.00   
+  2  3    -5   0    1.2250     0.6701     -180.0  1.75270  0.00   
+  2  2    2    -4   9657.5433  5374.5367  180.0   1.75264  0.02   
+  2  4    -2   -3   1781.7852  1501.3542  -180.0  1.74860  0.00   
+  2  4    -2   0    1595.9335  1480.3538  -180.0  1.74728  0.00   
+  2  4    4    -2   9726.5924  11156.6958 -180.0  1.74045  0.00   
+  2  3    1    -4   8.5290     11.6952    0.0     1.73811  0.00   
+  2  1    1    -4   403.9072   931.7255   180.0   1.73054  0.00   
+  2  2    -4   2    4667.2816  5117.1459  -180.0  1.72195  0.00   
+  2  1    -7   -1   499.3939   545.0225   -0.0    1.72182  0.00   
+  2  0    4    3    1587.3506  1649.4526  180.0   1.72106  0.01   
+  2  0    6    2    4373.8026  4043.5236  180.0   1.71988  0.00   
+  2  2    -6   -2   6380.0623  5848.5073  180.0   1.71918  0.00   
+  2  1    -3   3    3937.7656  3892.2158  0.0     1.71826  0.01   
+  2  4    4    -1   3209.5575  3425.5582  -0.0    1.71591  0.00   
+  2  3    -1   -4   13.6526    26.3186    -0.0    1.70431  0.00   
+  2  3    5    -3   992.5166   1781.6481  180.0   1.70021  0.00   
+  2  1    -1   -4   619.1825   1087.4011  180.0   1.69848  0.01   
+  2  2    -2   -4   5653.4161  6608.9731  -0.0    1.68662  0.02   
+  2  2    -6   1    101.7376   111.9394   180.0   1.68555  0.00   
+  2  1    -7   1    1480.5687  1038.6759  0.0     1.68099  0.00   
+  2  4    -4   -1   5889.0107  3117.2039  -0.0    1.67520  0.00   
+  2  1    7    -2   5195.8299  3014.8201  0.0     1.67354  0.00   
+  2  4    -4   -2   4198.3997  3003.2514  -180.0  1.66831  0.00   
+  2  1    -5   -3   417.4916   322.9253   -180.0  1.66769  0.00   
+  2  2    4    2    7689.3215  6979.3358  -180.0  1.66653  0.01   
+  2  1    3    3    575.5586   605.5004   0.0     1.65306  0.00   
+  2  3    3    -4   479.1649   474.6538   180.0   1.65081  0.00   
+  2  2    6    1    14.1636    15.0367    180.0   1.64960  0.00   
+  2  4    4    -3   90.2504    81.4955    0.0     1.64484  0.00   
+  2  1    3    -4   1469.6772  1267.2150  -180.0  1.64315  0.00   
+  2  2    6    -3   442.1147   438.4626   0.0     1.63836  0.00   
+  2  1    7    1    1049.0036  959.5955   0.0     1.63551  0.00   
+  2  5    1    -2   53.0673    62.4140    -180.0  1.62197  0.00   
+  2  2    4    -4   6.1927     6.6339     0.0     1.60884  0.00   
+  2  3    -1   2    217.3057   237.2790   -180.0  1.60863  0.00   
+  2  4    0    -4   21.8066    25.6125    0.0     1.60793  0.00   
+  2  5    -1   -2   89.5826    104.9300   -0.0    1.60609  0.00   
+  2  3    1    2    4.9998     3.3551     -180.0  1.59744  0.00   
+  2  0    0    4    2568.3679  1719.8128  -0.0    1.59709  0.03   
+  2  0    8    0    8447.5653  4107.3731  -0.0    1.59408  0.00   
+  2  3    -5   -3   6084.4300  7051.8599  -180.0  1.58781  0.00   
+  2  4    2    -4   4235.5013  5769.4576  -180.0  1.58539  0.00   
+  2  4    4    0    58.0469    80.5808    180.0   1.58480  0.00   
+  2  3    -5   1    3308.3567  3544.9333  0.0     1.58147  0.00   
+  2  4    -4   0    761.2732   974.4663   180.0   1.57643  0.00   
+  2  1    -7   -2   86.5577    106.0891   180.0   1.57618  0.00   
+  2  4    0    1    1319.7864  1313.3069  0.0     1.57488  0.00   
+  2  5    1    -1   1367.4823  1840.0940  0.0     1.57300  0.00   
+  2  0    2    -4   5079.0117  6838.2135  -180.0  1.57293  0.02   
+  2  5    1    -3   5.2738     4.5439     0.0     1.57119  0.00   
+  2  0    8    -1   5622.1198  5108.4047  -180.0  1.57024  0.00   
+  2  3    -3   -4   234.3951   221.8879   -180.0  1.56802  0.00   
+  2  1    -3   -4   1170.7114  1168.3569  -180.0  1.56449  0.01   
+  2  5    -1   -1   3530.7003  3534.7232  -0.0    1.56443  0.00   
+  2  2    0    3    1670.1964  1763.7846  -180.0  1.55948  0.00   
+  2  4    -4   -3   627.1652   668.8022   0.0     1.55937  0.00   
+  2  3    5    1    6160.4717  6629.8139  -0.0    1.55901  0.00   
+  2  0    6    -3   45.8721    50.4743    180.0   1.55445  0.00   
+  2  5    -1   -3   2205.6108  3178.4708  180.0   1.55089  0.00   
+  2  5    3    -2   1264.7700  1684.4282  0.0     1.53983  0.00   
+  2  3    7    -1   284.7945   254.9952   -0.0    1.53513  0.00   
+  2  4    -2   -4   5763.2382  4568.5821  180.0   1.53411  0.00   
+  2  4    -2   1    390.0974   360.8410   -0.0    1.53262  0.00   
+  2  2    -2   3    2961.7133  3887.2133  0.0     1.53039  0.00   
+  2  1    -5   3    91.9210    114.2935   180.0   1.52853  0.00   
+  2  0    2    4    914.2310   1999.3181  180.0   1.52657  0.01   
+  2  3    7    -2   761.6230   1417.6635  180.0   1.52614  0.00   
+  2  4    2    1    48.7587    55.0449    -0.0    1.52528  0.00   
+  2  3    -3   2    762.1923   712.8094   0.0     1.52463  0.00   
+  2  0    8    1    56.4292    53.5251    0.0     1.52410  0.00   
+  2  2    -6   -3   1060.9512  973.4366   180.0   1.52179  0.00   
+  2  1    -7   2    2774.6440  2094.6801  180.0   1.51499  0.00   
+  2  2    -4   -4   4394.0859  3476.1609  -180.0  1.51046  0.01   
+  2  2    8    -1   9976.3412  8931.5081  0.0     1.50665  0.00   
+  2  5    3    -3   10772.6453 11219.2542 -0.0    1.50142  0.00   
+  2  5    -3   -2   1235.7868  1283.3353  0.0     1.50004  0.00   
+  2  2    2    3    244.0772   261.5188   0.0     1.49974  0.00   
+  2  4    6    -2   1602.9695  1643.3830  -180.0  1.49770  0.00   
+  2  3    3    2    2933.3596  2828.5069  0.0     1.49653  0.00   
+  2  5    3    -1   1865.1792  1376.0279  180.0   1.49254  0.00   
+  2  1    7    -3   1229.5806  964.3274   -0.0    1.49160  0.00   
+  2  3    -7   -1   4.7478     4.1999     -180.0  1.48788  0.00   
+  2  3    5    -4   1111.6897  976.8667   0.0     1.48729  0.00   
+  2  2    -6   2    1807.6277  2226.8314  -180.0  1.48326  0.00   
+  2  1    5    -4   400.9935   569.1069   -0.0    1.48082  0.00   
+  2  4    4    -4   922.8719   936.7134   -0.0    1.47744  0.00   
+  2  4    6    -1   2415.1375  2424.8622  -0.0    1.47693  0.00   
+  2  5    -3   -1   3293.7024  2253.8519  180.0   1.47087  0.00   
+  2  2    8    -2   3608.4472  2036.6636  -0.0    1.46934  0.00   
+  2  0    4    -4   3407.8441  1799.7706  0.0     1.46567  0.00   
+  2  0    8    -2   5161.0264  2671.9714  0.0     1.46392  0.00   
+  2  2    8    0    33247.8044 17370.7343 180.0   1.46351  0.01   
+  2  3    7    0    2173.9188  1344.1131  -0.0    1.46125  0.00   
+  2  2    -8   -1   390.2022   277.7262   0.0     1.45912  0.00   
+  2  0    6    3    12391.1487 9727.7514  -180.0  1.45876  0.02   
+  2  2    -8   0    24447.3424 14988.7252 -180.0  1.45690  0.01   
+  2  1    5    3    103.9002   84.4671    0.0     1.45338  0.00   
+  2  3    -7   0    2184.6275  1877.7552  -0.0    1.45264  0.00   
+  2  5    -3   -3   4844.1317  3977.9159  -0.0    1.45001  0.00   
+  2  5    1    0    543.8388   469.7462   0.0     1.44762  0.00   
+  2  1    7    2    412.0002   339.7406   180.0   1.44722  0.00   
+  2  5    -1   0    331.9030   283.8520   0.0     1.44561  0.00   
+  2  3    -7   -2   476.3340   408.0009   -180.0  1.44559  0.00   
+  2  5    1    -4   434.0471   376.3042   -0.0    1.44479  0.00   
+  2  4    6    -3   4998.5816  4798.5294  180.0   1.44009  0.00   
+  2  3    7    -3   1998.4605  2066.7908  0.0     1.43834  0.00   
+  2  4    -6   -1   14007.2040 13999.2250 -0.0    1.43815  0.00   
+  2  1    -1   4    1818.1846  1748.3144  -0.0    1.43185  0.01   
+  2  2    6    2    14479.8273 14125.2857 -180.0  1.43041  0.01   
+  2  4    -6   -2   14122.3206 11512.2174 -180.0  1.42921  0.00   
+  2  2    -4   3    13619.0605 9314.3328  -0.0    1.42576  0.01   
+  2  3    1    -5   104.3459   54.5613    0.0     1.42510  0.00   
+  2  5    -1   -4   12973.3505 6194.5216  0.0     1.42444  0.01   
+  2  2    0    -5   781.5911   530.7241   -0.0    1.41979  0.00   
+  2  2    6    -4   5296.9358  4109.5441  -0.0    1.41943  0.00   
+  2  4    -4   1    2048.0122  2331.0537  -180.0  1.41782  0.00   
+  2  1    1    4    6493.1127  9766.5845  -0.0    1.41427  0.05   
+  2  2    2    -5   338.2455   102.1717   180.0   1.40780  0.00   
+  2  4    4    1    19850.8489 4251.4610  -180.0  1.40625  0.01   
+  2  1    9    -1   1187.1398  313.3291   180.0   1.40438  0.00   
+  2  3    -1   -5   1771.2408  559.5402   180.0   1.40198  0.00   
+  2  4    -4   -4   716.1354   334.4149   -180.0  1.39725  0.00   
+  2  5    5    -2   232.3880   121.8382   180.0   1.39676  0.00   
+  2  5    3    -4   15626.1607 10292.8662 -180.0  1.39419  0.01   
+  2  0    4    4    696.9643   603.2748   180.0   1.39298  0.00   
+  2  1    9    0    7793.1352  6061.6196  -180.0  1.39246  0.00   
+  2  0    8    2    949.9134   842.1064   -0.0    1.39148  0.00   
+  2  1    -7   -3   9.0784     8.6388     0.0     1.39111  0.00   
+  2  2    -8   -2   451.1602   389.2731   0.0     1.39040  0.00   
+  2  1    -9   0    6266.7660  5036.1864  -180.0  1.38925  0.00   
+  2  3    -5   -4   924.9234   714.2717   180.0   1.38894  0.00   
+  2  1    -5   -4   11.2602    12.2639    -0.0    1.38719  0.00   
+  2  4    6    0    6460.1210  6881.3324  0.0     1.38665  0.00   
+  2  2    -8   1    3122.3602  2589.0744  -0.0    1.38467  0.00   
+  2  3    -5   2    102.5244   107.3821   180.0   1.38257  0.00   
+  2  1    -3   4    9377.0267  11503.5261 180.0   1.38045  0.01   
+  2  5    3    0    1739.7195  2065.5040  180.0   1.38006  0.00   
+  2  3    3    -5   524.8514   601.4217   -0.0    1.37985  0.00   
+  2  4    -6   0    2457.7663  2933.5616  0.0     1.37825  0.00   
+  2  2    4    3    5809.4471  7682.8626  -0.0    1.37724  0.01   
+  2  5    -3   0    1344.2518  1849.8117  -180.0  1.37486  0.00   
+  2  4    0    -5   7415.0508  9855.5152  -0.0    1.37293  0.01   
+  2  5    5    -3   621.7409   1000.1579  -0.0    1.37191  0.00   
+  2  1    1    -5   53.8389    51.8485    180.0   1.36885  0.00   
+  2  2    8    -3   1226.9308  897.3178   0.0     1.36737  0.00   
+  2  2    -2   -5   1158.8934  891.2006   -180.0  1.36490  0.00   
+  2  1    -9   -1   3371.5834  2521.6117  180.0   1.36405  0.00   
+  2  4    2    -5   12263.9728 11337.4504 180.0   1.36275  0.01   
+  2  2    8    1    6761.0856  3611.4778  -180.0  1.35801  0.00   
+  2  5    5    -1   2111.3437  870.3877   -180.0  1.35726  0.00   
+  2  4    -6   -3   12514.6815 4131.6380  180.0   1.35503  0.00   
+  2  3    -7   1    2009.1796  578.8574   0.0     1.35446  0.00   
+  2  6    0    -2   37113.7999 16999.9716 180.0   1.35222  0.01   
+  2  1    9    -2   36437.3896 16151.5223 0.0     1.35170  0.01   
+  2  1    -9   1    8621.9295  3743.5555  -0.0    1.35110  0.00   
+  2  1    -1   -5   12590.8808 10684.6947 -0.0    1.34898  0.10   
+  2  3    5    2    310.0462   209.3105   0.0     1.34800  0.00   
+  2  5    -5   -2   842.8519   569.3229   180.0   1.34796  0.00   
+  2  4    0    2    16426.2962 20281.5496 180.0   1.34415  0.01   
+  2  6    0    -3   441.3645   425.5759   0.0     1.34325  0.00   
+  2  3    -7   -3   1093.5930  987.4854   180.0   1.34309  0.00   
+  2  5    -3   -4   21.0852    19.5836    -0.0    1.34131  0.00   
+  2  3    7    1    644.5188   545.0817   0.0     1.33472  0.00   
+  2  1    3    4    358.1658   303.9149   180.0   1.33470  0.00   
+  2  2    4    -5   1821.2798  2138.3293  -0.0    1.33364  0.00   
+  2  6    2    -2   9114.4669  7476.5144  0.0     1.33195  0.00   
+  2  3    -1   3    375.2301   551.8654   -0.0    1.33039  0.00   
+  2  5    -5   -1   2043.9657  3083.6461  -180.0  1.33032  0.00   
+  2  1    -7   3    676.8842   846.7620   -180.0  1.32861  0.00   
+  2  1    3    -5   9204.2305  12958.6368 180.0   1.32799  0.02   
+  2  4    6    -4   865.3950   1218.9271  0.0     1.32736  0.00   
+  2  6    2    -3   4.3092     5.9956     -0.0    1.32699  0.00   
+  2  4    -2   -5   2878.3781  3148.2794  0.0     1.32250  0.00   
+  2  4    -2   2    2066.3529  2257.9872  0.0     1.32117  0.00   
+  2  1    9    1    886.0498   1105.0576  -0.0    1.32053  0.00   
+  2  3    1    3    2551.5295  3239.2591  0.0     1.32043  0.00   
+  2  2    -6   -4   86.0398    114.1536   0.0     1.31958  0.00   
+  2  3    -3   -5   1640.7370  2180.4261  180.0   1.31953  0.00   
+  2  0    6    -4   2552.1037  3687.4603  0.0     1.31759  0.00   
+  2  0    8    -3   3050.2114  4548.2663  -0.0    1.31684  0.00   
+  2  6    -2   -2   260.4007   331.0134   180.0   1.31384  0.00   
+  2  4    2    2    395.0582   505.6991   0.0     1.30940  0.00   
+  2  5    -5   -3   7368.3848  6219.1169  0.0     1.30780  0.00   
+  2  3    7    -4   13.9789    11.5411    -180.0  1.30589  0.00   
+  2  6    0    -1   769.0810   635.8821   -0.0    1.30347  0.00   
+  2  6    -2   -3   4577.7713  4805.7953  0.0     1.30215  0.00   
+  2  1    7    -4   781.8406   817.0588   180.0   1.30092  0.00   
+  2  4    4    -5   739.2286   839.8610   -180.0  1.29572  0.00   
+  2  5    -1   1    528.3451   561.7539   -180.0  1.29375  0.00   
+  2  5    5    -4   104.6435   102.0613   -0.0    1.29201  0.00   
+  2  5    1    1    217.2031   213.3445   180.0   1.29181  0.00   
+  2  5    1    -5   993.8050   1297.9127  -180.0  1.28880  0.00   
+  2  3    -3   3    5165.2563  3825.8482  180.0   1.28498  0.00   
+  2  1    -9   -2   10692.9074 7597.1469  0.0     1.28482  0.00   
+  2  2    -6   3    155.7959   98.1026    -0.0    1.28448  0.00   
+  2  3    5    -5   5572.6112  3037.7152  -0.0    1.28329  0.00   
+  2  6    2    -1   4452.9071  2449.2829  180.0   1.28198  0.00   
+  2  6    0    -4   5965.4513  4647.3829  0.0     1.27977  0.00   
+  2  4    8    -2   20414.1004 16039.4631 -0.0    1.27964  0.01   
+  2  1    -5   4    0.3502     0.2752     -0.0    1.27938  0.00   
+  2  0    0    5    1521.9374  1505.0398  0.0     1.27767  0.01   
+  2  2    -8   -3   1387.5254  971.0655   0.0     1.27634  0.00   
+  2  1    -3   -5   2393.8492  1649.2139  -180.0  1.27560  0.01   
+  2  0    10   0    7945.8506  5615.7294  -0.0    1.27526  0.00   
+  2  3    9    -1   1116.5334  567.6078   180.0   1.27289  0.00   
+  2  6    -2   -1   1167.5292  606.3424   -180.0  1.27218  0.00   
+  2  4    -6   1    3960.7155  2160.8901  180.0   1.27166  0.00   
+  2  5    -1   -5   6394.1756  3289.9147  -0.0    1.27108  0.00   
+  2  3    9    -2   437.2607   209.2136   0.0     1.27094  0.00   
+  2  2    -8   2    18049.1961 15688.9183 0.0     1.26897  0.01   
+  2  2    0    4    6462.6138  5973.6167  -0.0    1.26887  0.02   
+  2  6    2    -4   2852.8339  2644.4850  -180.0  1.26887  0.00   
+  2  0    2    -5   4316.6296  4142.0269  180.0   1.26837  0.01   
+  2  5    5    0    2389.8561  1539.1598  -0.0    1.26784  0.00   
+  2  0    10   -1   886.2829   722.6067   -180.0  1.26611  0.00   
+  3  1    1    0    8634.8388  5229.9408  0.0     5.76223  0.02   
+  3  1    1    -1   2282.4830  1404.4642  0.0     5.75058  0.01   
+  3  0    0    2    10675.6272 6648.0829  0.0     5.73783  0.01   
+  3  2    0    0    1117.8860  777.9553   180.0   5.31049  0.00   
+  3  2    0    -2   15085.1049 11512.6160 0.0     5.27425  0.02   
+  3  1    1    1    7975.6159  5916.0442  -180.0  4.70453  0.01   
+  3  1    1    -2   657.2293   471.3091   -180.0  4.68555  0.00   
+  3  1    1    2    3465.4149  1811.9004  -180.0  3.64096  0.00   
+  3  1    1    -3   11487.2954 6224.7494  180.0   3.62630  0.01   
+  3  0    2    0    4149.9810  1737.0665  180.0   3.42976  0.00   
+  3  3    1    -1   1735.8861  1015.3644  -0.0    3.40570  0.00   
+  3  3    1    -2   5001.6175  3188.4694  180.0   3.39848  0.00   
+  3  0    2    1    5516.6436  5005.7893  -0.0    3.28613  0.00   
+  3  2    0    2    14511.1155 11618.0014 -0.0    3.23222  0.01   
+  3  2    0    -4   6368.5852  5013.3058  180.0   3.20774  0.00   
+  3  3    1    0    2727.0215  2138.8026  0.0     3.14602  0.00   
+  3  3    1    -3   3029.9507  2677.5527  180.0   3.12903  0.00   
+  3  4    0    -2   82201.9181 80922.8191 -180.0  2.98220  0.03   
+  3  2    2    -1   80840.5124 75006.4942 -0.0    2.97323  0.05   
+  3  0    2    2    1039.1932  793.4329   0.0     2.94392  0.00   
+  3  2    2    0    1760.5358  1808.9163  0.0     2.88112  0.00   
+  3  1    1    3    2497.5766  2492.8532  -0.0    2.87630  0.00   
+  3  2    2    -2   533.8131   529.3047   -0.0    2.87529  0.00   
+  3  0    0    4    10843.7711 10346.8898 -0.0    2.86891  0.00   
+  3  1    1    -4   6178.6778  5819.5912  -0.0    2.86618  0.00   
+  3  3    1    1    3082.4691  3759.3145  -180.0  2.76244  0.00   
+  3  3    1    -4   2647.4432  3268.9679  -0.0    2.74331  0.00   
+  3  4    0    0    57521.7832 71136.5042 0.0     2.65525  0.01   
+  3  2    2    1    115247.4364 133079.6522 0.0     2.64437  0.06   
+  3  4    0    -4   123196.9435 140762.5963 180.0   2.63712  0.03   
+  3  2    2    -3   57875.0190 66325.7874 -180.0  2.63538  0.03   
+  3  0    2    3    16628.0154 14209.8323 180.0   2.55361  0.01   
+  3  3    1    2    12312.5450 9802.7498  -180.0  2.38205  0.00   
+  3  3    1    -5   7616.2936  5880.0373  -0.0    2.36488  0.00   
+  3  2    2    2    214.4773   144.0770   -180.0  2.35226  0.00   
+  3  1    1    4    4788.6944  2979.7862  -0.0    2.34727  0.00   
+  3  2    2    -4   1514.8489  883.3747   180.0   2.34277  0.00   
+  3  1    1    -5   535.9594   301.3334   -0.0    2.34018  0.00   
+  3  4    2    -2   1582.4317  1407.3210  -0.0    2.25045  0.00   
+  3  5    1    -2   2292.3922  2123.4244  180.0   2.24430  0.00   
+  3  5    1    -3   565.1692   539.2561   180.0   2.24086  0.00   
+  3  1    3    0    53.1031    52.4259    0.0     2.23529  0.00   
+  3  1    3    -1   4224.9661  4180.3508  -0.0    2.23461  0.00   
+  3  4    2    -1   906.4816   918.1952   0.0     2.21103  0.00   
+  3  4    2    -3   12762.0605 13296.5582 -0.0    2.20576  0.00   
+  3  0    2    4    914.3141   970.4662   180.0   2.20056  0.00   
+  3  5    1    -1   9894.7170  11525.6216 -0.0    2.16619  0.00   
+  3  5    1    -4   572.9887   710.3618   -180.0  2.15694  0.00   
+  3  1    3    1    829.3711   1031.4626  -0.0    2.15564  0.00   
+  3  1    3    -2   8799.1126  10966.5101 0.0     2.15380  0.00   
+  3  2    0    4    1332.9284  1641.1119  0.0     2.14805  0.00   
+  3  2    0    -6   6821.0291  7250.4262  0.0     2.13603  0.00   
+  3  4    2    0    825.6703   728.7537   -180.0  2.09958  0.00   
+  3  4    2    -4   687.2972   549.0412   -180.0  2.09059  0.00   
+  3  4    0    2    388889.1717 286836.0728 180.0   2.07622  0.06   
+  3  2    2    3    388299.1037 293751.3685 0.0     2.06884  0.11   
+  3  2    2    -5   383513.0065 298115.3825 0.0     2.06023  0.11   
+  3  4    0    -6   390453.5433 303411.3942 -180.0  2.05893  0.06   
+  3  3    1    3    1410.9357  1086.0204  -180.0  2.05577  0.00   
+  3  3    1    -6   207.5413   155.3313   -0.0    2.04158  0.00   
+  3  5    1    0    976.4955   771.9891   180.0   2.02913  0.00   
+  3  1    3    2    16287.8435 14029.5270 -0.0    2.01843  0.00   
+  3  5    1    -5   16319.0522 14178.8649 -0.0    2.01648  0.00   
+  3  1    3    -3   1424.0830  1239.6149  -0.0    2.01592  0.00   
+  3  3    3    -1   7104.5759  7019.4194  -0.0    1.97551  0.00   
+  3  3    3    -2   189.3066   188.0566   0.0     1.97410  0.00   
+  3  1    1    5    4629.2370  4644.9116  180.0   1.97138  0.00   
+  3  1    1    -6   1533.2876  1571.2732  -0.0    1.96624  0.00   
+  3  6    0    -2   922.7573   971.0780   180.0   1.96172  0.00   
+  3  6    0    -4   16237.5898 17269.6602 -180.0  1.95620  0.00   
+  3  4    2    1    20883.4630 20996.6238 -0.0    1.94504  0.01   
+  3  4    2    -5   71.2788    71.0915    180.0   1.93434  0.00   
+  3  3    3    0    9850.2791  9835.0988  180.0   1.92074  0.00   
+  3  3    3    -3   2759.0676  2769.3680  -0.0    1.91686  0.00   
+  3  0    0    6    1710.9080  1720.5415  -0.0    1.91261  0.00   
+  3  0    2    5    90.9484    90.4715    -180.0  1.90745  0.00   
+  3  5    1    1    3820.9633  2507.7680  -180.0  1.86396  0.00   
+  3  1    3    3    6423.6975  3431.0335  0.0     1.85410  0.00   
+  3  1    3    -4   1012.4147  510.0263   -180.0  1.85138  0.00   
+  3  5    1    -6   5857.6956  2907.0512  -180.0  1.85026  0.00   
+  3  3    3    1    4542.6019  3298.3860  -0.0    1.82251  0.00   
+  3  2    2    4    2697.6132  2013.9090  180.0   1.82048  0.00   
+  3  3    3    -4   19717.8266 15089.5976 -180.0  1.81699  0.00   
+  3  2    2    -6   147.2626   111.5713   -0.0    1.81315  0.00   
+  3  3    1    4    1923.6175  1178.4243  -0.0    1.78975  0.00   
+  3  3    1    -7   1082.0490  725.9349   -180.0  1.77829  0.00   
+  3  4    2    2    901.0285   571.7609   -0.0    1.77613  0.00   
+  3  6    0    0    66203.9286 33181.4274 180.0   1.77016  0.01   
+  3  4    2    -6   2965.9396  1202.5389  -0.0    1.76527  0.00   
+  3  6    0    -6   5.6070     2.0490     0.0     1.75808  0.00   
+  3  6    2    -3   337084.2537 369938.5795 -180.0  1.72004  0.07   
+  3  0    4    0    302821.3137 348479.5467 -180.0  1.71488  0.03   
+  3  6    2    -2   305.0335   389.5943   -0.0    1.70285  0.00   
+  3  3    3    2    3005.7829  3606.5174  -0.0    1.69941  0.00   
+  3  6    2    -4   1305.5878  1559.9063  180.0   1.69924  0.00   
+  3  0    4    1    2969.3586  3255.7850  -0.0    1.69605  0.00   
+  3  5    1    2    2400.9524  2577.0016  -180.0  1.69525  0.00   
+  3  1    1    6    710.6412   746.2082   -0.0    1.69440  0.00   
+  3  3    3    -5   10348.1911 10555.5299 0.0     1.69315  0.00   
+  3  1    1    -7   12904.1660 12532.2843 -180.0  1.69054  0.00   
+  3  1    3    4    49.9101    45.2175    -0.0    1.68665  0.00   
+  3  1    3    -5   5529.3686  4696.9172  0.0     1.68402  0.00   
+  3  5    1    -7   331.8202   266.7848   -180.0  1.68201  0.00   
+  3  0    2    6    1340.2897  1010.9792  0.0     1.67043  0.00   
+  3  6    2    -1   883.7245   866.1805   -180.0  1.65090  0.00   
+  3  7    1    -3   36.2760    35.4940    180.0   1.65053  0.00   
+  3  7    1    -4   576.1953   557.7399   -0.0    1.64861  0.00   
+  3  2    4    -1   2943.2727  2839.6979  180.0   1.64811  0.00   
+  3  5    3    -2   351.0392   336.5571   -180.0  1.64721  0.00   
+  3  5    3    -3   1297.8946  1232.3026  -180.0  1.64584  0.00   
+  3  6    2    -5   537.6106   505.7360   -180.0  1.64434  0.00   
+  3  0    4    2    653.1297   611.2974   -180.0  1.64307  0.00   
+  3  2    4    0    772.6394   752.6479   -0.0    1.63190  0.00   
+  3  2    4    -2   4545.0530  4457.0559  180.0   1.63084  0.00   
+  3  7    1    -2   3306.5993  3573.3164  180.0   1.61922  0.00   
+  3  4    0    4    59364.0486 64734.1102 180.0   1.61611  0.01   
+  3  5    3    -1   886.5164   966.5143   0.0     1.61557  0.00   
+  3  7    1    -5   845.7205   917.7423   -0.0    1.61380  0.00   
+  3  4    2    3    25.4204    27.2643    180.0   1.61197  0.00   
+  3  5    3    -4   3583.6647  3835.3161  -180.0  1.61172  0.00   
+  3  2    2    5    34898.6341 37309.7254 -180.0  1.61160  0.01   
+  3  2    2    -7   68356.9088 66901.8211 0.0     1.60550  0.01   
+  3  4    0    -8   39405.8732 37138.8177 0.0     1.60387  0.00   
+  3  4    2    -7   2919.5593  2596.5146  -0.0    1.60183  0.00   
+  3  2    4    1    2011.5860  1923.8493  0.0     1.58503  0.00   
+  3  2    0    6    29903.1552 29168.2638 -0.0    1.58415  0.00   
+  3  2    4    -3   1890.1972  1875.8650  0.0     1.58309  0.00   
+  3  2    0    -8   4919.1674  5028.2109  -180.0  1.57739  0.00   
+  3  3    1    5    1723.4259  1753.8851  180.0   1.57535  0.00   
+  3  6    2    0    316.0895   317.6799   -0.0    1.57301  0.00   
+  3  3    3    3    497.7348   487.1948   0.0     1.56818  0.00   
+  3  3    1    -8   1918.9621  1875.6642  0.0     1.56611  0.00   
+  3  0    4    3    2973.8130  2916.6965  -0.0    1.56482  0.00   
+  3  6    2    -6   1272.0799  1249.2285  -180.0  1.56452  0.00   
+  3  3    3    -6   1500.6536  1497.2639  -180.0  1.56185  0.00   
+  3  7    1    -1   2019.3808  2044.6251  -0.0    1.55998  0.00   
+  3  5    3    0    3591.5904  3765.1112  180.0   1.55625  0.00   
+  3  7    1    -6   3441.0838  3792.3266  -180.0  1.55192  0.00   
+  3  5    3    -5   1258.8569  1408.4097  0.0     1.55053  0.00   
+  3  5    1    3    752.2052   793.3049   0.0     1.53703  0.00   
+  3  1    3    5    6.9969     7.3229     -180.0  1.52974  0.00   
+  3  1    3    -6   1114.4657  1163.6125  0.0     1.52733  0.00   
+  3  5    1    -8   5.2873     5.2918     0.0     1.52497  0.00   
+  3  2    4    2    5080.7823  4257.8935  180.0   1.51487  0.00   
+  3  2    4    -4   2960.4623  2489.4645  -0.0    1.51233  0.00   
+  3  6    0    2    10452.3762 8969.7388  -180.0  1.50899  0.00   
+  3  6    0    -8   4917.0982  4411.8311  -180.0  1.49655  0.00   
+  3  8    0    -4   23723.8541 20108.3695 0.0     1.49110  0.00   
+  3  4    4    -2   23154.3050 20463.8926 -0.0    1.48662  0.00   
+  3  1    1    7    9908.2738  9171.7752  -0.0    1.48331  0.00   
+  3  7    1    0    567.7183   523.6927   0.0     1.48147  0.00   
+  3  1    1    -8   8240.5615  7477.8736  0.0     1.48033  0.00   
+  3  6    2    1    567.7415   511.3441   180.0   1.47995  0.00   
+  3  0    2    7    2868.8316  2531.9941  180.0   1.47910  0.00   
+  3  5    3    1    1727.3254  1472.7063  180.0   1.47789  0.00   
+  3  4    4    -1   232.0581   180.4329   180.0   1.47508  0.00   
+  3  4    4    -3   2255.5681  1668.7785  180.0   1.47351  0.00   
+  3  0    4    4    831.5101   588.3828   180.0   1.47196  0.00   
+  3  7    1    -7   330.1229   232.7897   -180.0  1.47183  0.00   
+  3  5    3    -6   0.2582     0.1783     -180.0  1.47103  0.00   
+  3  6    2    -7   1602.5194  1093.6180  180.0   1.47053  0.00   
+  3  4    2    4    483.0766   311.3563   -180.0  1.46194  0.00   
+  3  4    2    -8   400.9093   304.9106   -180.0  1.45286  0.00   
+  3  8    0    -2   64263.3731 52333.9892 0.0     1.44612  0.00   
+  3  4    4    0    47503.3127 40400.3932 -180.0  1.44056  0.01   
+  3  8    0    -6   46379.7375 39537.2697 -180.0  1.44024  0.00   
+  3  3    3    4    5440.0857  4643.0050  -180.0  1.44007  0.00   
+  3  2    2    6    0.9699     0.8356     -180.0  1.43815  0.00   
+  3  4    4    -4   62755.1013 54118.1487 0.0     1.43764  0.01   
+  3  0    0    8    317480.4267 269542.3856 -0.0    1.43446  0.02   
+  3  3    3    -7   1725.7681  1457.5261  0.0     1.43408  0.00   
+  3  2    2    -8   2210.2212  1833.8366  -0.0    1.43309  0.00   
+  3  2    4    3    3499.4456  2703.6576  180.0   1.43051  0.00   
+  3  2    4    -5   2393.6717  1676.0081  180.0   1.42766  0.00   
+  3  3    1    6    2450.2131  953.3228   180.0   1.40181  0.00   
+  3  5    1    4    1411.2307  769.3977   0.0     1.39510  0.00   
+  3  3    1    -9   1258.0407  719.7991   -0.0    1.39429  0.00   
+  3  7    1    1    80.4385    50.2578    -180.0  1.39276  0.00   
+  3  5    3    2    614.2080   444.3953   -180.0  1.38945  0.00   
+  3  1    3    6    4319.3705  3177.0263  0.0     1.38898  0.00   
+  3  4    4    1    4717.2640  3624.9875  -0.0    1.38761  0.00   
+  3  1    3    -7   620.1723   487.0361   -180.0  1.38685  0.00   
+  3  5    1    -9   3822.6738  3195.9143  -0.0    1.38443  0.00   
+  3  4    4    -5   1437.7701  1225.1211  0.0     1.38370  0.00   
+  3  7    1    -8   263.5750   232.0851   0.0     1.38247  0.00   
+  3  5    3    -7   1214.4312  1078.8823  180.0   1.38213  0.00   
+  3  6    2    2    281.9211   256.0783   -180.0  1.38122  0.00   
+  3  0    4    5    373.9332   361.4245   -180.0  1.37376  0.00   
+  3  6    2    -8   3.0332     2.8092     0.0     1.37165  0.00   
+  3  8    2    -4   944.3182   738.8453   180.0   1.36746  0.00   
+  3  7    3    -3   4458.6543  3196.5118  -180.0  1.36450  0.00   
+  3  7    3    -4   662.3173   462.3097   -180.0  1.36342  0.00   
+  3  1    5    0    6976.1958  4364.1111  -180.0  1.36060  0.00   
+  3  1    5    -1   92.3049    57.2778    -0.0    1.36045  0.00   
+  3  8    2    -3   3347.5404  1922.4893  180.0   1.35908  0.00   
+  3  8    2    -5   27967.9399 14154.5714 180.0   1.35663  0.00   
+  3  7    3    -2   10199.8495 6970.2714  0.0     1.34665  0.00   
+  3  7    3    -5   3220.8180  2391.0016  180.0   1.34353  0.00   
+  3  1    5    1    9933.2919  7427.3532  0.0     1.34202  0.00   
+  3  1    5    -2   3744.2030  2798.0482  180.0   1.34157  0.00   
+  3  2    4    4    275.6908   205.2037   -180.0  1.34018  0.00   
+  3  2    4    -6   5625.3901  4289.0376  180.0   1.33725  0.00   
+  3  8    2    -2   211.8792   192.3295   0.0     1.33251  0.00   
+  3  4    2    5    12535.3719 12924.4778 0.0     1.32907  0.00   
+  3  8    2    -6   110.3879   116.8075   0.0     1.32791  0.00   
+  3  8    0    0    119457.2449 126985.7272 0.0     1.32762  0.01   
+  3  0    2    8    344.7308   372.5808   180.0   1.32337  0.00   
+  3  4    4    2    105088.5368 114041.8510 0.0     1.32219  0.01   
+  3  4    2    -9   5089.1987  5567.4086  180.0   1.32111  0.00   
+  3  3    3    5    1146.8526  1254.7052  -0.0    1.32110  0.00   
+  3  8    0    -8   125032.9439 139622.3566 -0.0    1.31856  0.01   
+  3  1    1    8    140.4453   157.1123   180.0   1.31776  0.00   
+  3  4    4    -6   108077.5267 120901.7616 0.0     1.31769  0.01   
+  3  3    3    -8   6472.7327  7156.4686  180.0   1.31564  0.00   
+  3  1    1    -9   655.1238   722.4364   180.0   1.31539  0.00   
+  3  7    3    -1   986.4989   1032.7373  180.0   1.31200  0.00   
+  3  7    3    -6   8093.6834  7548.7798  -0.0    1.30719  0.00   
+  3  1    5    2    1873.0715  1737.2292  180.0   1.30689  0.00   
+  3  1    5    -3   7973.1570  7318.6861  -0.0    1.30620  0.00   
+  3  7    1    2    4483.8185  3990.0856  -180.0  1.30123  0.00   
+  3  9    1    -4   949.9704   841.0437   0.0     1.29987  0.00   
+  3  9    1    -5   288.9237   256.8743   0.0     1.29866  0.00   
+  3  6    4    -3   2646.6661  2355.2525  -0.0    1.29855  0.00   
+  3  5    3    3    376.4117   335.9562   180.0   1.29826  0.00   
+  3  4    0    6    20586.0027 18741.5605 180.0   1.29693  0.00   
+  3  3    5    -1   659.8790   622.0208   0.0     1.29502  0.00   
+  3  3    5    -2   2308.5507  2189.0430  -0.0    1.29462  0.00   
+  3  2    2    7    17160.5151 16386.2542 -0.0    1.29407  0.00   
+  3  6    4    -2   26.4117    25.5642    0.0     1.29111  0.00   
+  3  7    1    -9   137.8837   133.3647   180.0   1.29098  0.00   
+  3  5    3    -8   3621.2041  3502.1832  180.0   1.29096  0.00   
+  3  8    2    -1   9246.3714  8931.9049  180.0   1.29080  0.00   
+  3  2    2    -9   21057.1216 20077.2594 0.0     1.28985  0.00   
+  3  6    4    -4   7539.3565  7137.8005  -0.0    1.28953  0.00   
+  3  4    0    -10  22931.2300 20993.9087 -180.0  1.28848  0.00   
+  3  9    1    -3   7397.1385  5509.0756  180.0   1.28467  0.00   
+  3  8    2    -7   581.7233   430.2999   -180.0  1.28453  0.00   
+  3  6    2    3    0.5528     0.3928     180.0   1.28356  0.00   
+  3  9    1    -6   269.9660   186.6299   -0.0    1.28119  0.00   
+  3  3    5    0    1019.0386  721.1811   -0.0    1.27922  0.00   
+  3  3    5    -3   8501.9860  6042.2846  -0.0    1.27807  0.00   
+  3  0    4    6    170.8067   119.4400   180.0   1.27681  0.00   
+  3  6    2    -9   722.5386   468.2664   180.0   1.27435  0.00   
+  3  5    1    5    7790.9299  4654.3749  180.0   1.27052  0.00   
+  3  6    0    4    12258.0849 7336.9163  180.0   1.27006  0.00   
+  3  6    4    -1   784.1399   481.6983   -180.0  1.26802  0.00   
+  3  1    3    7    13289.3449 8492.7416  -0.0    1.26540  0.00   
+  3  6    4    -5   906.1071   581.7489   -180.0  1.26504  0.00   
+  4  1    1    0    1676.5995  1271.7368  -0.0    3.25001  0.02   
+  4  1    0    1    572.2579   492.3378   -0.0    2.48987  0.01   
+  4  2    0    0    200.8487   149.3356   -0.0    2.29811  0.00   
+  4  1    1    1    333.4284   375.0134   180.0   2.18927  0.00   
+  4  2    1    0    177.2084   152.6586   0.0     2.05549  0.00   
+  4  2    1    1    784.0731   880.1039   -0.0    1.68873  0.01   
+  4  2    2    0    1057.3902  1142.2908  -0.0    1.62501  0.00   
+  4  0    0    2    927.7371   1419.6113  -0.0    1.48108  0.00   
+  4  3    1    0    442.0807   356.5837   -0.0    1.45345  0.00   
+  4  2    2    1    58.8136    28.2210    180.0   1.42470  0.00   
+  4  3    0    1    1070.8999  1054.8092  -0.0    1.36083  0.00   
+  4  1    1    2    780.9770   541.9815   -0.0    1.34773  0.00   
+  4  3    1    1    36.4823    32.7302    0.0     1.30484  0.00   
+  4  3    2    0    21.7664    15.0074    180.0   1.27476  0.00   
+_reflns_number_total  650
+_reflns_d_resolution_low    6.388
+_reflns_d_resolution_high   1.265
+
+# POWDER DATA TABLE
+_pd_meas_2theta_range_min  10.01687
+_pd_meas_2theta_range_max  89.99342
+_pd_meas_2theta_range_inc  0.01313
+_pd_meas_number_of_points  6092
+
+loop_
+   _pd_meas_intensity_total
+   _pd_calc_intensity_total
+   _pd_proc_intensity_bkg_calc
+   _pd_proc_ls_weight
+  1125         0            0           0         
+  1129         0            0           0         
+  1150         0            0           0         
+  1109         0            0           0         
+  1050         0            0           0         
+  1113         0            0           0         
+  1099         0            0           0         
+  1125         0            0           0         
+  1065         0            0           0         
+  1084         0            0           0         
+  1096         0            0           0         
+  1074         0            0           0         
+  1142         0            0           0         
+  1044         0            0           0         
+  1141         0            0           0         
+  1155         0            0           0         
+  1090         0            0           0         
+  1109         0            0           0         
+  1058         0            0           0         
+  1136         0            0           0         
+  1039         0            0           0         
+  1095         0            0           0         
+  1126         0            0           0         
+  1138         0            0           0         
+  1116         0            0           0         
+  1084         0            0           0         
+  1065         0            0           0         
+  1080         0            0           0         
+  1063         0            0           0         
+  1093         0            0           0         
+  1079         0            0           0         
+  1105         0            0           0         
+  1105         0            0           0         
+  1074         0            0           0         
+  1080         0            0           0         
+  1105         0            0           0         
+  1060         0            0           0         
+  1061         0            0           0         
+  1081         0            0           0         
+  1077         0            0           0         
+  1079         0            0           0         
+  1095         0            0           0         
+  1051         0            0           0         
+  1126         0            0           0         
+  1036         0            0           0         
+  1056         0            0           0         
+  1058         0            0           0         
+  1064         0            0           0         
+  1056         0            0           0         
+  1050         0            0           0         
+  1019         0            0           0         
+  1014         0            0           0         
+  1099         0            0           0         
+  1081         0            0           0         
+  1078         0            0           0         
+  1068         0            0           0         
+  1077         0            0           0         
+  990          0            0           0         
+  1075         0            0           0         
+  1021         0            0           0         
+  1041         0            0           0         
+  1020         0            0           0         
+  982          0            0           0         
+  1049         0            0           0         
+  1063         0            0           0         
+  1060         0            0           0         
+  1030         0            0           0         
+  1043         0            0           0         
+  1072         0            0           0         
+  1064         0            0           0         
+  1012         0            0           0         
+  1049         0            0           0         
+  982          0            0           0         
+  1077         0            0           0         
+  1037         0            0           0         
+  1036         0            0           0         
+  985          0            0           0         
+  1033         0            0           0         
+  1066         0            0           0         
+  1009         0            0           0         
+  1075         0            0           0         
+  1000         0            0           0         
+  1019         0            0           0         
+  1040         0            0           0         
+  1065         0            0           0         
+  1007         0            0           0         
+  982          0            0           0         
+  985          0            0           0         
+  999          0            0           0         
+  1034         0            0           0         
+  956          0            0           0         
+  1025         0            0           0         
+  973          0            0           0         
+  991          0            0           0         
+  995          0            0           0         
+  989          0            0           0         
+  1024         0            0           0         
+  971          0            0           0         
+  964          0            0           0         
+  968          0            0           0         
+  1038         0            0           0         
+  987          0            0           0         
+  942          0            0           0         
+  1007         0            0           0         
+  947          0            0           0         
+  987          0            0           0         
+  946          0            0           0         
+  989          0            0           0         
+  1046         0            0           0         
+  1006         0            0           0         
+  1035         0            0           0         
+  959          0            0           0         
+  946          0            0           0         
+  995          0            0           0         
+  1003         0            0           0         
+  994          0            0           0         
+  926          0            0           0         
+  1015         0            0           0         
+  987          0            0           0         
+  995          0            0           0         
+  960          0            0           0         
+  919          0            0           0         
+  990          0            0           0         
+  981          0            0           0         
+  987          0            0           0         
+  947          0            0           0         
+  997          0            0           0         
+  1004         0            0           0         
+  931          0            0           0         
+  926          0            0           0         
+  988          0            0           0         
+  989          0            0           0         
+  996          0            0           0         
+  938          0            0           0         
+  965          0            0           0         
+  993          0            0           0         
+  928          0            0           0         
+  976          0            0           0         
+  959          0            0           0         
+  902          0            0           0         
+  924          0            0           0         
+  930          0            0           0         
+  940          0            0           0         
+  966          0            0           0         
+  961          0            0           0         
+  959          0            0           0         
+  968          0            0           0         
+  957          0            0           0         
+  942          0            0           0         
+  929          0            0           0         
+  930          0            0           0         
+  989          0            0           0         
+  937          0            0           0         
+  917          0            0           0         
+  915          0            0           0         
+  941          0            0           0         
+  907          0            0           0         
+  939          0            0           0         
+  979          0            0           0         
+  979          0            0           0         
+  998          0            0           0         
+  952          0            0           0         
+  936          0            0           0         
+  917          0            0           0         
+  878          0            0           0         
+  896          0            0           0         
+  929          0            0           0         
+  949          0            0           0         
+  944          0            0           0         
+  927          0            0           0         
+  982          0            0           0         
+  958          0            0           0         
+  899          0            0           0         
+  909          0            0           0         
+  923          0            0           0         
+  894          0            0           0         
+  882          0            0           0         
+  895          0            0           0         
+  916          0            0           0         
+  879          0            0           0         
+  924          0            0           0         
+  911          0            0           0         
+  900          0            0           0         
+  887          0            0           0         
+  904          0            0           0         
+  887          0            0           0         
+  888          0            0           0         
+  908          0            0           0         
+  884          0            0           0         
+  964          0            0           0         
+  917          0            0           0         
+  879          0            0           0         
+  891          0            0           0         
+  913          0            0           0         
+  908          0            0           0         
+  907          0            0           0         
+  928          0            0           0         
+  891          0            0           0         
+  886          0            0           0         
+  881          0            0           0         
+  845          0            0           0         
+  913          0            0           0         
+  900          0            0           0         
+  900          0            0           0         
+  878          0            0           0         
+  902          0            0           0         
+  914          0            0           0         
+  869          0            0           0         
+  877          0            0           0         
+  912          0            0           0         
+  838          0            0           0         
+  895          0            0           0         
+  862          0            0           0         
+  820          0            0           0         
+  925          0            0           0         
+  836          0            0           0         
+  860          0            0           0         
+  907          0            0           0         
+  814          0            0           0         
+  892          0            0           0         
+  859          0            0           0         
+  844          0            0           0         
+  876          0            0           0         
+  825          0            0           0         
+  832          0            0           0         
+  816          0            0           0         
+  860          0            0           0         
+  903          0            0           0         
+  870          0            0           0         
+  850          0            0           0         
+  852          0            0           0         
+  874          0            0           0         
+  811          0            0           0         
+  870          0            0           0         
+  823          0            0           0         
+  894          0            0           0         
+  855          0            0           0         
+  814          0            0           0         
+  839          0            0           0         
+  838          0            0           0         
+  862          0            0           0         
+  855          0            0           0         
+  870          0            0           0         
+  825          0            0           0         
+  878          0            0           0         
+  842          0            0           0         
+  807          0            0           0         
+  818          0            0           0         
+  841          0            0           0         
+  872          0            0           0         
+  819          0            0           0         
+  872          0            0           0         
+  804          0            0           0         
+  817          0            0           0         
+  871          0            0           0         
+  794          0            0           0         
+  834          0            0           0         
+  837          0            0           0         
+  811          0            0           0         
+  776          0            0           0         
+  836          0            0           0         
+  852          0            0           0         
+  849          0            0           0         
+  776          0            0           0         
+  765          0            0           0         
+  831          0            0           0         
+  785          0            0           0         
+  822          0            0           0         
+  786          0            0           0         
+  778          0            0           0         
+  846          0            0           0         
+  816          0            0           0         
+  837          0            0           0         
+  846          0            0           0         
+  786          0            0           0         
+  748          0            0           0         
+  801          0            0           0         
+  835          0            0           0         
+  753          0            0           0         
+  830          0            0           0         
+  814          0            0           0         
+  765          0            0           0         
+  835          0            0           0         
+  805          0            0           0         
+  789          0            0           0         
+  832          0            0           0         
+  859          0            0           0         
+  778          0            0           0         
+  797          0            0           0         
+  830          0            0           0         
+  791          0            0           0         
+  785          0            0           0         
+  765          0            0           0         
+  805          0            0           0         
+  787          0            0           0         
+  811          0            0           0         
+  807          0            0           0         
+  807          0            0           0         
+  781          0            0           0         
+  784          0            0           0         
+  811          0            0           0         
+  794          0            0           0         
+  791          0            0           0         
+  768          0            0           0         
+  774          0            0           0         
+  773          0            0           0         
+  798          0            0           0         
+  797          0            0           0         
+  780          0            0           0         
+  798          0            0           0         
+  767          0            0           0         
+  799          0            0           0         
+  776          0            0           0         
+  781          0            0           0         
+  768          0            0           0         
+  750          0            0           0         
+  743          0            0           0         
+  724          0            0           0         
+  757          0            0           0         
+  765          0            0           0         
+  799          0            0           0         
+  729          0            0           0         
+  785          0            0           0         
+  748          0            0           0         
+  736          0            0           0         
+  794          0            0           0         
+  785          0            0           0         
+  767          0            0           0         
+  737          0            0           0         
+  734          0            0           0         
+  713          0            0           0         
+  789          0            0           0         
+  779          0            0           0         
+  762          0            0           0         
+  792          0            0           0         
+  788          0            0           0         
+  768          0            0           0         
+  765          0            0           0         
+  751          0            0           0         
+  758          0            0           0         
+  811          0            0           0         
+  821          0            0           0         
+  763          0            0           0         
+  745          0            0           0         
+  724          0            0           0         
+  742          0            0           0         
+  738          0            0           0         
+  766          0            0           0         
+  735          0            0           0         
+  768          0            0           0         
+  763          0            0           0         
+  762          0            0           0         
+  751          0            0           0         
+  723          0            0           0         
+  711          0            0           0         
+  729          0            0           0         
+  735          0            0           0         
+  780          0            0           0         
+  742          0            0           0         
+  793          0            0           0         
+  722          0            0           0         
+  717          0            0           0         
+  714          0            0           0         
+  730          0            0           0         
+  724          0            0           0         
+  724          0            0           0         
+  749          0            0           0         
+  677          0            0           0         
+  748          0            0           0         
+  746          0            0           0         
+  703          0            0           0         
+  706          0            0           0         
+  706          0            0           0         
+  749          0            0           0         
+  789          0            0           0         
+  711          0            0           0         
+  767          0            0           0         
+  755          0            0           0         
+  751          0            0           0         
+  715          0            0           0         
+  731          0            0           0         
+  723          0            0           0         
+  733          0            0           0         
+  726          0            0           0         
+  729          0            0           0         
+  672          0            0           0         
+  694          690.30742    689.73057   0.00144092 
+  720          689.54188    688.95633   0.00138889 
+  685          688.7775     688.18298   0.00145985 
+  688          688.01429    687.4105    0.00145349 
+  706          687.25226    686.6389    0.00141643 
+  638          686.49142    685.86817   0.0015674 
+  735          685.73179    685.09833   0.00136054 
+  716          684.9734     684.32935   0.00139665 
+  701          684.21625    683.56125   0.00142653 
+  703          683.46037    682.79402   0.00142248 
+  712          682.70577    682.02767   0.00140449 
+  668          681.95248    681.26218   0.00149701 
+  689          681.20053    680.49757   0.00145138 
+  726          680.44994    679.73382   0.00137741 
+  707          679.70073    678.97095   0.00141443 
+  692          678.95295    678.20894   0.00144509 
+  682          678.20661    677.4478    0.00146628 
+  654          677.46177    676.68752   0.00152905 
+  693          676.71845    675.92811   0.001443  
+  699          675.9767     675.16956   0.00143062 
+  674          675.23656    674.41187   0.00148368 
+  705          674.49809    673.65505   0.00141844 
+  663          673.76134    672.89909   0.0015083 
+  705          673.02637    672.14399   0.00141844 
+  729          672.29325    671.38975   0.00137174 
+  698          671.56204    670.63637   0.00143266 
+  692          670.83282    669.88384   0.00144509 
+  662          670.10569    669.13217   0.00151057 
+  692          669.38074    668.38136   0.00144509 
+  689          668.65806    667.63141   0.00145138 
+  679          667.93779    666.8823    0.00147275 
+  658          667.22005    666.13406   0.00151976 
+  681          666.50497    665.38666   0.00146843 
+  706          665.79273    664.64012   0.00141643 
+  700          665.0835     663.89442   0.00142857 
+  695          664.37748    663.14958   0.00143885 
+  696          663.67489    662.40559   0.00143678 
+  645          662.97598    661.66244   0.00155039 
+  700          662.28104    660.92014   0.00142857 
+  686          661.5904     660.17869   0.00145773 
+  680          660.9044     659.43808   0.00147059 
+  693          660.22349    658.69832   0.001443  
+  687          659.54811    657.9594    0.0014556 
+  689          658.87882    657.22133   0.00145138 
+  655          658.21626    656.4841    0.00152672 
+  676          657.56139    655.74771   0.00147929 
+  668          656.91456    655.01216   0.00149701 
+  737          656.27702    654.27745   0.00135685 
+  669          655.64991    653.54357   0.00149477 
+  704          655.0346     652.81054   0.00142045 
+  623          654.43273    652.07834   0.00160514 
+  717          653.84621    651.34698   0.0013947 
+  723          653.2774     650.61646   0.00138313 
+  632          652.72926    649.88677   0.00158228 
+  684          652.20498    649.15791   0.00146199 
+  673          651.70896    648.42988   0.00148588 
+  667          651.24653    647.70269   0.00149925 
+  678          650.82435    646.97633   0.00147493 
+  684          650.45096    646.2508    0.00146199 
+  639          650.13739    645.5261    0.00156495 
+  698          649.898      644.80222   0.00143266 
+  662          649.75209    644.07918   0.00151057 
+  620          649.72601    643.35696   0.0016129 
+  753          649.857      642.63556   0.00132802 
+  708          650.2027     641.91499   0.00141243 
+  674          650.86413    641.19525   0.00148368 
+  720          652.03772    640.47633   0.00138889 
+  671          654.104      639.75823   0.00149031 
+  663          657.72206    639.04096   0.0015083 
+  713          663.87671    638.3245    0.00140252 
+  709          673.80319    637.60887   0.00141044 
+  735          688.64522    636.89405   0.00136054 
+  722          709.98011    636.18005   0.00138504 
+  784          740.73049    635.46687   0.00127551 
+  780          781.92833    634.75451   0.00128205 
+  844          834.93234    634.04296   0.00118483 
+  896          896.58794    633.33223   0.00111607 
+  990          951.97305    632.62231   0.0010101 
+  1067         979.55029    631.9132    0.00093721 
+  1071         961.66917    631.20491   0.00093371 
+  950          911.51888    630.49743   0.00105263 
+  914          848.7341     629.79076   0.00109409 
+  880          783.37955    629.0849    0.00113636 
+  767          728.85262    628.37984   0.00130378 
+  691          691.7168     627.6756    0.00144718 
+  676          669.70491    626.97217   0.00147929 
+  662          657.74443    626.26954   0.00151057 
+  657          651.15516    625.56771   0.00152207 
+  641          646.79885    624.86669   0.00156006 
+  604          643.23569    624.16648   0.00165563 
+  650          640.23167    623.46707   0.00153846 
+  640          637.74689    622.76846   0.0015625 
+  654          635.78842    622.07065   0.00152905 
+  657          634.26237    621.37365   0.00152207 
+  589          632.83615    620.67744   0.00169779 
+  656          631.09931    619.98203   0.00152439 
+  618          629.05915    619.28742   0.00161812 
+  611          626.95903    618.59361   0.00163666 
+  623          624.89705    617.9006    0.00160514 
+  641          623.02585    617.20838   0.00156006 
+  638          621.45625    616.51696   0.0015674 
+  598          620.16107    615.82633   0.00167224 
+  631          619.05999    615.13649   0.00158479 
+  616          618.07789    614.44745   0.00162338 
+  606          617.16504    613.75919   0.00165017 
+  637          616.29497    613.07173   0.00156986 
+  649          615.45485    612.38506   0.00154083 
+  607          614.63795    611.69918   0.00164745 
+  621          613.84006    611.01409   0.00161031 
+  632          613.05815    610.32978   0.00158228 
+  640          612.28992    609.64626   0.0015625 
+  580          611.53356    608.96353   0.00172414 
+  600          610.78763    608.28158   0.00166667 
+  633          610.05093    607.60042   0.00157978 
+  609          609.3225     606.92004   0.00164204 
+  632          608.60153    606.24044   0.00158228 
+  617          607.88734    605.56163   0.00162075 
+  601          607.17934    604.88359   0.00166389 
+  653          606.47707    604.20634   0.00153139 
+  574          605.78009    603.52987   0.00174216 
+  591          605.08807    602.85417   0.00169205 
+  618          604.40068    602.17925   0.00161812 
+  584          603.71767    601.50511   0.00171233 
+  604          603.03882    600.83175   0.00165563 
+  629          602.36393    600.15916   0.00158983 
+  589          601.69285    599.48735   0.00169779 
+  623          601.02542    598.81631   0.00160514 
+  655          600.36153    598.14604   0.00152672 
+  629          599.70109    597.47655   0.00158983 
+  618          599.044      596.80782   0.00161812 
+  606          598.39022    596.13987   0.00165017 
+  561          597.73968    595.47269   0.00178253 
+  588          597.09235    594.80628   0.00170068 
+  631          596.4482     594.14063   0.00158479 
+  610          595.80721    593.47575   0.00163934 
+  608          595.1694     592.81164   0.00164474 
+  609          594.53475    592.1483    0.00164204 
+  544          593.90329    591.48572   0.00183824 
+  615          593.27505    590.8239    0.00162602 
+  596          592.65007    590.16285   0.00167785 
+  602          592.0284     589.50256   0.00166113 
+  637          591.41008    588.84303   0.00156986 
+  629          590.7952     588.18426   0.00158983 
+  553          590.18383    587.52626   0.00180832 
+  566          589.57605    586.86901   0.00176678 
+  593          588.97198    586.21252   0.00168634 
+  649          588.37173    585.55679   0.00154083 
+  581          587.77542    584.90182   0.00172117 
+  628          587.1832     584.2476    0.00159236 
+  581          586.59522    583.59414   0.00172117 
+  610          586.01166    582.94143   0.00163934 
+  570          585.43272    582.28948   0.00175439 
+  644          584.85861    581.63828   0.0015528 
+  576          584.28957    580.98783   0.00173611 
+  640          583.72587    580.33814   0.0015625 
+  543          583.16782    579.68919   0.00184162 
+  601          582.61577    579.041     0.00166389 
+  578          582.07009    578.39355   0.0017301 
+  539          581.53124    577.74685   0.00185529 
+  561          580.99974    577.10091   0.00178253 
+  574          580.47621    576.4557    0.00174216 
+  576          579.96137    575.81125   0.00173611 
+  565          579.45614    575.16754   0.00176991 
+  570          578.96165    574.52457   0.00175439 
+  586          578.4794     573.88235   0.00170648 
+  588          578.01159    573.24087   0.00170068 
+  554          577.56187    572.60013   0.00180505 
+  592          577.137      571.96013   0.00168919 
+  628          576.7494     571.32088   0.00159236 
+  593          576.41972    570.68236   0.00168634 
+  570          576.17812    570.04459   0.00175439 
+  605          576.06134    569.40755   0.00165289 
+  552          576.1069     568.77125   0.00181159 
+  586          576.37769    568.13568   0.00170648 
+  561          576.93523    567.50086   0.00178253 
+  594          577.78358    566.86676   0.0016835 
+  591          578.86163    566.23341   0.00169205 
+  590          579.84445    565.60078   0.00169492 
+  586          580.2058     564.96889   0.00170648 
+  603          579.55498    564.33773   0.00165837 
+  590          578.20435    563.70731   0.00169492 
+  589          576.63737    563.07761   0.00169779 
+  596          575.00529    562.44864   0.00167785 
+  582          573.55159    561.8204    0.00171821 
+  584          572.48391    561.19289   0.00171233 
+  565          571.80485    560.56611   0.00176991 
+  544          571.39388    559.94006   0.00183824 
+  574          571.15845    559.31473   0.00174216 
+  576          571.03015    558.69012   0.00173611 
+  584          570.97979    558.06625   0.00171233 
+  527          570.984      557.44309   0.00189753 
+  577          571.04269    556.82066   0.0017331 
+  590          571.15397    556.19895   0.00169492 
+  566          571.31705    555.57796   0.00176678 
+  528          571.53121    554.95769   0.00189394 
+  593          571.7954     554.33814   0.00168634 
+  552          572.10807    553.71931   0.00181159 
+  558          572.46662    553.1012    0.00179211 
+  560          572.86712    552.48381   0.00178571 
+  539          573.30424    551.86713   0.00185529 
+  584          573.77065    551.25117   0.00171233 
+  601          574.2569     550.63593   0.00166389 
+  555          574.75142    550.0214    0.0018018 
+  574          575.24021    549.40758   0.00174216 
+  553          575.70698    548.79448   0.00180832 
+  600          576.13367    548.18209   0.00166667 
+  570          576.50065    547.57041   0.00175439 
+  564          576.78742    546.95945   0.00177305 
+  579          576.97374    546.34919   0.00172712 
+  555          577.04036    545.73964   0.0018018 
+  552          576.96999    545.1308    0.00181159 
+  618          576.74854    544.52267   0.00161812 
+  545          576.36575    543.91525   0.00183486 
+  547          575.81574    543.30853   0.00182815 
+  585          575.09748    542.70252   0.0017094 
+  581          574.21474    542.09721   0.00172117 
+  568          573.17574    541.49261   0.00176056 
+  530          571.99271    540.88871   0.00188679 
+  522          570.68114    540.28551   0.00191571 
+  559          569.25884    539.68302   0.00178891 
+  549          567.74509    539.08122   0.00182149 
+  560          566.15957    538.48013   0.00178571 
+  597          564.52186    537.87974   0.00167504 
+  574          562.85036    537.28004   0.00174216 
+  549          561.16188    536.68105   0.00182149 
+  551          559.47148    536.08275   0.00181488 
+  572          557.79194    535.48515   0.00174825 
+  521          556.13381    534.88824   0.00191939 
+  572          554.5057     534.29203   0.00174825 
+  555          552.91411    533.69651   0.0018018 
+  577          551.36374    533.10169   0.0017331 
+  550          549.85789    532.50756   0.00181818 
+  567          548.39852    531.91413   0.00176367 
+  540          546.98649    531.32138   0.00185185 
+  536          545.62196    530.72933   0.00186567 
+  521          544.30447    530.13796   0.00191939 
+  518          543.03302    529.54729   0.0019305 
+  535          541.8065     528.9573    0.00186916 
+  564          540.62363    528.36801   0.00177305 
+  551          539.48314    527.77939   0.00181488 
+  492          538.38395    527.19147   0.00203252 
+  511          537.32544    526.60423   0.00195695 
+  573          536.30776    526.01768   0.0017452 
+  535          535.33291    525.43181   0.00186916 
+  487          534.40681    524.84662   0.00205339 
+  512          533.5428     524.26212   0.00195312 
+  520          532.76594    523.6783    0.00192308 
+  507          532.11619    523.09516   0.00197239 
+  589          531.64683    522.51271   0.00169779 
+  558          531.41604    521.93093   0.00179211 
+  552          531.50894    521.34983   0.00181159 
+  548          532.00991    520.76941   0.00182482 
+  509          532.90455    520.18967   0.00196464 
+  527          534.03254    519.6106    0.00189753 
+  511          534.88249    519.03221   0.00195695 
+  522          534.7099     518.4545    0.00191571 
+  512          533.2043     517.87746   0.00195312 
+  512          530.99637    517.3011    0.00195312 
+  524          528.59914    516.7254    0.0019084 
+  503          526.10559    516.15039   0.00198807 
+  516          523.81873    515.57604   0.00193798 
+  473          521.99202    515.00237   0.00211416 
+  509          520.6098     514.42936   0.00196464 
+  528          519.54186    513.85703   0.00189394 
+  545          518.65613    513.28536   0.00183486 
+  522          517.86436    512.71437   0.00191571 
+  483          517.12163    512.14404   0.00207039 
+  515          516.40843    511.57438   0.00194175 
+  494          515.71616    511.00538   0.00202429 
+  501          515.04032    510.43705   0.00199601 
+  531          514.37806    509.86939   0.00188324 
+  496          513.72744    509.30239   0.00201613 
+  525          513.08708    508.73605   0.00190476 
+  507          512.45584    508.17038   0.00197239 
+  519          511.83298    507.60537   0.00192678 
+  523          511.21788    507.04102   0.00191205 
+  507          510.61007    506.47733   0.00197239 
+  472          510.00918    505.9143    0.00211864 
+  513          509.41491    505.35193   0.00194932 
+  511          508.82705    504.79021   0.00195695 
+  516          508.24544    504.22916   0.00193798 
+  482          507.66993    503.66876   0.00207469 
+  536          507.10046    503.10902   0.00186567 
+  504          506.53697    502.54994   0.00198413 
+  519          505.97945    501.99151   0.00192678 
+  454          505.42791    501.43373   0.00220264 
+  467          504.88239    500.87661   0.00214133 
+  536          504.34298    500.32014   0.00186567 
+  502          503.80976    499.76433   0.00199203 
+  519          503.28288    499.20916   0.00192678 
+  563          502.76247    498.65465   0.0017762 
+  510          502.24872    498.10079   0.00196078 
+  535          501.74186    497.54757   0.00186916 
+  492          501.24211    496.99501   0.00203252 
+  509          500.74975    496.44309   0.00196464 
+  543          500.26511    495.89182   0.00184162 
+  485          499.7885     495.3412    0.00206186 
+  537          499.32032    494.79122   0.0018622 
+  469          498.86099    494.24189   0.0021322 
+  511          498.41096    493.6932    0.00195695 
+  489          497.97073    493.14516   0.00204499 
+  502          497.54088    492.59776   0.00199203 
+  480          497.12194    492.051     0.00208333 
+  453          496.71459    491.50488   0.00220751 
+  502          496.3195     490.95941   0.00199203 
+  508          495.93741    490.41458   0.0019685 
+  529          495.5691     489.87038   0.00189036 
+  489          495.21542    489.32683   0.00204499 
+  530          494.8772     488.78391   0.00188679 
+  485          494.55538    488.24163   0.00206186 
+  472          494.25118    487.69999   0.00211864 
+  465          493.96494    487.15898   0.00215054 
+  483          493.69794    486.61861   0.00207039 
+  442          493.4511     486.07888   0.00226244 
+  493          493.22528    485.53978   0.0020284 
+  503          493.02131    485.00131   0.00198807 
+  512          492.83989    484.46348   0.00195312 
+  500          492.68149    483.92628   0.002     
+  486          492.54663    483.38971   0.00205761 
+  492          492.43497    482.85377   0.00203252 
+  471          492.34629    482.31846   0.00212314 
+  492          492.27985    481.78378   0.00203252 
+  518          492.23432    481.24973   0.0019305 
+  463          492.20769    480.71631   0.00215983 
+  473          492.19734    480.18351   0.00211416 
+  480          492.19974    479.65134   0.00208333 
+  485          492.21037    479.1198    0.00206186 
+  478          492.22379    478.58889   0.00209205 
+  515          492.23333    478.0586    0.00194175 
+  467          492.23133    477.52893   0.00214133 
+  438          492.20893    476.99988   0.00228311 
+  451          492.15643    476.47146   0.00221729 
+  498          492.06344    475.94366   0.00200803 
+  470          491.91924    475.41649   0.00212766 
+  485          491.71342    474.88993   0.00206186 
+  460          491.43636    474.36399   0.00217391 
+  506          491.07987    473.83868   0.00197628 
+  508          490.63789    473.31398   0.0019685 
+  506          490.10685    472.7899    0.00197628 
+  470          489.48607    472.26644   0.00212766 
+  458          488.77781    471.74359   0.00218341 
+  498          487.98706    471.22136   0.00200803 
+  466          487.12135    470.69975   0.00214592 
+  498          486.18998    470.17875   0.00200803 
+  463          485.20357    469.65836   0.00215983 
+  482          484.17339    469.13859   0.00207469 
+  464          483.11066    468.61943   0.00215517 
+  447          482.02612    468.10089   0.00223714 
+  483          480.92968    467.58295   0.00207039 
+  481          479.83001    467.06563   0.002079  
+  482          478.73456    466.54891   0.00207469 
+  477          477.64949    466.03281   0.00209644 
+  471          476.57961    465.51731   0.00212314 
+  460          475.52862    465.00242   0.00217391 
+  436          474.4992     464.48814   0.00229358 
+  456          473.49309    463.97447   0.00219298 
+  472          472.51133    463.4614    0.00211864 
+  460          471.55439    462.94894   0.00217391 
+  414          470.6222     462.43708   0.00241546 
+  452          469.71439    461.92583   0.00221239 
+  484          468.83033    461.41518   0.00206612 
+  460          467.96914    460.90514   0.00217391 
+  488          467.12986    460.39569   0.00204918 
+  457          466.31147    459.88685   0.00218818 
+  418          465.51286    459.37861   0.00239234 
+  452          464.73292    458.87097   0.00221239 
+  455          463.9706     458.36393   0.0021978 
+  457          463.22481    457.85748   0.00218818 
+  482          462.49453    457.35164   0.00207469 
+  450          461.7788     456.84639   0.00222222 
+  450          461.07667    456.34174   0.00222222 
+  442          460.38728    455.83769   0.00226244 
+  428          459.7098     455.33423   0.00233645 
+  449          459.04344    454.83137   0.00222717 
+  432          458.3875     454.32911   0.00231481 
+  479          457.74154    453.82743   0.00208768 
+  424          457.10446    453.32635   0.00235849 
+  434          456.4759     452.82586   0.00230415 
+  418          455.85534    452.32597   0.00239234 
+  450          455.24227    451.82666   0.00222222 
+  405          454.63622    451.32795   0.00246914 
+  467          454.03679    450.82983   0.00214133 
+  471          453.44355    450.33229   0.00212314 
+  444          452.85614    449.83534   0.00225225 
+  430          452.27436    449.33899   0.00232558 
+  411          451.69764    448.84322   0.00243309 
+  438          451.12581    448.34803   0.00228311 
+  469          450.5586     447.85343   0.0021322 
+  414          449.99577    447.35942   0.00241546 
+  437          449.43709    446.86599   0.00228833 
+  436          448.88233    446.37315   0.00229358 
+  458          448.33133    445.88089   0.00218341 
+  446          447.78387    445.38922   0.00224215 
+  426          447.23981    444.89812   0.00234742 
+  403          446.69895    444.40761   0.00248139 
+  465          446.16118    443.91768   0.00215054 
+  451          445.62657    443.42833   0.00221729 
+  452          445.09456    442.93955   0.00221239 
+  462          444.56526    442.45136   0.0021645 
+  422          444.03855    441.96375   0.00236967 
+  417          443.51434    441.47671   0.00239808 
+  416          442.99252    440.99025   0.00240385 
+  416          442.47302    440.50437   0.00240385 
+  415          441.95575    440.01906   0.00240964 
+  432          441.44288    439.53433   0.00231481 
+  440          440.92996    439.05018   0.00227273 
+  419          440.41898    438.5666    0.00238663 
+  429          439.90993    438.08359   0.002331  
+  438          439.40391    437.60115   0.00228311 
+  409          438.89862    437.11929   0.00244499 
+  472          438.39513    436.638     0.00211864 
+  424          437.89339    436.15728   0.00235849 
+  446          437.39336    435.67712   0.00224215 
+  404          436.895      435.19754   0.00247525 
+  416          436.39827    434.71853   0.00240385 
+  384          435.90316    434.24009   0.00260417 
+  384          435.4096     433.76221   0.00260417 
+  437          434.91758    433.28491   0.00228833 
+  402          434.42707    432.80816   0.00248756 
+  412          433.93804    432.33199   0.00242718 
+  433          433.45048    431.85638   0.00230947 
+  417          432.96437    431.38133   0.00239808 
+  443          432.47968    430.90685   0.00225734 
+  437          431.99639    430.43293   0.00228833 
+  420          431.5145     429.95958   0.00238095 
+  409          431.03399    429.48679   0.00244499 
+  431          430.55484    429.01456   0.00232019 
+  433          430.07713    428.54289   0.00230947 
+  418          429.60069    428.07178   0.00239234 
+  419          429.1256     427.60123   0.00238663 
+  433          428.65184    427.13124   0.00230947 
+  424          428.17941    426.6618    0.00235849 
+  418          427.70832    426.19293   0.00239234 
+  410          427.23856    425.72461   0.00243902 
+  416          426.77012    425.25685   0.00240385 
+  442          426.30303    424.78965   0.00226244 
+  431          425.8373     424.323     0.00232019 
+  412          425.37288    423.85691   0.00242718 
+  438          424.90982    423.39137   0.00228311 
+  421          424.44811    422.92638   0.0023753 
+  421          423.98777    422.46195   0.0023753 
+  402          423.52882    421.99807   0.00248756 
+  424          423.07126    421.53475   0.00235849 
+  406          422.61512    421.07197   0.00246305 
+  424          422.1604     420.60974   0.00235849 
+  406          421.70714    420.14807   0.00246305 
+  415          421.25535    419.68694   0.00240964 
+  442          420.80505    419.22636   0.00226244 
+  422          420.35628    418.76633   0.00236967 
+  407          419.90907    418.30685   0.002457  
+  381          419.46344    417.84792   0.00262467 
+  412          419.01943    417.38953   0.00242718 
+  428          418.57708    416.93169   0.00233645 
+  389          418.13642    416.47439   0.00257069 
+  396          417.69751    416.01764   0.00252525 
+  443          417.26039    415.56143   0.00225734 
+  443          416.82512    415.10577   0.00225734 
+  440          416.39174    414.65064   0.00227273 
+  381          415.96032    414.19606   0.00262467 
+  426          415.53093    413.74203   0.00234742 
+  409          415.10363    413.28853   0.00244499 
+  393          414.6785     412.83557   0.00254453 
+  404          414.25562    412.38316   0.00247525 
+  437          413.83509    411.93128   0.00228833 
+  435          413.41698    411.47994   0.00229885 
+  397          413.00142    411.02914   0.00251889 
+  404          412.58851    410.57888   0.00247525 
+  414          412.17836    410.12915   0.00241546 
+  429          411.77111    409.67996   0.002331  
+  373          411.36691    409.23131   0.00268097 
+  434          410.96589    408.78319   0.00230415 
+  401          410.56823    408.3356    0.00249377 
+  405          410.1741     407.88855   0.00246914 
+  388          409.78369    407.44203   0.00257732 
+  404          409.3972     406.99605   0.00247525 
+  429          409.01488    406.5506    0.002331  
+  414          408.63695    406.10567   0.00241546 
+  407          408.26367    405.66128   0.002457  
+  402          407.89533    405.21742   0.00248756 
+  390          407.53225    404.77409   0.0025641 
+  395          407.17474    404.33129   0.00253165 
+  384          406.82318    403.88902   0.00260417 
+  416          406.47794    403.44728   0.00240385 
+  378          406.13945    403.00606   0.0026455 
+  398          405.80815    402.56537   0.00251256 
+  382          405.48454    402.12521   0.0026178 
+  372          405.16913    401.68557   0.00268817 
+  413          404.86251    401.24646   0.00242131 
+  396          404.56525    400.80787   0.00252525 
+  372          404.27801    400.36981   0.00268817 
+  374          404.00147    399.93227   0.0026738 
+  345          403.73639    399.49525   0.00289855 
+  384          403.48349    399.05875   0.00260417 
+  410          403.24363    398.62278   0.00243902 
+  365          403.0176     398.18733   0.00273973 
+  380          402.80741    397.75239   0.00263158 
+  418          402.61172    397.31798   0.00239234 
+  383          402.43253    396.88409   0.00261097 
+  385          402.27072    396.45071   0.0025974 
+  457          402.12709    396.01786   0.00218818 
+  397          402.00298    395.58552   0.00251889 
+  420          401.89784    395.1537    0.00238095 
+  395          401.81268    394.72239   0.00253165 
+  400          401.74769    394.2916    0.0025    
+  417          401.70277    393.86133   0.00239808 
+  403          401.6773     393.43157   0.00248139 
+  380          401.67026    393.00233   0.00263158 
+  354          401.67979    392.5736    0.00282486 
+  380          401.69858    392.14538   0.00263158 
+  374          401.7329     391.71767   0.0026738 
+  400          401.77342    391.29048   0.0025    
+  373          401.8124     390.8638    0.00268097 
+  368          401.84811    390.43762   0.00271739 
+  380          401.87044    390.01196   0.00263158 
+  367          401.87115    389.58681   0.0027248 
+  392          401.84121    389.16217   0.00255102 
+  370          401.77144    388.73803   0.0027027 
+  382          401.65283    388.31441   0.0026178 
+  369          401.47709    387.89129   0.00271003 
+  377          401.23736    387.46868   0.00265252 
+  399          400.92828    387.04657   0.00250627 
+  406          400.54672    386.62497   0.00246305 
+  402          400.09174    386.20387   0.00248756 
+  406          399.56476    385.78328   0.00246305 
+  379          398.96928    385.3632    0.00263852 
+  374          398.31107    384.94361   0.0026738 
+  379          397.59712    384.52453   0.00263852 
+  365          396.8357     384.10595   0.00273973 
+  387          396.03601    383.68788   0.00258398 
+  403          395.20775    383.2703    0.00248139 
+  416          394.36097    382.85323   0.00240385 
+  406          393.50595    382.43665   0.00246305 
+  399          392.65216    382.02058   0.00250627 
+  362          391.80812    381.605     0.00276243 
+  356          390.98122    381.18992   0.00280899 
+  400          390.16241    380.77534   0.0025    
+  386          389.34283    380.36126   0.00259067 
+  392          388.50803    379.94768   0.00255102 
+  352          387.66343    379.53459   0.00284091 
+  390          386.83711    379.12199   0.0025641 
+  395          386.02478    378.70989   0.00253165 
+  375          385.22771    378.29829   0.00266667 
+  403          384.44907    377.88718   0.00248139 
+  390          383.69817    377.47656   0.0025641 
+  407          382.97718    377.06644   0.002457  
+  378          382.27898    376.6568    0.0026455 
+  374          381.60285    376.24766   0.0026738 
+  362          380.94571    375.83901   0.00276243 
+  357          380.31088    375.43086   0.00280112 
+  389          379.68603    375.02319   0.00257069 
+  334          379.07554    374.61601   0.00299401 
+  353          378.47847    374.20932   0.00283286 
+  374          377.89392    373.80312   0.0026738 
+  365          377.32112    373.3974    0.00273973 
+  336          376.75928    372.99218   0.00297619 
+  368          376.20771    372.58744   0.00271739 
+  368          375.66572    372.18318   0.00271739 
+  371          375.13544    371.77942   0.00269542 
+  372          374.61079    371.37613   0.00268817 
+  352          374.09397    370.97334   0.00284091 
+  360          373.58448    370.57102   0.00277778 
+  325          373.08185    370.16919   0.00307692 
+  379          372.58566    369.76785   0.00263852 
+  371          372.09549    369.36698   0.00269542 
+  350          371.6165     368.9666    0.00285714 
+  385          371.1373     368.5667    0.0025974 
+  372          370.66589    368.16728   0.00268817 
+  388          370.19638    367.76834   0.00257732 
+  336          369.7313     367.36988   0.00297619 
+  357          369.2704     366.9719    0.00280112 
+  375          368.81343    366.57439   0.00266667 
+  361          368.36019    366.17737   0.00277008 
+  384          367.91049    365.78082   0.00260417 
+  355          367.46687    365.38475   0.0028169 
+  370          367.02367    364.98916   0.0027027 
+  354          366.58488    364.59404   0.00282486 
+  336          366.14757    364.1994    0.00297619 
+  363          365.71298    363.80523   0.00275482 
+  350          365.281      363.41154   0.00285714 
+  388          364.85151    363.01832   0.00257732 
+  362          364.42441    362.62558   0.00276243 
+  351          363.9996     362.23331   0.002849  
+  365          363.57697    361.84151   0.00273973 
+  391          363.15644    361.45018   0.00255754 
+  367          362.73794    361.05932   0.0027248 
+  343          362.32139    360.66894   0.00291545 
+  344          361.90672    360.27902   0.00290698 
+  359          361.49388    359.88957   0.00278552 
+  329          361.08279    359.50059   0.00303951 
+  385          360.6734     359.11209   0.0025974 
+  384          360.26567    358.72405   0.00260417 
+  321          359.85954    358.33647   0.00311526 
+  333          359.45498    357.94937   0.003003  
+  352          359.05193    357.56273   0.00284091 
+  344          358.65037    357.17655   0.00290698 
+  364          358.25093    356.79084   0.00274725 
+  316          357.85224    356.4056    0.00316456 
+  377          357.45493    356.02082   0.00265252 
+  342          357.05899    355.6365    0.00292398 
+  352          356.66439    355.25265   0.00284091 
+  356          356.27143    354.86926   0.00280899 
+  328          355.87943    354.48634   0.00304878 
+  353          355.48871    354.10387   0.00283286 
+  364          355.09924    353.72187   0.00274725 
+  359          354.71103    353.34032   0.00278552 
+  352          354.32444    352.95924   0.00284091 
+  319          353.93868    352.57862   0.0031348 
+  345          353.55513    352.19845   0.00289855 
+  372          353.17168    351.81875   0.00268817 
+  375          352.78974    351.4395    0.00266667 
+  339          352.4088     351.06071   0.00294985 
+  379          352.02899    350.68237   0.00263852 
+  352          351.65093    350.3045    0.00284091 
+  338          351.27357    349.92708   0.00295858 
+  390          350.8974     349.55011   0.0025641 
+  352          350.52243    349.1736    0.00284091 
+  344          350.14867    348.79755   0.00290698 
+  373          349.77613    348.42195   0.00268097 
+  349          349.4048     348.0468    0.00286533 
+  301          349.03472    347.6721    0.00332226 
+  365          348.66589    347.29786   0.00273973 
+  340          348.29832    346.92407   0.00294118 
+  319          347.93204    346.55073   0.0031348 
+  368          347.56707    346.17784   0.00271739 
+  357          347.20342    345.8054    0.00280112 
+  315          346.84113    345.43342   0.0031746 
+  334          346.48021    345.06188   0.00299401 
+  351          346.12071    344.69079   0.002849  
+  316          345.76266    344.32015   0.00316456 
+  340          345.40609    343.94995   0.00294118 
+  298          345.05105    343.58021   0.0033557 
+  346          344.69758    343.21091   0.00289017 
+  341          344.34574    342.84205   0.00293255 
+  355          343.99557    342.47365   0.0028169 
+  330          343.64715    342.10568   0.0030303 
+  321          343.30053    341.73817   0.00311526 
+  333          342.9558     341.37109   0.003003  
+  332          342.61305    341.00446   0.00301205 
+  328          342.27239    340.63828   0.00304878 
+  317          341.93395    340.27254   0.00315457 
+  341          341.59796    339.90723   0.00293255 
+  333          341.26476    339.54238   0.003003  
+  329          340.93488    339.17796   0.00303951 
+  351          340.60908    338.81398   0.002849  
+  303          340.28848    338.45044   0.00330033 
+  344          339.97334    338.08735   0.00290698 
+  349          339.664      337.72469   0.00286533 
+  340          339.35855    337.36247   0.00294118 
+  319          339.05332    337.00069   0.0031348 
+  327          338.74319    336.63935   0.0030581 
+  328          338.42946    336.27844   0.00304878 
+  315          338.11839    335.91797   0.0031746 
+  338          337.81256    335.55794   0.00295858 
+  336          337.51056    335.19835   0.00297619 
+  313          337.21214    334.83918   0.00319489 
+  334          336.92019    334.48046   0.00299401 
+  351          336.63649    334.12217   0.002849  
+  356          336.36146    333.76431   0.00280899 
+  334          336.09467    333.40688   0.00299401 
+  350          335.83614    333.04989   0.00285714 
+  331          335.58615    332.69333   0.00302115 
+  331          335.34528    332.3372    0.00302115 
+  339          335.11433    331.98151   0.00294985 
+  325          334.89423    331.62624   0.00307692 
+  324          334.68611    331.27141   0.00308642 
+  309          334.49128    330.917     0.00323625 
+  331          334.31117    330.56303   0.00302115 
+  312          334.14751    330.20948   0.00320513 
+  320          334.0023     329.85636   0.003125  
+  313          333.87777    329.50367   0.00319489 
+  328          333.7766     329.15141   0.00304878 
+  323          333.70196    328.79957   0.00309598 
+  312          333.65748    328.44816   0.00320513 
+  308          333.64755    328.09718   0.00324675 
+  360          333.67742    327.74662   0.00277778 
+  325          333.75321    327.39648   0.00307692 
+  312          333.88248    327.04678   0.00320513 
+  311          334.0744     326.69749   0.00321543 
+  363          334.34011    326.34863   0.00275482 
+  321          334.69346    326.00019   0.00311526 
+  312          335.15184    325.65218   0.00320513 
+  306          335.73676    325.30458   0.00326797 
+  347          336.47604    324.95741   0.00288184 
+  346          337.40549    324.61066   0.00289017 
+  299          338.57183    324.26433   0.00334448 
+  322          340.03744    323.91842   0.00310559 
+  325          341.88881    323.57293   0.00307692 
+  349          344.24852    323.22786   0.00286533 
+  352          347.30542    322.88321   0.00284091 
+  340          351.36738    322.53897   0.00294118 
+  395          356.95565    322.19516   0.00253165 
+  341          364.94593    321.85176   0.00293255 
+  405          376.73898    321.50878   0.00246914 
+  400          394.40002    321.16621   0.0025    
+  427          420.6075     320.82406   0.00234192 
+  428          458.09802    320.48233   0.00233645 
+  484          507.85111    320.14101   0.00206612 
+  478          566.5854     319.8001    0.00209205 
+  493          628.29638    319.45961   0.0020284 
+  529          685.84707    319.11953   0.00189036 
+  560          721.53586    318.77987   0.00178571 
+  501          717.40425    318.44062   0.00199601 
+  478          683.69106    318.10178   0.00209205 
+  450          642.78468    317.76335   0.00222222 
+  412          599.9948     317.42533   0.00242718 
+  382          549.56896    317.08773   0.0026178 
+  394          495.75796    316.75053   0.00253807 
+  368          448.55222    316.41374   0.00271739 
+  359          412.36186    316.07736   0.00278552 
+  309          386.54461    315.7414    0.00323625 
+  297          368.80371    315.40584   0.003367  
+  320          356.76831    315.07068   0.003125  
+  328          348.42016    314.73594   0.00304878 
+  286          342.4033     314.4016    0.0034965 
+  294          337.84972    314.06767   0.00340136 
+  297          334.25293    313.73414   0.003367  
+  312          331.31889    313.40102   0.00320513 
+  330          328.8694     313.06831   0.0030303 
+  332          326.78844    312.736     0.00301205 
+  322          324.99443    312.40409   0.00310559 
+  325          323.42778    312.07259   0.00307692 
+  305          322.04403    311.74149   0.00327869 
+  303          320.80887    311.41079   0.00330033 
+  322          319.69584    311.0805    0.00310559 
+  286          318.684      310.7506    0.0034965 
+  322          317.75683    310.42111   0.00310559 
+  328          316.90101    310.09202   0.00304878 
+  356          316.10586    309.76333   0.00280899 
+  301          315.36262    309.43504   0.00332226 
+  319          314.66388    309.10715   0.0031348 
+  292          314.0039     308.77966   0.00342466 
+  338          313.37739    308.45256   0.00295858 
+  336          312.78024    308.12587   0.00297619 
+  320          312.20893    307.79957   0.003125  
+  319          311.66041    307.47367   0.0031348 
+  316          311.13208    307.14817   0.00316456 
+  309          310.62176    306.82306   0.00323625 
+  327          310.12753    306.49835   0.0030581 
+  318          309.6478     306.17403   0.00314465 
+  335          309.18106    305.85011   0.00298507 
+  301          308.726      305.52659   0.00332226 
+  326          308.28159    305.20345   0.00306748 
+  273          307.84686    304.88071   0.003663  
+  308          307.42098    304.55837   0.00324675 
+  309          307.00319    304.23641   0.00323625 
+  285          306.59285    303.91485   0.00350877 
+  272          306.18935    303.59368   0.00367647 
+  293          305.79219    303.27291   0.00341297 
+  308          305.40094    302.95252   0.00324675 
+  292          305.01514    302.63252   0.00342466 
+  316          304.63441    302.31291   0.00316456 
+  300          304.25845    301.9937    0.00333333 
+  262          303.88698    301.67487   0.00381679 
+  300          303.51974    301.35643   0.00333333 
+  288          303.15649    301.03838   0.00347222 
+  332          302.79704    300.72071   0.00301205 
+  312          302.44121    300.40343   0.00320513 
+  312          302.08885    300.08654   0.00320513 
+  287          301.73984    299.77004   0.00348432 
+  292          301.39403    299.45392   0.00342466 
+  293          301.05133    299.13819   0.00341297 
+  305          300.71169    298.82284   0.00327869 
+  286          300.37503    298.50788   0.0034965 
+  301          300.04131    298.1933    0.00332226 
+  313          299.71052    297.87911   0.00319489 
+  302          299.38264    297.56529   0.00331126 
+  311          299.05769    297.25187   0.00321543 
+  271          298.73571    296.93882   0.00369004 
+  279          298.41675    296.62615   0.00358423 
+  309          298.10102    296.31387   0.00323625 
+  293          297.78837    296.00197   0.00341297 
+  298          297.47905    295.69045   0.0033557 
+  308          297.17324    295.3793    0.00324675 
+  314          296.87116    295.06854   0.00318471 
+  309          296.57305    294.75816   0.00323625 
+  315          296.27923    294.44816   0.0031746 
+  315          295.99006    294.13853   0.0031746 
+  271          295.70601    293.82928   0.00369004 
+  272          295.42759    293.52041   0.00367647 
+  304          295.15553    293.21192   0.00328947 
+  292          294.8905     292.9038    0.00342466 
+  275          294.63351    292.59606   0.00363636 
+  330          294.38574    292.2887    0.0030303 
+  265          294.14866    291.98171   0.00377358 
+  291          293.92404    291.6751    0.00343643 
+  289          293.71414    291.36886   0.00346021 
+  292          293.52182    291.06299   0.00342466 
+  292          293.3507     290.7575    0.00342466 
+  289          293.20549    290.45238   0.00346021 
+  304          293.0924     290.14763   0.00328947 
+  275          293.01958    289.84326   0.00363636 
+  316          292.9982     289.53926   0.00316456 
+  280          293.04371    289.23562   0.00357143 
+  304          293.1784     288.93236   0.00328947 
+  311          293.43464    288.62948   0.00321543 
+  314          293.86821    288.32696   0.00318471 
+  337          294.58676    288.02481   0.00296736 
+  328          295.82287    287.72303   0.00304878 
+  369          298.06736    287.42162   0.00271003 
+  367          302.22764    287.12057   0.0027248 
+  379          309.78454    286.8199    0.00263852 
+  379          322.62397    286.51959   0.00263852 
+  415          341.98776    286.21965   0.00240964 
+  435          367.52659    285.92008   0.00229885 
+  537          395.32985    285.62087   0.0018622 
+  596          414.47206    285.32203   0.00167785 
+  559          414.82452    285.02355   0.00178891 
+  554          399.25338    284.72544   0.00180505 
+  492          382.80816    284.42769   0.00203252 
+  479          370.50105    284.13031   0.00208768 
+  497          357.18184    283.83329   0.00201207 
+  390          339.0838     283.53664   0.0025641 
+  379          320.63822    283.24034   0.00263852 
+  378          306.60497    282.94441   0.0026455 
+  297          297.7237     282.64885   0.003367  
+  291          292.681      282.35364   0.00343643 
+  274          289.83825    282.05879   0.00364964 
+  310          288.06261    281.76431   0.00322581 
+  281          286.7899     281.47018   0.00355872 
+  300          285.78419    281.17642   0.00333333 
+  256          284.94578    280.88302   0.00390625 
+  259          284.22373    280.58997   0.003861  
+  288          283.58683    280.29728   0.00347222 
+  276          283.01401    280.00495   0.00362319 
+  319          282.49051    279.71298   0.0031348 
+  307          282.00554    279.42137   0.00325733 
+  332          281.55124    279.13011   0.00301205 
+  301          281.12167    278.83921   0.00332226 
+  284          280.71228    278.54867   0.00352113 
+  282          280.31957    278.25848   0.0035461 
+  281          279.94081    277.96865   0.00355872 
+  268          279.57379    277.67917   0.00373134 
+  257          279.21676    277.39005   0.00389105 
+  270          278.86832    277.10128   0.0037037 
+  276          278.52731    276.81286   0.00362319 
+  290          278.19278    276.5248    0.00344828 
+  258          277.86395    276.23709   0.00387597 
+  296          277.54016    275.94973   0.00337838 
+  258          277.22085    275.66273   0.00387597 
+  302          276.90558    275.37607   0.00331126 
+  277          276.59396    275.08977   0.00361011 
+  290          276.28564    274.80382   0.00344828 
+  265          275.98035    274.51822   0.00377358 
+  248          275.67785    274.23297   0.00403226 
+  310          275.37794    273.94807   0.00322581 
+  272          275.0806     273.66352   0.00367647 
+  262          274.78537    273.37931   0.00381679 
+  277          274.49228    273.09546   0.00361011 
+  278          274.20122    272.81195   0.00359712 
+  268          273.9121     272.52879   0.00373134 
+  267          273.62487    272.24598   0.00374532 
+  274          273.33945    271.96351   0.00364964 
+  258          273.05581    271.68139   0.00387597 
+  283          272.77395    271.39962   0.00353357 
+  274          272.49377    271.11819   0.00364964 
+  272          272.21539    270.83711   0.00367647 
+  266          271.93865    270.55637   0.0037594 
+  278          271.66365    270.27597   0.00359712 
+  239          271.39042    269.99592   0.0041841 
+  268          271.119      269.71622   0.00373134 
+  277          270.84944    269.43685   0.00361011 
+  272          270.58181    269.15783   0.00367647 
+  295          270.31621    268.87915   0.00338983 
+  280          270.05276    268.60081   0.00357143 
+  265          269.79159    268.32282   0.00377358 
+  259          269.53282    268.04516   0.003861  
+  269          269.27665    267.76785   0.00371747 
+  235          269.02333    267.49088   0.00425532 
+  271          268.77311    267.21424   0.00369004 
+  272          268.52632    266.93795   0.00367647 
+  263          268.28334    266.66199   0.00380228 
+  280          268.04465    266.38638   0.00357143 
+  278          267.81081    266.1111    0.00359712 
+  266          267.58252    265.83616   0.0037594 
+  270          267.36063    265.56156   0.0037037 
+  264          267.1462     265.28729   0.00378788 
+  285          266.94059    265.01336   0.00350877 
+  281          266.74546    264.73977   0.00355872 
+  258          266.56301    264.46651   0.00387597 
+  259          266.39606    264.19359   0.003861  
+  277          266.24837    263.921     0.00361011 
+  282          266.12497    263.64875   0.0035461 
+  261          266.0328     263.37683   0.00383142 
+  276          265.98155    263.10525   0.00362319 
+  276          265.98547    262.834     0.00362319 
+  299          266.0672     262.56308   0.00334448 
+  297          266.26822    262.2925    0.003367  
+  271          266.67592    262.02225   0.00369004 
+  297          267.48075    261.75233   0.003367  
+  257          269.06483    261.48274   0.00389105 
+  299          272.10087    261.21348   0.00334448 
+  310          277.54833    260.94456   0.00322581 
+  293          286.273      260.67596   0.00341297 
+  350          298.26466    260.4077    0.00285714 
+  340          312.05044    260.13976   0.00294118 
+  401          322.84949    259.87215   0.00249377 
+  470          324.87644    259.60488   0.00212766 
+  403          317.88446    259.33793   0.00248139 
+  357          309.19169    259.0713    0.00280112 
+  368          303.28913    258.80501   0.00271739 
+  366          298.18317    258.53904   0.00273224 
+  361          290.65392    258.2734    0.00277008 
+  324          281.37467    258.00809   0.00308642 
+  275          273.39811    257.74311   0.00363636 
+  268          267.95788    257.47844   0.00373134 
+  235          264.7404     257.21411   0.00425532 
+  282          262.93525    256.9501    0.0035461 
+  272          261.85723    256.68641   0.00367647 
+  262          261.12237    256.42305   0.00381679 
+  277          260.56232    256.16001   0.00361011 
+  272          260.10911    255.8973    0.00367647 
+  299          259.73195    255.63491   0.00334448 
+  257          259.41401    255.37284   0.00389105 
+  266          259.1451     255.11109   0.0037594 
+  270          258.91909    254.84967   0.0037037 
+  243          258.73267    254.58856   0.00411523 
+  249          258.58463    254.32778   0.00401606 
+  258          258.47899    254.06732   0.00387597 
+  280          258.4114     253.80718   0.00357143 
+  261          258.3893     253.54736   0.00383142 
+  274          258.41881    253.28786   0.00364964 
+  263          258.50846    253.02868   0.00380228 
+  242          258.66966    252.76982   0.00413223 
+  298          258.91975    252.51127   0.0033557 
+  271          259.27641    252.25305   0.00369004 
+  275          259.81951    251.99514   0.00363636 
+  301          260.49092    251.73755   0.00332226 
+  292          261.39731    251.48027   0.00342466 
+  296          262.62399    251.22332   0.00337838 
+  309          264.31198    250.96668   0.00323625 
+  269          266.75471    250.71035   0.00371747 
+  288          270.48394    250.45434   0.00347222 
+  310          276.78338    250.19865   0.00322581 
+  291          288.13549    249.94327   0.00343643 
+  345          308.73976    249.6882    0.00289855 
+  374          344.23901    249.43345   0.0026738 
+  416          398.26754    249.17902   0.00240385 
+  501          468.62525    248.92489   0.00199601 
+  507          542.2806     248.67108   0.00197239 
+  521          588.23922    248.41758   0.00191939 
+  491          580.83039    248.1644    0.00203666 
+  481          535.47368    247.91152   0.002079  
+  413          494.02469    247.65896   0.00242131 
+  439          468.68562    247.40671   0.0022779 
+  391          442.44557    247.15477   0.00255754 
+  345          400.47888    246.90314   0.00289855 
+  342          352.28743    246.65182   0.00292398 
+  309          313.39952    246.40081   0.00323625 
+  287          288.1572     246.1501    0.00348432 
+  240          273.88251    245.89971   0.00416667 
+  278          266.17543    245.64963   0.00359712 
+  261          261.71505    245.39985   0.00383142 
+  236          258.76491    245.15038   0.00423729 
+  235          256.58847    244.90122   0.00425532 
+  284          254.88217    244.65237   0.00352113 
+  240          253.49914    244.40382   0.00416667 
+  249          252.34879    244.15558   0.00401606 
+  240          251.37388    243.90764   0.00416667 
+  285          250.53364    243.66001   0.00350877 
+  262          249.7986     243.41269   0.00381679 
+  263          249.14797    243.16567   0.00380228 
+  261          248.56429    242.91896   0.00383142 
+  239          248.03604    242.67255   0.0041841 
+  235          247.55383    242.42644   0.00425532 
+  272          247.11044    242.18063   0.00367647 
+  272          246.70015    241.93513   0.00367647 
+  234          246.31853    241.68994   0.0042735 
+  264          245.96203    241.44504   0.00378788 
+  245          245.62895    241.20045   0.00408163 
+  244          245.31499    240.95616   0.00409836 
+  244          245.01957    240.71217   0.00409836 
+  273          244.74148    240.46848   0.003663  
+  263          244.47991    240.22509   0.00380228 
+  230          244.23435    239.982     0.00434783 
+  271          244.00525    239.73921   0.00369004 
+  279          243.79179    239.49672   0.00358423 
+  256          243.59518    239.25453   0.00390625 
+  239          243.41654    239.01264   0.0041841 
+  234          243.25761    238.77105   0.0042735 
+  246          243.12086    238.52975   0.00406504 
+  234          243.00974    238.28875   0.0042735 
+  232          242.92914    238.04805   0.00431034 
+  241          242.88599    237.80765   0.00414938 
+  265          242.89054    237.56754   0.00377358 
+  243          242.95904    237.32773   0.00411523 
+  268          243.12169    237.08822   0.00373134 
+  269          243.44197    236.849     0.00371747 
+  235          244.05777    236.61008   0.00425532 
+  287          245.24461    236.37145   0.00348432 
+  284          247.47834    236.13312   0.00352113 
+  281          251.40316    235.89508   0.00355872 
+  293          257.48214    235.65733   0.00341297 
+  317          265.44412    235.41988   0.00315457 
+  339          273.78863    235.18272   0.00294985 
+  320          279.04434    234.94585   0.003125  
+  325          278.38985    234.70928   0.00307692 
+  323          273.82638    234.473     0.00309598 
+  326          270.25983    234.23701   0.00306748 
+  313          269.48001    234.00131   0.00319489 
+  341          270.15916    233.7659    0.00293255 
+  345          271.21104    233.53078   0.00289855 
+  414          274.27486    233.29595   0.00241546 
+  437          281.60462    233.06142   0.00228833 
+  443          292.58616    232.82717   0.00225734 
+  437          304.01232    232.59321   0.00228833 
+  438          312.33544    232.35954   0.00228311 
+  386          314.25039    232.12616   0.00259067 
+  390          308.29114    231.89307   0.0025641 
+  395          298.61031    231.66027   0.00253165 
+  326          290.26869    231.42775   0.00306748 
+  316          283.71431    231.19552   0.00316456 
+  341          276.61155    230.96358   0.00293255 
+  279          267.4319     230.73192   0.00358423 
+  284          258.26751    230.50056   0.00352113 
+  237          251.38195    230.26947   0.00421941 
+  242          247.08339    230.03867   0.00413223 
+  257          244.69488    229.80816   0.00389105 
+  262          243.40058    229.57793   0.00381679 
+  220          242.63532    229.34799   0.00454545 
+  247          242.11144    229.11833   0.00404858 
+  243          241.70444    228.88895   0.00411523 
+  221          241.36028    228.65986   0.00452489 
+  235          241.04947    228.43105   0.00425532 
+  222          240.7513     228.20253   0.0045045 
+  265          240.44998    227.97428   0.00377358 
+  232          240.1345     227.74632   0.00431034 
+  263          239.79801    227.51864   0.00380228 
+  226          239.4361     227.29124   0.00442478 
+  232          239.04591    227.06413   0.00431034 
+  222          238.62632    226.83729   0.0045045 
+  229          238.17773    226.61074   0.00436681 
+  222          237.70198    226.38446   0.0045045 
+  230          237.20208    226.15846   0.00434783 
+  235          236.68182    225.93275   0.00425532 
+  247          236.14546    225.70731   0.00404858 
+  278          235.5975     225.48215   0.00359712 
+  260          235.04241    225.25727   0.00384615 
+  231          234.48442    225.03267   0.004329  
+  196          233.92741    224.80835   0.00510204 
+  259          233.37483    224.5843    0.003861  
+  242          232.82954    224.36053   0.00413223 
+  231          232.29388    224.13704   0.004329  
+  241          231.7697     223.91382   0.00414938 
+  241          231.25833    223.69088   0.00414938 
+  234          230.76073    223.46822   0.0042735 
+  242          230.27748    223.24583   0.00413223 
+  210          229.80883    223.02371   0.0047619 
+  248          229.35478    222.80187   0.00403226 
+  221          228.91516    222.58031   0.00452489 
+  228          228.48964    222.35902   0.00438596 
+  234          228.07774    222.138     0.0042735 
+  223          227.67903    221.91726   0.0044843 
+  214          227.29292    221.69679   0.0046729 
+  272          226.91881    221.47659   0.00367647 
+  207          226.55613    221.25667   0.00483092 
+  258          226.20428    221.03701   0.00387597 
+  237          225.86268    220.81763   0.00421941 
+  216          225.53081    220.59852   0.00462963 
+  221          225.20813    220.37969   0.00452489 
+  229          224.89415    220.16112   0.00436681 
+  213          224.5884     219.94282   0.00469484 
+  266          224.29045    219.7248    0.0037594 
+  226          223.99989    219.50704   0.00442478 
+  227          223.71641    219.28955   0.00440529 
+  221          223.43964    219.07234   0.00452489 
+  224          223.16931    218.85539   0.00446429 
+  227          222.90515    218.63871   0.00440529 
+  235          222.64695    218.42229   0.00425532 
+  231          222.3945     218.20615   0.004329  
+  209          222.14768    217.99027   0.00478469 
+  232          221.90639    217.77467   0.00431034 
+  218          221.67048    217.55932   0.00458716 
+  192          221.43994    217.34425   0.00520833 
+  209          221.21479    217.12944   0.00478469 
+  231          220.99507    216.9149    0.004329  
+  239          220.78093    216.70062   0.0041841 
+  235          220.57246    216.48661   0.00425532 
+  211          220.36994    216.27286   0.00473934 
+  206          220.17367    216.05938   0.00485437 
+  243          219.98408    215.84616   0.00411523 
+  212          219.8017     215.63321   0.00471698 
+  215          219.62725    215.42052   0.00465116 
+  249          219.46153    215.20809   0.00401606 
+  222          219.30588    214.99593   0.0045045 
+  215          219.16128    214.78403   0.00465116 
+  232          219.02973    214.57239   0.00431034 
+  223          218.91358    214.36102   0.0044843 
+  224          218.81583    214.1499    0.00446429 
+  203          218.74045    213.93905   0.00492611 
+  208          218.69283    213.72846   0.00480769 
+  230          218.68024    213.51813   0.00434783 
+  238          218.71285    213.30806   0.00420168 
+  247          218.80515    213.09825   0.00404858 
+  234          218.97902    212.8887    0.0042735 
+  246          219.27064    212.67942   0.00406504 
+  247          219.75012    212.47039   0.00404858 
+  249          220.57222    212.26162   0.00401606 
+  234          222.07944    212.0531    0.0042735 
+  248          224.95879    211.84485   0.00403226 
+  238          230.37138    211.63686   0.00420168 
+  262          239.753      211.42912   0.00381679 
+  314          253.77747    211.22164   0.00318471 
+  308          271.03051    211.01442   0.00324675 
+  325          286.72391    210.80745   0.00307692 
+  277          292.69544    210.60074   0.00361011 
+  313          285.625      210.39429   0.00319489 
+  268          273.65887    210.18809   0.00373134 
+  294          265.60071    209.98215   0.00340136 
+  228          261.98477    209.77646   0.00438596 
+  291          257.60512    209.57103   0.00343643 
+  242          248.65992    209.36586   0.00413223 
+  228          237.7081     209.16094   0.00438596 
+  210          228.71962    208.95627   0.0047619 
+  228          222.90693    208.75185   0.00438596 
+  221          219.76163    208.54769   0.00452489 
+  244          218.36656    208.34379   0.00409836 
+  185          218.07895    208.14013   0.00540541 
+  235          218.5754     207.93673   0.00425532 
+  242          219.5853     207.73358   0.00413223 
+  242          220.64877    207.53068   0.00413223 
+  239          220.98863    207.32804   0.0041841 
+  245          220.15062    207.12565   0.00408163 
+  241          218.75582    206.9235    0.00414938 
+  218          217.69026    206.72161   0.00458716 
+  200          217.11212    206.51997   0.005     
+  217          216.57775    206.31858   0.00460829 
+  233          215.65332    206.11743   0.00429185 
+  216          214.47916    205.91654   0.00462963 
+  198          213.44867    205.7159    0.00505051 
+  204          212.71562    205.5155    0.00490196 
+  228          212.24582    205.31536   0.00438596 
+  218          211.94522    205.11546   0.00458716 
+  216          211.73526    204.91581   0.00462963 
+  240          211.57242    204.71641   0.00416667 
+  217          211.43868    204.51726   0.00460829 
+  225          211.32447    204.31835   0.00444444 
+  226          211.22714    204.11969   0.00442478 
+  217          211.14464    203.92128   0.00460829 
+  207          211.07572    203.72311   0.00483092 
+  235          211.01954    203.52519   0.00425532 
+  232          210.97609    203.32751   0.00431034 
+  226          210.94422    203.13008   0.00442478 
+  258          210.92453    202.9329    0.00387597 
+  240          210.91754    202.73596   0.00416667 
+  225          210.92435    202.53926   0.00444444 
+  237          210.94686    202.34281   0.00421941 
+  242          210.98436    202.1466    0.00413223 
+  240          211.03552    201.95064   0.00416667 
+  270          211.09486    201.75492   0.0037037 
+  279          211.15404    201.55944   0.00358423 
+  262          211.21122    201.36421   0.00381679 
+  258          211.27611    201.16921   0.00387597 
+  266          211.35626    200.97446   0.0037594 
+  233          211.45193    200.77995   0.00429185 
+  237          211.55803    200.58569   0.00421941 
+  269          211.67142    200.39166   0.00371747 
+  229          211.79565    200.19788   0.00436681 
+  225          211.93551    200.00433   0.00444444 
+  237          212.0931     199.81103   0.00421941 
+  233          212.26889    199.61796   0.00429185 
+  209          212.463      199.42514   0.00478469 
+  248          212.67571    199.23256   0.00403226 
+  232          212.90771    199.04021   0.00431034 
+  215          213.15976    198.8481    0.00465116 
+  204          213.43268    198.65624   0.00490196 
+  230          213.72721    198.46461   0.00434783 
+  215          214.04405    198.27321   0.00465116 
+  197          214.38489    198.08206   0.00507614 
+  204          214.74811    197.89114   0.00490196 
+  213          215.13565    197.70047   0.00469484 
+  205          215.54861    197.51002   0.00487805 
+  204          215.98913    197.31982   0.00490196 
+  218          216.45852    197.12985   0.00458716 
+  229          216.96105    196.94011   0.00436681 
+  210          217.50021    196.75062   0.0047619 
+  194          218.08267    196.56135   0.00515464 
+  228          218.71662    196.37233   0.00438596 
+  230          219.41296    196.18354   0.00434783 
+  201          220.185      195.99498   0.00497512 
+  226          221.05033    195.80666   0.00442478 
+  216          222.03173    195.61857   0.00462963 
+  237          223.15853    195.43071   0.00421941 
+  248          224.46951    195.24309   0.00403226 
+  224          226.01801    195.0557    0.00446429 
+  232          227.88243    194.86854   0.00431034 
+  221          230.19496    194.68162   0.00452489 
+  228          233.21905    194.49493   0.00438596 
+  240          237.53282    194.30847   0.00416667 
+  235          244.35236    194.12224   0.00425532 
+  297          255.91198    193.93625   0.003367  
+  279          275.42766    193.75048   0.00358423 
+  277          305.51144    193.56495   0.00361011 
+  302          344.76043    193.37965   0.00331126 
+  342          385.12724    193.19458   0.00292398 
+  342          409.69671    193.00973   0.00292398 
+  353          405.24235    192.82512   0.00283286 
+  346          383.54166    192.64074   0.00289017 
+  314          367.82535    192.45658   0.00318471 
+  330          365.68818    192.27266   0.0030303 
+  328          369.10525    192.08896   0.00304878 
+  316          365.77308    191.90549   0.00316456 
+  334          354.92197    191.72226   0.00299401 
+  328          346.80472    191.53924   0.00304878 
+  357          348.22111    191.35646   0.00280112 
+  376          360.86482    191.1739    0.00265957 
+  432          385.0582     190.99157   0.00231481 
+  456          422.89867    190.80947   0.00219298 
+  531          480.56739    190.62759   0.00188324 
+  627          569.82884    190.44594   0.0015949 
+  734          708.24574    190.26452   0.0013624 
+  956          916.41947    190.08332   0.00104603 
+  1197         1210.80974   189.90234   0.00083542 
+  1518         1588.03321   189.7216    0.00065876 
+  2258         1991.08827   189.54107   0.00044287 
+  2867         2273.2431    189.36077   0.0003488 
+  3596         2291.92492   189.1807    0.00027809 
+  3831         2109.01402   189.00085   0.00026103 
+  3274         1904.53052   188.82122   0.00030544 
+  2452         1768.44958   188.64182   0.00040783 
+  2008         1665.3464    188.46264   0.00049801 
+  2028         1502.54704   188.28368   0.0004931 
+  2074         1260.17802   188.10494   0.00048216 
+  1637         1004.95237   187.92643   0.00061087 
+  1097         789.85268    187.74814   0.00091158 
+  687          628.55864    187.57007   0.0014556 
+  478          515.36687    187.39223   0.00209205 
+  355          438.72512    187.2146    0.0028169 
+  329          387.04113    187.0372    0.00303951 
+  297          351.2918     186.86001   0.003367  
+  281          325.46403    186.68305   0.00355872 
+  318          305.93959    186.5063    0.00314465 
+  300          290.62539    186.32978   0.00333333 
+  300          278.29504    186.15348   0.00333333 
+  228          268.18216    185.97739   0.00438596 
+  272          259.77504    185.80153   0.00367647 
+  274          252.70568    185.62588   0.00364964 
+  293          246.71037    185.45045   0.00341297 
+  224          241.584      185.27525   0.00446429 
+  243          237.16754    185.10025   0.00411523 
+  230          233.33894    184.92548   0.00434783 
+  249          230.00324    184.75092   0.00401606 
+  223          227.08262    184.57659   0.0044843 
+  193          224.51492    184.40246   0.00518135 
+  209          222.24891    184.22856   0.00478469 
+  202          220.24318    184.05487   0.0049505 
+  223          218.46149    183.8814    0.0044843 
+  189          216.87468    183.70814   0.00529101 
+  190          215.45771    183.5351    0.00526316 
+  191          214.18886    183.36228   0.0052356 
+  220          213.04891    183.18967   0.00454545 
+  191          212.02104    183.01727   0.0052356 
+  202          211.09028    182.84509   0.0049505 
+  246          210.24307    182.67313   0.00406504 
+  191          209.46765    182.50137   0.0052356 
+  190          208.75317    182.32984   0.00526316 
+  199          208.09038    182.15851   0.00502513 
+  218          207.4712     181.9874    0.00458716 
+  213          206.88893    181.8165    0.00469484 
+  224          206.33822    181.64582   0.00446429 
+  208          205.81529    181.47534   0.00480769 
+  211          205.31766    181.30508   0.00473934 
+  218          204.84381    181.13504   0.00458716 
+  194          204.39386    180.9652    0.00515464 
+  190          203.96892    180.79557   0.00526316 
+  227          203.57107    180.62616   0.00440529 
+  175          203.20346    180.45696   0.00571429 
+  217          202.87005    180.28797   0.00460829 
+  209          202.5754     180.11918   0.00478469 
+  181          202.32527    179.95061   0.00552486 
+  181          202.12643    179.78225   0.00552486 
+  184          201.98705    179.6141    0.00543478 
+  191          201.91745    179.44616   0.0052356 
+  186          201.93084    179.27842   0.00537634 
+  240          202.04473    179.1109    0.00416667 
+  174          202.28382    178.94358   0.00574713 
+  192          202.68519    178.77648   0.00520833 
+  201          203.31205    178.60958   0.00497512 
+  236          204.29277    178.44289   0.00423729 
+  193          205.91867    178.27641   0.00518135 
+  228          208.83645    178.11013   0.00438596 
+  210          214.31099    177.94406   0.0047619 
+  248          224.31182    177.7782    0.00403226 
+  242          240.76519    177.61254   0.00413223 
+  284          263.39948    177.4471    0.00352113 
+  303          287.74255    177.28185   0.00330033 
+  311          303.69089    177.11682   0.00321543 
+  328          301.29697    176.95199   0.00304878 
+  350          285.48398    176.78736   0.00285714 
+  340          271.36284    176.62294   0.00294118 
+  314          265.12537    176.45872   0.00318471 
+  294          263.66742    176.29471   0.00340136 
+  274          258.93965    176.13091   0.00364964 
+  274          246.84912    175.9673    0.00364964 
+  282          233.29169    175.80391   0.0035461 
+  248          223.15098    175.64071   0.00403226 
+  262          217.29341    175.47772   0.00381679 
+  264          214.6705     175.31493   0.00378788 
+  231          213.92694    175.15235   0.004329  
+  213          214.15381    174.98996   0.00469484 
+  202          214.95517    174.82778   0.0049505 
+  197          216.19131    174.6658    0.00507614 
+  207          217.85453    174.50403   0.00483092 
+  219          220.0047     174.34245   0.00456621 
+  226          222.80685    174.18108   0.00442478 
+  236          226.62485    174.01991   0.00423729 
+  268          232.31818    173.85894   0.00373134 
+  260          241.6841     173.69817   0.00384615 
+  322          257.78105    173.5376    0.00310559 
+  283          284.3755     173.37723   0.00353357 
+  333          323.09083    173.21706   0.003003  
+  348          368.33339    173.05709   0.00287356 
+  385          408.02869    172.89732   0.0025974 
+  418          424.26654    172.73774   0.00239234 
+  384          408.23432    172.57837   0.00260417 
+  395          384.97042    172.4192    0.00253165 
+  390          376.10616    172.26022   0.0025641 
+  401          382.81991    172.10144   0.00249377 
+  480          395.17312    171.94286   0.00208333 
+  453          399.71106    171.78448   0.00220751 
+  487          399.1533     171.6263    0.00205339 
+  564          408.71498    171.46831   0.00177305 
+  621          440.91738    171.31052   0.00161031 
+  773          511.7793     171.15293   0.00129366 
+  961          654.16227    170.99553   0.00104058 
+  1325         928.81787    170.83833   0.00075472 
+  1801         1417.88281   170.68133   0.00055525 
+  2398         2172.37744   170.52452   0.00041701 
+  2977         3098.00904   170.36791   0.00033591 
+  3891         3935.65401   170.21149   0.000257  
+  4258         4303.82886   170.05527   0.00023485 
+  3869         3907.51793   169.89924   0.00025846 
+  3152         3213.71355   169.74341   0.00031726 
+  2772         2767.88877   169.58777   0.00036075 
+  2875         2644.5312    169.43232   0.00034783 
+  3259         2626.81946   169.27707   0.00030684 
+  3099         2375.30009   169.12202   0.00032268 
+  2142         1833.56839   168.96715   0.00046685 
+  1386         1278.89534   168.81248   0.0007215 
+  1042         875.86282    168.65801   0.00095969 
+  883          634.32335    168.50372   0.0011325 
+  905          499.07338    168.34963   0.00110497 
+  746          418.70236    168.19573   0.00134048 
+  505          367.57661    168.04202   0.0019802 
+  378          334.81495    167.88851   0.0026455 
+  370          315.42114    167.73518   0.0027027 
+  317          307.21711    167.58205   0.00315457 
+  316          308.16411    167.4291    0.00316456 
+  386          314.22118    167.27635   0.00259067 
+  381          319.40079    167.12379   0.00262467 
+  407          315.8131     166.97142   0.002457  
+  415          300.74289    166.81924   0.00240964 
+  365          284.42958    166.66725   0.00273973 
+  335          274.49839    166.51545   0.00298507 
+  349          270.65855    166.36384   0.00286533 
+  316          268.45515    166.21242   0.00316456 
+  299          262.30262    166.06118   0.00334448 
+  305          253.02821    165.91014   0.00327869 
+  339          246.14273    165.75928   0.00294985 
+  319          244.98985    165.60861   0.0031348 
+  327          250.59407    165.45814   0.0030581 
+  343          261.76191    165.30784   0.00291545 
+  347          274.6903     165.15774   0.00288184 
+  328          284.15347    165.00782   0.00304878 
+  333          284.01925    164.85809   0.003003  
+  304          276.57026    164.70855   0.00328947 
+  291          271.11807    164.55919   0.00343643 
+  285          271.63825    164.41002   0.00350877 
+  318          276.63226    164.26104   0.00314465 
+  299          282.03364    164.11224   0.00334448 
+  312          284.56414    163.96363   0.00320513 
+  325          287.10595    163.8152    0.00307692 
+  319          293.92884    163.66696   0.0031348 
+  417          307.35044    163.5189    0.00239808 
+  442          329.23472    163.37103   0.00226244 
+  510          363.14795    163.22335   0.00196078 
+  577          416.86449    163.07584   0.0017331 
+  714          504.86255    162.92852   0.00140056 
+  921          649.26608    162.78139   0.00108578 
+  1142         876.00686    162.63444   0.00087566 
+  1528         1200.04069   162.48767   0.00065445 
+  1989         1595.53464   162.34109   0.00050277 
+  2404         1977.72906   162.19469   0.00041597 
+  2852         2219.31889   162.04847   0.00035063 
+  2601         2189.19102   161.90243   0.00038447 
+  2157         1949.21385   161.75658   0.00046361 
+  1548         1708.8851    161.61091   0.00064599 
+  1508         1566.75695   161.46542   0.00066313 
+  1534         1493.42937   161.32011   0.00065189 
+  1522         1395.85059   161.17498   0.00065703 
+  1233         1197.5193    161.03004   0.00081103 
+  842          944.11036    160.88528   0.00118765 
+  549          717.15588    160.74069   0.00182149 
+  395          548.37869    160.59629   0.00253165 
+  325          435.59042    160.45207   0.00307692 
+  275          364.60613    160.30802   0.00363636 
+  247          320.23797    160.16416   0.00404858 
+  227          291.19828    160.02048   0.00440529 
+  209          270.75132    159.87698   0.00478469 
+  216          255.38852    159.73365   0.00462963 
+  239          243.33261    159.59051   0.0041841 
+  222          233.61227    159.44754   0.0045045 
+  204          225.62953    159.30475   0.00490196 
+  191          218.97954    159.16214   0.0052356 
+  211          213.37084    159.01971   0.00473934 
+  199          208.58928    158.87746   0.00502513 
+  164          204.47383    158.73538   0.00609756 
+  188          200.90104    158.59348   0.00531915 
+  183          197.77594    158.45176   0.00546448 
+  162          195.02307    158.31022   0.00617284 
+  190          192.58298    158.16885   0.00526316 
+  192          190.40757    158.02766   0.00520833 
+  196          188.45793    157.88665   0.00510204 
+  177          186.70211    157.74581   0.00564972 
+  185          185.11404    157.60515   0.00540541 
+  169          183.67167    157.46466   0.00591716 
+  211          182.35688    157.32435   0.00473934 
+  180          181.15431    157.18421   0.00555556 
+  173          180.05061    157.04425   0.00578035 
+  169          179.03469    156.90447   0.00591716 
+  155          178.09719    156.76486   0.00645161 
+  171          177.22984    156.62542   0.00584795 
+  158          176.42554    156.48616   0.00632911 
+  161          175.67814    156.34707   0.00621118 
+  175          174.9823     156.20816   0.00571429 
+  165          174.3327     156.06941   0.00606061 
+  182          173.72652    155.93085   0.00549451 
+  192          173.15946    155.79245   0.00520833 
+  175          172.62844    155.65423   0.00571429 
+  164          172.1307     155.51618   0.00609756 
+  179          171.66331    155.37831   0.00558659 
+  157          171.22475    155.2406    0.00636943 
+  159          170.81273    155.10307   0.00628931 
+  147          170.42557    154.96571   0.00680272 
+  156          170.0614     154.82852   0.00641026 
+  164          169.71959    154.6915    0.00609756 
+  169          169.39847    154.55466   0.00591716 
+  167          169.09615    154.41798   0.00598802 
+  172          168.81341    154.28148   0.00581395 
+  161          168.54836    154.14515   0.00621118 
+  148          168.30065    154.00898   0.00675676 
+  182          168.06945    153.87299   0.00549451 
+  153          167.85375    153.73717   0.00653595 
+  174          167.65396    153.60152   0.00574713 
+  174          167.4692     153.46603   0.00574713 
+  149          167.29916    153.33072   0.00671141 
+  159          167.14356    153.19557   0.00628931 
+  161          167.00222    153.0606    0.00621118 
+  162          166.87492    152.92579   0.00617284 
+  180          166.76161    152.79115   0.00555556 
+  161          166.66221    152.65668   0.00621118 
+  175          166.57673    152.52238   0.00571429 
+  151          166.50526    152.38824   0.00662252 
+  159          166.44789    152.25428   0.00628931 
+  167          166.4048     152.12048   0.00598802 
+  184          166.37623    151.98685   0.00543478 
+  159          166.36238    151.85338   0.00628931 
+  154          166.36364    151.72008   0.00649351 
+  169          166.38034    151.58695   0.00591716 
+  169          166.41297    151.45399   0.00591716 
+  150          166.46201    151.32119   0.00666667 
+  139          166.52805    151.18856   0.00719424 
+  178          166.61172    151.05609   0.00561798 
+  161          166.71367    150.92379   0.00621118 
+  158          166.83473    150.79165   0.00632911 
+  172          166.97575    150.65968   0.00581395 
+  159          167.13768    150.52787   0.00628931 
+  157          167.32158    150.39623   0.00636943 
+  148          167.52853    150.26476   0.00675676 
+  160          167.75981    150.13345   0.00625   
+  165          168.01673    150.0023    0.00606061 
+  141          168.30077    149.87132   0.0070922 
+  135          168.61354    149.7405    0.00740741 
+  147          168.9568     149.60984   0.00680272 
+  149          169.33236    149.47935   0.00671141 
+  164          169.7423     149.34902   0.00609756 
+  162          170.18875    149.21885   0.00617284 
+  155          170.67412    149.08885   0.00645161 
+  165          171.20097    148.95901   0.00606061 
+  182          171.7721     148.82933   0.00549451 
+  143          172.39037    148.69981   0.00699301 
+  148          173.05904    148.57046   0.00675676 
+  175          173.78138    148.44126   0.00571429 
+  161          174.56108    148.31223   0.00621118 
+  159          175.40194    148.18336   0.00628931 
+  154          176.30922    148.05465   0.00649351 
+  173          177.28484    147.92611   0.00578035 
+  173          178.33444    147.79772   0.00578035 
+  168          179.46249    147.66949   0.00595238 
+  170          180.67376    147.54143   0.00588235 
+  176          181.97303    147.41352   0.00568182 
+  163          183.36499    147.28577   0.00613497 
+  152          184.85497    147.15819   0.00657895 
+  154          186.44591    147.03076   0.00649351 
+  157          188.1421     146.9035    0.00636943 
+  185          189.94678    146.77639   0.00540541 
+  156          191.86215    146.64944   0.00641026 
+  161          193.88912    146.52265   0.00621118 
+  183          196.02733    146.39602   0.00546448 
+  177          198.27385    146.26955   0.00564972 
+  194          200.62358    146.14323   0.00515464 
+  207          203.069      146.01708   0.00483092 
+  194          205.59932    145.89108   0.00515464 
+  187          208.20034    145.76524   0.00534759 
+  181          210.85462    145.63955   0.00552486 
+  214          213.5405     145.51403   0.0046729 
+  203          216.23298    145.38866   0.00492611 
+  176          218.90439    145.26344   0.00568182 
+  243          221.52422    145.13839   0.00411523 
+  206          224.06005    145.01349   0.00485437 
+  222          226.4786     144.88875   0.0045045 
+  209          228.74649    144.76416   0.00478469 
+  246          230.83107    144.63973   0.00406504 
+  261          232.70316    144.51546   0.00383142 
+  245          234.33781    144.39134   0.00408163 
+  275          235.71699    144.26737   0.00363636 
+  291          236.83367    144.14356   0.00343643 
+  297          237.70049    144.01991   0.003367  
+  298          238.37309    143.89641   0.0033557 
+  309          239.01147    143.77306   0.00323625 
+  297          239.99771    143.64987   0.003367  
+  291          242.07315    143.52684   0.00343643 
+  275          246.31387    143.40396   0.00363636 
+  318          253.58487    143.28123   0.00314465 
+  295          263.13466    143.15865   0.00338983 
+  290          271.63595    143.03623   0.00344828 
+  260          274.0876     142.91396   0.00384615 
+  274          266.62009    142.79185   0.00364964 
+  244          254.58428    142.66989   0.00409836 
+  245          245.46552    142.54808   0.00408163 
+  259          241.42156    142.42642   0.003861  
+  231          240.57672    142.30491   0.004329  
+  223          239.5058     142.18356   0.0044843 
+  224          235.8193     142.06236   0.00446429 
+  209          231.97733    141.94131   0.00478469 
+  195          230.51159    141.82041   0.00512821 
+  186          230.25031    141.69967   0.00537634 
+  227          227.70673    141.57907   0.00440529 
+  162          220.36022    141.45863   0.00617284 
+  180          211.59213    141.33834   0.00555556 
+  200          205.33008    141.21819   0.005     
+  203          202.28459    141.0982    0.00492611 
+  210          200.867      140.97836   0.0047619 
+  163          198.57481    140.85867   0.00613497 
+  209          193.76918    140.73913   0.00478469 
+  170          187.95423    140.61973   0.00588235 
+  182          182.9805     140.50049   0.00549451 
+  174          179.38087    140.3814    0.00574713 
+  163          176.9474     140.26245   0.00613497 
+  169          175.28779    140.14366   0.00591716 
+  164          174.12724    140.02501   0.00609756 
+  176          173.38297    139.90651   0.00568182 
+  187          173.17295    139.78816   0.00534759 
+  228          173.89967    139.66996   0.00438596 
+  230          176.41429    139.55191   0.00434783 
+  292          182.05773    139.434     0.00342466 
+  338          192.1618     139.31625   0.00295858 
+  401          206.51166    139.19864   0.00249377 
+  417          221.81024    139.08117   0.00239808 
+  430          232.48671    138.96386   0.00232558 
+  356          232.87402    138.84669   0.00280899 
+  336          226.71664    138.72967   0.00297619 
+  358          221.38617    138.61279   0.0027933 
+  334          217.42594    138.49606   0.00299401 
+  334          213.04267    138.37948   0.00299401 
+  280          208.12686    138.26304   0.00357143 
+  273          200.85162    138.14675   0.003663  
+  248          192.1662     138.0306    0.00403226 
+  216          184.56021    137.9146    0.00462963 
+  196          177.6064     137.79875   0.00510204 
+  190          170.63669    137.68304   0.00526316 
+  196          164.77126    137.56748   0.00510204 
+  164          160.60713    137.45206   0.00609756 
+  172          157.92857    137.33678   0.00581395 
+  156          156.2504     137.22165   0.00641026 
+  136          155.13299    137.10666   0.00735294 
+  175          154.3047     136.99182   0.00571429 
+  166          153.63501    136.87712   0.0060241 
+  168          153.06732    136.76257   0.00595238 
+  162          152.57457    136.64816   0.00617284 
+  139          152.14117    136.53389   0.00719424 
+  139          151.75675    136.41976   0.00719424 
+  129          151.41402    136.30578   0.00775194 
+  176          151.10763    136.19194   0.00568182 
+  134          150.83372    136.07825   0.00746269 
+  154          150.58994    135.96469   0.00649351 
+  151          150.37295    135.85128   0.00662252 
+  144          150.18166    135.73801   0.00694444 
+  148          150.01483    135.62488   0.00675676 
+  147          149.87151    135.5119    0.00680272 
+  135          149.75104    135.39905   0.00740741 
+  132          149.6529     135.28635   0.00757576 
+  128          149.57705    135.17379   0.0078125 
+  155          149.52256    135.06137   0.00645161 
+  143          149.48953    134.94909   0.00699301 
+  139          149.47771    134.83695   0.00719424 
+  123          149.48688    134.72495   0.00813008 
+  135          149.51674    134.6131    0.00740741 
+  133          149.5669     134.50138   0.0075188 
+  138          149.63683    134.3898    0.00724638 
+  144          149.72588    134.27836   0.00694444 
+  130          149.83315    134.16706   0.00769231 
+  157          149.95762    134.05591   0.00636943 
+  116          150.09806    133.94489   0.00862069 
+  165          150.25302    133.83401   0.00606061 
+  148          150.42091    133.72327   0.00675676 
+  139          150.60479    133.61266   0.00719424 
+  140          150.79317    133.5022    0.00714286 
+  156          150.989      133.39187   0.00641026 
+  126          151.19048    133.28169   0.00793651 
+  134          151.39598    133.17164   0.00746269 
+  166          151.60413    133.06173   0.0060241 
+  138          151.81417    132.95196   0.00724638 
+  149          152.02858    132.84232   0.00671141 
+  149          152.24366    132.73282   0.00671141 
+  159          152.4651     132.62346   0.00628931 
+  133          152.69902    132.51424   0.0075188 
+  144          152.95599    132.40515   0.00694444 
+  156          153.2543     132.2962    0.00641026 
+  150          153.62745    132.18739   0.00666667 
+  180          154.14665    132.07871   0.00555556 
+  179          154.98373    131.97017   0.00558659 
+  176          156.54903    131.86177   0.00568182 
+  178          159.68198    131.7535    0.00561798 
+  201          165.70689    131.64537   0.00497512 
+  196          175.91043    131.53737   0.00510204 
+  204          189.9358     131.42951   0.00490196 
+  183          203.93887    131.32178   0.00546448 
+  197          211.41767    131.21419   0.00507614 
+  205          206.2533     131.10674   0.00487805 
+  195          193.23452    130.99942   0.00512821 
+  191          182.65112    130.89223   0.0052356 
+  166          178.69713    130.78518   0.0060241 
+  198          179.699      130.67826   0.00505051 
+  175          180.955      130.57148   0.00571429 
+  139          177.41711    130.46483   0.00719424 
+  145          169.02507    130.35831   0.00689655 
+  178          160.35014    130.25193   0.00561798 
+  180          153.93889    130.14568   0.00555556 
+  159          149.99105    130.03956   0.00628931 
+  150          147.7575     129.93358   0.00666667 
+  150          146.44982    129.82773   0.00666667 
+  139          145.59131    129.72201   0.00719424 
+  121          144.98263    129.61643   0.00826446 
+  147          144.58518    129.51098   0.00680272 
+  150          144.46491    129.40566   0.00666667 
+  186          144.77727    129.30047   0.00537634 
+  146          145.70992    129.19542   0.00684932 
+  176          147.28606    129.09049   0.00568182 
+  141          149.06924    128.9857    0.0070922 
+  159          150.18277    128.88104   0.00628931 
+  172          149.62841    128.77651   0.00581395 
+  152          147.65832    128.67211   0.00657895 
+  152          145.77252    128.56785   0.00657895 
+  154          144.80598    128.46371   0.00649351 
+  152          144.69015    128.3597    0.00657895 
+  168          144.82047    128.25583   0.00595238 
+  147          144.43842    128.15209   0.00680272 
+  156          143.26162    128.04847   0.00641026 
+  144          141.87417    127.94499   0.00694444 
+  123          140.75941    127.84163   0.00813008 
+  140          140.01674    127.73841   0.00714286 
+  135          139.55953    127.63531   0.00740741 
+  150          139.26731    127.53235   0.00666667 
+  130          139.05708    127.42951   0.00769231 
+  118          138.88877    127.3268    0.00847458 
+  122          138.74554    127.22422   0.00819672 
+  125          138.62086    127.12178   0.008     
+  133          138.51095    127.01945   0.0075188 
+  151          138.41372    126.91726   0.00662252 
+  137          138.32764    126.8152    0.00729927 
+  148          138.25235    126.71326   0.00675676 
+  110          138.1856     126.61145   0.00909091 
+  124          138.12752    126.50977   0.00806452 
+  111          138.07767    126.40822   0.00900901 
+  110          138.03581    126.30679   0.00909091 
+  119          138.00178    126.2055    0.00840336 
+  140          137.976      126.10433   0.00714286 
+  136          137.95677    126.00328   0.00735294 
+  140          137.94497    125.90236   0.00714286 
+  130          137.94062    125.80157   0.00769231 
+  118          137.94383    125.70091   0.00847458 
+  159          137.95473    125.60037   0.00628931 
+  138          137.9736     125.49996   0.00724638 
+  159          138.00102    125.39968   0.00628931 
+  123          138.03718    125.29952   0.00813008 
+  133          138.0821     125.19949   0.0075188 
+  122          138.13708    125.09958   0.00819672 
+  124          138.20346    124.9998    0.00806452 
+  116          138.28395    124.90014   0.00862069 
+  163          138.38404    124.80061   0.00613497 
+  151          138.5157     124.7012    0.00662252 
+  123          138.69906    124.60192   0.00813008 
+  140          138.95816    124.50276   0.00714286 
+  121          139.30083    124.40373   0.00826446 
+  156          139.68583    124.30482   0.00641026 
+  157          140.02151    124.20604   0.00636943 
+  137          140.20451    124.10738   0.00729927 
+  143          140.27296    124.00884   0.00699301 
+  145          140.43525    123.91043   0.00689655 
+  127          140.88514    123.81214   0.00787402 
+  144          141.79166    123.71398   0.00694444 
+  147          143.30195    123.61594   0.00680272 
+  133          145.41915    123.51802   0.0075188 
+  149          147.76975    123.42022   0.00671141 
+  129          149.80026    123.32255   0.00775194 
+  145          150.22585    123.225     0.00689655 
+  135          149.26792    123.12757   0.00740741 
+  129          148.188      123.03027   0.00775194 
+  138          147.65187    122.93309   0.00724638 
+  147          147.63035    122.83603   0.00680272 
+  144          147.90065    122.73909   0.00694444 
+  130          147.98004    122.64227   0.00769231 
+  134          147.55957    122.54558   0.00746269 
+  133          146.80648    122.449     0.0075188 
+  123          146.20333    122.35255   0.00813008 
+  138          145.78142    122.25622   0.00724638 
+  140          145.55652    122.16001   0.00714286 
+  120          145.5543     122.06392   0.00833333 
+  129          145.74033    121.96795   0.00775194 
+  145          146.06119    121.87211   0.00689655 
+  170          146.47074    121.77638   0.00588235 
+  152          146.93753    121.68077   0.00657895 
+  112          147.44654    121.58529   0.00892857 
+  142          147.98973    121.48992   0.00704225 
+  159          148.56376    121.39467   0.00628931 
+  133          149.16675    121.29955   0.0075188 
+  152          149.79792    121.20454   0.00657895 
+  133          150.45694    121.10965   0.0075188 
+  130          151.14421    121.01488   0.00769231 
+  150          151.86036    120.92023   0.00666667 
+  162          152.60687    120.8257    0.00617284 
+  161          153.38578    120.73129   0.00621118 
+  178          154.19948    120.637     0.00561798 
+  124          155.05109    120.54283   0.00806452 
+  139          155.94432    120.44877   0.00719424 
+  142          156.8834     120.35483   0.00704225 
+  144          157.87304    120.26101   0.00694444 
+  154          158.91853    120.16731   0.00649351 
+  155          160.02529    120.07373   0.00645161 
+  142          161.20002    119.98026   0.00704225 
+  181          162.44802    119.88691   0.00552486 
+  128          163.7767     119.79368   0.0078125 
+  158          165.1907     119.70057   0.00632911 
+  158          166.70368    119.60757   0.00632911 
+  148          168.32109    119.51469   0.00675676 
+  152          170.05227    119.42193   0.00657895 
+  162          171.90784    119.32928   0.00617284 
+  167          173.89739    119.23676   0.00598802 
+  165          176.03694    119.14434   0.00606061 
+  169          178.34013    119.05205   0.00591716 
+  163          180.8232     118.95986   0.00613497 
+  153          183.50556    118.8678    0.00653595 
+  155          186.40958    118.77585   0.00645161 
+  148          189.56068    118.68402   0.00675676 
+  172          192.98846    118.5923    0.00581395 
+  176          196.72763    118.5007    0.00568182 
+  171          200.81682    118.40921   0.00584795 
+  141          205.30212    118.31784   0.0070922 
+  175          210.23714    118.22658   0.00571429 
+  170          215.62124    118.13544   0.00588235 
+  190          221.65439    118.04441   0.00526316 
+  187          228.36086    117.9535    0.00534759 
+  183          235.84169    117.8627    0.00546448 
+  177          244.22077    117.77202   0.00564972 
+  205          253.64411    117.68145   0.00487805 
+  207          264.26299    117.59099   0.00483092 
+  225          276.35849    117.50065   0.00444444 
+  245          290.17198    117.41042   0.00408163 
+  241          306.03653    117.32031   0.00414938 
+  277          324.37921    117.2303    0.00361011 
+  317          345.7382     117.14042   0.00315457 
+  299          370.81163    117.05064   0.00334448 
+  386          400.50765    116.96098   0.00259067 
+  399          436.03689    116.87143   0.00250627 
+  485          479.01135    116.78199   0.00206186 
+  529          531.66813    116.69267   0.00189036 
+  678          597.15793    116.60346   0.00147493 
+  687          680.16971    116.51436   0.0014556 
+  897          788.35298    116.42537   0.00111483 
+  1054         935.94139    116.3365    0.00094877 
+  1297         1151.91861   116.24773   0.00077101 
+  1668         1495.07313   116.15908   0.00059952 
+  2126         2070.80316   116.07054   0.00047037 
+  2882         3031.26608   115.98212   0.00034698 
+  4036         4530.30444   115.8938    0.00024777 
+  5731         6611.74908   115.80559   0.00017449 
+  7731         8990.97364   115.7175    0.00012935 
+  10341        10723.70648  115.62952   0.0000967 
+  12238        10642.97956  115.54164   0.00008171 
+  13010        9056.19868   115.45388   0.00007686 
+  10828        7331.52934   115.36623   0.00009235 
+  7559         6294.95183   115.27869   0.00013229 
+  5904         6090.58326   115.19126   0.00016938 
+  5815         6368.84913   115.10394   0.00017197 
+  6362         6362.315     115.01673   0.00015718 
+  6572         5537.16622   114.92963   0.00015216 
+  6131         4249.96179   114.84264   0.00016311 
+  4287         3040.63437   114.75576   0.00023326 
+  2447         2126.00279   114.66898   0.00040866 
+  1430         1513.50158   114.58232   0.0006993 
+  1078         1131.63347   114.49577   0.00092764 
+  730          897.02507    114.40932   0.00136986 
+  621          746.50078    114.32299   0.00161031 
+  549          642.40568    114.23676   0.00182149 
+  504          565.29145    114.15064   0.00198413 
+  445          505.47816    114.06464   0.00224719 
+  448          457.78902    113.97873   0.00223214 
+  401          419.07132    113.89294   0.00249377 
+  403          387.22139    113.80726   0.00248139 
+  348          360.74835    113.72168   0.00287356 
+  333          338.54317    113.63621   0.003003  
+  321          319.7331     113.55085   0.00311526 
+  308          303.6025     113.4656    0.00324675 
+  326          289.58036    113.38045   0.00306748 
+  297          277.33897    113.29541   0.003367  
+  261          266.70707    113.21048   0.00383142 
+  264          257.46592    113.12566   0.00378788 
+  266          249.49345    113.04094   0.0037594 
+  259          242.54022    112.95633   0.003861  
+  212          236.41163    112.87183   0.00471698 
+  212          230.96371    112.78743   0.00471698 
+  210          226.13208    112.70314   0.0047619 
+  169          221.93206    112.61896   0.00591716 
+  180          218.29872    112.53488   0.00555556 
+  188          215.17469    112.45091   0.00531915 
+  169          212.5073     112.36704   0.00591716 
+  186          210.25192    112.28328   0.00537634 
+  213          208.37451    112.19962   0.00469484 
+  184          206.84789    112.11608   0.00543478 
+  197          205.65118    112.03263   0.00507614 
+  176          204.76646    111.94929   0.00568182 
+  162          204.17998    111.86606   0.00617284 
+  158          203.88026    111.78293   0.00632911 
+  172          203.85966    111.69991   0.00581395 
+  157          204.1146     111.61699   0.00636943 
+  155          204.65049    111.53417   0.00645161 
+  138          205.48215    111.45146   0.00724638 
+  163          206.63019    111.36886   0.00613497 
+  184          208.09849    111.28636   0.00543478 
+  164          209.83609    111.20396   0.00609756 
+  180          211.72599    111.12167   0.00555556 
+  132          213.63422    111.03948   0.00757576 
+  146          215.57497    110.95739   0.00684932 
+  168          217.72248    110.87541   0.00595238 
+  149          220.18016    110.79353   0.00671141 
+  177          222.94993    110.71176   0.00564972 
+  154          225.96283    110.63009   0.00649351 
+  155          229.11656    110.54852   0.00645161 
+  167          232.32479    110.46705   0.00598802 
+  201          235.60457    110.38569   0.00497512 
+  182          239.02054    110.30443   0.00549451 
+  194          242.59052    110.22327   0.00515464 
+  181          246.29399    110.14221   0.00552486 
+  179          250.09663    110.06126   0.00558659 
+  196          253.96288    109.98041   0.00510204 
+  206          257.86001    109.89966   0.00485437 
+  229          261.7567     109.81902   0.00436681 
+  225          265.62108    109.73847   0.00444444 
+  230          269.42136    109.65803   0.00434783 
+  240          273.12825    109.57769   0.00416667 
+  274          276.71883    109.49745   0.00364964 
+  261          280.18853    109.41731   0.00383142 
+  281          283.58424    109.33727   0.00355872 
+  321          287.09029    109.25733   0.00311526 
+  349          291.19524    109.1775    0.00286533 
+  390          296.8618     109.09777   0.0025641 
+  372          305.39765    109.01813   0.00268817 
+  365          317.53168    108.9386    0.00273973 
+  355          331.4788     108.85917   0.0028169 
+  332          341.87625    108.77983   0.00301205 
+  323          341.77503    108.7006    0.00309598 
+  298          330.26597    108.62147   0.0033557 
+  336          316.29233    108.54244   0.00297619 
+  337          306.70142    108.46351   0.00296736 
+  302          302.96179    108.38467   0.00331126 
+  276          302.75522    108.30594   0.00362319 
+  307          301.64757    108.22731   0.00325733 
+  245          295.30797    108.14877   0.00408163 
+  286          283.93935    108.07034   0.0034965 
+  260          271.84866    107.992     0.00384615 
+  236          261.51158    107.91377   0.00423729 
+  277          253.21303    107.83563   0.00361011 
+  221          246.34477    107.75759   0.00452489 
+  235          240.23172    107.67965   0.00425532 
+  248          234.46871    107.60181   0.00403226 
+  240          228.89974    107.52407   0.00416667 
+  220          223.49604    107.44642   0.00454545 
+  189          218.26424    107.36888   0.00529101 
+  189          213.21384    107.29143   0.00529101 
+  192          208.35089    107.21408   0.00520833 
+  161          203.67729    107.13682   0.00621118 
+  149          199.19384    107.05967   0.00671141 
+  163          194.90611    106.98261   0.00613497 
+  157          190.82157    106.90565   0.00636943 
+  126          186.94154    106.82879   0.00793651 
+  150          183.26259    106.75202   0.00666667 
+  139          179.77863    106.67536   0.00719424 
+  112          176.48247    106.59878   0.00892857 
+  147          173.36614    106.52231   0.00680272 
+  125          170.42197    106.44593   0.008     
+  149          167.64165    106.36965   0.00671141 
+  147          165.0168     106.29347   0.00680272 
+  173          162.53886    106.21738   0.00578035 
+  154          160.19957    106.14139   0.00649351 
+  138          157.99067    106.06549   0.00724638 
+  142          155.9046     105.98969   0.00704225 
+  118          153.93384    105.91399   0.00847458 
+  141          152.07126    105.83838   0.0070922 
+  129          150.31007    105.76287   0.00775194 
+  128          148.60686    105.68745   0.0078125 
+  151          147.02969    105.61213   0.00662252 
+  116          145.53594    105.53691   0.00862069 
+  133          144.12033    105.46178   0.0075188 
+  142          142.77797    105.38674   0.00704225 
+  132          141.48563    105.3118    0.00757576 
+  130          140.27631    105.23695   0.00769231 
+  127          139.12732    105.1622    0.00787402 
+  131          138.03505    105.08755   0.00763359 
+  109          136.99608    105.01299   0.00917431 
+  119          136.00727    104.93852   0.00840336 
+  118          135.06562    104.86415   0.00847458 
+  125          134.16844    104.78987   0.008     
+  121          133.31315    104.71568   0.00826446 
+  96           132.49746    104.64159   0.01041667 
+  112          131.71926    104.5676    0.00892857 
+  137          130.97654    104.49369   0.00729927 
+  130          130.26745    104.41989   0.00769231 
+  134          129.59029    104.34617   0.00746269 
+  112          128.94349    104.27255   0.00892857 
+  140          128.32564    104.19902   0.00714286 
+  123          127.73543    104.12558   0.00813008 
+  126          127.17171    104.05224   0.00793651 
+  119          126.63369    103.97899   0.00840336 
+  132          126.11965    103.90583   0.00757576 
+  143          125.62911    103.83277   0.00699301 
+  123          125.16115    103.7598    0.00813008 
+  123          124.71516    103.68692   0.00813008 
+  130          124.29049    103.61413   0.00769231 
+  150          123.88659    103.54144   0.00666667 
+  108          123.50301    103.46884   0.00925926 
+  132          123.13955    103.39633   0.00757576 
+  96           122.79554    103.32391   0.01041667 
+  121          122.471      103.25158   0.00826446 
+  98           122.1658     103.17935   0.01020408 
+  118          121.87991    103.1072    0.00847458 
+  112          121.61341    103.03515   0.00892857 
+  106          121.3665     102.96319   0.00943396 
+  116          121.14172    102.89132   0.00862069 
+  111          120.93506    102.81954   0.00900901 
+  117          120.7494     102.74786   0.00854701 
+  135          120.58553    102.67626   0.00740741 
+  134          120.44453    102.60476   0.00746269 
+  94           120.32781    102.53334   0.0106383 
+  140          120.23717    102.46202   0.00714286 
+  125          120.17507    102.39079   0.008     
+  120          120.14482    102.31964   0.00833333 
+  97           120.1513     102.24859   0.01030928 
+  114          120.20029    102.17763   0.00877193 
+  106          120.30204    102.10676   0.00943396 
+  116          120.47317    102.03598   0.00862069 
+  104          120.74799    101.96528   0.00961538 
+  119          121.2096     101.89468   0.00840336 
+  122          122.06012    101.82417   0.00819672 
+  144          123.72243    101.75374   0.00694444 
+  145          126.85691    101.68341   0.00689655 
+  145          132.06186    101.61317   0.00689655 
+  157          139.03604    101.54301   0.00636943 
+  169          145.60656    101.47294   0.00591716 
+  150          148.14032    101.40297   0.00666667 
+  139          144.42733    101.33308   0.00719424 
+  141          137.87629    101.26328   0.0070922 
+  147          132.89375    101.19357   0.00680272 
+  160          131.13429    101.12394   0.00625   
+  156          132.17845    101.05441   0.00641026 
+  129          134.19495    100.98496   0.00775194 
+  162          134.74183    100.91561   0.00617284 
+  142          132.28408    100.84634   0.00704225 
+  125          128.22882    100.77716   0.008     
+  148          124.59845    100.70806   0.00675676 
+  136          122.08483    100.63906   0.00735294 
+  127          120.54907    100.57014   0.00787402 
+  127          119.60544    100.50131   0.00787402 
+  131          118.9424     100.43256   0.00763359 
+  139          118.39626    100.36391   0.00719424 
+  122          117.90147    100.29534   0.00819672 
+  107          117.43534    100.22686   0.00934579 
+  117          116.99091    100.15847   0.00854701 
+  115          116.56796    100.09016   0.00869565 
+  106          116.17243    100.02194   0.00943396 
+  130          115.82101    99.9538     0.00769231 
+  108          115.55779    99.88576    0.00925926 
+  135          115.46277    99.8178     0.00740741 
+  108          115.64679    99.74992    0.00925926 
+  123          116.17977    99.68214    0.00813008 
+  105          116.93098    99.61443    0.00952381 
+  107          117.45948    99.54682    0.00934579 
+  125          117.18194    99.47929    0.008     
+  120          116.01724    99.41185    0.00833333 
+  129          114.68183    99.34449    0.00775194 
+  124          113.73788    99.27722    0.00806452 
+  113          113.32777    99.21003    0.00884956 
+  138          113.3124     99.14293    0.00724638 
+  98           113.36414    99.07592    0.01020408 
+  116          113.10329    99.00899    0.00862069 
+  132          112.39763    98.94214    0.00757576 
+  130          111.55461    98.87538    0.00769231 
+  105          110.84161    98.80871    0.00952381 
+  102          110.3228     98.74212    0.00980392 
+  114          109.95825    98.67561    0.00877193 
+  100          109.68639    98.60919    0.01      
+  126          109.46358    98.54286    0.00793651 
+  116          109.26818    98.4766     0.00862069 
+  114          109.09155    98.41044    0.00877193 
+  96           108.93028    98.34436    0.01041667 
+  112          108.78297    98.27836    0.00892857 
+  114          108.64905    98.21244    0.00877193 
+  98           108.52868    98.14661    0.01020408 
+  109          108.42267    98.08087    0.00917431 
+  117          108.33265    98.0152     0.00854701 
+  100          108.26154    97.94962    0.01      
+  102          108.21455    97.88413    0.00980392 
+  113          108.20269    97.81872    0.00884956 
+  110          108.25276    97.75339    0.00909091 
+  132          108.4306     97.68814    0.00757576 
+  109          108.87535    97.62298    0.00917431 
+  102          109.80909    97.5579     0.00980392 
+  114          111.44036    97.4929     0.00877193 
+  125          113.69025    97.42799    0.008     
+  143          115.84801    97.36316    0.00699301 
+  131          116.67741    97.29841    0.00763359 
+  109          115.39652    97.23375    0.00917431 
+  125          113.11343    97.16916    0.008     
+  132          111.32373    97.10466    0.00757576 
+  121          110.61663    97.04024    0.00826446 
+  125          110.90488    96.97591    0.008     
+  115          111.63892    96.91165    0.00869565 
+  124          112.01614    96.84748    0.00806452 
+  117          111.41632    96.78339    0.00854701 
+  111          110.1621     96.71938    0.00900901 
+  127          108.98753    96.65546    0.00787402 
+  137          108.20532    96.59161    0.00729927 
+  105          107.80778    96.52785    0.00952381 
+  131          107.84476    96.46417    0.00763359 
+  102          107.91889    96.40056    0.00980392 
+  112          108.20595    96.33704    0.00892857 
+  106          108.81901    96.27361    0.00943396 
+  103          109.91169    96.21025    0.00970874 
+  121          111.52132    96.14697    0.00826446 
+  107          113.31665    96.08377    0.00934579 
+  114          114.53811    96.02066    0.00877193 
+  125          114.45345    95.95762    0.008     
+  121          113.56597    95.89467    0.00826446 
+  115          112.9609     95.8318     0.00869565 
+  132          113.63764    95.769      0.00757576 
+  104          116.34965    95.70629    0.00961538 
+  126          121.89475    95.64366    0.00793651 
+  133          130.73083    95.5811     0.0075188 
+  122          141.82634    95.51863    0.00819672 
+  137          151.5323     95.45624    0.00729927 
+  138          154.34579    95.39392    0.00724638 
+  155          147.31219    95.33169    0.00645161 
+  159          136.25517    95.26953    0.00628931 
+  151          127.99492    95.20746    0.00662252 
+  144          125.01198    95.14546    0.00694444 
+  158          126.75991    95.08355    0.00632911 
+  126          130.62842    95.02171    0.00793651 
+  134          132.82211    94.95995    0.00746269 
+  155          130.37959    94.89827    0.00645161 
+  145          124.75601    94.83667    0.00689655 
+  119          119.31717    94.77515    0.00840336 
+  126          115.41331    94.71371    0.00793651 
+  124          113.04469    94.65234    0.00806452 
+  128          111.80869    94.59106    0.0078125 
+  116          111.26908    94.52985    0.00862069 
+  96           111.13214    94.46872    0.01041667 
+  124          111.22011    94.40767    0.00806452 
+  116          111.39501    94.3467     0.00862069 
+  105          111.54215    94.2858     0.00952381 
+  120          111.63752    94.22498    0.00833333 
+  105          111.76329    94.16424    0.00952381 
+  127          111.97976    94.10358    0.00787402 
+  110          112.29975    94.043      0.00909091 
+  117          112.71544    93.98249    0.00854701 
+  106          113.21929    93.92207    0.00943396 
+  120          113.81596    93.86171    0.00833333 
+  106          114.53031    93.80144    0.00943396 
+  113          115.41843    93.74124    0.00884956 
+  101          116.57191    93.68112    0.00990099 
+  121          118.09115    93.62108    0.00826446 
+  123          119.99495    93.56112    0.00813008 
+  146          122.09029    93.50123    0.00684932 
+  130          123.97907    93.44141    0.00769231 
+  139          125.38608    93.38168    0.00719424 
+  141          126.74177    93.32202    0.0070922 
+  123          128.78403    93.26244    0.00813008 
+  138          132.06835    93.20293    0.00724638 
+  141          137.14646    93.1435     0.0070922 
+  152          144.79662    93.08415    0.00657895 
+  150          156.17807    93.02487    0.00666667 
+  155          172.80924    92.96567    0.00645161 
+  178          196.29717    92.90654    0.00561798 
+  187          227.00809    92.84749    0.00534759 
+  228          261.14       92.78852    0.00438596 
+  211          287.42344    92.72962    0.00473934 
+  246          291.48978    92.6708     0.00406504 
+  223          273.55655    92.61205    0.0044843 
+  175          248.99898    92.55338    0.00571429 
+  175          230.5103     92.49478    0.00571429 
+  191          222.60769    92.43626    0.0052356 
+  171          224.1922     92.37781    0.00584795 
+  208          229.56196    92.31944    0.00480769 
+  207          229.51548    92.26115    0.00483092 
+  200          218.98639    92.20292    0.005     
+  176          202.58986    92.14478    0.00568182 
+  177          187.05906    92.0867     0.00564972 
+  168          175.67448    92.02871    0.00595238 
+  148          169.28033    91.97078    0.00675676 
+  154          167.82421    91.91293    0.00649351 
+  186          170.67707    91.85516    0.00537634 
+  170          176.08825    91.79746    0.00588235 
+  171          180.84341    91.73983    0.00584795 
+  196          181.62322    91.68228    0.00510204 
+  171          178.91333    91.6248     0.00584795 
+  162          176.62723    91.5674     0.00617284 
+  191          177.17342    91.51007    0.0052356 
+  166          181.04561    91.45281    0.0060241 
+  177          187.56677    91.39563    0.00564972 
+  182          195.19665    91.33852    0.00549451 
+  186          202.05525    91.28148    0.00537634 
+  217          207.41242    91.22452    0.00460829 
+  199          212.94633    91.16763    0.00502513 
+  196          220.39291    91.11081    0.00510204 
+  229          230.44077    91.05407    0.00436681 
+  227          243.25856    90.99739    0.00440529 
+  240          258.97117    90.9408     0.00416667 
+  292          277.92772    90.88427    0.00342466 
+  328          300.80688    90.82782    0.00304878 
+  314          328.63885    90.77144    0.00318471 
+  375          362.95448    90.71513    0.00266667 
+  374          405.93143    90.6589     0.0026738 
+  428          460.65694    90.60274    0.00233645 
+  571          531.69603    90.54665    0.00175131 
+  715          626.86989    90.49063    0.0013986 
+  930          762.30125    90.43468    0.00107527 
+  1176         972.64192    90.37881    0.00085034 
+  1580         1323.422     90.32301    0.00063291 
+  2082         1912.4421    90.26728    0.00048031 
+  2733         2845.38974   90.21162    0.0003659 
+  3925         4171.42891   90.15603    0.00025478 
+  5339         5751.9653    90.10052    0.0001873 
+  6736         7041.38994   90.04507    0.00014846 
+  7141         7198.49105   89.9897     0.00014004 
+  6241         6179.46617   89.9344     0.00016023 
+  4469         4855.17919   89.87917    0.00022376 
+  3413         3885.30972   89.82401    0.000293  
+  2762         3486.18038   89.76892    0.00036206 
+  2931         3610.14081   89.71391    0.00034118 
+  3418         3994.04827   89.65896    0.00029257 
+  3789         4146.40202   89.60409    0.00026392 
+  3523         3700.85128   89.54929    0.00028385 
+  2677         2881.08115   89.49455    0.00037355 
+  1730         2075.24137   89.43989    0.00057803 
+  1012         1453.46806   89.3853     0.00098814 
+  744          1032.34204   89.33078    0.00134409 
+  548          768.41259    89.27633    0.00182482 
+  494          606.68587    89.22194    0.00202429 
+  359          503.83262    89.16763    0.00278552 
+  390          433.46242    89.11339    0.0025641 
+  361          381.70323    89.05922    0.00277008 
+  280          341.69173    89.00512    0.00357143 
+  295          309.85891    88.95109    0.00338983 
+  282          284.15357    88.89713    0.0035461 
+  256          263.32384    88.84324    0.00390625 
+  256          246.61769    88.78942    0.00390625 
+  239          233.52354    88.73566    0.0041841 
+  245          223.34405    88.68198    0.00408163 
+  202          214.7824     88.62837    0.0049505 
+  198          206.11935    88.57482    0.00505051 
+  181          196.58471    88.52135    0.00552486 
+  203          187.52854    88.46794    0.00492611 
+  189          180.17182    88.4146     0.00529101 
+  181          174.43844    88.36134    0.00552486 
+  174          169.53986    88.30814    0.00574713 
+  187          164.92662    88.25501    0.00534759 
+  184          160.42542    88.20194    0.00543478 
+  160          155.65979    88.14895    0.00625   
+  144          150.81852    88.09603    0.00694444 
+  150          146.60864    88.04317    0.00666667 
+  146          143.19196    87.99038    0.00684932 
+  137          140.21286    87.93766    0.00729927 
+  142          137.27706    87.88501    0.00704225 
+  142          134.44628    87.83243    0.00704225 
+  136          131.96581    87.77991    0.00735294 
+  120          129.94989    87.72746    0.00833333 
+  163          128.44034    87.67508    0.00613497 
+  151          127.46187    87.62277    0.00662252 
+  114          126.97333    87.57053    0.00877193 
+  123          126.71857    87.51835    0.00813008 
+  122          126.17278    87.46624    0.00819672 
+  124          124.87721    87.4142     0.00806452 
+  130          123.16846    87.36223    0.00769231 
+  114          121.83893    87.31032    0.00877193 
+  109          121.31891    87.25848    0.00917431 
+  122          121.57461    87.20671    0.00819672 
+  144          122.08209    87.155      0.00694444 
+  146          121.97187    87.10336    0.00684932 
+  123          120.71519    87.05179    0.00813008 
+  118          118.82363    87.00029    0.00847458 
+  113          117.22433    86.94885    0.00884956 
+  104          116.50111    86.89748    0.00961538 
+  127          116.77772    86.84618    0.00787402 
+  119          117.71722    86.79494    0.00840336 
+  114          118.46347    86.74377    0.00877193 
+  131          117.95462    86.69266    0.00763359 
+  139          116.01051    86.64162    0.00719424 
+  150          113.71271    86.59065    0.00666667 
+  136          111.91998    86.53974    0.00735294 
+  131          110.86693    86.4889     0.00763359 
+  121          110.44464    86.43813    0.00826446 
+  113          110.35483    86.38742    0.00884956 
+  121          110.1715     86.33677    0.00826446 
+  130          109.5072     86.2862     0.00769231 
+  108          108.41983    86.23569    0.00925926 
+  127          107.31004    86.18524    0.00787402 
+  125          106.39431    86.13486    0.008     
+  117          105.69229    86.08454    0.00854701 
+  118          105.14308    86.03429    0.00847458 
+  105          104.68193    85.98411    0.00952381 
+  110          104.26905    85.93399    0.00909091 
+  105          103.88584    85.88394    0.00952381 
+  109          103.52426    85.83395    0.00917431 
+  105          103.18022    85.78402    0.00952381 
+  105          102.85074    85.73416    0.00952381 
+  88           102.5335     85.68437    0.01136364 
+  88           102.2258     85.63464    0.01136364 
+  96           101.92594    85.58497    0.01041667 
+  111          101.6321     85.53537    0.00900901 
+  105          101.34282    85.48584    0.00952381 
+  97           101.05688    85.43637    0.01030928 
+  104          100.77339    85.38696    0.00961538 
+  94           100.49187    85.33762    0.0106383 
+  107          100.21204    85.28834    0.00934579 
+  101          99.9339      85.23912    0.00990099 
+  97           99.65776     85.18997    0.01030928 
+  103          99.38407     85.14089    0.00970874 
+  95           99.11345     85.09186    0.01052632 
+  106          98.84659     85.0429     0.00943396 
+  82           98.58436     84.99401    0.01219512 
+  104          98.32765     84.94518    0.00961538 
+  91           98.07704     84.89641    0.01098901 
+  87           97.83346     84.8477     0.01149425 
+  111          97.5977      84.79906    0.00900901 
+  90           97.37094     84.75049    0.01111111 
+  95           97.1546      84.70197    0.01052632 
+  102          96.95011     84.65352    0.00980392 
+  90           96.75786     84.60513    0.01111111 
+  98           96.57394     84.55681    0.01020408 
+  101          96.39082     84.50855    0.00990099 
+  109          96.20163     84.46035    0.00917431 
+  115          96.00988     84.41221    0.00869565 
+  109          95.82401     84.36414    0.00917431 
+  96           95.64783     84.31613    0.01041667 
+  113          95.48118     84.26818    0.00884956 
+  94           95.32183     84.22029    0.0106383 
+  94           95.16409     84.17247    0.0106383 
+  95           95.00234     84.12471    0.01052632 
+  95           94.83399     84.07701    0.01052632 
+  100          94.662       84.02937    0.01      
+  108          94.49143     83.9818     0.00925926 
+  96           94.32393     83.93429    0.01041667 
+  112          94.15979     83.88684    0.00892857 
+  111          93.99905     83.83945    0.00900901 
+  111          93.84185     83.79212    0.00900901 
+  106          93.69121     83.74486    0.00943396 
+  100          93.55626     83.69766    0.01      
+  91           93.45727     83.65052    0.01098901 
+  106          93.42998     83.60344    0.00943396 
+  100          93.51708     83.55642    0.01      
+  112          93.73217     83.50946    0.00892857 
+  93           93.99633     83.46257    0.01075269 
+  120          94.10575     83.41574    0.00833333 
+  97           93.86817     83.36896    0.01030928 
+  90           93.39835     83.32225    0.01111111 
+  93           93.01125     83.2756     0.01075269 
+  91           92.91581     83.22901    0.01098901 
+  95           93.20207     83.18249    0.01052632 
+  114          93.8224      83.13602    0.00877193 
+  101          94.49754     83.08961    0.00990099 
+  98           94.72425     83.04327    0.01020408 
+  88           94.1569      82.99698    0.01136364 
+  92           93.1606      82.95076    0.01086957 
+  99           92.28803     82.90459    0.01010101 
+  108          91.76816     82.85849    0.00925926 
+  106          91.60655     82.81245    0.00943396 
+  103          91.69471     82.76647    0.00970874 
+  97           91.84293     82.72054    0.01030928 
+  89           91.81631     82.67468    0.01123596 
+  132          91.50907     82.62888    0.00757576 
+  119          91.09428     82.58314    0.00840336 
+  97           90.75756     82.53745    0.01030928 
+  110          90.55715     82.49183    0.00909091 
+  102          90.48282     82.44627    0.00980392 
+  109          90.51595     82.40077    0.00917431 
+  119          90.66531     82.35532    0.00840336 
+  113          91.01112     82.30994    0.00884956 
+  137          91.76691     82.26462    0.00729927 
+  110          93.33762     82.21935    0.00909091 
+  148          96.23876     82.17415    0.00675676 
+  140          100.69123    82.129      0.00714286 
+  168          105.85804    82.08391    0.00595238 
+  154          109.38634    82.03889    0.00649351 
+  152          108.71903    81.99392    0.00657895 
+  146          104.4992     81.94901    0.00684932 
+  150          99.77002     81.90416    0.00666667 
+  153          96.59691     81.85937    0.00653595 
+  159          95.63996     81.81463    0.00628931 
+  134          96.59528     81.76996    0.00746269 
+  128          98.26397     81.72535    0.0078125 
+  159          99.43301     81.68079    0.00628931 
+  158          98.54631     81.63629    0.00632911 
+  160          96.06042     81.59185    0.00625   
+  113          93.40162     81.54747    0.00884956 
+  115          91.39006     81.50315    0.00869565 
+  117          90.06072     81.45888    0.00854701 
+  120          89.39219     81.41468    0.00833333 
+  114          89.0405      81.37053    0.00877193 
+  127          88.84387     81.32644    0.00787402 
+  106          88.72406     81.28241    0.00943396 
+  104          88.64887     81.23843    0.00961538 
+  112          88.60555     81.19452    0.00892857 
+  101          88.58891     81.15066    0.00990099 
+  95           88.59731     81.10686    0.01052632 
+  92           88.63208     81.06312    0.01086957 
+  97           88.69903     81.01943    0.01030928 
+  91           88.8154      80.9758     0.01098901 
+  107          89.0278      80.93223    0.00934579 
+  102          89.43988     80.88872    0.00980392 
+  97           90.21583     80.84526    0.01030928 
+  73           91.49347     80.80186    0.01369863 
+  92           93.17801     80.75852    0.01086957 
+  87           94.63986     80.71524    0.01149425 
+  104          94.79601     80.67201    0.00961538 
+  92           93.64878     80.62884    0.01086957 
+  97           92.31273     80.58573    0.01030928 
+  108          91.4829      80.54267    0.00925926 
+  96           91.34609     80.49967    0.01041667 
+  95           91.83759     80.45673    0.01052632 
+  99           92.74449     80.41384    0.01010101 
+  109          93.64173     80.37102    0.00917431 
+  99           93.95049     80.32824    0.01010101 
+  101          93.69012     80.28553    0.00990099 
+  100          93.4139      80.24287    0.01      
+  91           93.44546     80.20026    0.01098901 
+  98           93.85202     80.15771    0.01020408 
+  81           94.59692     80.11522    0.01234568 
+  98           95.64573     80.07279    0.01020408 
+  97           97.0163      80.03041    0.01030928 
+  91           98.79387     79.98809    0.01098901 
+  103          101.15384    79.94582    0.00970874 
+  100          104.42169    79.90361    0.01      
+  93           109.17411    79.86145    0.01075269 
+  114          116.3504     79.81935    0.00877193 
+  124          127.26348    79.77731    0.00806452 
+  129          143.41719    79.73532    0.00775194 
+  149          165.95074    79.69339    0.00671141 
+  172          194.46676    79.65151    0.00581395 
+  210          224.51423    79.60969    0.0047619 
+  227          244.94621    79.56792    0.00440529 
+  244          244.78108    79.52621    0.00409836 
+  212          228.78805    79.48455    0.00471698 
+  198          212.9231     79.44295    0.00505051 
+  173          208.64427    79.40141    0.00578035 
+  145          218.56278    79.35991    0.00689655 
+  151          235.66434    79.31848    0.00662252 
+  179          243.67261    79.2771     0.00558659 
+  153          233.2464     79.23577    0.00653595 
+  176          209.86545    79.1945     0.00568182 
+  163          183.00647    79.15328    0.00613497 
+  149          161.5242     79.11212    0.00671141 
+  130          149.2411     79.07101    0.00769231 
+  112          145.24785    79.02996    0.00892857 
+  111          144.94941    78.98896    0.00900901 
+  108          140.66647    78.94802    0.00925926 
+  117          129.76095    78.90713    0.00854701 
+  111          117.60909    78.86629    0.00900901 
+  84           108.1429     78.82551    0.01190476 
+  112          102.05468    78.78478    0.00892857 
+  86           98.51924     78.74411    0.01162791 
+  100          96.45401     78.70349    0.01      
+  108          95.1265      78.66292    0.00925926 
+  84           94.17819     78.62241    0.01190476 
+  83           93.45732     78.58195    0.01204819 
+  94           92.89533     78.54155    0.0106383 
+  95           92.45459     78.5012     0.01052632 
+  84           92.11202     78.4609     0.01190476 
+  87           91.85545     78.42066    0.01149425 
+  116          91.6844      78.38047    0.00862069 
+  87           91.60783     78.34033    0.01149425 
+  108          91.63185     78.30025    0.00925926 
+  105          91.73471     78.26022    0.00952381 
+  97           91.83113     78.22024    0.01030928 
+  100          91.79966     78.18032    0.01      
+  73           91.66013     78.14045    0.01369863 
+  78           91.53602     78.10063    0.01282051 
+  99           91.49445     78.06087    0.01010101 
+  102          91.55003     78.02116    0.00980392 
+  85           91.69301     77.9815     0.01176471 
+  99           91.89916     77.94189    0.01010101 
+  72           92.12203     77.90234    0.01388889 
+  88           92.29545     77.86284    0.01136364 
+  94           92.41758     77.82339    0.0106383 
+  81           92.54962     77.784      0.01234568 
+  94           92.72835     77.74466    0.0106383 
+  96           92.96042     77.70537    0.01041667 
+  98           93.24094     77.66613    0.01020408 
+  98           93.56513     77.62694    0.01020408 
+  116          93.93509     77.58781    0.00862069 
+  115          94.36548     77.54873    0.00869565 
+  94           94.8963      77.5097     0.0106383 
+  91           95.61339     77.47073    0.01098901 
+  119          96.65039     77.4318     0.00840336 
+  98           98.10974     77.39293    0.01020408 
+  97           99.87825     77.35411    0.01030928 
+  104          101.38519    77.31534    0.00961538 
+  114          101.80321    77.27662    0.00877193 
+  125          101.32338    77.23796    0.008     
+  106          100.83493    77.19934    0.00943396 
+  121          100.82046    77.16078    0.00826446 
+  89           101.39754    77.12227    0.01123596 
+  119          102.5242     77.08381    0.00840336 
+  118          104.06859    77.0454     0.00847458 
+  109          105.75087    77.00705    0.00917431 
+  98           107.16128    76.96874    0.01020408 
+  102          108.3553     76.93049    0.00980392 
+  100          109.92857    76.89228    0.01      
+  111          112.44236    76.85413    0.00900901 
+  121          116.41577    76.81603    0.00826446 
+  104          122.44552    76.77798    0.00961538 
+  121          131.16488    76.73998    0.00826446 
+  126          142.99612    76.70203    0.00793651 
+  138          157.50722    76.66414    0.00724638 
+  161          172.07652    76.62629    0.00621118 
+  155          180.89016    76.58849    0.00645161 
+  147          179.20472    76.55075    0.00680272 
+  177          169.98172    76.51305    0.00564972 
+  139          159.93212    76.47541    0.00719424 
+  155          153.15162    76.43782    0.00645161 
+  131          150.90349    76.40027    0.00763359 
+  145          152.87168    76.36278    0.00689655 
+  123          157.41007    76.32534    0.00813008 
+  130          161.23404    76.28794    0.00769231 
+  132          160.92016    76.2506     0.00757576 
+  141          156.62149    76.21331    0.0070922 
+  123          151.34129    76.17607    0.00813008 
+  126          147.29926    76.13888    0.00793651 
+  155          145.26786    76.10173    0.00645161 
+  133          145.31165    76.06464    0.0075188 
+  110          147.17107    76.0276     0.00909091 
+  148          150.33768    75.99061    0.00675676 
+  143          154.00204    75.95366    0.00699301 
+  146          157.61518    75.91677    0.00684932 
+  176          161.61567    75.87992    0.00568182 
+  160          166.61236    75.84313    0.00625   
+  193          172.91529    75.80638    0.00518135 
+  219          180.68043    75.76969    0.00456621 
+  219          190.02271    75.73304    0.00456621 
+  222          201.04856    75.69644    0.0045045 
+  217          213.79813    75.6599     0.00460829 
+  233          228.38621    75.6234     0.00429185 
+  276          245.48461    75.58695    0.00362319 
+  260          266.14852    75.55055    0.00384615 
+  268          291.50202    75.5142     0.00373134 
+  309          322.94464    75.47789    0.00323625 
+  367          362.42413    75.44164    0.0027248 
+  407          412.94293    75.40543    0.002457  
+  492          479.66176    75.36928    0.00203252 
+  687          572.55989    75.33317    0.0014556 
+  833          712.08835    75.29711    0.00120048 
+  1155         938.1128     75.2611     0.0008658 
+  1484         1317.44844   75.22514    0.00067385 
+  2243         1937.66185   75.18923    0.00044583 
+  3104         2872.62066   75.15336    0.00032216 
+  4354         4108.60501   75.11754    0.00022967 
+  5637         5395.65308   75.08178    0.0001774 
+  6810         6100.08365   75.04606    0.00014684 
+  6332         5694.81445   75.01038    0.00015793 
+  4808         4582.89      74.97476    0.00020799 
+  3319         3483.51438   74.93918    0.0003013 
+  2635         2759.93342   74.90366    0.00037951 
+  2307         2501.12571   74.86818    0.00043346 
+  2547         2656.8095    74.83274    0.00039262 
+  3090         3063.73113   74.79736    0.00032362 
+  3444         3393.80221   74.76202    0.00029036 
+  3462         3258.89367   74.72674    0.00028885 
+  2708         2671.67414   74.69149    0.00036928 
+  1863         1976.48562   74.6563     0.00053677 
+  1127         1395.35483   74.62116    0.00088731 
+  789          982.71279    74.58606    0.00126743 
+  517          717.05661    74.55101    0.00193424 
+  418          553.90971    74.516      0.00239234 
+  368          452.47421    74.48105    0.00271739 
+  310          385.34711    74.44614    0.00322581 
+  264          337.36521    74.41128    0.00378788 
+  266          300.92499    74.37646    0.0037594 
+  232          272.16912    74.3417     0.00431034 
+  191          248.92175    74.30698    0.0052356 
+  178          229.81603    74.2723     0.00561798 
+  204          213.89314    74.23768    0.00490196 
+  201          200.47255    74.2031     0.00497512 
+  151          189.04645    74.16856    0.00662252 
+  149          179.23482    74.13408    0.00671141 
+  179          170.74803    74.09964    0.00558659 
+  161          163.36305    74.06525    0.00621118 
+  147          156.90716    74.0309     0.00680272 
+  146          151.24689    73.9966     0.00684932 
+  152          146.28083    73.96235    0.00657895 
+  138          141.93685    73.92814    0.00724638 
+  117          138.17669    73.89398    0.00854701 
+  130          135.02763    73.85987    0.00769231 
+  118          132.66101    73.8258     0.00847458 
+  141          131.5494     73.79178    0.0070922 
+  146          132.55904    73.75781    0.00684932 
+  126          136.67735    73.72388    0.00793651 
+  139          144.10143    73.69       0.00719424 
+  153          152.61285    73.65616    0.00653595 
+  133          156.76909    73.62237    0.0075188 
+  155          153.96771    73.58863    0.00645161 
+  147          146.91881    73.55493    0.00680272 
+  139          138.55772    73.52128    0.00719424 
+  128          132.02365    73.48767    0.0078125 
+  115          127.99185    73.45411    0.00869565 
+  128          126.17343    73.42059    0.0078125 
+  118          126.58988    73.38712    0.00847458 
+  107          127.3289     73.3537     0.00934579 
+  126          125.68637    73.32032    0.00793651 
+  100          121.84438    73.28698    0.01      
+  104          116.92488    73.2537     0.00961538 
+  98           112.23051    73.22045    0.01020408 
+  113          108.41474    73.18725    0.00884956 
+  99           105.04112    73.1541     0.01010101 
+  100          102.12578    73.12099    0.01      
+  84           99.88833     73.08793    0.01190476 
+  100          98.28264     73.05491    0.01      
+  100          97.14109     73.02194    0.01      
+  81           96.29209     72.98902    0.01234568 
+  96           95.61427     72.95613    0.01041667 
+  83           95.0409      72.9233     0.01204819 
+  77           94.54162     72.8905     0.01298701 
+  108          94.10136     72.85775    0.00925926 
+  106          93.7113      72.82505    0.00943396 
+  98           93.36536     72.79239    0.01020408 
+  90           93.05887     72.75978    0.01111111 
+  93           92.78812     72.72721    0.01075269 
+  90           92.54951     72.69468    0.01111111 
+  78           92.341       72.6622     0.01282051 
+  84           92.1598      72.62977    0.01190476 
+  86           92.003       72.59737    0.01162791 
+  93           91.86829     72.56503    0.01075269 
+  95           91.75315     72.53272    0.01052632 
+  85           91.655       72.50046    0.01176471 
+  89           91.57105     72.46825    0.01123596 
+  106          91.49902     72.43608    0.00943396 
+  96           91.43612     72.40395    0.01041667 
+  96           91.37985     72.37187    0.01041667 
+  78           91.32793     72.33983    0.01282051 
+  89           91.2783      72.30783    0.01123596 
+  94           91.22921     72.27588    0.0106383 
+  83           91.1795      72.24397    0.01204819 
+  99           91.1283      72.21211    0.01010101 
+  92           91.07542     72.18029    0.01086957 
+  95           91.021       72.14851    0.01052632 
+  89           90.96695     72.11678    0.01123596 
+  90           90.912       72.08509    0.01111111 
+  89           90.85901     72.05344    0.01123596 
+  76           90.81019     72.02184    0.01315789 
+  60           90.76817     71.99028    0.01666667 
+  90           90.73698     71.95876    0.01111111 
+  78           90.72145     71.92729    0.01282051 
+  79           90.7296      71.89586    0.01265823 
+  90           90.7754      71.86447    0.01111111 
+  77           90.89355     71.83312    0.01298701 
+  73           91.17431     71.80182    0.01369863 
+  81           91.81772     71.77056    0.01234568 
+  88           93.15347     71.73935    0.01136364 
+  74           95.48155     71.70818    0.01351351 
+  87           98.67021     71.67705    0.01149425 
+  103          101.54498    71.64596    0.00970874 
+  91           101.85524    71.61492    0.01098901 
+  104          99.26896     71.58392    0.00961538 
+  77           96.02155     71.55296    0.01298701 
+  95           93.64816     71.52204    0.01052632 
+  95           92.5663      71.49117    0.01052632 
+  90           92.65965     71.46034    0.01111111 
+  90           93.57798     71.42955    0.01111111 
+  78           94.79775     71.3988     0.01282051 
+  89           95.43238     71.3681     0.01123596 
+  98           94.549       71.33743    0.01020408 
+  73           92.67425     71.30681    0.01369863 
+  67           90.88683     71.27624    0.01492537 
+  94           89.63009     71.2457     0.0106383 
+  79           88.88601     71.21521    0.01265823 
+  71           88.45137     71.18476    0.01408451 
+  73           88.11657     71.15435    0.01369863 
+  91           87.7947      71.12398    0.01098901 
+  72           87.50327     71.09365    0.01388889 
+  84           87.26091     71.06337    0.01190476 
+  90           87.06822     71.03313    0.01111111 
+  80           86.91724     71.00293    0.0125    
+  81           86.80019     70.97277    0.01234568 
+  85           86.71362     70.94265    0.01176471 
+  78           86.65976     70.91258    0.01282051 
+  80           86.64883     70.88254    0.0125    
+  70           86.70435     70.85255    0.01428571 
+  71           86.86496     70.8226     0.01408451 
+  80           87.16791     70.79269    0.0125    
+  78           87.60556     70.76282    0.01282051 
+  74           88.05502     70.73299    0.01351351 
+  84           88.28394     70.70321    0.01190476 
+  92           88.22523     70.67346    0.01086957 
+  83           88.07123     70.64376    0.01204819 
+  96           88.04211     70.6141     0.01041667 
+  75           88.25737     70.58448    0.01333333 
+  98           88.78327     70.55489    0.01020408 
+  98           89.66989     70.52536    0.01020408 
+  96           90.90512     70.49586    0.01041667 
+  111          92.29889     70.4664     0.00900901 
+  70           93.43769     70.43698    0.01428571 
+  87           94.13114     70.4076     0.01149425 
+  80           94.88133     70.37827    0.0125    
+  101          96.37067     70.34897    0.00990099 
+  95           99.27881     70.31972    0.01052632 
+  103          104.5374     70.29051    0.00970874 
+  93           113.32435    70.26133    0.01075269 
+  105          126.49184    70.2322     0.00952381 
+  118          143.40077    70.20311    0.00847458 
+  134          160.86714    70.17405    0.00746269 
+  144          176.59711    70.14504    0.00694444 
+  148          191.06051    70.11607    0.00675676 
+  131          200.02917    70.08714    0.00763359 
+  142          197.43196    70.05825    0.00704225 
+  180          186.32895    70.02939    0.00555556 
+  205          175.4636     70.00058    0.00487805 
+  268          168.65572    69.97181    0.00373134 
+  279          163.5632     69.94308    0.00358423 
+  291          158.39673    69.91439    0.00343643 
+  221          154.96691    69.88574    0.00452489 
+  161          153.95666    69.85713    0.00621118 
+  176          151.8302     69.82855    0.00568182 
+  172          145.22427    69.80002    0.00581395 
+  128          135.9107     69.77153    0.0078125 
+  161          127.26498    69.74307    0.00621118 
+  192          119.99581    69.71466    0.00520833 
+  183          113.05827    69.68629    0.00546448 
+  163          106.87839    69.65795    0.00613497 
+  134          102.37723    69.62966    0.00746269 
+  105          99.29747     69.6014     0.00952381 
+  99           97.07236     69.57319    0.01010101 
+  113          95.9321      69.54501    0.00884956 
+  95           96.5159      69.51687    0.01052632 
+  88           98.77409     69.48877    0.01136364 
+  98           102.24046    69.46071    0.01020408 
+  96           104.86347    69.43269    0.01041667 
+  101          104.19876    69.40471    0.00990099 
+  110          101.2153     69.37677    0.00909091 
+  90           98.31088     69.34886    0.01111111 
+  92           96.49332     69.321      0.01086957 
+  110          95.73911     69.29317    0.00909091 
+  100          95.53677     69.26539    0.01      
+  90           95.91224     69.23764    0.01111111 
+  91           96.89069     69.20993    0.01098901 
+  90           97.31526     69.18226    0.01111111 
+  97           96.23818     69.15463    0.01030928 
+  91           94.46445     69.12703    0.01098901 
+  97           93.11106     69.09948    0.01030928 
+  78           92.46007     69.07196    0.01282051 
+  94           92.16811     69.04448    0.0106383 
+  103          91.81357     69.01704    0.00970874 
+  95           91.43278     68.98964    0.01052632 
+  93           91.19536     68.96228    0.01075269 
+  89           91.1511      68.93496    0.01123596 
+  88           91.27032     68.90767    0.01136364 
+  94           91.50016     68.88042    0.0106383 
+  77           91.80059     68.85321    0.01298701 
+  89           92.02422     68.82604    0.01123596 
+  76           92.42764     68.7989     0.01315789 
+  89           92.8854      68.77181    0.01123596 
+  75           93.39686     68.74475    0.01333333 
+  94           93.94092     68.71773    0.0106383 
+  89           94.46603     68.69075    0.01123596 
+  100          94.94296     68.6638     0.01      
+  97           95.35304     68.6369     0.01030928 
+  84           95.87221     68.61003    0.01190476 
+  84           96.45198     68.58319    0.01190476 
+  108          97.09364     68.5564     0.00925926 
+  102          97.7942      68.52964    0.00980392 
+  110          98.54857     68.50293    0.00909091 
+  101          99.34354     68.47624    0.00990099 
+  108          100.15327    68.4496     0.00925926 
+  113          100.97094    68.42299    0.00884956 
+  103          101.82494    68.39642    0.00970874 
+  109          102.7403     68.36989    0.00917431 
+  95           103.72721    68.3434     0.01052632 
+  121          104.79261    68.31694    0.00826446 
+  102          105.94993    68.29052    0.00980392 
+  129          107.2378     68.26414    0.00775194 
+  130          108.75007    68.23779    0.00769231 
+  107          110.65942    68.21148    0.00934579 
+  132          113.16652    68.18521    0.00757576 
+  128          116.31381    68.15897    0.0078125 
+  113          119.66674    68.13278    0.00884956 
+  142          122.04449    68.10661    0.00704225 
+  118          122.65956    68.08049    0.00847458 
+  119          122.52502    68.0544     0.00840336 
+  107          122.75737    68.02835    0.00934579 
+  149          123.7632     68.00234    0.00671141 
+  132          125.55535    67.97636    0.00757576 
+  151          128.03604    67.95042    0.00662252 
+  166          131.06016    67.92451    0.0060241 
+  151          134.30596    67.89864    0.00662252 
+  142          137.13243    67.87281    0.00704225 
+  167          139.19891    67.84702    0.00598802 
+  171          141.05507    67.82126    0.00584795 
+  217          143.22006    67.79553    0.00460829 
+  161          145.84856    67.76985    0.00621118 
+  220          148.89663    67.7442     0.00454545 
+  195          152.27006    67.71858    0.00512821 
+  208          155.9001     67.693      0.00480769 
+  234          159.75943    67.66746    0.0042735 
+  240          163.85657    67.64196    0.00416667 
+  240          168.25018    67.61649    0.00416667 
+  258          173.10493    67.59105    0.00387597 
+  272          178.75459    67.56565    0.00367647 
+  322          185.64184    67.54029    0.00310559 
+  293          193.96462    67.51496    0.00341297 
+  308          203.02127    67.48967    0.00324675 
+  318          210.44525    67.46442    0.00314465 
+  313          213.79288    67.4392     0.00319489 
+  300          214.60323    67.41402    0.00333333 
+  285          215.6591     67.38887    0.00350877 
+  334          218.13312    67.36376    0.00299401 
+  320          222.14951    67.33868    0.003125  
+  324          227.48753    67.31364    0.00308642 
+  312          233.8449     67.28863    0.00320513 
+  321          240.64009    67.26366    0.00311526 
+  285          246.57991    67.23872    0.00350877 
+  320          250.41468    67.21382    0.003125  
+  325          252.90443    67.18896    0.00307692 
+  283          255.39711    67.16413    0.00353357 
+  247          258.40782    67.13934    0.00404858 
+  295          261.88889    67.11458    0.00338983 
+  305          265.59811    67.08985    0.00327869 
+  282          269.31889    67.06516    0.0035461 
+  304          272.92522    67.04051    0.00328947 
+  319          276.35783    67.01589    0.0031348 
+  371          279.58919    66.9913     0.00269542 
+  379          282.60822    66.96675    0.00263852 
+  387          285.41115    66.94224    0.00258398 
+  433          287.99898    66.91776    0.00230947 
+  414          290.37562    66.89331    0.00241546 
+  447          292.54429    66.8689     0.00223714 
+  496          294.50976    66.84453    0.00201613 
+  448          296.27121    66.82019    0.00223214 
+  373          297.82478    66.79588    0.00268097 
+  361          299.16135    66.77161    0.00277008 
+  371          300.26691    66.74737    0.00269542 
+  405          301.12265    66.72317    0.00246914 
+  401          301.70794    66.699      0.00249377 
+  384          302.01119    66.67486    0.00260417 
+  431          302.04235    66.65076    0.00232019 
+  400          301.83679    66.6267     0.0025    
+  322          301.43852    66.60266    0.00310559 
+  292          300.80792    66.57867    0.00342466 
+  275          299.70253    66.5547     0.00363636 
+  264          297.6285     66.53077    0.00378788 
+  241          294.44663    66.50688    0.00414938 
+  278          290.68728    66.48302    0.00359712 
+  287          286.86705    66.45919    0.00348432 
+  268          283.35294    66.4354     0.00373134 
+  279          280.41036    66.41164    0.00358423 
+  271          278.01519    66.38791    0.00369004 
+  263          275.4262     66.36422    0.00380228 
+  241          270.89709    66.34056    0.00414938 
+  262          263.47519    66.31693    0.00381679 
+  263          254.63508    66.29334    0.00380228 
+  294          246.00607    66.26979    0.00340136 
+  275          238.25002    66.24626    0.00363636 
+  317          231.4368     66.22277    0.00315457 
+  290          225.44904    66.19932    0.00344828 
+  264          220.10804    66.17589    0.00378788 
+  286          215.0106     66.1525     0.0034965 
+  255          209.33985    66.12915    0.00392157 
+  235          202.60385    66.10582    0.00425532 
+  267          195.50648    66.08253    0.00374532 
+  244          188.78424    66.05928    0.00409836 
+  329          182.6692     66.03605    0.00303951 
+  272          177.11462    66.01286    0.00367647 
+  290          171.98881    65.9897     0.00344828 
+  243          167.18796    65.96658    0.00411523 
+  215          162.65842    65.94349    0.00465116 
+  204          158.37108    65.92043    0.00490196 
+  215          154.31379    65.89741    0.00465116 
+  176          150.47597    65.87441    0.00568182 
+  179          146.84809    65.85145    0.00558659 
+  182          143.4211     65.82853    0.00549451 
+  198          140.18446    65.80563    0.00505051 
+  177          137.12883    65.78277    0.00564972 
+  171          134.24445    65.75994    0.00584795 
+  164          131.52265    65.73715    0.00609756 
+  142          128.95486    65.71439    0.00704225 
+  158          126.5319     65.69166    0.00632911 
+  141          124.24593    65.66896    0.0070922 
+  135          122.08947    65.64629    0.00740741 
+  144          120.05548    65.62366    0.00694444 
+  133          118.13739    65.60106    0.0075188 
+  144          116.32955    65.57849    0.00694444 
+  145          114.62711    65.55595    0.00689655 
+  128          113.02521    65.53345    0.0078125 
+  112          111.52199    65.51098    0.00892857 
+  127          110.11543    65.48854    0.00787402 
+  111          108.8074     65.46613    0.00900901 
+  126          107.60734    65.44376    0.00793651 
+  109          106.5458     65.42141    0.00917431 
+  133          105.70735    65.3991     0.0075188 
+  120          105.27158    65.37682    0.00833333 
+  146          105.49768    65.35458    0.00684932 
+  121          106.55303    65.33236    0.00826446 
+  127          108.16126    65.31018    0.00787402 
+  124          109.12939    65.28803    0.00806452 
+  130          107.85301    65.26591    0.00769231 
+  113          104.81745    65.24382    0.00884956 
+  111          101.72428    65.22177    0.00900901 
+  95           99.41474     65.19974    0.01052632 
+  114          98.02553     65.17775    0.00877193 
+  121          97.44584     65.15579    0.00826446 
+  116          97.53985     65.13386    0.00862069 
+  95           98.09572     65.11196    0.01052632 
+  94           98.57619     65.09009    0.0106383 
+  135          98.10364     65.06826    0.00740741 
+  116          96.60268     65.04645    0.00862069 
+  101          94.90924     65.02468    0.00990099 
+  110          93.5436      65.00294    0.00909091 
+  107          92.5965      64.98123    0.00934579 
+  94           91.96613     64.95955    0.0106383 
+  124          91.52194     64.93791    0.00806452 
+  93           91.17809     64.91629    0.01075269 
+  94           90.89372     64.8947     0.0106383 
+  100          90.65183     64.87315    0.01      
+  119          90.44454     64.85163    0.00840336 
+  94           90.26678     64.83014    0.0106383 
+  62           90.11443     64.80867    0.01612903 
+  102          89.98364     64.78724    0.00980392 
+  100          89.87055     64.76585    0.01      
+  97           89.77136     64.74448    0.01030928 
+  92           89.68206     64.72314    0.01086957 
+  93           89.59859     64.70183    0.01075269 
+  83           89.51689     64.68056    0.01204819 
+  75           89.43315     64.65931    0.01333333 
+  81           89.35402     64.6381     0.01234568 
+  96           89.25728     64.61691    0.01041667 
+  88           89.15343     64.59576    0.01136364 
+  92           89.05029     64.57463    0.01086957 
+  84           88.97252     64.55354    0.01190476 
+  96           88.97064     64.53248    0.01041667 
+  98           89.10939     64.51145    0.01020408 
+  88           89.41304     64.49045    0.01136364 
+  109          89.76646     64.46947    0.00917431 
+  83           89.80849     64.44853    0.01204819 
+  88           89.2146      64.42762    0.01136364 
+  77           88.25888     64.40674    0.01298701 
+  87           87.32854     64.38589    0.01149425 
+  84           86.58547     64.36507    0.01190476 
+  82           86.04209     64.34428    0.01219512 
+  95           85.66969     64.32352    0.01052632 
+  74           85.43997     64.30279    0.01351351 
+  91           85.29906     64.28209    0.01098901 
+  83           85.1004      64.26142    0.01204819 
+  85           84.635       64.24078    0.01176471 
+  98           83.93905     64.22017    0.01020408 
+  99           83.23617     64.19959    0.01010101 
+  86           82.66092     64.17904    0.01162791 
+  87           82.27432     64.15851    0.01149425 
+  79           82.12799     64.13802    0.01265823 
+  82           82.26916     64.11756    0.01219512 
+  75           82.66469     64.09713    0.01333333 
+  103          83.05531     64.07673    0.00970874 
+  81           82.89891     64.05635    0.01234568 
+  86           82.02586     64.03601    0.01162791 
+  85           80.95413     64.01569    0.01176471 
+  101          80.09269     63.99541    0.00990099 
+  62           79.58101     63.97515    0.01612903 
+  67           79.46508     63.95493    0.01492537 
+  80           79.81747     63.93473    0.0125    
+  75           80.71828     63.91456    0.01333333 
+  87           82.07169     63.89442    0.01149425 
+  106          83.32048     63.87431    0.00943396 
+  97           83.5025      63.85423    0.01030928 
+  86           82.52222     63.83418    0.01162791 
+  102          81.5292      63.81416    0.00980392 
+  76           81.42323     63.79417    0.01315789 
+  75           82.33877     63.7742     0.01333333 
+  92           83.62133     63.75427    0.01086957 
+  59           83.97071     63.73436    0.01694915 
+  86           83.03117     63.71448    0.01162791 
+  89           81.83673     63.69464    0.01123596 
+  74           80.91628     63.67482    0.01351351 
+  87           80.17027     63.65503    0.01149425 
+  77           79.85555     63.63526    0.01298701 
+  95           80.58735     63.61553    0.01052632 
+  97           83.00893     63.59582    0.01030928 
+  99           87.53432     63.57615    0.01010101 
+  97           93.6403      63.5565     0.01030928 
+  95           99.2354      63.53688    0.01052632 
+  84           100.67252    63.51729    0.01190476 
+  96           96.16834     63.49773    0.01041667 
+  106          89.40415     63.47819    0.00943396 
+  82           83.86432     63.45869    0.01219512 
+  103          80.59953     63.43921    0.00970874 
+  82           79.46726     63.41976    0.01219512 
+  85           80.09497     63.40034    0.01176471 
+  75           82.17784     63.38095    0.01333333 
+  93           85.12624     63.36158    0.01075269 
+  87           87.37614     63.34225    0.01149425 
+  72           86.87152     63.32294    0.01388889 
+  75           84.13788     63.30366    0.01333333 
+  86           81.28709     63.28441    0.01162791 
+  70           79.3567      63.26518    0.01428571 
+  91           78.4465      63.24599    0.01098901 
+  74           78.28783     63.22682    0.01351351 
+  79           78.6097      63.20768    0.01265823 
+  75           79.28558     63.18857    0.01333333 
+  89           80.34838     63.16948    0.01123596 
+  80           82.03974     63.15043    0.0125    
+  88           84.99606     63.1314     0.01136364 
+  94           90.47513     63.11239    0.0106383 
+  87           100.1675     63.09342    0.01149425 
+  96           115.03898    63.07447    0.01041667 
+  103          133.13039    63.05556    0.00970874 
+  104          146.92565    63.03666    0.00961538 
+  122          148.67864    63.0178     0.00819672 
+  137          144.42933    62.99897    0.00729927 
+  171          144.35787    62.98016    0.00584795 
+  205          151.73733    62.96138    0.00487805 
+  195          163.00143    62.94262    0.00512821 
+  181          170.03369    62.92389    0.00552486 
+  182          167.73457    62.90519    0.00549451 
+  165          159.94704    62.88652    0.00606061 
+  126          151.84543    62.86788    0.00793651 
+  130          142.46038    62.84926    0.00769231 
+  116          131.4242     62.83067    0.00862069 
+  140          123.23568    62.81211    0.00714286 
+  140          120.51185    62.79357    0.00714286 
+  131          122.24999    62.77506    0.00763359 
+  141          124.50402    62.75658    0.0070922 
+  139          122.56617    62.73812    0.00719424 
+  114          115.57916    62.71969    0.00877193 
+  117          106.96062    62.70129    0.00854701 
+  107          99.71954     62.68292    0.00934579 
+  77           94.66298     62.66457    0.01298701 
+  88           91.06496     62.64625    0.01136364 
+  73           87.77946     62.62795    0.01369863 
+  93           84.74938     62.60968    0.01075269 
+  77           82.4249      62.59144    0.01298701 
+  59           80.93985     62.57323    0.01694915 
+  80           80.19645     62.55504    0.0125    
+  75           79.9812      62.53688    0.01333333 
+  87           79.9868      62.51874    0.01149425 
+  85           79.94165     62.50063    0.01176471 
+  67           79.78593     62.48255    0.01492537 
+  78           79.31431     62.46449    0.01282051 
+  81           78.44005     62.44646    0.01234568 
+  79           77.52984     62.42846    0.01265823 
+  84           76.86841     62.41048    0.01190476 
+  78           76.52832     62.39253    0.01282051 
+  71           76.48167     62.37461    0.01408451 
+  64           76.66433     62.35671    0.015625  
+  86           76.99971     62.33884    0.01162791 
+  82           77.49409     62.32099    0.01219512 
+  95           78.13995     62.30317    0.01052632 
+  84           78.56149     62.28538    0.01190476 
+  76           78.24991     62.26761    0.01315789 
+  81           77.40117     62.24986    0.01234568 
+  74           76.50269     62.23215    0.01351351 
+  72           75.8242      62.21446    0.01388889 
+  67           75.45554     62.19679    0.01492537 
+  62           75.37896     62.17915    0.01612903 
+  91           75.55783     62.16154    0.01098901 
+  75           75.94004     62.14395    0.01333333 
+  68           76.38455     62.12639    0.01470588 
+  79           76.59534     62.10886    0.01265823 
+  80           76.41057     62.09134    0.0125    
+  77           76.03823     62.07386    0.01298701 
+  60           75.68913     62.0564     0.01666667 
+  57           75.46096     62.03897    0.01754386 
+  61           75.35942     62.02156    0.01639344 
+  67           75.34586     62.00418    0.01492537 
+  66           75.38202     61.98682    0.01515152 
+  78           75.44397     61.96949    0.01282051 
+  75           75.51982     61.95218    0.01333333 
+  54           75.60444     61.9349     0.01851852 
+  85           75.69581     61.91764    0.01176471 
+  77           75.79314     61.90041    0.01298701 
+  68           75.89633     61.8832     0.01470588 
+  86           76.00564     61.86602    0.01162791 
+  73           76.12162     61.84887    0.01369863 
+  72           76.24496     61.83174    0.01388889 
+  65           76.37656     61.81463    0.01538462 
+  77           76.5175      61.79755    0.01298701 
+  71           76.66914     61.78049    0.01408451 
+  80           76.83344     61.76346    0.0125    
+  74           77.0141      61.74646    0.01351351 
+  68           77.22038     61.72948    0.01470588 
+  89           77.47471     61.71252    0.01123596 
+  84           77.81964     61.69559    0.01190476 
+  63           78.30773     61.67868    0.01587302 
+  75           78.95621     61.6618     0.01333333 
+  90           79.66645     61.64494    0.01111111 
+  80           80.13865     61.62811    0.0125    
+  73           80.11171     61.6113     0.01369863 
+  88           79.80765     61.59452    0.01136364 
+  75           79.43203     61.57776    0.01333333 
+  89           79.32305     61.56102    0.01123596 
+  74           79.37137     61.54431    0.01351351 
+  71           79.54682     61.52763    0.01408451 
+  78           79.8292      61.51097    0.01282051 
+  64           80.19242     61.49433    0.015625  
+  68           80.56232     61.47772    0.01470588 
+  79           80.75178     61.46113    0.01265823 
+  79           80.692       61.44456    0.01265823 
+  96           80.48206     61.42802    0.01041667 
+  88           80.36624     61.41151    0.01136364 
+  80           80.32735     61.39502    0.0125    
+  87           80.35348     61.37855    0.01149425 
+  75           80.42012     61.36211    0.01333333 
+  83           80.51007     61.34569    0.01204819 
+  105          80.61647     61.32929    0.00952381 
+  85           80.7382      61.31292    0.01176471 
+  89           80.88084     61.29657    0.01123596 
+  79           81.03933     61.28025    0.01265823 
+  85           81.22043     61.26395    0.01176471 
+  104          81.42737     61.24767    0.00961538 
+  84           81.66335     61.23142    0.01190476 
+  74           81.93172     61.21519    0.01351351 
+  76           82.23593     61.19899    0.01315789 
+  72           82.57945     61.18281    0.01388889 
+  78           82.96595     61.16665    0.01282051 
+  84           83.39917     61.15052    0.01190476 
+  60           83.88348     61.13441    0.01666667 
+  86           84.4229      61.11832    0.01162791 
+  74           85.0225      61.10226    0.01351351 
+  81           85.68794     61.08622    0.01234568 
+  74           86.42543     61.0702     0.01351351 
+  87           87.24256     61.05421    0.01149425 
+  96           88.14837     61.03824    0.01041667 
+  82           89.15404     61.02229    0.01219512 
+  91           90.27414     61.00637    0.01098901 
+  87           91.52917     60.99047    0.01149425 
+  80           92.95274     60.97459    0.0125    
+  103          94.62348     60.95874    0.00970874 
+  105          96.71589     60.94291    0.00952381 
+  97           99.57785     60.9271     0.01030928 
+  107          103.70057    60.91132    0.00934579 
+  93           109.40485    60.89556    0.01075269 
+  118          116.20606    60.87982    0.00847458 
+  120          121.96076    60.86411    0.00833333 
+  138          123.80896    60.84842    0.00724638 
+  148          122.70099    60.83275    0.00675676 
+  128          121.75666    60.8171     0.0078125 
+  147          122.52678    60.80148    0.00680272 
+  136          125.2803     60.78588    0.00735294 
+  141          129.84855    60.7703     0.0070922 
+  148          136.10583    60.75474    0.00675676 
+  132          143.9824     60.73921    0.00757576 
+  159          153.17698    60.7237     0.00628931 
+  173          162.682      60.70822    0.00578035 
+  158          171.4333     60.69275    0.00632911 
+  175          180.48386    60.67731    0.00571429 
+  159          191.73209    60.66189    0.00628931 
+  165          206.36614    60.64649    0.00606061 
+  208          225.15272    60.63112    0.00480769 
+  208          248.95828    60.61577    0.00480769 
+  236          279.14103    60.60044    0.00423729 
+  303          318.03381    60.58513    0.00330033 
+  365          369.95091    60.56985    0.00273973 
+  428          443.36421    60.55458    0.00233645 
+  582          555.46217    60.53934    0.00171821 
+  803          738.37527    60.52413    0.00124533 
+  1077         1042.8984    60.50893    0.00092851 
+  1438         1530.56444   60.49376    0.00069541 
+  2089         2245.11443   60.4786     0.0004787 
+  2914         3153.71064   60.46347    0.00034317 
+  3801         4032.01635   60.44837    0.00026309 
+  4189         4396.3131    60.43328    0.00023872 
+  3742         3964.11064   60.41822    0.00026724 
+  2880         3104.31146   60.40318    0.00034722 
+  1942         2283.00882   60.38816    0.00051493 
+  1537         1703.11667   60.37316    0.00065062 
+  1232         1406.98848   60.35818    0.00081169 
+  1320         1376.0429    60.34323    0.00075758 
+  1444         1569.98617   60.3283     0.00069252 
+  1779         1921.05896   60.31339    0.00056211 
+  2254         2280.66302   60.2985     0.00044366 
+  2276         2387.07207   60.28363    0.00043937 
+  2019         2105.80455   60.26878    0.00049529 
+  1442         1626.94355   60.25396    0.00069348 
+  1050         1171.1808    60.23916    0.00095238 
+  744          824.2428     60.22438    0.00134409 
+  502          590.54071    60.20962    0.00199203 
+  433          444.09754    60.19488    0.00230947 
+  309          354.07347    60.18016    0.00323625 
+  268          296.6004     60.16547    0.00373134 
+  223          257.14768    60.15079    0.0044843 
+  204          228.07664    60.13614    0.00490196 
+  151          205.55853    60.12151    0.00662252 
+  170          187.58131    60.1069     0.00588235 
+  147          172.93135    60.09231    0.00680272 
+  124          160.80971    60.07774    0.00806452 
+  146          150.6525     60.0632     0.00684932 
+  117          142.04777    60.04867    0.00854701 
+  127          134.68787    60.03417    0.00787402 
+  142          128.33826    60.01969    0.00704225 
+  114          122.82033    60.00522    0.00877193 
+  102          117.99231    59.99078    0.00980392 
+  113          113.74289    59.97636    0.00884956 
+  118          109.98314    59.96196    0.00847458 
+  101          106.64082    59.94758    0.00990099 
+  120          103.65938    59.93323    0.00833333 
+  92           100.99091    59.91889    0.01086957 
+  76           98.59718     59.90457    0.01315789 
+  99           96.44748     59.89028    0.01010101 
+  95           94.51784     59.87601    0.01052632 
+  106          92.79079     59.86175    0.00943396 
+  86           91.25637     59.84752    0.01162791 
+  78           89.91862     59.83331    0.01282051 
+  79           88.81282     59.81911    0.01265823 
+  88           88.05674     59.80494    0.01136364 
+  98           87.93204     59.79079    0.01020408 
+  102          88.91089     59.77666    0.00980392 
+  82           91.43896     59.76255    0.01219512 
+  98           95.36424     59.74846    0.01020408 
+  88           99.04223     59.73439    0.01136364 
+  109          99.13618     59.72034    0.00917431 
+  90           94.81754     59.70632    0.01111111 
+  78           89.27088     59.69231    0.01282051 
+  93           84.81847     59.67832    0.01075269 
+  89           82.0485      59.66435    0.01123596 
+  83           80.76804     59.6504     0.01204819 
+  95           80.70519     59.63648    0.01052632 
+  75           81.74578     59.62257    0.01333333 
+  85           83.69492     59.60868    0.01176471 
+  86           85.764       59.59482    0.01162791 
+  79           86.31587     59.58097    0.01265823 
+  93           84.77168     59.56714    0.01075269 
+  90           82.75138     59.55333    0.01111111 
+  89           81.76736     59.53955    0.01123596 
+  103          82.85971     59.52578    0.00970874 
+  77           87.42104     59.51203    0.01298701 
+  109          97.53411     59.4983     0.00917431 
+  112          114.84268    59.4846     0.00892857 
+  114          137.61243    59.47091    0.00877193 
+  112          156.37701    59.45724    0.00892857 
+  95           155.78897    59.44359    0.01052632 
+  97           136.44199    59.42996    0.01030928 
+  93           113.65364    59.41635    0.01075269 
+  112          96.57835     59.40276    0.00892857 
+  111          87.02806     59.38919    0.00900901 
+  93           83.83875     59.37564    0.01075269 
+  100          85.83049     59.36211    0.01      
+  81           92.51638     59.3486     0.01234568 
+  95           102.72817    59.33511    0.01052632 
+  88           112.13171    59.32163    0.01136364 
+  101          112.86916    59.30818    0.00990099 
+  83           103.52937    59.29474    0.01204819 
+  86           91.48019     59.28133    0.01162791 
+  81           81.86401     59.26793    0.01234568 
+  77           75.80518     59.25456    0.01298701 
+  76           72.48875     59.2412     0.01315789 
+  77           70.725       59.22786    0.01298701 
+  69           69.69015     59.21454    0.01449275 
+  61           68.98382     59.20124    0.01639344 
+  74           68.44525     59.18796    0.01351351 
+  76           68.00952     59.1747     0.01315789 
+  69           67.64545     59.16145    0.01449275 
+  63           67.33418     59.14823    0.01587302 
+  71           67.0634      59.13502    0.01408451 
+  70           66.82405     59.12184    0.01428571 
+  69           66.61003     59.10867    0.01449275 
+  65           66.41683     59.09552    0.01538462 
+  71           66.241       59.08239    0.01408451 
+  71           66.07995     59.06928    0.01408451 
+  75           65.93156     59.05619    0.01333333 
+  72           65.79428     59.04311    0.01388889 
+  71           65.66682     59.03006    0.01408451 
+  65           65.54815     59.01702    0.01538462 
+  70           65.43745     59.004      0.01428571 
+  69           65.33402     58.99101    0.01449275 
+  62           65.23731     58.97802    0.01612903 
+  66           65.14682     58.96506    0.01515152 
+  67           65.06216     58.95212    0.01492537 
+  64           64.98299     58.93919    0.015625  
+  73           64.90906     58.92629    0.01369863 
+  69           64.84008     58.9134     0.01449275 
+  90           64.77585     58.90053    0.01111111 
+  59           64.71619     58.88768    0.01694915 
+  70           64.66092     58.87484    0.01428571 
+  59           64.60988     58.86203    0.01694915 
+  74           64.56294     58.84923    0.01351351 
+  86           64.51994     58.83645    0.01162791 
+  61           64.48074     58.82369    0.01639344 
+  60           64.44519     58.81095    0.01666667 
+  58           64.41339     58.79822    0.01724138 
+  67           64.38474     58.78551    0.01492537 
+  53           64.35933     58.77283    0.01886792 
+  64           64.33709     58.76016    0.015625  
+  56           64.31798     58.7475     0.01785714 
+  77           64.30213     58.73487    0.01298701 
+  71           64.29012     58.72225    0.01408451 
+  76           64.28382     58.70965    0.01315789 
+  67           64.28812     58.69707    0.01492537 
+  72           64.3139      58.68451    0.01388889 
+  67           64.37616     58.67196    0.01492537 
+  79           64.48457     58.65943    0.01265823 
+  67           64.62279     58.64692    0.01492537 
+  58           64.72224     58.63443    0.01724138 
+  62           64.69248     58.62195    0.01612903 
+  61           64.56665     58.6095     0.01639344 
+  65           64.44807     58.59706    0.01538462 
+  53           64.38539     58.58463    0.01886792 
+  69           64.37413     58.57223    0.01449275 
+  54           64.37672     58.55984    0.01851852 
+  79           64.36632     58.54747    0.01265823 
+  67           64.365       58.53512    0.01492537 
+  72           64.39392     58.52278    0.01388889 
+  74           64.43582     58.51046    0.01351351 
+  61           64.44028     58.49816    0.01639344 
+  61           64.39484     58.48588    0.01639344 
+  54           64.34603     58.47361    0.01851852 
+  69           64.32647     58.46137    0.01449275 
+  62           64.33987     58.44913    0.01612903 
+  55           64.3699      58.43692    0.01818182 
+  59           64.39539     58.42472    0.01694915 
+  52           64.41706     58.41254    0.01923077 
+  69           64.44991     58.40038    0.01449275 
+  66           64.50251     58.38823    0.01515152 
+  71           64.57835     58.3761     0.01408451 
+  73           64.68018     58.36399    0.01369863 
+  55           64.81353     58.35189    0.01818182 
+  63           64.9899      58.33981    0.01587302 
+  89           65.23336     58.32775    0.01123596 
+  89           65.6024      58.31571    0.01123596 
+  83           66.2499      58.30368    0.01204819 
+  84           67.53071     58.29167    0.01190476 
+  82           70.06535     58.27967    0.01219512 
+  90           74.51584     58.26769    0.01111111 
+  100          80.89167     58.25573    0.01      
+  115          87.38816     58.24379    0.00869565 
+  99           89.64655     58.23186    0.01010101 
+  137          85.45862     58.21995    0.00729927 
+  143          78.72561     58.20805    0.00699301 
+  135          73.06804     58.19617    0.00740741 
+  126          69.5619      58.18431    0.00793651 
+  91           67.99872     58.17247    0.01098901 
+  93           67.93725     58.16064    0.01075269 
+  93           69.19539     58.14882    0.01075269 
+  86           71.69524     58.13703    0.01162791 
+  109          74.88234     58.12525    0.00917431 
+  97           77.00769     58.11348    0.01030928 
+  101          76.02751     58.10174    0.00990099 
+  108          72.86979     58.09       0.00925926 
+  105          69.75811     58.07829    0.00952381 
+  90           67.62165     58.06659    0.01111111 
+  88           66.36275     58.05491    0.01136364 
+  91           65.56877     58.04324    0.01098901 
+  66           65.02448     58.03159    0.01515152 
+  63           64.66827     58.01995    0.01587302 
+  78           64.4825      58.00833    0.01282051 
+  72           64.47708     57.99673    0.01388889 
+  69           64.72121     57.98514    0.01449275 
+  62           65.38613     57.97357    0.01612903 
+  76           66.70498     57.96202    0.01315789 
+  79           68.76786     57.95048    0.01265823 
+  71           71.15511     57.93895    0.01408451 
+  67           72.53977     57.92745    0.01492537 
+  86           71.63627     57.91595    0.01162791 
+  76           69.33079     57.90448    0.01315789 
+  73           67.14197     57.89302    0.01369863 
+  76           65.68184     57.88157    0.01315789 
+  86           64.96168     57.87014    0.01162791 
+  78           64.81436     57.85873    0.01282051 
+  67           65.1365      57.84733    0.01492537 
+  62           65.90863     57.83595    0.01612903 
+  77           67.03614     57.82458    0.01298701 
+  81           68.10033     57.81323    0.01234568 
+  78           68.31509     57.80189    0.01282051 
+  69           67.53213     57.79057    0.01449275 
+  74           66.50838     57.77927    0.01351351 
+  81           65.76963     57.76797    0.01234568 
+  77           65.44461     57.7567     0.01298701 
+  92           65.49292     57.74544    0.01086957 
+  76           65.86872     57.7342     0.01315789 
+  81           66.57805     57.72297    0.01234568 
+  90           67.63041     57.71175    0.01111111 
+  71           68.92364     57.70055    0.01408451 
+  88           70.23056     57.68937    0.01136364 
+  75           71.72683     57.6782     0.01333333 
+  94           74.55646     57.66705    0.0106383 
+  71           80.0101      57.65591    0.01408451 
+  102          88.45674     57.64478    0.00980392 
+  105          98.01427     57.63368    0.00952381 
+  93           104.21267    57.62258    0.01075269 
+  88           102.99284    57.6115     0.01136364 
+  82           95.37423     57.60044    0.01219512 
+  99           86.92377     57.58939    0.01010101 
+  91           80.76177     57.57835    0.01098901 
+  107          77.23062     57.56734    0.00934579 
+  92           76.07576     57.55633    0.01086957 
+  102          77.2214      57.54534    0.00980392 
+  100          80.70895     57.53436    0.01      
+  98           86.26638     57.5234     0.01020408 
+  95           92.62896     57.51246    0.01052632 
+  109          97.88403     57.50153    0.00917431 
+  105          100.95705    57.49061    0.00952381 
+  106          102.70656    57.47971    0.00943396 
+  95           102.74495    57.46882    0.01052632 
+  119          100.13218    57.45794    0.00840336 
+  100          97.47492     57.44709    0.01      
+  126          96.34714     57.43624    0.00793651 
+  94           95.15513     57.42541    0.0106383 
+  119          92.91876     57.41459    0.00840336 
+  89           91.37519     57.40379    0.01123596 
+  112          92.10008     57.393      0.00892857 
+  134          95.8021      57.38223    0.00746269 
+  129          102.70574    57.37147    0.00775194 
+  130          112.57741    57.36073    0.00769231 
+  150          124.86022    57.35       0.00666667 
+  177          140.43604    57.33928    0.00564972 
+  159          160.36861    57.32858    0.00628931 
+  186          182.98617    57.31789    0.00537634 
+  216          209.3409     57.30722    0.00462963 
+  227          245.09313    57.29656    0.00440529 
+  257          291.2901     57.28591    0.00389105 
+  309          337.1531     57.27528    0.00323625 
+  279          359.33417    57.26466    0.00358423 
+  246          341.96376    57.25405    0.00406504 
+  214          298.20545    57.24346    0.0046729 
+  180          251.94046    57.23289    0.00555556 
+  171          216.22043    57.22232    0.00584795 
+  169          193.61893    57.21177    0.00591716 
+  147          182.47339    57.20124    0.00680272 
+  181          182.47447    57.19072    0.00552486 
+  204          193.42042    57.18021    0.00490196 
+  174          211.56445    57.16971    0.00574713 
+  175          227.15225    57.15923    0.00571429 
+  206          226.97319    57.14876    0.00485437 
+  181          207.6223     57.13831    0.00552486 
+  155          179.19543    57.12787    0.00645161 
+  147          152.01626    57.11744    0.00680272 
+  131          130.3497     57.10703    0.00763359 
+  99           114.69341    57.09663    0.01010101 
+  133          104.11833    57.08624    0.0075188 
+  131          97.34164     57.07587    0.00763359 
+  95           93.1762      57.06551    0.01052632 
+  108          90.66553     57.05516    0.00925926 
+  109          89.09405     57.04483    0.00917431 
+  99           88.19388     57.03451    0.01010101 
+  115          88.12603     57.0242     0.00869565 
+  135          89.2009      57.01391    0.00740741 
+  114          91.96003     57.00363    0.00877193 
+  154          97.4176      56.99336    0.00649351 
+  130          107.18167    56.9831     0.00769231 
+  150          123.15997    56.97286    0.00666667 
+  162          146.57959    56.96264    0.00617284 
+  186          176.07083    56.95242    0.00537634 
+  219          204.40457    56.94222    0.00456621 
+  235          216.77746    56.93203    0.00425532 
+  203          204.71334    56.92185    0.00492611 
+  191          180.06548    56.91169    0.0052356 
+  175          158.34016    56.90154    0.00571429 
+  177          148.16746    56.8914     0.00564972 
+  169          155.88568    56.88127    0.00591716 
+  202          189.3069     56.87116    0.0049505 
+  205          255.23823    56.86106    0.00487805 
+  197          349.68003    56.85097    0.00507614 
+  240          441.32418    56.8409     0.00416667 
+  259          466.74716    56.83084    0.003861  
+  231          404.63206    56.82079    0.004329  
+  236          308.45643    56.81075    0.00423729 
+  203          224.74426    56.80073    0.00492611 
+  198          169.26816    56.79072    0.00505051 
+  155          140.193      56.78072    0.00645161 
+  161          131.8719     56.77073    0.00621118 
+  161          141.75355    56.76076    0.00621118 
+  154          169.08409    56.7508     0.00649351 
+  162          208.19735    56.74085    0.00617284 
+  132          239.46222    56.73091    0.00757576 
+  156          233.80992    56.72098    0.00641026 
+  122          194.66751    56.71107    0.00819672 
+  117          150.76704    56.70117    0.00854701 
+  138          117.47974    56.69128    0.00724638 
+  125          96.96016     56.68141    0.008     
+  114          85.74104     56.67154    0.00877193 
+  107          79.67144     56.66169    0.00934579 
+  93           76.07204     56.65185    0.01075269 
+  108          73.69158     56.64202    0.00925926 
+  99           72.03677     56.63221    0.01010101 
+  101          70.91656     56.62241    0.00990099 
+  83           70.23205     56.61261    0.01204819 
+  91           69.8555      56.60284    0.01098901 
+  86           69.52677     56.59307    0.01162791 
+  87           68.9233      56.58331    0.01149425 
+  88           68.09576     56.57357    0.01136364 
+  87           67.33026     56.56384    0.01149425 
+  85           66.76641     56.55412    0.01176471 
+  100          66.41283     56.54441    0.01      
+  84           66.22661     56.53471    0.01190476 
+  69           66.1677      56.52503    0.01449275 
+  91           66.23177     56.51535    0.01098901 
+  91           66.43225     56.50569    0.01098901 
+  86           66.74352     56.49604    0.01162791 
+  95           67.05544     56.4864     0.01052632 
+  68           67.24888     56.47678    0.01470588 
+  79           67.41292     56.46716    0.01265823 
+  69           67.71903     56.45756    0.01449275 
+  75           68.26764     56.44796    0.01333333 
+  93           69.11745     56.43838    0.01075269 
+  84           70.33557     56.42881    0.01190476 
+  88           72.05919     56.41926    0.01136364 
+  89           74.63071     56.40971    0.01123596 
+  93           78.9478      56.40017    0.01075269 
+  107          87.21939     56.39065    0.00934579 
+  122          103.83224    56.38114    0.00819672 
+  113          134.74005    56.37163    0.00884956 
+  158          183.29302    56.36214    0.00632911 
+  158          242.03715    56.35266    0.00632911 
+  185          282.18167    56.3432     0.00540541 
+  153          268.24997    56.33374    0.00653595 
+  173          214.68814    56.32429    0.00578035 
+  129          159.92009    56.31486    0.00775194 
+  132          121.46079    56.30543    0.00757576 
+  95           100.68019    56.29602    0.01052632 
+  94           93.32343     56.28662    0.0106383 
+  83           96.21458     56.27723    0.01204819 
+  113          109.07743    56.26785    0.00884956 
+  129          131.86785    56.25848    0.00775194 
+  121          159.57561    56.24912    0.00826446 
+  136          176.55748    56.23977    0.00735294 
+  110          166.08265    56.23044    0.00909091 
+  142          137.62187    56.22111    0.00704225 
+  94           109.79868    56.21179    0.0106383 
+  81           90.2931      56.20249    0.01234568 
+  87           79.07728     56.1932     0.01149425 
+  83           73.3185      56.18391    0.01204819 
+  72           70.34939     56.17464    0.01388889 
+  63           68.6322      56.16538    0.01587302 
+  71           67.49667     56.15613    0.01408451 
+  60           66.6813      56.14689    0.01666667 
+  63           66.07321     56.13766    0.01587302 
+  61           65.61251     56.12844    0.01639344 
+  55           65.26078     56.11923    0.01818182 
+  73           64.99213     56.11003    0.01369863 
+  57           64.78826     56.10084    0.01754386 
+  64           64.63626     56.09166    0.015625  
+  76           64.52549     56.08249    0.01315789 
+  57           64.44873     56.07333    0.01754386 
+  64           64.40003     56.06419    0.015625  
+  61           64.37464     56.05505    0.01639344 
+  61           64.36862     56.04592    0.01639344 
+  75           64.37881     56.0368     0.01333333 
+  62           64.40257     56.0277     0.01612903 
+  58           64.43847     56.0186     0.01724138 
+  55           64.48719     56.00951    0.01818182 
+  79           64.55525     56.00044    0.01265823 
+  74           64.66095     55.99137    0.01351351 
+  82           64.83736     55.98232    0.01219512 
+  65           65.11851     55.97327    0.01538462 
+  73           65.49943     55.96423    0.01369863 
+  68           65.87108     55.95521    0.01470588 
+  86           65.98534     55.94619    0.01162791 
+  74           65.73532     55.93718    0.01351351 
+  59           65.34704     55.92819    0.01694915 
+  87           65.01544     55.9192     0.01149425 
+  66           64.79475     55.91022    0.01515152 
+  80           64.66951     55.90125    0.0125    
+  76           64.61317     55.89229    0.01315789 
+  64           64.61656     55.88335    0.015625  
+  73           64.68943     55.87441    0.01369863 
+  85           64.84021     55.86548    0.01176471 
+  76           65.04787     55.85656    0.01315789 
+  82           65.50696     55.84765    0.01219512 
+  78           65.67259     55.83875    0.01282051 
+  85           65.90336     55.82986    0.01176471 
+  74           66.12729     55.82098    0.01351351 
+  59           66.03416     55.81211    0.01694915 
+  77           65.55324     55.80324    0.01298701 
+  76           64.9925      55.79439    0.01315789 
+  72           64.53327     55.78555    0.01388889 
+  72           64.1763      55.77671    0.01388889 
+  80           63.90869     55.76789    0.0125    
+  70           63.74131     55.75907    0.01428571 
+  73           63.68471     55.75026    0.01369863 
+  105          63.74712     55.74147    0.00952381 
+  88           64.04457     55.73268    0.01136364 
+  83           64.22325     55.7239     0.01204819 
+  107          64.24492     55.71513    0.00934579 
+  120          64.05731     55.70637    0.00833333 
+  107          63.82005     55.69762    0.00934579 
+  121          63.64499     55.68888    0.00826446 
+  110          63.54978     55.68014    0.00909091 
+  105          63.55256     55.67142    0.00952381 
+  109          63.72071     55.6627     0.00917431 
+  93           64.17958     55.654      0.01075269 
+  107          65.08984     55.6453     0.00934579 
+  137          66.51844     55.63661    0.00729927 
+  134          68.19712     55.62793    0.00746269 
+  116          69.23519     55.61926    0.00862069 
+  91           68.72834     55.6106     0.01098901 
+  99           67.26547     55.60194    0.01010101 
+  106          65.89562     55.5933     0.00943396 
+  123          65.05354     55.58466    0.00813008 
+  113          64.7693      55.57603    0.00884956 
+  102          64.97478     55.56742    0.00980392 
+  97           65.73595     55.55881    0.01030928 
+  115          67.39793     55.5502     0.00869565 
+  104          70.57438     55.54161    0.00961538 
+  125          75.81094     55.53303    0.008     
+  119          82.76343     55.52445    0.00840336 
+  103          89.2861      55.51588    0.00970874 
+  109          91.63783     55.50732    0.00917431 
+  100          87.57609     55.49877    0.01      
+  94           80.31144     55.49023    0.0106383 
+  80           73.89237     55.4817     0.0125    
+  77           69.72844     55.47317    0.01298701 
+  73           67.64892     55.46466    0.01369863 
+  81           67.08246     55.45615    0.01234568 
+  78           67.72109     55.44765    0.01282051 
+  88           69.61625     55.43915    0.01136364 
+  93           72.80394     55.43067    0.01075269 
+  92           76.63975     55.4222     0.01086957 
+  78           79.23238     55.41373    0.01282051 
+  80           78.55866     55.40527    0.0125    
+  78           75.36273     55.39682    0.01282051 
+  65           72.02373     55.38837    0.01538462 
+  74           69.73836     55.37994    0.01351351 
+  57           68.37948     55.37151    0.01754386 
+  79           67.38779     55.36309    0.01265823 
+  76           66.61436     55.35468    0.01315789 
+  58           66.12944     55.34628    0.01724138 
+  72           65.95419     55.33788    0.01388889 
+  63           66.05528     55.32949    0.01587302 
+  63           66.34586     55.32111    0.01587302 
+  77           66.66504     55.31274    0.01298701 
+  54           66.83692     55.30438    0.01851852 
+  61           66.91563     55.29602    0.01639344 
+  77           67.05068     55.28767    0.01298701 
+  58           67.2135      55.27933    0.01724138 
+  65           67.27207     55.271      0.01538462 
+  58           67.27415     55.26267    0.01724138 
+  82           67.38623     55.25435    0.01219512 
+  63           67.75689     55.24604    0.01587302 
+  78           68.58056     55.23774    0.01282051 
+  69           70.12785     55.22944    0.01449275 
+  71           72.59905     55.22115    0.01408451 
+  69           75.76057     55.21287    0.01449275 
+  67           78.3926      55.2046     0.01492537 
+  90           78.54014     55.19634    0.01111111 
+  75           76.32344     55.18808    0.01333333 
+  70           73.72477     55.17983    0.01428571 
+  74           71.86635     55.17158    0.01351351 
+  80           70.93227     55.16335    0.0125    
+  77           70.71919     55.15512    0.01298701 
+  74           71.01557     55.1469     0.01351351 
+  55           71.76536     55.13868    0.01818182 
+  69           73.01827     55.13047    0.01449275 
+  51           74.72457     55.12227    0.01960784 
+  74           76.43888     55.11408    0.01351351 
+  62           77.19047     55.1059     0.01612903 
+  74           76.6027      55.09772    0.01351351 
+  81           75.5681      55.08955    0.01234568 
+  67           74.82065     55.08138    0.01492537 
+  66           74.5518      55.07322    0.01515152 
+  56           74.6801      55.06507    0.01785714 
+  53           75.05563     55.05693    0.01886792 
+  57           75.56731     55.04879    0.01754386 
+  69           76.16169     55.04066    0.01449275 
+  77           76.82433     55.03254    0.01298701 
+  83           77.55757     55.02442    0.01204819 
+  78           78.37492     55.01631    0.01282051 
+  74           79.31354     55.00821    0.01351351 
+  66           80.46815     55.00012    0.01515152 
+  83           82.03606     54.99203    0.01204819 
+  69           84.30646     54.98394    0.01449275 
+  75           87.4901      54.97587    0.01333333 
+  69           91.35165     54.9678     0.01449275 
+  60           94.67985     54.95974    0.01666667 
+  68           95.60131     54.95168    0.01470588 
+  71           94.33875     54.94363    0.01408451 
+  59           92.81557     54.93559    0.01694915 
+  66           92.08283     54.92755    0.01515152 
+  71           92.30035     54.91952    0.01408451 
+  80           93.2668      54.9115     0.0125    
+  83           94.78613     54.90348    0.01204819 
+  75           96.81402     54.89547    0.01333333 
+  72           99.4079      54.88747    0.01388889 
+  82           102.53142    54.87947    0.01219512 
+  88           105.78386    54.87148    0.01136364 
+  62           108.24064    54.8635     0.01612903 
+  71           109.46966    54.85552    0.01408451 
+  79           110.30358    54.84755    0.01265823 
+  66           111.48681    54.83958    0.01515152 
+  84           113.22775    54.83162    0.01190476 
+  100          115.45823    54.82367    0.01      
+  94           118.03604    54.81572    0.0106383 
+  92           120.85896    54.80778    0.01086957 
+  111          123.89334    54.79984    0.00900901 
+  102          127.18065    54.79191    0.00980392 
+  105          130.86512    54.78399    0.00952381 
+  114          135.2275     54.77607    0.00877193 
+  113          140.62913    54.76816    0.00884956 
+  123          147.30017    54.76025    0.00813008 
+  149          154.88557    54.75235    0.00671141 
+  136          161.99643    54.74446    0.00735294 
+  162          167.69684    54.73657    0.00617284 
+  145          172.18668    54.72869    0.00689655 
+  154          174.46911    54.72082    0.00649351 
+  184          175.19873    54.71295    0.00543478 
+  197          176.83039    54.70508    0.00507614 
+  199          179.60629    54.69722    0.00502513 
+  197          182.2527     54.68937    0.00507614 
+  235          184.77231    54.68152    0.00425532 
+  243          187.37286    54.67368    0.00411523 
+  182          190.3233     54.66584    0.00549451 
+  199          192.42213    54.65801    0.00502513 
+  192          191.10264    54.65019    0.00520833 
+  199          187.49205    54.64237    0.00502513 
+  186          183.57485    54.63455    0.00537634 
+  194          180.06491    54.62675    0.00515464 
+  181          177.88551    54.61894    0.00552486 
+  219          177.27235    54.61115    0.00456621 
+  177          176.92       54.60335    0.00564972 
+  184          175.53554    54.59557    0.00543478 
+  190          173.14063    54.58779    0.00526316 
+  157          170.38935    54.58001    0.00636943 
+  161          167.68648    54.57224    0.00621118 
+  154          164.21173    54.56447    0.00649351 
+  134          159.54809    54.55671    0.00746269 
+  139          154.82258    54.54896    0.00719424 
+  129          150.73849    54.54121    0.00775194 
+  144          147.43254    54.53347    0.00694444 
+  152          144.73599    54.52573    0.00657895 
+  110          142.33099    54.51799    0.00909091 
+  123          139.78424    54.51026    0.00813008 
+  103          136.82028    54.50254    0.00970874 
+  101          133.65435    54.49482    0.00990099 
+  78           130.56553    54.48711    0.01282051 
+  103          127.65264    54.4794     0.00970874 
+  96           124.90624    54.47169    0.01041667 
+  103          122.2836     54.46399    0.00970874 
+  100          119.75024    54.4563     0.01      
+  81           117.29025    54.44861    0.01234568 
+  87           114.90057    54.44093    0.01149425 
+  93           112.58313    54.43325    0.01075269 
+  75           110.34142    54.42557    0.01333333 
+  83           108.17873    54.4179     0.01204819 
+  72           106.09836    54.41024    0.01388889 
+  66           104.1029     54.40258    0.01515152 
+  76           102.19362    54.39492    0.01315789 
+  95           100.37193    54.38727    0.01052632 
+  93           98.63792     54.37962    0.01075269 
+  62           96.99137     54.37198    0.01612903 
+  72           95.43187     54.36434    0.01388889 
+  79           93.95912     54.35671    0.01265823 
+  71           92.57373     54.34908    0.01408451 
+  64           91.27562     54.34146    0.015625  
+  68           90.06247     54.33384    0.01470588 
+  76           88.92558     54.32623    0.01315789 
+  75           87.84828     54.31862    0.01333333 
+  64           86.82255     54.31101    0.015625  
+  77           85.86002     54.30341    0.01298701 
+  78           84.97142     54.29581    0.01282051 
+  61           84.15974     54.28822    0.01639344 
+  69           83.42562     54.28063    0.01449275 
+  67           82.77279     54.27305    0.01492537 
+  68           82.21534     54.26547    0.01470588 
+  81           81.78733     54.25789    0.01234568 
+  63           81.5463      54.25032    0.01587302 
+  69           81.55596     54.24275    0.01449275 
+  74           81.84139     54.23519    0.01351351 
+  61           82.34091     54.22763    0.01639344 
+  66           82.9609      54.22008    0.01515152 
+  65           84.072       54.21253    0.01538462 
+  65           86.67328     54.20498    0.01538462 
+  68           91.41816     54.19744    0.01470588 
+  68           97.55833     54.1899     0.01470588 
+  75           101.81597    54.18237    0.01333333 
+  71           100.03271    54.17484    0.01408451 
+  69           93.69603     54.16731    0.01449275 
+  87           87.22285     54.15979    0.01149425 
+  67           82.67644     54.15227    0.01492537 
+  83           80.1955      54.14475    0.01204819 
+  78           79.12523     54.13724    0.01282051 
+  78           78.82602     54.12974    0.01282051 
+  60           79.23059     54.12223    0.01666667 
+  73           80.67345     54.11473    0.01369863 
+  65           83.23877     54.10724    0.01538462 
+  67           86.16729     54.09974    0.01492537 
+  76           87.39489     54.09226    0.01315789 
+  68           85.4626      54.08477    0.01470588 
+  86           82.01195     54.07729    0.01162791 
+  86           78.95228     54.06981    0.01162791 
+  88           76.91482     54.06234    0.01136364 
+  79           75.7951      54.05487    0.01265823 
+  69           75.26013     54.0474     0.01449275 
+  85           75.03951     54.03994    0.01176471 
+  72           74.99457     54.03248    0.01388889 
+  73           75.0801      54.02502    0.01369863 
+  94           75.29976     54.01757    0.0106383 
+  80           75.69079     54.01012    0.0125    
+  101          76.34398     54.00267    0.00990099 
+  81           77.49365     53.99523    0.01234568 
+  85           79.7322      53.98779    0.01176471 
+  91           84.31016     53.98035    0.01098901 
+  105          93.11849     53.97292    0.00952381 
+  122          107.66091    53.96549    0.00819672 
+  118          126.73775    53.95806    0.00847458 
+  105          142.99476    53.95064    0.00952381 
+  101          143.97429    53.94322    0.00990099 
+  105          129.99367    53.9358     0.00952381 
+  101          114.61471    53.92839    0.00990099 
+  114          106.70506    53.92098    0.00877193 
+  101          108.46111    53.91357    0.00990099 
+  107          117.21265    53.90616    0.00934579 
+  110          125.55217    53.89876    0.00909091 
+  101          124.81769    53.89136    0.00990099 
+  100          117.47188    53.88397    0.01      
+  83           112.35249    53.87658    0.01204819 
+  103          112.40805    53.86919    0.00970874 
+  130          113.41751    53.8618     0.00769231 
+  99           108.53364    53.85442    0.01010101 
+  102          98.98458     53.84703    0.00980392 
+  116          90.76563     53.83966    0.00862069 
+  77           87.05444     53.83228    0.01298701 
+  92           88.1632      53.82491    0.01086957 
+  104          92.10973     53.81754    0.00961538 
+  76           94.48717     53.81017    0.01315789 
+  79           91.25903     53.80281    0.01265823 
+  75           84.50985     53.79544    0.01333333 
+  70           78.17124     53.78809    0.01428571 
+  72           73.80599     53.78073    0.01388889 
+  65           71.34382     53.77337    0.01538462 
+  79           70.11445     53.76602    0.01265823 
+  71           69.29062     53.75867    0.01408451 
+  73           68.53883     53.75133    0.01369863 
+  86           67.87851     53.74398    0.01162791 
+  86           67.36877     53.73664    0.01162791 
+  74           67.01048     53.7293     0.01351351 
+  72           66.77406     53.72197    0.01388889 
+  58           66.6297      53.71463    0.01724138 
+  84           66.56298     53.7073     0.01190476 
+  82           66.5762      53.69997    0.01219512 
+  64           66.67663     53.69265    0.015625  
+  85           66.85642     53.68532    0.01176471 
+  72           67.06943     53.678      0.01388889 
+  77           67.26077     53.67068    0.01298701 
+  70           67.42231     53.66336    0.01428571 
+  97           67.71729     53.65605    0.01030928 
+  79           68.28342     53.64873    0.01265823 
+  76           69.21209     53.64142    0.01315789 
+  89           70.48929     53.63411    0.01123596 
+  95           71.88485     53.62681    0.01052632 
+  79           72.97197     53.6195     0.01265823 
+  102          73.81915     53.6122     0.00980392 
+  105          75.14913     53.6049     0.00952381 
+  96           77.58681     53.5976     0.01041667 
+  104          81.49171     53.59031    0.00961538 
+  106          86.99291     53.58301    0.00943396 
+  120          94.36596     53.57572    0.00833333 
+  144          104.56826    53.56843    0.00694444 
+  171          118.23826    53.56114    0.00584795 
+  183          134.24719    53.55385    0.00546448 
+  244          148.09257    53.54657    0.00409836 
+  260          152.50747    53.53928    0.00384615 
+  237          144.57414    53.532      0.00421941 
+  214          129.78068    53.52472    0.0046729 
+  189          115.00017    53.51745    0.00529101 
+  134          103.57016    53.51017    0.00746269 
+  117          96.24216     53.5029     0.00854701 
+  138          92.66957     53.49562    0.00724638 
+  108          92.34545     53.48835    0.00925926 
+  117          95.14835     53.48108    0.00854701 
+  127          100.90037    53.47382    0.00787402 
+  113          108.57199    53.46655    0.00884956 
+  164          115.37002    53.45929    0.00609756 
+  172          117.35039    53.45202    0.00581395 
+  130          113.86449    53.44476    0.00769231 
+  148          108.83796    53.4375     0.00675676 
+  116          106.17726    53.43024    0.00862069 
+  105          106.7029     53.42299    0.00952381 
+  103          107.16945    53.41573    0.00970874 
+  84           102.43189    53.40848    0.01190476 
+  91           93.34538     53.40123    0.01098901 
+  87           84.65013     53.39397    0.01149425 
+  96           78.6194      53.38672    0.01041667 
+  96           75.31697     53.37948    0.01041667 
+  76           73.85866     53.37223    0.01315789 
+  77           73.32549     53.36498    0.01298701 
+  64           73.49069     53.35774    0.015625  
+  86           74.66495     53.3505     0.01162791 
+  65           77.13922     53.34325    0.01538462 
+  86           80.58128     53.33601    0.01162791 
+  79           83.21087     53.32877    0.01265823 
+  83           82.58661     53.32153    0.01204819 
+  95           79.376       53.3143     0.01052632 
+  93           76.13195     53.30706    0.01075269 
+  78           74.1533      53.29982    0.01282051 
+  85           73.67905     53.29259    0.01176471 
+  58           74.57861     53.28536    0.01724138 
+  84           76.77799     53.27812    0.01190476 
+  63           80.38637     53.27089    0.01587302 
+  72           85.57329     53.26366    0.01388889 
+  76           92.2738      53.25643    0.01315789 
+  71           99.63081     53.2492     0.01408451 
+  68           105.258      53.24198    0.01470588 
+  79           106.03539    53.23475    0.01265823 
+  78           101.58802    53.22752    0.01282051 
+  73           94.83229     53.2203     0.01369863 
+  85           88.48989     53.21308    0.01176471 
+  79           83.70228     53.20585    0.01265823 
+  76           80.69892     53.19863    0.01315789 
+  79           79.38386     53.19141    0.01265823 
+  90           79.59036     53.18419    0.01111111 
+  89           81.15389     53.17697    0.01123596 
+  66           83.84974     53.16975    0.01515152 
+  79           87.14629     53.16253    0.01265823 
+  69           89.81756     53.15531    0.01449275 
+  80           90.23462     53.14809    0.0125    
+  85           88.07138     53.14087    0.01176471 
+  73           84.72877     53.13366    0.01369863 
+  83           81.63324     53.12644    0.01204819 
+  67           79.49053     53.11922    0.01492537 
+  72           78.58003     53.11201    0.01388889 
+  87           78.96966     53.10479    0.01149425 
+  79           80.41786     53.09758    0.01265823 
+  85           82.05627     53.09036    0.01176471 
+  75           82.34381     53.08315    0.01333333 
+  77           80.86331     53.07594    0.01298701 
+  83           78.94276     53.06872    0.01204819 
+  78           77.55987     53.06151    0.01282051 
+  76           76.95354     53.0543     0.01315789 
+  82           77.00184     53.04709    0.01219512 
+  85           77.48335     53.03988    0.01176471 
+  84           78.19232     53.03266    0.01190476 
+  84           79.00954     53.02545    0.01190476 
+  68           80.04824     53.01824    0.01470588 
+  76           81.43225     53.01103    0.01315789 
+  78           82.91954     53.00382    0.01282051 
+  92           83.81455     52.99661    0.01086957 
+  82           83.79769     52.9894     0.01219512 
+  77           83.48929     52.98219    0.01298701 
+  67           83.43506     52.97498    0.01492537 
+  83           83.79195     52.96777    0.01204819 
+  71           84.51349     52.96056    0.01408451 
+  85           85.48453     52.95335    0.01176471 
+  104          86.57975     52.94614    0.00961538 
+  73           87.68786     52.93893    0.01369863 
+  77           88.80393     52.93172    0.01298701 
+  99           90.0039      52.92451    0.01010101 
+  83           91.33416     52.9173     0.01204819 
+  95           92.80934     52.91009    0.01052632 
+  90           94.43296     52.90287    0.01111111 
+  105          96.2122      52.89566    0.00952381 
+  96           98.16244     52.88845    0.01041667 
+  86           100.32001    52.88124    0.01162791 
+  105          102.77789    52.87403    0.00952381 
+  93           105.69514    52.86682    0.01075269 
+  131          109.20916    52.85961    0.00763359 
+  125          113.26961    52.85239    0.008     
+  117          117.41547    52.84518    0.00854701 
+  138          120.77936    52.83797    0.00724638 
+  139          123.31212    52.83075    0.00719424 
+  171          125.92955    52.82354    0.00584795 
+  153          129.24233    52.81633    0.00653595 
+  169          133.41859    52.80911    0.00591716 
+  192          138.43209    52.8019     0.00520833 
+  192          144.23789    52.79468    0.00520833 
+  187          150.86995    52.78746    0.00534759 
+  190          158.46269    52.78025    0.00526316 
+  193          167.20098    52.77303    0.00518135 
+  200          177.24467    52.76581    0.005     
+  206          188.61073    52.75859    0.00485437 
+  210          201.12895    52.75138    0.0047619 
+  209          214.94208    52.74416    0.00478469 
+  221          230.8422     52.73694    0.00452489 
+  256          249.67448    52.72972    0.00390625 
+  256          272.14341    52.72249    0.00390625 
+  266          299.04155    52.71527    0.0037594 
+  321          331.54889    52.70805    0.00311526 
+  349          371.34064    52.70083    0.00286533 
+  407          420.7452     52.6936     0.002457  
+  457          483.20049    52.68638    0.00218818 
+  603          564.276      52.67915    0.00165837 
+  669          674.06956    52.67192    0.00149477 
+  930          832.36504    52.6647     0.00107527 
+  1304         1077.62895   52.65747    0.00076687 
+  1701         1476.63581   52.65024    0.00058789 
+  2424         2126.42101   52.64301    0.00041254 
+  3324         3131.55083   52.63578    0.00030084 
+  4736         4544.1188    52.62855    0.00021115 
+  6250         6241.7238    52.62131    0.00016   
+  7329         7703.07384   52.61408    0.00013644 
+  7905         8032.08815   52.60685    0.0001265 
+  6984         6976.29011   52.59961    0.00014318 
+  5289         5332.08134   52.59237    0.00018907 
+  3985         3831.07222   52.58513    0.00025094 
+  2869         2736.70974   52.5779     0.00034855 
+  2292         2064.00867   52.57065    0.0004363 
+  2004         1749.39599   52.56341    0.000499  
+  1987         1732.12757   52.55617    0.00050327 
+  2206         1985.13224   52.54893    0.00045331 
+  2710         2498.70373   52.54168    0.000369  
+  3282         3223.7235    52.53444    0.00030469 
+  3935         3964.73097   52.52719    0.00025413 
+  4206         4297.11547   52.51994    0.00023776 
+  3812         3915.16551   52.51269    0.00026233 
+  3051         3088.24535   52.50544    0.00032776 
+  2300         2241.96462   52.49819    0.00043478 
+  1632         1571.74286   52.49093    0.00061275 
+  1150         1106.29      52.48368    0.00086957 
+  847          807.96173    52.47642    0.00118064 
+  625          622.98584    52.46917    0.0016    
+  515          506.06824    52.46191    0.00194175 
+  457          427.4709     52.45465    0.00218818 
+  369          370.77202    52.44738    0.00271003 
+  318          327.5852     52.44012    0.00314465 
+  281          293.56854    52.43286    0.00355872 
+  285          266.31827    52.42559    0.00350877 
+  257          244.48932    52.41832    0.00389105 
+  237          227.44725    52.41105    0.00421941 
+  196          214.92978    52.40378    0.00510204 
+  205          206.43071    52.39651    0.00487805 
+  190          200.23737    52.38923    0.00526316 
+  179          192.59222    52.38196    0.00558659 
+  186          180.81418    52.37468    0.00537634 
+  154          167.47001    52.3674     0.00649351 
+  156          155.6371     52.36012    0.00641026 
+  153          146.26939    52.35284    0.00653595 
+  146          139.10515    52.34556    0.00684932 
+  124          133.53376    52.33827    0.00806452 
+  123          129.10796    52.33098    0.00813008 
+  108          125.70813    52.32369    0.00925926 
+  117          123.45333    52.3164     0.00854701 
+  137          122.43825    52.30911    0.00729927 
+  109          122.32177    52.30181    0.00917431 
+  117          121.80219    52.29452    0.00854701 
+  104          119.03743    52.28722    0.00961538 
+  93           114.35754    52.27992    0.01075269 
+  91           109.62085    52.27262    0.01098901 
+  84           105.78067    52.26531    0.01190476 
+  105          102.93574    52.25801    0.00952381 
+  113          100.83227    52.2507     0.00884956 
+  101          99.18552     52.24339    0.00990099 
+  91           97.81042     52.23608    0.01098901 
+  82           96.6153      52.22876    0.01219512 
+  77           95.55756     52.22145    0.01298701 
+  84           94.61008     52.21413    0.01190476 
+  75           93.75444     52.20681    0.01333333 
+  86           92.9805      52.19949    0.01162791 
+  86           92.28311     52.19216    0.01162791 
+  79           91.65529     52.18483    0.01265823 
+  73           91.08925     52.17751    0.01369863 
+  83           90.57828     52.17018    0.01204819 
+  91           90.10939     52.16284    0.01098901 
+  93           89.68894     52.15551    0.01075269 
+  95           89.30627     52.14817    0.01052632 
+  80           88.95732     52.14083    0.0125    
+  69           88.63868     52.13349    0.01449275 
+  85           88.34728     52.12614    0.01176471 
+  87           88.08095     52.1188     0.01149425 
+  87           87.83669     52.11145    0.01149425 
+  75           87.61456     52.1041     0.01333333 
+  77           87.40885     52.09675    0.01298701 
+  84           87.21926     52.08939    0.01190476 
+  75           87.04134     52.08203    0.01333333 
+  90           86.87895     52.07467    0.01111111 
+  67           86.72766     52.06731    0.01492537 
+  79           86.58617     52.05994    0.01265823 
+  66           86.45387     52.05258    0.01515152 
+  71           86.33061     52.04521    0.01408451 
+  71           86.21712     52.03783    0.01408451 
+  84           86.11539     52.03046    0.01190476 
+  71           86.02908     52.02308    0.01408451 
+  72           85.96482     52.0157     0.01388889 
+  85           85.93394     52.00832    0.01176471 
+  84           85.95691     52.00093    0.01190476 
+  69           86.06406     51.99354    0.01449275 
+  88           86.30447     51.98615    0.01136364 
+  81           86.73836     51.97876    0.01234568 
+  83           87.41835     51.97137    0.01204819 
+  112          88.34373     51.96397    0.00892857 
+  89           89.37093     51.95657    0.01123596 
+  75           90.11249     51.94916    0.01333333 
+  80           90.12685     51.94176    0.0125    
+  82           89.38396     51.93435    0.01219512 
+  82           88.29013     51.92693    0.01219512 
+  80           87.31627     51.91952    0.0125    
+  83           86.49117     51.9121     0.01204819 
+  76           85.91386     51.90468    0.01315789 
+  82           85.56247     51.89726    0.01219512 
+  93           85.40431     51.88983    0.01075269 
+  83           85.4074      51.8824     0.01204819 
+  70           85.54524     51.87497    0.01428571 
+  79           85.78384     51.86754    0.01265823 
+  87           86.00432     51.8601     0.01149425 
+  92           85.97346     51.85266    0.01086957 
+  97           85.52208     51.84522    0.01030928 
+  73           84.7339      51.83777    0.01369863 
+  67           83.83354     51.83032    0.01492537 
+  63           82.97545     51.82287    0.01587302 
+  89           82.24437     51.81542    0.01123596 
+  96           81.56375     51.80796    0.01041667 
+  73           80.94766     51.8005     0.01369863 
+  62           80.36949     51.79303    0.01612903 
+  69           79.80357     51.78557    0.01449275 
+  61           79.2382      51.7781     0.01639344 
+  85           78.67508     51.77062    0.01176471 
+  74           78.11744     51.76315    0.01351351 
+  63           77.56787     51.75567    0.01587302 
+  79           77.02861     51.74818    0.01265823 
+  77           76.50397     51.7407     0.01298701 
+  74           75.99961     51.73321    0.01351351 
+  73           75.52409     51.72572    0.01369863 
+  84           75.08906     51.71822    0.01190476 
+  73           74.71115     51.71072    0.01369863 
+  71           74.41512     51.70322    0.01408451 
+  75           74.24519     51.69572    0.01333333 
+  85           74.30033     51.68821    0.01176471 
+  94           74.82902     51.6807     0.0106383 
+  86           76.39765     51.67318    0.01162791 
+  97           80.00164     51.66566    0.01030928 
+  97           86.74803     51.65814    0.01030928 
+  99           96.80396     51.65062    0.01010101 
+  97           107.59367    51.64309    0.01030928 
+  128          112.18489    51.63556    0.0078125 
+  130          105.78022    51.62802    0.00769231 
+  104          94.07941     51.62048    0.00961538 
+  84           83.62606     51.61294    0.01190476 
+  92           76.60779     51.6054     0.01086957 
+  92           72.72641     51.59785    0.01086957 
+  94           70.95532     51.5903     0.0106383 
+  78           70.57791     51.58274    0.01282051 
+  99           71.50507     51.57518    0.01010101 
+  100          74.08811     51.56762    0.01      
+  114          78.56654     51.56005    0.00877193 
+  123          84.19673     51.55248    0.00813008 
+  129          88.61874     51.54491    0.00775194 
+  111          88.40833     51.53733    0.00900901 
+  116          83.08181     51.52975    0.00862069 
+  105          76.43718     51.52217    0.00952381 
+  95           71.1584      51.51458    0.01052632 
+  78           67.80258     51.50699    0.01282051 
+  83           65.95203     51.4994     0.01204819 
+  79           65.0091      51.4918     0.01265823 
+  72           64.575       51.4842     0.01388889 
+  80           64.4734      51.47659    0.0125    
+  78           64.61596     51.46898    0.01282051 
+  91           64.84654     51.46137    0.01098901 
+  90           64.85013     51.45375    0.01111111 
+  74           64.44904     51.44613    0.01351351 
+  79           63.90294     51.4385     0.01265823 
+  80           63.48168     51.43088    0.0125    
+  84           63.29818     51.42324    0.01190476 
+  73           63.42089     51.41561    0.01369863 
+  65           63.98507     51.40797    0.01538462 
+  77           65.22        51.40032    0.01298701 
+  69           67.29964     51.39268    0.01449275 
+  65           70.00546     51.38503    0.01538462 
+  77           72.22059     51.37737    0.01298701 
+  55           72.16248     51.36971    0.01818182 
+  70           69.95132     51.36205    0.01428571 
+  65           67.41687     51.35438    0.01538462 
+  73           65.64941     51.34671    0.01369863 
+  61           64.94391     51.33904    0.01639344 
+  50           65.29125     51.33136    0.02      
+  63           66.60355     51.32367    0.01587302 
+  69           68.63815     51.31599    0.01449275 
+  61           70.65897     51.3083     0.01639344 
+  62           71.44081     51.3006     0.01612903 
+  64           70.95855     51.2929     0.015625  
+  48           70.34258     51.2852     0.02083333 
+  59           69.76131     51.27749    0.01694915 
+  67           68.54112     51.26978    0.01492537 
+  59           66.82302     51.26207    0.01694915 
+  60           65.32392     51.25435    0.01666667 
+  60           64.37715     51.24663    0.01666667 
+  61           64.036       51.2389     0.01639344 
+  61           64.28688     51.23117    0.01639344 
+  59           65.1276      51.22343    0.01694915 
+  51           66.47957     51.21569    0.01960784 
+  75           67.93661     51.20795    0.01333333 
+  63           68.73633     51.2002     0.01587302 
+  82           68.52379     51.19245    0.01219512 
+  67           67.35125     51.18469    0.01492537 
+  66           65.71326     51.17693    0.01515152 
+  62           64.29495     51.16916    0.01612903 
+  60           63.34013     51.1614     0.01666667 
+  46           62.7917      51.15362    0.02173913 
+  68           62.51002     51.14584    0.01470588 
+  75           62.38239     51.13806    0.01333333 
+  69           62.35772     51.13028    0.01449275 
+  60           62.44071     51.12248    0.01666667 
+  52           62.66626     51.11469    0.01923077 
+  65           63.05693     51.10689    0.01538462 
+  53           63.55386     51.09909    0.01886792 
+  66           63.93087     51.09128    0.01515152 
+  53           63.90747     51.08347    0.01886792 
+  73           63.60645     51.07565    0.01369863 
+  60           63.36503     51.06783    0.01666667 
+  54           63.35345     51.06       0.01851852 
+  68           63.57784     51.05217    0.01470588 
+  55           63.91823     51.04434    0.01818182 
+  60           64.18804     51.0365     0.01666667 
+  67           64.37392     51.02865    0.01492537 
+  62           64.68038     51.02081    0.01612903 
+  63           65.27663     51.01295    0.01587302 
+  79           66.1759      51.0051     0.01265823 
+  63           67.19101     50.99724    0.01587302 
+  55           68.07855     50.98937    0.01818182 
+  72           69.18786     50.9815     0.01388889 
+  73           71.59331     50.97362    0.01369863 
+  85           76.72778     50.96574    0.01176471 
+  71           85.93067     50.95786    0.01408451 
+  89           99.19973     50.94997    0.01123596 
+  59           112.99839    50.94208    0.01694915 
+  80           118.60251    50.93418    0.0125    
+  78           110.99491    50.92628    0.01282051 
+  81           97.70811     50.91837    0.01234568 
+  91           86.37613     50.91046    0.01098901 
+  96           79.36929     50.90254    0.01041667 
+  90           76.1154      50.89462    0.01111111 
+  69           75.2091      50.8867     0.01449275 
+  87           75.82092     50.87876    0.01149425 
+  90           77.94474     50.87083    0.01111111 
+  95           81.90541     50.86289    0.01052632 
+  93           87.75985     50.85495    0.01075269 
+  92           94.86903     50.847      0.01086957 
+  90           101.81018    50.83904    0.01111111 
+  81           105.0225     50.83108    0.01234568 
+  76           102.20104    50.82312    0.01315789 
+  88           97.02854     50.81515    0.01136364 
+  90           93.3303      50.80718    0.01111111 
+  89           92.31608     50.7992     0.01123596 
+  94           93.7762      50.79122    0.0106383 
+  108          97.09297     50.78323    0.00925926 
+  120          101.90426    50.77524    0.00833333 
+  103          108.30621    50.76724    0.00970874 
+  136          116.60317    50.75924    0.00735294 
+  147          127.17138    50.75123    0.00680272 
+  182          140.77542    50.74322    0.00549451 
+  183          159.6651     50.7352     0.00546448 
+  205          188.43889    50.72718    0.00487805 
+  285          235.05274    50.71915    0.00350877 
+  396          311.72074    50.71112    0.00252525 
+  519          433.37238    50.70309    0.00192678 
+  650          611.52392    50.69505    0.00153846 
+  773          841.27688    50.687      0.00129366 
+  1013         1075.02015   50.67895    0.00098717 
+  1119         1198.50218   50.67089    0.00089366 
+  1106         1119.2063    50.66283    0.00090416 
+  848          903.11828    50.65477    0.00117925 
+  637          673.41596    50.6467     0.00156986 
+  495          491.2759     50.63862    0.0020202 
+  412          368.60108    50.63054    0.00242718 
+  329          297.92222    50.62245    0.00303951 
+  313          268.09836    50.61436    0.00319489 
+  338          272.02738    50.60627    0.00295858 
+  354          308.46518    50.59816    0.00282486 
+  404          378.84037    50.59006    0.00247525 
+  522          479.78667    50.58195    0.00191571 
+  530          590.10044    50.57383    0.00188679 
+  598          655.74584    50.56571    0.00167224 
+  617          623.44286    50.55758    0.00162075 
+  512          515.96469    50.54945    0.00195312 
+  382          396.27083    50.54132    0.0026178 
+  304          299.45784    50.53317    0.00328947 
+  230          232.79034    50.52503    0.00434783 
+  178          190.39894    50.51688    0.00561798 
+  141          162.54669    50.50872    0.0070922 
+  119          142.01514    50.50056    0.00840336 
+  138          125.08467    50.49239    0.00724638 
+  116          111.40561    50.48422    0.00862069 
+  101          101.15662    50.47604    0.00990099 
+  103          93.80331     50.46786    0.00970874 
+  78           88.5743      50.45967    0.01282051 
+  76           84.83593     50.45148    0.01315789 
+  87           82.25914     50.44328    0.01149425 
+  80           80.79348     50.43507    0.0125    
+  88           80.48722     50.42686    0.01136364 
+  92           81.16991     50.41865    0.01086957 
+  77           82.00327     50.41043    0.01298701 
+  72           81.68218     50.40221    0.01388889 
+  75           79.74735     50.39398    0.01333333 
+  73           76.49295     50.38574    0.01369863 
+  64           72.98117     50.3775     0.015625  
+  70           70.12631     50.36926    0.01428571 
+  62           68.10622     50.361      0.01612903 
+  68           66.73037     50.35275    0.01470588 
+  73           65.74963     50.34449    0.01369863 
+  70           64.9939      50.33622    0.01428571 
+  63           64.37434     50.32795    0.01587302 
+  56           63.84864     50.31967    0.01785714 
+  70           63.39587     50.31139    0.01428571 
+  63           63.00501     50.3031     0.01587302 
+  63           62.67303     50.29481    0.01587302 
+  58           62.40922     50.28651    0.01724138 
+  61           62.24557     50.2782     0.01639344 
+  60           62.24187     50.26989    0.01666667 
+  68           62.46509     50.26158    0.01470588 
+  67           62.92198     50.25326    0.01492537 
+  44           63.44434     50.24493    0.02272727 
+  63           63.58888     50.2366     0.01587302 
+  50           63.04929     50.22827    0.02      
+  55           62.18669     50.21992    0.01818182 
+  51           61.41952     50.21158    0.01960784 
+  65           60.88849     50.20322    0.01538462 
+  74           60.57427     50.19487    0.01351351 
+  56           60.40818     50.1865     0.01785714 
+  49           60.33607     50.17813    0.02040816 
+  60           60.33963     50.16976    0.01666667 
+  55           60.43333     50.16138    0.01818182 
+  56           60.64942     50.15299    0.01785714 
+  65           61.00684     50.1446     0.01538462 
+  56           61.45982     50.13621    0.01785714 
+  61           61.83186     50.12781    0.01639344 
+  53           61.90828     50.1194     0.01886792 
+  55           61.78253     50.11099    0.01818182 
+  67           61.69841     50.10257    0.01492537 
+  52           61.7723      50.09414    0.01923077 
+  61           62.02242     50.08571    0.01639344 
+  85           62.43021     50.07728    0.01176471 
+  52           62.97939     50.06884    0.01923077 
+  49           63.67155     50.06039    0.02040816 
+  70           64.5263      50.05194    0.01428571 
+  63           65.5781      50.04349    0.01587302 
+  50           66.8789      50.03502    0.02      
+  56           68.50164     50.02655    0.01785714 
+  63           70.55673     50.01808    0.01587302 
+  61           73.22146     50.0096     0.01639344 
+  63           76.79788     50.00112    0.01587302 
+  71           81.79817     49.99263    0.01408451 
+  98           89.06828     49.98413    0.01020408 
+  98           99.86872     49.97563    0.01020408 
+  121          115.83455    49.96712    0.00826446 
+  147          138.68372    49.95861    0.00680272 
+  179          169.52243    49.95009    0.00558659 
+  177          207.39469    49.94157    0.00564972 
+  217          245.65288    49.93304    0.00460829 
+  211          269.67968    49.92451    0.00473934 
+  183          265.16351    49.91597    0.00546448 
+  137          235.73917    49.90742    0.00729927 
+  127          198.0441     49.89887    0.00787402 
+  130          164.28863    49.89031    0.00769231 
+  93           138.84484    49.88175    0.01075269 
+  94           122.08       49.87318    0.0106383 
+  83           112.94718    49.8646     0.01204819 
+  84           110.24788    49.85603    0.01190476 
+  108          113.4026     49.84744    0.00925926 
+  113          122.26278    49.83885    0.00884956 
+  121          136.28358    49.83025    0.00826446 
+  118          153.21303    49.82165    0.00847458 
+  131          167.17441    49.81304    0.00763359 
+  150          169.53396    49.80443    0.00666667 
+  109          157.58061    49.79581    0.00917431 
+  95           137.94875    49.78718    0.01052632 
+  85           118.26706    49.77855    0.01176471 
+  86           102.07139    49.76992    0.01162791 
+  86           90.01492     49.76127    0.01162791 
+  84           81.53244     49.75263    0.01190476 
+  77           75.65573     49.74397    0.01298701 
+  78           71.51645     49.73531    0.01282051 
+  53           68.57702     49.72665    0.01886792 
+  54           66.50261     49.71798    0.01851852 
+  74           65.09293     49.7093     0.01351351 
+  65           64.27311     49.70062    0.01538462 
+  59           64.07097     49.69193    0.01694915 
+  77           64.5615      49.68324    0.01298701 
+  87           65.6251      49.67454    0.01149425 
+  62           66.55953     49.66584    0.01612903 
+  70           66.13975     49.65712    0.01428571 
+  73           64.27609     49.64841    0.01369863 
+  79           62.16084     49.63969    0.01265823 
+  63           60.54612     49.63096    0.01587302 
+  50           59.56893     49.62223    0.02      
+  63           59.06491     49.61349    0.01587302 
+  62           58.79087     49.60474    0.01612903 
+  64           58.63918     49.59599    0.015625  
+  60           58.69379     49.58724    0.01666667 
+  44           59.13396     49.57847    0.02272727 
+  69           60.24818     49.56971    0.01449275 
+  59           62.40237     49.56093    0.01694915 
+  88           65.75029     49.55215    0.01136364 
+  77           69.70023     49.54337    0.01298701 
+  61           72.7098      49.53458    0.01639344 
+  61           72.77168     49.52578    0.01639344 
+  49           69.52309     49.51698    0.02040816 
+  84           65.3721      49.50817    0.01190476 
+  56           62.14108     49.49936    0.01785714 
+  59           60.21913     49.49054    0.01694915 
+  63           59.33314     49.48171    0.01587302 
+  59           59.12415     49.47288    0.01694915 
+  49           59.37895     49.46404    0.02040816 
+  62           60.08153     49.4552     0.01612903 
+  63           61.51676     49.44635    0.01587302 
+  56           64.38888     49.4375     0.01785714 
+  58           69.88051     49.42864    0.01724138 
+  51           79.36955     49.41977    0.01960784 
+  68           93.23138     49.4109     0.01470588 
+  79           109.28161    49.40203    0.01265823 
+  60           121.58834    49.39314    0.01666667 
+  69           120.5452     49.38425    0.01449275 
+  56           106.21138    49.37536    0.01785714 
+  64           89.20289     49.36646    0.015625  
+  67           76.06754     49.35755    0.01492537 
+  63           68.08205     49.34864    0.01587302 
+  66           64.08245     49.33972    0.01515152 
+  61           62.45484     49.3308     0.01639344 
+  59           62.11295     49.32187    0.01694915 
+  75           62.65849     49.31294    0.01333333 
+  63           64.49815     49.304      0.01587302 
+  72           68.53187     49.29505    0.01388889 
+  50           75.16319     49.2861     0.02      
+  54           83.0887      49.27714    0.01851852 
+  53           87.91408     49.26818    0.01886792 
+  60           85.09419     49.25921    0.01666667 
+  53           77.33271     49.25023    0.01886792 
+  74           69.74045     49.24125    0.01351351 
+  57           64.52754     49.23227    0.01754386 
+  68           61.75051     49.22327    0.01470588 
+  51           60.48207     49.21428    0.01960784 
+  67           59.68082     49.20527    0.01492537 
+  68           58.88337     49.19626    0.01470588 
+  55           58.09202     49.18725    0.01818182 
+  53           57.41981     49.17823    0.01886792 
+  79           56.94165     49.1692     0.01265823 
+  70           56.64444     49.16017    0.01428571 
+  52           56.48142     49.15113    0.01923077 
+  55           56.41042     49.14208    0.01818182 
+  63           56.40977     49.13303    0.01587302 
+  65           56.47992     49.12398    0.01538462 
+  65           56.63315     49.11492    0.01538462 
+  58           56.87084     49.10585    0.01724138 
+  49           57.14828     49.09678    0.02040816 
+  52           57.33781     49.0877     0.01923077 
+  63           57.32755     49.07861    0.01587302 
+  60           57.20819     49.06952    0.01666667 
+  51           57.11426     49.06043    0.01960784 
+  63           57.09605     49.05133    0.01587302 
+  63           57.1517      49.04222    0.01587302 
+  58           57.26112     49.03311    0.01724138 
+  52           57.40704     49.02399    0.01923077 
+  66           57.58307     49.01486    0.01515152 
+  60           57.79632     49.00573    0.01666667 
+  67           58.07145     48.9966     0.01492537 
+  61           58.45215     48.98746    0.01639344 
+  70           58.98412     48.97831    0.01428571 
+  67           59.66696     48.96915    0.01492537 
+  70           60.37412     48.96       0.01428571 
+  62           60.79492     48.95083    0.01612903 
+  51           60.75792     48.94166    0.01960784 
+  69           60.5352      48.93249    0.01449275 
+  67           60.39609     48.9233     0.01492537 
+  73           60.42453     48.91412    0.01369863 
+  69           60.60489     48.90492    0.01449275 
+  61           60.89234     48.89572    0.01639344 
+  49           61.25383     48.88652    0.02040816 
+  63           61.67999     48.87731    0.01587302 
+  71           62.18315     48.86809    0.01408451 
+  62           62.79277     48.85887    0.01612903 
+  64           63.54349     48.84965    0.015625  
+  60           64.45756     48.84041    0.01666667 
+  72           65.53027     48.83118    0.01388889 
+  75           66.7748      48.82193    0.01333333 
+  82           68.46958     48.81268    0.01219512 
+  70           71.13329     48.80343    0.01428571 
+  88           74.97454     48.79417    0.01136364 
+  86           79.29564     48.7849     0.01162791 
+  88           81.95544     48.77563    0.01136364 
+  99           81.15937     48.76635    0.01010101 
+  79           78.50064     48.75707    0.01265823 
+  89           76.19881     48.74778    0.01123596 
+  84           75.08037     48.73848    0.01190476 
+  92           75.11043     48.72918    0.01086957 
+  87           75.96482     48.71988    0.01149425 
+  84           77.36849     48.71056    0.01190476 
+  75           79.2139      48.70125    0.01333333 
+  94           81.56167     48.69192    0.0106383 
+  98           84.61283     48.6826     0.01020408 
+  110          88.64388     48.67326    0.00909091 
+  116          93.84444     48.66392    0.00862069 
+  100          100.00052    48.65458    0.01      
+  120          106.14192    48.64523    0.00833333 
+  115          111.48511    48.63587    0.00869565 
+  130          116.30579    48.62651    0.00769231 
+  127          120.76154    48.61714    0.00787402 
+  152          125.86486    48.60777    0.00657895 
+  161          133.08001    48.59839    0.00621118 
+  140          143.28391    48.58901    0.00714286 
+  156          157.13501    48.57962    0.00641026 
+  184          175.60712    48.57022    0.00543478 
+  218          200.61793    48.56082    0.00458716 
+  293          236.09462    48.55142    0.00341297 
+  325          289.82472    48.542      0.00307692 
+  450          375.68415    48.53259    0.00222222 
+  628          514.81793    48.52316    0.00159236 
+  785          732.23934    48.51374    0.00127389 
+  1098         1046.05176   48.5043     0.00091075 
+  1443         1445.03865   48.49486    0.000693  
+  1634         1843.53215   48.48542    0.000612  
+  1734         2044.66399   48.47597    0.0005767 
+  1587         1897.72168   48.46651    0.00063012 
+  1204         1522.09233   48.45705    0.00083056 
+  907          1125.98747   48.44759    0.00110254 
+  674          811.47428    48.43812    0.00148368 
+  565          597.70306    48.42864    0.00176991 
+  436          470.26558    48.41916    0.00229358 
+  419          406.97479    48.40967    0.00238663 
+  419          392.47753    48.40018    0.00238663 
+  488          423.95342    48.39068    0.00204918 
+  578          506.4773     48.38117    0.0017301 
+  659          644.65819    48.37166    0.00151745 
+  769          829.4897     48.36215    0.00130039 
+  949          1014.09941   48.35263    0.00105374 
+  935          1096.69735   48.3431     0.00106952 
+  868          1005.66385   48.33357    0.00115207 
+  638          805.7578     48.32404    0.0015674 
+  496          599.70303    48.3145     0.00201613 
+  379          435.5001     48.30495    0.00263852 
+  276          320.83408    48.2954     0.00362319 
+  199          246.92313    48.28584    0.00502513 
+  197          200.47007    48.27628    0.00507614 
+  141          170.32425    48.26671    0.0070922 
+  161          149.76536    48.25714    0.00621118 
+  113          135.25253    48.24756    0.00884956 
+  132          125.11907    48.23797    0.00757576 
+  120          118.27427    48.22839    0.00833333 
+  128          113.31591    48.21879    0.0078125 
+  90           108.22006    48.20919    0.01111111 
+  92           101.84843    48.19959    0.01086957 
+  97           95.29335     48.18998    0.01030928 
+  96           89.70576     48.18036    0.01041667 
+  72           85.37078     48.17074    0.01388889 
+  85           82.11476     48.16112    0.01176471 
+  93           79.64284     48.15149    0.01075269 
+  88           77.71076     48.14185    0.01136364 
+  81           76.15072     48.13221    0.01234568 
+  70           74.8384      48.12257    0.01428571 
+  55           73.77177     48.11291    0.01818182 
+  92           73.11008     48.10326    0.01086957 
+  71           72.9292      48.0936     0.01408451 
+  80           73.00244     48.08393    0.0125    
+  76           72.68076     48.07426    0.01315789 
+  73           71.53977     48.06458    0.01369863 
+  75           70.08001     48.0549     0.01333333 
+  77           68.75818     48.04521    0.01298701 
+  79           67.60211     48.03552    0.01265823 
+  66           66.49014     48.02583    0.01515152 
+  59           65.78802     48.01612    0.01694915 
+  79           65.23725     48.00642    0.01265823 
+  62           64.64396     47.9967     0.01612903 
+  77           63.9859      47.98699    0.01298701 
+  60           63.37996     47.97727    0.01666667 
+  65           62.88652     47.96754    0.01538462 
+  71           62.50944     47.95781    0.01408451 
+  56           62.23384     47.94807    0.01785714 
+  68           62.0485      47.93833    0.01470588 
+  74           61.94607     47.92858    0.01351351 
+  86           61.90852     47.91883    0.01162791 
+  73           61.87518     47.90908    0.01369863 
+  63           61.68473     47.89931    0.01587302 
+  68           61.51302     47.88955    0.01470588 
+  81           61.37356     47.87978    0.01234568 
+  65           61.28058     47.87       0.01538462 
+  63           61.18247     47.86022    0.01587302 
+  66           61.09257     47.85044    0.01515152 
+  56           61.0896      47.84065    0.01785714 
+  65           61.18159     47.83085    0.01538462 
+  56           61.24882     47.82105    0.01785714 
+  74           61.10201     47.81125    0.01351351 
+  70           60.76065     47.80144    0.01428571 
+  64           60.40021     47.79162    0.015625  
+  60           60.11488     47.7818     0.01666667 
+  67           59.91549     47.77198    0.01492537 
+  84           59.77943     47.76215    0.01190476 
+  61           59.68103     47.75232    0.01639344 
+  54           59.60516     47.74248    0.01851852 
+  54           59.54886     47.73264    0.01851852 
+  63           59.51975     47.72279    0.01587302 
+  45           59.53392     47.71294    0.02222222 
+  67           59.61152     47.70309    0.01492537 
+  62           59.76808     47.69322    0.01612903 
+  61           59.99752     47.68336    0.01639344 
+  52           60.2661      47.67349    0.01923077 
+  47           60.60026     47.66361    0.0212766 
+  66           61.00566     47.65374    0.01515152 
+  60           61.2609      47.64385    0.01666667 
+  56           61.03367     47.63396    0.01785714 
+  58           60.46723     47.62407    0.01724138 
+  57           59.95488     47.61417    0.01754386 
+  54           59.72805     47.60427    0.01851852 
+  63           59.94254     47.59437    0.01587302 
+  51           60.80278     47.58446    0.01960784 
+  58           62.54419     47.57454    0.01724138 
+  43           65.19981     47.56462    0.02325581 
+  51           68.14437     47.5547     0.01960784 
+  67           69.64577     47.54477    0.01492537 
+  55           68.36739     47.53484    0.01818182 
+  64           65.56173     47.5249     0.015625  
+  59           62.93611     47.51496    0.01694915 
+  53           61.10043     47.50501    0.01886792 
+  52           59.85738     47.49506    0.01923077 
+  63           58.94224     47.48511    0.01587302 
+  58           58.2972      47.47515    0.01724138 
+  73           57.90733     47.46519    0.01369863 
+  68           57.78318     47.45522    0.01470588 
+  40           57.99273     47.44525    0.025     
+  52           58.65577     47.43528    0.01923077 
+  46           59.85136     47.4253     0.02173913 
+  56           61.41856     47.41531    0.01785714 
+  57           62.6779      47.40532    0.01754386 
+  64           62.7318      47.39533    0.015625  
+  63           61.78854     47.38534    0.01587302 
+  51           60.60999     47.37534    0.01960784 
+  53           59.57215     47.36533    0.01886792 
+  61           58.5733      47.35532    0.01639344 
+  53           57.53385     47.34531    0.01886792 
+  66           56.6401      47.33529    0.01515152 
+  55           55.98783     47.32527    0.01818182 
+  57           55.55396     47.31525    0.01754386 
+  52           55.27488     47.30522    0.01923077 
+  51           55.09257     47.29519    0.01960784 
+  64           54.97594     47.28515    0.015625  
+  59           54.92136     47.27511    0.01694915 
+  57           54.94153     47.26507    0.01754386 
+  66           55.04793     47.25502    0.01515152 
+  55           55.21835     47.24497    0.01818182 
+  58           55.37807     47.23491    0.01724138 
+  60           55.44975     47.22485    0.01666667 
+  49           55.35958     47.21479    0.02040816 
+  60           55.06156     47.20472    0.01666667 
+  47           54.6964      47.19465    0.0212766 
+  60           54.39361     47.18457    0.01666667 
+  61           54.18689     47.1745     0.01639344 
+  59           54.06183     47.16441    0.01694915 
+  56           53.99357     47.15433    0.01785714 
+  60           53.9703      47.14424    0.01666667 
+  56           54.00065     47.13414    0.01785714 
+  71           54.11552     47.12405    0.01408451 
+  59           54.35087     47.11395    0.01694915 
+  56           54.71475     47.10384    0.01785714 
+  56           55.11397     47.09373    0.01785714 
+  64           55.30121     47.08362    0.015625  
+  54           55.10627     47.07351    0.01851852 
+  49           54.74977     47.06339    0.02040816 
+  49           54.50375     47.05327    0.02040816 
+  48           54.48647     47.04314    0.02083333 
+  64           54.68936     47.03301    0.015625  
+  62           54.98407     47.02288    0.01612903 
+  68           55.1172      47.01274    0.01470588 
+  65           54.91548     47.0026     0.01538462 
+  64           54.57773     46.99246    0.015625  
+  63           54.32131     46.98231    0.01587302 
+  43           54.23238     46.97216    0.02325581 
+  55           54.31327     46.96201    0.01818182 
+  73           54.50971     46.95185    0.01369863 
+  67           54.70312     46.9417     0.01492537 
+  58           54.74879     46.93153    0.01724138 
+  56           54.67475     46.92137    0.01785714 
+  61           54.64438     46.9112     0.01639344 
+  50           54.78395     46.90103    0.02      
+  70           55.18903     46.89085    0.01428571 
+  60           55.94054     46.88067    0.01666667 
+  61           57.04119     46.87049    0.01639344 
+  64           58.33019     46.8603     0.015625  
+  65           59.44822     46.85012    0.01538462 
+  78           59.70713     46.83993    0.01282051 
+  74           58.91362     46.82973    0.01351351 
+  71           57.87244     46.81953    0.01408451 
+  63           57.24533     46.80933    0.01587302 
+  85           57.33239     46.79913    0.01176471 
+  66           58.34032     46.78892    0.01515152 
+  72           60.4947      46.77872    0.01388889 
+  95           63.85926     46.7685     0.01052632 
+  87           67.89745     46.75829    0.01149425 
+  96           71.19366     46.74807    0.01041667 
+  96           71.55821     46.73785    0.01041667 
+  104          68.73198     46.72763    0.00961538 
+  73           65.24479     46.7174     0.01369863 
+  72           62.74226     46.70717    0.01388889 
+  88           61.28444     46.69694    0.01136364 
+  70           60.26239     46.68671    0.01428571 
+  57           59.48622     46.67647    0.01754386 
+  74           59.12181     46.66623    0.01351351 
+  86           59.26942     46.65599    0.01162791 
+  80           59.92864     46.64574    0.0125    
+  67           61.00764     46.6355     0.01492537 
+  71           62.44004     46.62525    0.01408451 
+  62           64.28415     46.61499    0.01612903 
+  81           66.29032     46.60474    0.01234568 
+  79           67.62537     46.59448    0.01265823 
+  80           67.45086     46.58422    0.0125    
+  99           66.62867     46.57396    0.01010101 
+  92           66.86918     46.56369    0.01086957 
+  75           69.41624     46.55343    0.01333333 
+  94           74.87402     46.54316    0.0106383 
+  96           82.66631     46.53288    0.01041667 
+  71           89.88334     46.52261    0.01408451 
+  98           91.27671     46.51233    0.01020408 
+  73           85.88617     46.50206    0.01369863 
+  76           78.70013     46.49177    0.01315789 
+  82           73.2061      46.48149    0.01219512 
+  75           70.37469     46.47121    0.01333333 
+  71           70.09241     46.46092    0.01408451 
+  105          71.8057      46.45063    0.00952381 
+  104          74.63471     46.44034    0.00961538 
+  119          77.02529     46.43004    0.00840336 
+  107          77.44258     46.41975    0.00934579 
+  89           76.8228      46.40945    0.01123596 
+  97           77.24703     46.39915    0.01030928 
+  113          79.66895     46.38885    0.00884956 
+  87           83.60096     46.37854    0.01149425 
+  87           86.87567     46.36824    0.01149425 
+  100          86.97237     46.35793    0.01      
+  108          84.79686     46.34762    0.00925926 
+  95           82.93408     46.33731    0.01052632 
+  117          82.72977     46.32699    0.00854701 
+  116          84.63659     46.31668    0.00862069 
+  114          88.86843     46.30636    0.00877193 
+  119          95.64913     46.29604    0.00840336 
+  139          104.93488    46.28572    0.00719424 
+  117          115.77929    46.2754     0.00854701 
+  161          126.33686    46.26508    0.00621118 
+  142          134.5487     46.25475    0.00704225 
+  158          139.02769    46.24443    0.00632911 
+  142          139.03443    46.2341     0.00704225 
+  152          135.41036    46.22377    0.00657895 
+  132          130.91308    46.21344    0.00757576 
+  131          127.92066    46.20311    0.00763359 
+  130          127.47702    46.19277    0.00769231 
+  130          129.80933    46.18244    0.00769231 
+  131          134.9115     46.1721     0.00763359 
+  144          142.85879    46.16176    0.00694444 
+  178          153.97394    46.15142    0.00561798 
+  213          168.89114    46.14108    0.00469484 
+  206          188.49695    46.13074    0.00485437 
+  243          213.73087    46.1204     0.00411523 
+  270          245.47014    46.11005    0.0037037 
+  318          285.41517    46.09971    0.00314465 
+  411          338.74103    46.08936    0.00243309 
+  540          417.36335    46.07901    0.00185185 
+  661          543.10019    46.06866    0.00151286 
+  922          746.06947    46.05831    0.0010846 
+  1224         1056.31189   46.04796    0.00081699 
+  1674         1486.44227   46.03761    0.00059737 
+  2233         1996.14826   46.02726    0.00044783 
+  2608         2427.40367   46.0169     0.00038344 
+  2512         2519.11407   46.00655    0.00039809 
+  2371         2200.82829   45.99619    0.00042176 
+  1858         1702.8193    45.98584    0.00053821 
+  1424         1240.06114   45.97548    0.00070225 
+  1008         891.4588     45.96512    0.00099206 
+  820          660.57509    45.95477    0.00121951 
+  676          524.07152    45.94441    0.00147929 
+  579          455.66754    45.93405    0.00172712 
+  549          438.48529    45.92369    0.00182149 
+  612          468.61497    45.91332    0.00163399 
+  712          552.30646    45.90296    0.00140449 
+  825          698.79063    45.8926     0.00121212 
+  1060         908.29694    45.88224    0.0009434 
+  1239         1150.1145    45.87188    0.0008071 
+  1341         1329.39384   45.86151    0.00074571 
+  1336         1319.27653   45.85115    0.0007485 
+  1195         1120.44595   45.84078    0.00083682 
+  920          859.32285    45.83042    0.00108696 
+  711          628.61247    45.82005    0.00140647 
+  503          456.93575    45.80969    0.00198807 
+  420          341.13356    45.79932    0.00238095 
+  370          267.38175    45.78896    0.0027027 
+  288          221.0278     45.77859    0.00347222 
+  243          190.93227    45.76823    0.00411523 
+  180          170.17559    45.75786    0.00555556 
+  176          154.96978    45.74749    0.00568182 
+  155          143.32479    45.73713    0.00645161 
+  142          134.12495    45.72676    0.00704225 
+  137          126.67711    45.7164     0.00729927 
+  151          120.56628    45.70603    0.00662252 
+  138          115.53018    45.69567    0.00724638 
+  132          111.35348    45.6853     0.00757576 
+  133          107.85506    45.67493    0.0075188 
+  106          104.93951    45.66457    0.00943396 
+  103          102.57829    45.6542     0.00970874 
+  103          100.77871    45.64384    0.00970874 
+  96           99.55416     45.63348    0.01041667 
+  103          98.83604     45.62311    0.00970874 
+  100          98.33457     45.61275    0.01      
+  81           97.46503     45.60239    0.01234568 
+  103          95.98007     45.59202    0.00970874 
+  97           94.3872      45.58166    0.01030928 
+  95           93.16709     45.5713     0.01052632 
+  96           92.56394     45.56094    0.01041667 
+  110          92.75821     45.55058    0.00909091 
+  67           93.90285     45.54022    0.01492537 
+  90           95.94645     45.52986    0.01111111 
+  87           98.24047     45.5195     0.01149425 
+  104          99.24326     45.50915    0.00961538 
+  106          97.78978     45.49879    0.00943396 
+  105          95.01604     45.48843    0.00952381 
+  108          92.55832     45.47808    0.00925926 
+  100          91.0137      45.46772    0.01      
+  89           90.21601     45.45737    0.01123596 
+  98           89.62898     45.44702    0.01020408 
+  93           88.93092     45.43667    0.01075269 
+  99           88.25494     45.42632    0.01010101 
+  74           87.7724      45.41597    0.01351351 
+  91           87.57766     45.40562    0.01098901 
+  82           87.74876     45.39528    0.01219512 
+  79           88.35661     45.38493    0.01265823 
+  68           89.36606     45.37459    0.01470588 
+  86           90.41167     45.36425    0.01162791 
+  98           90.74828     45.3539     0.01020408 
+  83           89.78989     45.34356    0.01204819 
+  65           88.11849     45.33323    0.01538462 
+  103          86.524       45.32289    0.00970874 
+  93           85.29961     45.31255    0.01075269 
+  81           84.4286      45.30222    0.01234568 
+  80           83.79159     45.29189    0.0125    
+  101          83.28541     45.28156    0.00990099 
+  69           82.86607     45.27123    0.01449275 
+  75           82.5565      45.2609     0.01333333 
+  78           82.4683      45.25058    0.01282051 
+  67           82.84893     45.24025    0.01492537 
+  69           84.06826     45.22993    0.01449275 
+  88           86.48587     45.21961    0.01136364 
+  85           89.95876     45.20929    0.01176471 
+  76           93.21759     45.19898    0.01315789 
+  78           93.72822     45.18866    0.01282051 
+  93           91.01569     45.17835    0.01075269 
+  89           88.03464     45.16804    0.01123596 
+  94           87.3685      45.15773    0.0106383 
+  74           90.11429     45.14743    0.01351351 
+  98           95.8183      45.13713    0.01020408 
+  88           101.6979     45.12682    0.01136364 
+  71           102.53375    45.11653    0.01408451 
+  94           96.8221      45.10623    0.0106383 
+  72           89.4503      45.09594    0.01388889 
+  92           84.31585     45.08564    0.01086957 
+  83           82.40208     45.07535    0.01204819 
+  82           82.69336     45.06507    0.01219512 
+  99           82.99737     45.05478    0.01010101 
+  91           82.0124      45.0445     0.01098901 
+  97           79.56078     45.03422    0.01030928 
+  95           76.03354     45.02395    0.01052632 
+  88           72.9835      45.01367    0.01136364 
+  92           71.58892     45.0034     0.01086957 
+  75           72.23952     44.99313    0.01333333 
+  103          74.63564     44.98287    0.00970874 
+  74           77.45157     44.97261    0.01351351 
+  79           78.10368     44.96235    0.01265823 
+  89           75.51297     44.95209    0.01123596 
+  80           72.07085     44.94184    0.0125    
+  83           70.10038     44.93159    0.01204819 
+  80           70.53664     44.92134    0.0125    
+  84           73.19199     44.9111     0.01190476 
+  74           76.72778     44.90086    0.01351351 
+  68           79.03928     44.89062    0.01470588 
+  90           77.80743     44.88039    0.01111111 
+  68           73.32477     44.87016    0.01470588 
+  81           68.63394     44.85993    0.01234568 
+  102          65.5839      44.8497     0.00980392 
+  103          64.4012      44.83948    0.00970874 
+  75           64.32876     44.82927    0.01333333 
+  95           64.0392      44.81905    0.01052632 
+  90           62.60328     44.80884    0.01111111 
+  79           60.58409     44.79864    0.01265823 
+  69           58.9038      44.78844    0.01449275 
+  78           57.99795     44.77824    0.01282051 
+  67           58.02224     44.76804    0.01492537 
+  81           58.99829     44.75785    0.01234568 
+  75           60.72768     44.74767    0.01333333 
+  67           62.47272     44.73748    0.01492537 
+  72           62.80503     44.7273     0.01388889 
+  72           61.25254     44.71713    0.01388889 
+  56           59.1737      44.70696    0.01785714 
+  83           57.68738     44.69679    0.01204819 
+  82           57.08033     44.68663    0.01219512 
+  74           57.09808     44.67647    0.01351351 
+  62           57.14107     44.66632    0.01612903 
+  71           56.66234     44.65617    0.01408451 
+  68           55.82608     44.64602    0.01470588 
+  66           55.15442     44.63588    0.01515152 
+  70           54.9663      44.62575    0.01428571 
+  73           55.42471     44.61561    0.01369863 
+  64           56.60288     44.60549    0.015625  
+  74           58.3973      44.59536    0.01351351 
+  74           60.30266     44.58525    0.01351351 
+  63           61.59269     44.57513    0.01587302 
+  54           61.97607     44.56503    0.01851852 
+  69           61.66286     44.55492    0.01449275 
+  51           61.50063     44.54482    0.01960784 
+  68           62.0333      44.53473    0.01470588 
+  55           63.0017      44.52464    0.01818182 
+  60           63.59755     44.51456    0.01666667 
+  69           63.24153     44.50448    0.01449275 
+  52           62.15497     44.49441    0.01923077 
+  56           60.73219     44.48434    0.01785714 
+  57           59.19632     44.47427    0.01754386 
+  52           57.99211     44.46422    0.01923077 
+  61           57.49429     44.45416    0.01639344 
+  73           57.77727     44.44412    0.01369863 
+  59           58.61516     44.43408    0.01694915 
+  64           59.56767     44.42404    0.015625  
+  70           60.37506     44.41401    0.01428571 
+  65           61.06662     44.40399    0.01538462 
+  78           62.07576     44.39397    0.01282051 
+  72           63.96466     44.38395    0.01388889 
+  69           67.20549     44.37394    0.01449275 
+  71           72.64858     44.36394    0.01408451 
+  91           82.48216     44.35395    0.01098901 
+  87           100.78019    44.34396    0.01149425 
+  87           131.62419    44.33397    0.01149425 
+  94           174.33865    44.32399    0.0106383 
+  90           216.27735    44.31402    0.01111111 
+  83           228.71727    44.30406    0.01204819 
+  101          198.90374    44.2941     0.00990099 
+  92           152.7922     44.28414    0.01086957 
+  77           113.48525    44.2742     0.01298701 
+  93           87.61915     44.26426    0.01075269 
+  85           73.29863     44.25432    0.01176471 
+  74           66.21613     44.24439    0.01351351 
+  68           62.91471     44.23447    0.01470588 
+  65           61.63786     44.22456    0.01538462 
+  77           61.97619     44.21465    0.01298701 
+  53           64.57612     44.20475    0.01886792 
+  81           71.06816     44.19485    0.01234568 
+  87           83.53039     44.18496    0.01149425 
+  74           102.7618     44.17508    0.01351351 
+  71           125.17061    44.16521    0.01408451 
+  81           138.86233    44.15534    0.01234568 
+  82           131.19831    44.14548    0.01219512 
+  72           109.25737    44.13563    0.01388889 
+  64           87.32853     44.12578    0.015625  
+  69           71.52089     44.11594    0.01449275 
+  71           62.08061     44.10611    0.01408451 
+  77           57.03992     44.09628    0.01298701 
+  56           54.36841     44.08647    0.01785714 
+  60           52.80713     44.07666    0.01666667 
+  59           51.76707     44.06686    0.01694915 
+  60           51.00821     44.05706    0.01666667 
+  54           50.42905     44.04727    0.01851852 
+  59           49.97935     44.03749    0.01694915 
+  45           49.63978     44.02772    0.02222222 
+  64           49.38628     44.01796    0.015625  
+  60           49.21852     44.0082     0.01666667 
+  48           49.12289     43.99845    0.02083333 
+  70           49.05996     43.98871    0.01428571 
+  47           48.96609     43.97898    0.0212766 
+  64           48.84586     43.96926    0.015625  
+  61           48.80907     43.95954    0.01639344 
+  58           48.99407     43.94983    0.01724138 
+  70           49.54891     43.94013    0.01428571 
+  92           50.56984     43.93044    0.01086957 
+  108          51.94651     43.92076    0.00925926 
+  83           53.10791     43.91108    0.01204819 
+  94           53.08441     43.90141    0.0106383 
+  87           51.82732     43.89176    0.01149425 
+  60           50.29467     43.88211    0.01666667 
+  85           49.09179     43.87247    0.01176471 
+  64           48.35069     43.86283    0.015625  
+  51           47.97392     43.85321    0.01960784 
+  58           47.82125     43.84359    0.01724138 
+  68           47.76835     43.83399    0.01470588 
+  43           47.7345      43.82439    0.02325581 
+  72           47.70384     43.8148     0.01388889 
+  59           47.70624     43.80523    0.01694915 
+  71           47.82959     43.79566    0.01408451 
+  74           48.17377     43.7861     0.01351351 
+  55           48.76352     43.77654    0.01818182 
+  56           49.45622     43.767      0.01785714 
+  56           49.83635     43.75747    0.01785714 
+  81           49.54873     43.74795    0.01234568 
+  70           48.92264     43.73843    0.01428571 
+  79           48.44827     43.72893    0.01265823 
+  69           48.32909     43.71944    0.01449275 
+  58           48.52385     43.70995    0.01724138 
+  68           48.77102     43.70048    0.01470588 
+  59           48.68657     43.69101    0.01694915 
+  51           48.23538     43.68156    0.01960784 
+  54           47.71484     43.67211    0.01851852 
+  54           47.29458     43.66267    0.01851852 
+  48           47.00319     43.65325    0.02083333 
+  52           46.82121     43.64383    0.01923077 
+  48           46.71338     43.63443    0.02083333 
+  41           46.64986     43.62503    0.02439024 
+  62           46.61415     43.61565    0.01612903 
+  64           46.60148     43.60628    0.015625  
+  51           46.61829     43.59691    0.01960784 
+  45           46.68273     43.58756    0.02222222 
+  45           46.81564     43.57822    0.02222222 
+  46           47.02411     43.56889    0.02173913 
+  59           47.25884     43.55957    0.01694915 
+  48           47.39302     43.55025    0.02083333 
+  44           47.29447     43.54096    0.02272727 
+  66           47.05647     43.53167    0.01515152 
+  56           46.83346     43.52239    0.01785714 
+  60           46.69156     43.51312    0.01666667 
+  62           46.64032     43.50387    0.01612903 
+  42           46.66828     43.49462    0.02380952 
+  56           46.75643     43.48539    0.01785714 
+  47           46.87        43.47617    0.0212766 
+  53           46.94127     43.46696    0.01886792 
+  49           46.92198     43.45776    0.02040816 
+  56           46.8552      43.44857    0.01785714 
+  44           46.78708     43.4394     0.02272727 
+  52           46.74374     43.43023    0.01923077 
+  43           46.73509     43.42108    0.02325581 
+  51           46.76372     43.41194    0.01960784 
+  55           46.82687     43.40281    0.01818182 
+  62           46.92744     43.39369    0.01612903 
+  52           47.08213     43.38459    0.01923077 
+  52           47.3391      43.3755     0.01923077 
+  48           47.80637     43.36642    0.02083333 
+  63           48.66486     43.35735    0.01587302 
+  61           50.10751     43.34829    0.01639344 
+  49           52.15588     43.33925    0.02040816 
+  56           54.34888     43.33022    0.01785714 
+  75           55.46858     43.3212     0.01333333 
+  63           54.72274     43.31219    0.01587302 
+  62           53.24886     43.3032     0.01612903 
+  56           52.4052      43.29422    0.01785714 
+  60           52.74302     43.28525    0.01666667 
+  46           54.11629     43.27629    0.02173913 
+  46           55.66223     43.26735    0.02173913 
+  49           56.23666     43.25842    0.02040816 
+  50           55.84164     43.2495     0.02      
+  56           54.87108     43.2406     0.01785714 
+  65           53.36556     43.23171    0.01538462 
+  69           51.95673     43.22283    0.01449275 
+  47           51.2672      43.21397    0.0212766 
+  49           51.42635     43.20512    0.02040816 
+  51           52.15828     43.19628    0.01960784 
+  47           52.85804     43.18746    0.0212766 
+  58           52.85939     43.17865    0.01724138 
+  48           52.09801     43.16985    0.02083333 
+  48           51.30833     43.16107    0.02083333 
+  53           51.05053     43.1523     0.01886792 
+  56           51.44853     43.14355    0.01785714 
+  55           52.33999     43.13481    0.01818182 
+  70           53.328       43.12608    0.01428571 
+  54           54.05092     43.11737    0.01851852 
+  69           54.6773      43.10867    0.01449275 
+  49           55.16401     43.09999    0.02040816 
+  60           55.02027     43.09132    0.01666667 
+  53           54.123       43.08266    0.01886792 
+  63           52.88778     43.07402    0.01587302 
+  61           51.73115     43.0654     0.01639344 
+  55           50.86996     43.05678    0.01818182 
+  49           50.29642     43.04819    0.02040816 
+  46           49.98538     43.03961    0.02173913 
+  49           49.92449     43.03104    0.02040816 
+  58           50.10903     43.02249    0.01724138 
+  45           50.57886     43.01395    0.02222222 
+  53           51.42585     43.00543    0.01886792 
+  44           52.76486     42.99692    0.02272727 
+  41           54.59905     42.98843    0.02439024 
+  42           56.5119      42.97995    0.02380952 
+  50           57.5107      42.97149    0.02      
+  65           57.16445     42.96305    0.01538462 
+  61           56.13925     42.95462    0.01639344 
+  55           55.01156     42.9462     0.01818182 
+  56           54.1275      42.93781    0.01785714 
+  52           53.65269     42.92942    0.01923077 
+  55           53.64591     42.92106    0.01818182 
+  55           54.0903      42.91271    0.01818182 
+  60           54.93617     42.90437    0.01666667 
+  66           56.05268     42.89605    0.01515152 
+  71           57.323       42.88775    0.01408451 
+  58           58.52584     42.87946    0.01724138 
+  77           59.87547     42.87119    0.01298701 
+  61           61.80984     42.86294    0.01639344 
+  72           64.58813     42.8547     0.01388889 
+  74           68.2395      42.84648    0.01351351 
+  80           72.68209     42.83828    0.0125    
+  98           78.47594     42.83009    0.01020408 
+  104          87.00092     42.82192    0.00961538 
+  114          99.61207     42.81377    0.00877193 
+  120          117.19325    42.80563    0.00833333 
+  131          139.645      42.79752    0.00763359 
+  162          164.45492    42.78941    0.00617284 
+  153          184.58963    42.78133    0.00653595 
+  133          190.19943    42.77326    0.0075188 
+  116          178.1816     42.76521    0.00862069 
+  114          156.35947    42.75718    0.00877193 
+  117          134.16468    42.74916    0.00854701 
+  106          116.84386    42.74117    0.00943396 
+  93           106.54124    42.73319    0.01075269 
+  113          103.83587    42.72522    0.00884956 
+  93           107.88128    42.71728    0.01075269 
+  81           115.28938    42.70935    0.01234568 
+  114          119.19056    42.70145    0.00877193 
+  104          115.93726    42.69356    0.00961538 
+  86           110.91556    42.68568    0.01162791 
+  111          109.4308     42.67783    0.00900901 
+  124          113.09032    42.67       0.00806452 
+  103          120.63123    42.66218    0.00970874 
+  125          127.81683    42.65438    0.008     
+  117          128.9518     42.6466     0.00854701 
+  108          122.09136    42.63884    0.00925926 
+  111          111.01173    42.6311     0.00900901 
+  82           100.39095    42.62338    0.01219512 
+  76           92.76257     42.61567    0.01315789 
+  86           89.17259     42.60799    0.01162791 
+  93           90.4682      42.60032    0.01075269 
+  78           97.36054     42.59267    0.01282051 
+  88           108.69492    42.58505    0.01136364 
+  90           119.51493    42.57744    0.01111111 
+  101          122.74167    42.56985    0.00990099 
+  84           115.56768    42.56228    0.01190476 
+  84           103.59032    42.55473    0.01190476 
+  88           93.88586     42.5472     0.01136364 
+  89           89.47591     42.53969    0.01123596 
+  98           90.84754     42.5322     0.01020408 
+  103          97.82196     42.52473    0.00970874 
+  110          110.52576    42.51728    0.00909091 
+  124          129.45051    42.50985    0.00806452 
+  140          154.75451    42.50244    0.00714286 
+  184          184.68036    42.49505    0.00543478 
+  180          212.89387    42.48768    0.00555556 
+  181          227.99492    42.48034    0.00552486 
+  153          222.35595    42.47301    0.00653595 
+  163          201.77729    42.4657     0.00613497 
+  151          177.79855    42.45842    0.00662252 
+  106          155.97113    42.45115    0.00943396 
+  99           136.099      42.44391    0.01010101 
+  109          119.40028    42.43668    0.00917431 
+  92           108.37359    42.42948    0.01086957 
+  99           104.03758    42.4223     0.01010101 
+  97           106.44342    42.41514    0.01030928 
+  91           115.16895    42.408      0.01098901 
+  113          129.02782    42.40088    0.00884956 
+  118          145.95419    42.39379    0.00847458 
+  138          166.02618    42.38672    0.00724638 
+  145          191.20099    42.37966    0.00689655 
+  145          218.92382    42.37263    0.00689655 
+  140          239.12189    42.36563    0.00714286 
+  152          239.3418     42.35864    0.00657895 
+  133          217.80682    42.35168    0.0075188 
+  118          185.46547    42.34474    0.00847458 
+  113          153.61213    42.33782    0.00884956 
+  97           127.49352    42.33092    0.01030928 
+  89           108.16329    42.32405    0.01123596 
+  65           94.97108     42.31719    0.01538462 
+  88           86.86078     42.31036    0.01136364 
+  78           82.86219     42.30356    0.01282051 
+  66           82.12831     42.29678    0.01515152 
+  88           83.65183     42.29001    0.01136364 
+  79           85.98942     42.28328    0.01265823 
+  70           88.58314     42.27656    0.01428571 
+  52           92.59535     42.26987    0.01923077 
+  73           98.45957     42.2632     0.01369863 
+  84           104.37395    42.25656    0.01190476 
+  73           106.54473    42.24994    0.01369863 
+  67           102.34217    42.24334    0.01492537 
+  64           93.45669     42.23677    0.015625  
+  68           83.53545     42.23022    0.01470588 
+  60           74.84919     42.22369    0.01666667 
+  55           68.0856      42.21719    0.01818182 
+  54           63.16841     42.21071    0.01851852 
+  48           59.74723     42.20426    0.02083333 
+  46           57.40444     42.19783    0.02173913 
+  68           55.72092     42.19143    0.01470588 
+  54           54.36995     42.18505    0.01851852 
+  75           53.24571     42.17869    0.01333333 
+  72           52.34795     42.17236    0.01388889 
+  61           51.66256     42.16605    0.01639344 
+  63           51.16237     42.15977    0.01587302 
+  52           50.82067     42.15352    0.01923077 
+  67           50.61759     42.14729    0.01492537 
+  56           50.55244     42.14108    0.01785714 
+  60           50.66867     42.1349     0.01666667 
+  67           51.12936     42.12874    0.01492537 
+  58           52.11617     42.12261    0.01724138 
+  53           53.62903     42.11651    0.01886792 
+  65           55.22306     42.11043    0.01538462 
+  48           55.85495     42.10438    0.02083333 
+  52           55.04367     42.09835    0.01923077 
+  57           53.73831     42.09235    0.01754386 
+  66           52.75191     42.08637    0.01515152 
+  62           52.19885     42.08042    0.01612903 
+  47           51.81348     42.0745     0.0212766 
+  68           51.55229     42.0686     0.01470588 
+  54           51.81644     42.06273    0.01851852 
+  58           53.08012     42.05689    0.01724138 
+  64           55.68009     42.05107    0.015625  
+  49           59.50882     42.04528    0.02040816 
+  64           63.40804     42.03952    0.015625  
+  64           64.88079     42.03378    0.015625  
+  63           62.91534     42.02807    0.01587302 
+  38           59.83778     42.02239    0.02631579 
+  66           57.57891     42.01674    0.01515152 
+  72           56.3904      42.01111    0.01388889 
+  52           55.90887     42.00551    0.01923077 
+  78           56.53188     41.99994    0.01282051 
+  54           59.14892     41.99439    0.01851852 
+  59           64.23144     41.98887    0.01694915 
+  72           71.0743      41.98338    0.01388889 
+  63           76.76529     41.97792    0.01587302 
+  58           76.84208     41.97249    0.01724138 
+  62           71.45016     41.96708    0.01612903 
+  63           65.35311     41.96171    0.01587302 
+  67           61.43573     41.95636    0.01492537 
+  48           59.90521     41.95104    0.02083333 
+  45           59.25068     41.94575    0.02222222 
+  71           57.69839     41.94049    0.01408451 
+  61           55.39482     41.93525    0.01639344 
+  61           53.36328     41.93005    0.01639344 
+  62           52.08916     41.92487    0.01612903 
+  67           51.67667     41.91972    0.01492537 
+  50           52.18851     41.91461    0.02      
+  65           53.82787     41.90952    0.01538462 
+  56           56.83826     41.90446    0.01785714 
+  60           61.07562     41.89943    0.01666667 
+  69           65.29314     41.89443    0.01449275 
+  56           66.80857     41.88946    0.01785714 
+  66           64.34295     41.88452    0.01515152 
+  58           60.20229     41.87961    0.01724138 
+  68           56.62707     41.87473    0.01470588 
+  51           54.25619     41.86988    0.01960784 
+  77           52.95226     41.86506    0.01298701 
+  58           52.42813     41.86027    0.01724138 
+  74           52.42868     41.85551    0.01351351 
+  85           52.82184     41.85079    0.01176471 
+  84           53.60754     41.84609    0.01190476 
+  64           54.93112     41.84142    0.015625  
+  90           57.12845     41.83679    0.01111111 
+  83           60.78082     41.83218    0.01204819 
+  120          66.6442      41.82761    0.00833333 
+  121          75.39306     41.82307    0.00826446 
+  154          87.01808     41.81856    0.00649351 
+  228          99.85297     41.81408    0.00438596 
+  304          109.64411    41.80963    0.00328947 
+  318          110.92744    41.80522    0.00314465 
+  328          102.61744    41.80083    0.00304878 
+  246          90.0813      41.79648    0.00406504 
+  203          78.36624     41.79216    0.00492611 
+  149          69.44005     41.78787    0.00671141 
+  138          63.4212      41.78362    0.00724638 
+  117          59.76909     41.7794     0.00854701 
+  105          57.82161     41.77521    0.00952381 
+  89           57.11414     41.77105    0.01123596 
+  95           57.50269     41.76692    0.01052632 
+  110          59.21153     41.76283    0.00909091 
+  101          62.73327     41.75877    0.00990099 
+  114          68.57246     41.75475    0.00877193 
+  111          76.6859      41.75075    0.00900901 
+  146          85.68182     41.74679    0.00684932 
+  176          93.0531      41.74287    0.00568182 
+  191          96.70114     41.73897    0.0052356 
+  190          94.50324     41.73511    0.00526316 
+  191          86.96434     41.73129    0.0052356 
+  172          78.11527     41.7275     0.00581395 
+  116          70.86661     41.72374    0.00862069 
+  98           65.69617     41.72002    0.01020408 
+  107          62.37007     41.71633    0.00934579 
+  95           60.71068     41.71267    0.01052632 
+  107          60.51786     41.70905    0.00934579 
+  76           61.74893     41.70547    0.01315789 
+  87           64.86197     41.70191    0.01149425 
+  97           71.32899     41.6984     0.01030928 
+  105          84.16899     41.69492    0.00952381 
+  115          107.71657    41.69147    0.00869565 
+  162          145.06389    41.68806    0.00617284 
+  174          193.09223    41.68468    0.00574713 
+  201          235.13397    41.68134    0.00497512 
+  202          241.06597    41.67804    0.0049505 
+  206          205.2146     41.67477    0.00485437 
+  172          157.15037    41.67153    0.00581395 
+  147          118.70217    41.66833    0.00680272 
+  127          95.40337     41.66517    0.00787402 
+  119          84.38636     41.66205    0.00840336 
+  99           80.1051      41.65896    0.01010101 
+  95           77.01986     41.6559     0.01052632 
+  87           72.58298     41.65289    0.01149425 
+  84           68.24493     41.6499     0.01190476 
+  93           65.8384      41.64696    0.01075269 
+  76           66.62252     41.64405    0.01315789 
+  87           72.08199     41.64118    0.01149425 
+  101          84.00825     41.63835    0.00990099 
+  116          103.24156    41.63555    0.00862069 
+  122          126.72458    41.6328     0.00819672 
+  129          143.32427    41.63008    0.00775194 
+  119          138.80682    41.62739    0.00840336 
+  123          117.61675    41.62475    0.00813008 
+  115          95.07692     41.62214    0.00869565 
+  95           78.96725     41.61957    0.01052632 
+  94           70.38645     41.61703    0.0106383 
+  96           67.65937     41.61454    0.01041667 
+  92           68.47591     41.61208    0.01086957 
+  61           71.10681     41.60967    0.01639344 
+  71           75.42154     41.60729    0.01408451 
+  77           81.47313     41.60495    0.01298701 
+  50           86.19375     41.60265    0.02      
+  51           84.20324     41.60038    0.01960784 
+  60           76.03218     41.59816    0.01666667 
+  74           67.09973     41.59597    0.01351351 
+  51           60.38705     41.59383    0.01960784 
+  58           56.31264     41.59172    0.01724138 
+  55           54.10981     41.58966    0.01818182 
+  55           52.8099      41.58763    0.01818182 
+  45           51.87111     41.58564    0.02222222 
+  51           51.2008      41.5837     0.01960784 
+  65           50.8176      41.58179    0.01538462 
+  53           50.77033     41.57992    0.01886792 
+  55           51.19744     41.5781     0.01818182 
+  52           52.38835     41.57631    0.01923077 
+  68           54.71001     41.57456    0.01470588 
+  54           58.3137      41.57286    0.01851852 
+  48           62.56115     41.57119    0.02083333 
+  50           65.2698      41.56957    0.02      
+  57           64.00291     41.56799    0.01754386 
+  61           59.93478     41.56645    0.01639344 
+  54           55.79323     41.56495    0.01851852 
+  51           52.81554     41.56349    0.01960784 
+  45           51.06591     41.56207    0.02222222 
+  48           50.12421     41.56069    0.02083333 
+  58           49.53096     41.55936    0.01724138 
+  51           49.07025     41.55807    0.01960784 
+  54           48.71142     41.55682    0.01851852 
+  59           48.40094     41.55561    0.01694915 
+  57           48.21914     41.55445    0.01754386 
+  53           48.09498     41.55332    0.01886792 
+  51           48.00868     41.55224    0.01960784 
+  43           47.94705     41.55121    0.02325581 
+  48           47.90262     41.55021    0.02083333 
+  45           47.87069     41.54926    0.02222222 
+  54           47.84757     41.54835    0.01851852 
+  52           47.83287     41.54749    0.01923077 
+  57           47.82354     41.54666    0.01754386 
+  58           47.82168     41.54589    0.01724138 
+  53           47.82716     41.54515    0.01886792 
+  54           47.83977     41.54446    0.01851852 
+  51           47.85927     41.54381    0.01960784 
+  49           47.86154     41.54321    0.02040816 
+  54           47.89544     41.54265    0.01851852 
+  55           47.93748     41.54214    0.01818182 
+  59           47.98851     41.54167    0.01694915 
+  52           48.05017     41.54124    0.01923077 
+  53           48.12463     41.54086    0.01886792 
+  66           48.21579     41.54053    0.01515152 
+  54           48.3308      41.54023    0.01851852 
+  35           48.48651     41.53999    0.02857143 
+  60           48.72185     41.53979    0.01666667 
+  52           49.11266     41.53963    0.01923077 
+  62           49.76916     41.53952    0.01612903 
+  45           50.77929     41.53946    0.02222222 
+  46           52.08921     41.53944    0.02173913 
+  59           53.30162     41.53947    0.01694915 
+  50           53.67763     41.53954    0.02      
+  61           53.1232      41.53966    0.01639344 
+  48           52.46401     41.53983    0.02083333 
+  44           52.32133     41.54004    0.02272727 
+  52           52.8279      41.5403     0.01923077 
+  50           53.68023     41.54061    0.02      
+  41           54.13859     41.54096    0.02439024 
+  56           53.68658     41.54136    0.01785714 
+  45           52.79208     41.54181    0.02222222 
+  58           52.0515      41.5423     0.01724138 
+  51           51.70215     41.54284    0.01960784 
+  66           51.79773     41.54343    0.01515152 
+  50           52.37416     41.54407    0.02      
+  60           53.49651     41.54475    0.01666667 
+  57           55.16408     41.54549    0.01754386 
+  71           57.08233     41.54627    0.01408451 
+  62           58.38862     41.5471     0.01612903 
+  77           58.23703     41.54798    0.01298701 
+  66           57.09394     41.5489     0.01515152 
+  63           56.02043     41.54988    0.01587302 
+  52           55.58841     41.5509     0.01923077 
+  50           55.90953     41.55198    0.02      
+  64           56.81321     41.5531     0.015625  
+  68           57.8963      41.55427    0.01470588 
+  45           58.75403     41.55549    0.02222222 
+  50           59.24123     41.55676    0.02      
+  46           59.14492     41.55808    0.02173913 
+  43           58.62201     41.55945    0.02325581 
+  58           58.21578     41.56087    0.01724138 
+  49           58.24923     41.56234    0.02040816 
+  48           58.80963     41.56386    0.02083333 
+  52           59.86897     41.56543    0.01923077 
+  61           61.31835     41.56706    0.01639344 
+  63           62.96767     41.56873    0.01587302 
+  56           64.91953     41.57045    0.01785714 
+  74           68.11691     41.57223    0.01351351 
+  70           73.87613     41.57405    0.01428571 
+  89           83.0852      41.57593    0.01123596 
+  69           95.14442     41.57786    0.01449275 
+  77           105.76357    41.57983    0.01298701 
+  83           107.23262    41.58187    0.01204819 
+  79           98.6597      41.58395    0.01265823 
+  69           87.40486     41.58609    0.01449275 
+  64           78.15097     41.58827    0.015625  
+  76           71.85816     41.59051    0.01315789 
+  50           68.11201     41.59281    0.02      
+  58           66.12391     41.59515    0.01724138 
+  53           65.1763      41.59755    0.01886792 
+  71           64.83289     41.6        0.01408451 
+  45           64.88616     41.6025     0.02222222 
+  56           65.29023     41.60506    0.01785714 
+  54           66.15597     41.60767    0.01851852 
+  62           67.78282     41.61033    0.01612903 
+  55           70.63358     41.61305    0.01818182 
+  66           75.12101     41.61582    0.01515152 
+  81           81.11118     41.61865    0.01234568 
+  72           86.85083     41.62153    0.01388889 
+  73           88.55477     41.62446    0.01369863 
+  62           84.83072     41.62745    0.01612903 
+  73           79.16959     41.63049    0.01369863 
+  56           74.43484     41.63359    0.01785714 
+  67           71.3732      41.63674    0.01492537 
+  58           69.72307     41.63995    0.01724138 
+  65           69.00141     41.64321    0.01538462 
+  64           68.79978     41.64653    0.015625  
+  66           68.88209     41.6499     0.01515152 
+  60           69.14522     41.65333    0.01666667 
+  74           69.57548     41.65682    0.01351351 
+  71           70.22802     41.66036    0.01408451 
+  74           71.2121      41.66396    0.01351351 
+  80           72.61799     41.66761    0.0125    
+  77           74.37793     41.67132    0.01298701 
+  65           76.02942     41.67509    0.01538462 
+  69           76.68548     41.67891    0.01449275 
+  84           76.14484     41.68279    0.01190476 
+  72           75.27763     41.68673    0.01388889 
+  72           74.75999     41.69072    0.01388889 
+  82           74.8292      41.69477    0.01219512 
+  90           75.50263     41.69888    0.01111111 
+  75           76.69771     41.70305    0.01333333 
+  83           78.23515     41.70727    0.01204819 
+  81           79.8347      41.71155    0.01234568 
+  78           81.58261     41.71589    0.01282051 
+  87           84.00733     41.72029    0.01149425 
+  83           86.98841     41.72475    0.01204819 
+  82           89.09766     41.72927    0.01219512 
+  69           88.84994     41.73384    0.01449275 
+  75           87.3572      41.73848    0.01333333 
+  89           86.58617     41.74317    0.01123596 
+  84           87.10712     41.74792    0.01190476 
+  78           87.99221     41.75273    0.01282051 
+  78           87.60355     41.7576     0.01282051 
+  66           85.6741      41.76253    0.01515152 
+  81           83.46567     41.76752    0.01234568 
+  66           81.87896     41.77257    0.01515152 
+  77           81.13101     41.77769    0.01298701 
+  76           81.11617     41.78286    0.01315789 
+  68           81.63607     41.78809    0.01470588 
+  75           82.50269     41.79338    0.01333333 
+  67           83.70009     41.79873    0.01492537 
+  73           85.52226     41.80415    0.01369863 
+  66           88.0071      41.80962    0.01515152 
+  74           90.26052     41.81516    0.01351351 
+  63           90.64637     41.82076    0.01587302 
+  77           89.17641     41.82642    0.01298701 
+  68           87.6579      41.83214    0.01470588 
+  64           87.07125     41.83793    0.015625  
+  62           87.0412      41.84377    0.01612903 
+  63           86.49458     41.84968    0.01587302 
+  79           85.08496     41.85565    0.01265823 
+  62           83.51684     41.86168    0.01612903 
+  76           82.47417     41.86778    0.01315789 
+  70           82.19514     41.87394    0.01428571 
+  92           82.71623     41.88016    0.01086957 
+  88           84.10403     41.88645    0.01136364 
+  65           86.65829     41.8928     0.01538462 
+  90           91.05522     41.89921    0.01111111 
+  84           98.42242     41.90569    0.01190476 
+  107          110.24503    41.91223    0.00934579 
+  112          127.86182    41.91883    0.00892857 
+  144          151.59359    41.9255     0.00694444 
+  133          179.11351    41.93224    0.0075188 
+  147          202.64817    41.93903    0.00680272 
+  156          208.68267    41.9459     0.00641026 
+  161          192.14878    41.95283    0.00621118 
+  131          164.07455    41.95982    0.00763359 
+  108          136.46554    41.96688    0.00925926 
+  86           114.56569    41.974      0.01162791 
+  101          99.09351     41.98119    0.00990099 
+  76           88.99772     41.98845    0.01315789 
+  88           82.75612     41.99577    0.01136364 
+  75           79.05947     42.00316    0.01333333 
+  86           77.10362     42.01061    0.01162791 
+  75           76.58718     42.01813    0.01333333 
+  70           77.65427     42.02572    0.01428571 
+  69           80.8014      42.03337    0.01449275 
+  87           86.70894     42.0411     0.01149425 
+  98           95.90507     42.04888    0.01020408 
+  91           108.16597    42.05674    0.01098901 
+  103          121.12877    42.06466    0.00970874 
+  91           128.89635    42.07265    0.01098901 
+  106          125.53023    42.08071    0.00943396 
+  90           113.05368    42.08884    0.01111111 
+  86           98.37428     42.09704    0.01162791 
+  85           85.71955     42.1053     0.01176471 
+  64           76.26342     42.11363    0.015625  
+  71           69.74074     42.12203    0.01408451 
+  59           65.44181     42.1305     0.01694915 
+  58           62.62424     42.13904    0.01724138 
+  60           60.73859     42.14765    0.01666667 
+  63           59.44372     42.15633    0.01587302 
+  62           58.5407      42.16508    0.01612903 
+  44           57.88434     42.1739     0.02272727 
+  44           57.29378     42.18278    0.02272727 
+  48           56.61118     42.19174    0.02083333 
+  56           55.88639     42.20077    0.01785714 
+  48           55.25276     42.20987    0.02083333 
+  54           54.78008     42.21904    0.01851852 
+  59           54.50999     42.22828    0.01694915 
+  59           54.49754     42.23759    0.01694915 
+  46           54.81063     42.24697    0.02173913 
+  54           55.45872     42.25643    0.01851852 
+  46           56.25742     42.26595    0.02173913 
+  57           56.65086     42.27555    0.01754386 
+  65           56.09115     42.28522    0.01538462 
+  69           54.92349     42.29496    0.01449275 
+  66           53.78735     42.30477    0.01515152 
+  49           52.96107     42.31466    0.02040816 
+  65           52.46385     42.32462    0.01538462 
+  53           52.20782     42.33465    0.01886792 
+  51           52.07028     42.34476    0.01960784 
+  40           51.92236     42.35493    0.025     
+  39           51.70614     42.36519    0.02564103 
+  64           51.47738     42.37551    0.015625  
+  55           51.29611     42.38591    0.01818182 
+  52           51.19511     42.39638    0.01923077 
+  58           51.2088      42.40693    0.01724138 
+  49           51.39567     42.41755    0.02040816 
+  60           51.82405     42.42825    0.01666667 
+  46           52.51041     42.43902    0.02173913 
+  62           53.29641     42.44986    0.01612903 
+  55           53.73747     42.46079    0.01818182 
+  54           53.42939     42.47178    0.01851852 
+  61           52.55927     42.48285    0.01639344 
+  53           51.62417     42.494      0.01886792 
+  60           50.90873     42.50522    0.01666667 
+  53           50.45956     42.51652    0.01886792 
+  45           50.22459     42.5279     0.02222222 
+  50           50.13274     42.53935    0.02      
+  61           50.12184     42.55087    0.01639344 
+  58           50.12371     42.56248    0.01724138 
+  54           50.06859     42.57416    0.01851852 
+  50           49.96998     42.58592    0.02      
+  46           49.91348     42.59776    0.02173913 
+  55           49.98276     42.60967    0.01818182 
+  50           50.26023     42.62166    0.02      
+  40           50.81202     42.63373    0.025     
+  53           51.61604     42.64588    0.01886792 
+  47           52.43352     42.6581     0.0212766 
+  47           52.73009     42.6704     0.0212766 
+  44           52.22563     42.68279    0.02272727 
+  53           51.34244     42.69525    0.01886792 
+  48           50.5645      42.70779    0.02083333 
+  55           50.0856      42.72041    0.01818182 
+  52           49.90794     42.73311    0.01923077 
+  45           49.94662     42.74589    0.02222222 
+  37           50.05914     42.75874    0.02702703 
+  37           50.07018     42.77168    0.02702703 
+  49           49.92418     42.7847     0.02040816 
+  50           49.70962     42.7978     0.02      
+  46           49.52325     42.81098    0.02173913 
+  57           49.4239      42.82424    0.01754386 
+  62           49.43673     42.83758    0.01612903 
+  59           49.57603     42.851      0.01694915 
+  45           49.8472      42.8645     0.02222222 
+  49           50.21211     42.87809    0.02040816 
+  63           50.53042     42.89175    0.01587302 
+  51           50.5714      42.9055     0.01960784 
+  52           50.32368     42.91933    0.01923077 
+  54           50.01655     42.93325    0.01851852 
+  44           49.79931     42.94724    0.02272727 
+  61           49.71151     42.96132    0.01639344 
+  47           49.73705     42.97548    0.0212766 
+  64           49.83301     42.98972    0.015625  
+  44           49.93265     43.00405    0.02272727 
+  51           49.96247     43.01846    0.01960784 
+  57           49.92669     43.03296    0.01754386 
+  57           49.88524     43.04753    0.01754386 
+  47           49.87108     43.0622     0.0212766 
+  55           49.88938     43.07694    0.01818182 
+  53           49.93326     43.09177    0.01886792 
+  66           49.99422     43.10669    0.01515152 
+  44           50.06684     43.12169    0.02272727 
+  48           50.15061     43.13678    0.02083333 
+  57           50.25005     43.15195    0.01754386 
+  54           50.37807     43.1672     0.01851852 
+  47           50.55287     43.18255    0.0212766 
+  49           50.79061     43.19797    0.02040816 
+  47           51.08382     43.21349    0.0212766 
+  43           51.36764     43.22909    0.02325581 
+  55           51.5058      43.24477    0.01818182 
+  46           51.44993     43.26055    0.02173913 
+  59           51.32464     43.27641    0.01694915 
+  46           51.23413     43.29236    0.02173913 
+  40           51.20794     43.30839    0.025     
+  54           51.23809     43.32451    0.01851852 
+  54           51.3073      43.34072    0.01851852 
+  38           51.40426     43.35702    0.02631579 
+  48           51.52887     43.37341    0.02083333 
+  56           51.68946     43.38988    0.01785714 
+  51           51.89258     43.40644    0.01960784 
+  47           52.12815     43.42309    0.0212766 
+  51           52.34626     43.43983    0.01960784 
+  62           52.47034     43.45666    0.01612903 
+  39           52.51323     43.47358    0.02564103 
+  59           52.56747     43.49059    0.01694915 
+  64           52.68009     43.50769    0.015625  
+  44           52.82862     43.52488    0.02272727 
+  33           52.93781     43.54215    0.03030303 
+  61           52.97721     43.55952    0.01639344 
+  61           53.00613     43.57698    0.01639344 
+  48           53.07722     43.59453    0.02083333 
+  47           53.20741     43.61217    0.0212766 
+  33           53.3877      43.6299     0.03030303 
+  68           53.58739     43.64773    0.01470588 
+  62           53.7656      43.66564    0.01612903 
+  49           53.90878     43.68365    0.02040816 
+  54           54.05433     43.70175    0.01851852 
+  62           54.24082     43.71994    0.01612903 
+  44           54.4755      43.73822    0.02272727 
+  58           54.73315     43.7566     0.01724138 
+  49           54.96914     43.77507    0.02040816 
+  54           55.18265     43.79363    0.01851852 
+  48           55.41858     43.81229    0.02083333 
+  45           55.71025     43.83104    0.02222222 
+  37           56.07377     43.84988    0.02702703 
+  56           56.52215     43.86882    0.01785714 
+  53           57.07415     43.88785    0.01886792 
+  52           57.76482     43.90697    0.01923077 
+  71           58.65914     43.92619    0.01408451 
+  65           59.86401     43.94551    0.01538462 
+  72           61.54617     43.96492    0.01388889 
+  60           63.92638     43.98442    0.01666667 
+  55           67.26654     44.00402    0.01818182 
+  73           71.80479     44.02372    0.01369863 
+  60           77.73042     44.04351    0.01666667 
+  58           85.26342     44.0634     0.01724138 
+  72           94.39451     44.08338    0.01388889 
+  80           103.87907    44.10346    0.0125    
+  84           110.54832    44.12364    0.01190476 
+  78           110.79821    44.14392    0.01282051 
+  70           104.41089    44.16429    0.01428571 
+  70           94.81982     44.18476    0.01428571 
+  69           85.35991     44.20532    0.01449275 
+  58           77.53174     44.22599    0.01724138 
+  61           71.64815     44.24675    0.01639344 
+  62           67.50344     44.26761    0.01612903 
+  59           64.76725     44.28857    0.01694915 
+  57           63.11722     44.30963    0.01754386 
+  72           62.33406     44.33079    0.01388889 
+  49           62.3143      44.35204    0.02040816 
+  64           63.05665     44.3734     0.015625  
+  59           64.61878     44.39485    0.01694915 
+  63           67.06237     44.41641    0.01587302 
+  66           70.53356     44.43806    0.01515152 
+  72           75.19466     44.45982    0.01388889 
+  71           80.80921     44.48168    0.01408451 
+  57           86.20493     44.50363    0.01754386 
+  85           89.52204     44.52569    0.01176471 
+  81           89.63378     44.54785    0.01234568 
+  93           86.50438     44.57011    0.01075269 
+  76           80.63972     44.59247    0.01315789 
+  79           73.58798     44.61493    0.01265823 
+  67           67.24408     44.6375     0.01492537 
+  70           62.50171     44.66017    0.01428571 
+  64           59.3587      44.68294    0.015625  
+  60           57.48125     44.70581    0.01666667 
+  78           56.52624     44.72879    0.01282051 
+  69           56.25605     44.75187    0.01449275 
+  56           56.46872     44.77505    0.01785714 
+  56           56.81874     44.79833    0.01785714 
+  77           56.7232      44.82172    0.01298701 
+  59           55.97315     44.84522    0.01694915 
+  86           55.11535     44.86882    0.01162791 
+  71           54.69195     44.89252    0.01408451 
+  68           54.97988     44.91633    0.01470588 
+  75           56.04449     44.94024    0.01333333 
+  72           57.63816     44.96426    0.01388889 
+  59           58.99892     44.98838    0.01694915 
+  70           59.14254     45.01261    0.01428571 
+  81           57.85211     45.03695    0.01234568 
+  75           55.94891     45.06139    0.01333333 
+  53           54.29366     45.08593    0.01886792 
+  82           53.19998     45.11059    0.01219512 
+  68           52.64623     45.13535    0.01470588 
+  62           52.5156      45.16022    0.01612903 
+  68           52.7136      45.18519    0.01470588 
+  61           53.17867     45.21028    0.01639344 
+  63           53.82776     45.23547    0.01587302 
+  55           54.49394     45.26077    0.01818182 
+  54           55.13632     45.28617    0.01851852 
+  64           56.17121     45.31169    0.015625  
+  70           58.07242     45.33731    0.01428571 
+  70           60.83701     45.36305    0.01428571 
+  64           63.61705     45.38889    0.015625  
+  64           64.73686     45.41484    0.015625  
+  75           63.46789     45.4409     0.01333333 
+  64           61.17893     45.46707    0.015625  
+  63           59.22825     45.49335    0.01587302 
+  55           58.07195     45.51975    0.01818182 
+  54           57.80513     45.54625    0.01851852 
+  68           58.39019     45.57286    0.01470588 
+  61           59.87856     45.59959    0.01639344 
+  65           62.6288      45.62642    0.01538462 
+  59           67.41727     45.65337    0.01694915 
+  74           75.35952     45.68043    0.01351351 
+  72           87.40125     45.7076     0.01388889 
+  103          103.37803    45.73488    0.00970874 
+  109          120.48256    45.76228    0.00917431 
+  123          134.46637    45.78979    0.00813008 
+  128          143.21901    45.81741    0.0078125 
+  116          143.33805    45.84514    0.00862069 
+  145          132.83151    45.87299    0.00689655 
+  113          116.65586    45.90095    0.00884956 
+  108          100.47422    45.92903    0.00925926 
+  93           87.21426     45.95722    0.01075269 
+  91           77.93451     45.98552    0.01098901 
+  106          72.50961     46.01394    0.00943396 
+  85           70.43211     46.04247    0.01176471 
+  76           71.45675     46.07112    0.01315789 
+  87           75.29266     46.09989    0.01149425 
+  91           80.79012     46.12877    0.01098901 
+  103          85.13538     46.15776    0.00970874 
+  103          86.09237     46.18688    0.00970874 
+  90           85.90569     46.21611    0.01111111 
+  87           87.4304      46.24545    0.01149425 
+  94           91.25338     46.27491    0.0106383 
+  95           95.76318     46.30449    0.01052632 
+  103          99.097       46.33419    0.00970874 
+  105          99.65304     46.364      0.00952381 
+  84           95.25196     46.39393    0.01190476 
+  85           86.83467     46.42398    0.01176471 
+  79           77.87956     46.45415    0.01265823 
+  65           70.53187     46.48444    0.01538462 
+  74           65.31031     46.51485    0.01351351 
+  68           62.01861     46.54537    0.01470588 
+  74           60.32225     46.57602    0.01351351 
+  57           60.02897     46.60678    0.01754386 
+  68           61.08624     46.63766    0.01470588 
+  76           63.19471     46.66867    0.01315789 
+  93           65.2824      46.69979    0.01075269 
+  77           65.51512     46.73104    0.01298701 
+  69           63.54708     46.7624     0.01449275 
+  67           60.83876     46.79389    0.01492537 
+  69           58.39535     46.8255     0.01449275 
+  73           56.66827     46.85723    0.01369863 
+  72           55.69819     46.88908    0.01388889 
+  59           55.3201      46.92105    0.01694915 
+  69           55.33294     46.95315    0.01449275 
+  61           55.49744     46.98537    0.01639344 
+  79           55.73927     47.01771    0.01265823 
+  62           56.18434     47.05017    0.01612903 
+  60           56.68309     47.08276    0.01666667 
+  65           56.70288     47.11547    0.01538462 
+  77           56.07122     47.14831    0.01298701 
+  89           55.28423     47.18127    0.01123596 
+  59           54.74054     47.21435    0.01694915 
+  74           54.55383     47.24756    0.01351351 
+  67           54.70532     47.2809     0.01492537 
+  74           55.13152     47.31435    0.01351351 
+  66           55.84204     47.34794    0.01515152 
+  58           57.0308      47.38165    0.01724138 
+  79           59.16757     47.41548    0.01265823 
+  72           63.10838     47.44945    0.01388889 
+  86           70.00024     47.48354    0.01162791 
+  94           80.74698     47.51775    0.0106383 
+  93           94.74487     47.55209    0.01075269 
+  91           107.9177     47.58656    0.01098901 
+  79           113.25252    47.62116    0.01265823 
+  94           109.97934    47.65588    0.0106383 
+  87           104.46562    47.69074    0.01149425 
+  84           98.4869      47.72572    0.01190476 
+  87           89.61846     47.76083    0.01149425 
+  61           79.35906     47.79607    0.01639344 
+  67           70.83613     47.83143    0.01492537 
+  80           64.90018     47.86693    0.0125    
+  79           61.12378     47.90256    0.01265823 
+  85           58.91507     47.93831    0.01176471 
+  65           57.75414     47.9742     0.01538462 
+  98           57.29634     48.01022    0.01020408 
+  77           57.44383     48.04636    0.01298701 
+  74           58.36231     48.08264    0.01351351 
+  89           60.49552     48.11905    0.01123596 
+  66           64.43217     48.15559    0.01515152 
+  68           70.50204     48.19227    0.01470588 
+  78           77.98872     48.22907    0.01282051 
+  72           84.11067     48.26601    0.01388889 
+  88           85.47022     48.30308    0.01136364 
+  79           83.1018      48.34028    0.01265823 
+  70           80.19301     48.37761    0.01428571 
+  66           76.7148      48.41508    0.01515152 
+  74           71.62888     48.45269    0.01351351 
+  76           66.33484     48.49042    0.01315789 
+  55           62.18738     48.52829    0.01818182 
+#--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--#
+
+
+# start Validation Reply Form
+_vrf_PLAT741_QPAPBMXHandGrindSamplePrep_phase_1 # for all atoms in 1_quartz
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT741_QPAPBMXHandGrindSamplePrep_phase_3 # for all atoms in 3_pyrrhotite
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT741_QPAPBMXHandGrindSamplePrep_phase_4 # for all atoms in 4_rutile
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT741_QPAPBMXHandGrindSamplePrep_phase_2 # for all atoms in 2_albite
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT155_QPAPBMXHandGrindSamplePrep_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT141_QPAPBMXHandGrindSamplePrep_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT142_QPAPBMXHandGrindSamplePrep_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT143_QPAPBMXHandGrindSamplePrep_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT144_QPAPBMXHandGrindSamplePrep_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT145_QPAPBMXHandGrindSamplePrep_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT146_QPAPBMXHandGrindSamplePrep_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT151_QPAPBMXHandGrindSamplePrep_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT148_QPAPBMXHandGrindSamplePrep_phase_3 # for 3_pyrrhotite
+;
+PROBLEM: s.u. on the a-Axis and c-Axis is (Too) Large 
+RESPONSE: untreated sample, s.u. expected to be high
+;
+# end Validation Reply Form

--- a/data/hamish/vb5042sup3.cif
+++ b/data/hamish/vb5042sup3.cif
@@ -1,0 +1,6630 @@
+
+data_QPABAT3_publ
+_audit_creation_method  "created in GSAS-II"
+_audit_creation_date  2021-08-04T17:27
+_audit_author_name  "McDougall, Hamish"
+_audit_update_record
+   "2021-08-04T17:27  Initial software-generated CIF"
+_pd_block_id  2021-08-04T17:27|QPABAT3|McDougallHamish|Overall
+# GSAS-II edited template follows Publication_Template
+#=============================================================================
+# this information describes the project, paper etc. for the CIF             #
+# Acta Cryst. Section C papers and editorial correspondence is generated     #
+# from the information in this section                                       #
+#                                                                            #
+#   (from)   CIF submission form for Rietveld refinements (Acta Cryst. C)    #
+#                                                 Version 14 December 1998   #
+#=============================================================================
+# 1. SUBMISSION DETAILS
+
+_publ_contact_author_name            "Suzanne Neville; Vanessa Peterson; Christophe Didier"   # Name of author for correspondence
+_publ_contact_author_address             # Address of author for correspondence
+; ?
+;
+_publ_contact_author_email           "s.neville@unsw.edu.au; vanessa.peterson@ansto.gov.au; drchristophedidier@gmail.com"
+_publ_contact_author_fax             ?
+_publ_contact_author_phone           ?
+
+_publ_contact_letter
+; ?
+;
+   
+_publ_requested_journal              ?
+_publ_requested_coeditor_name        ?
+_publ_requested_category             ?   # Acta C: one of CI/CM/CO/FI/FM/FO
+
+#==============================================================================
+
+# 2. PROCESSING SUMMARY (IUCr Office Use Only)
+
+_journal_data_validation_number      ?
+
+_journal_date_recd_electronic        ?
+_journal_date_to_coeditor            ?
+_journal_date_from_coeditor          ?
+_journal_date_accepted               ?
+_journal_date_printers_first         ?
+_journal_date_printers_final         ?
+_journal_date_proofs_out             ?
+_journal_date_proofs_in              ?
+_journal_coeditor_name               ?
+_journal_coeditor_code               ?
+_journal_coeditor_notes
+; ?
+;
+_journal_techeditor_code             ?
+_journal_techeditor_notes
+; ?
+;
+_journal_coden_ASTM                  ?
+_journal_name_full                   ?
+_journal_year                        ?
+_journal_volume                      ?
+_journal_issue                       ?
+_journal_page_first                  ?
+_journal_page_last                   ?
+_journal_paper_category              ?
+_journal_suppl_publ_number           ?
+_journal_suppl_publ_pages            ?
+
+#==============================================================================
+
+# 3. TITLE AND AUTHOR LIST
+
+_publ_section_title
+; ?
+;
+_publ_section_title_footnote
+; ?
+;         
+ 
+# The loop structure below should contain the names and addresses of all 
+# authors, in the required order of publication. Repeat as necessary.
+
+loop_
+	_publ_author_name
+        _publ_author_footnote
+	_publ_author_address
+ ?                                   #<--'Last name, first name' 
+; ?
+;
+; ?
+;
+
+#==============================================================================
+
+# 4. TEXT
+
+_publ_section_synopsis
+;  ?
+;
+_publ_section_abstract                         
+; ?
+;          
+_publ_section_comment                          
+; ?
+;
+_publ_section_exptl_prep      # Details of the preparation of the sample(s)
+                              # should be given here. 
+; ?
+;
+_publ_section_exptl_refinement                  
+; ?
+;
+_publ_section_references
+; ?
+;
+_publ_section_figure_captions
+; ?
+;
+_publ_section_acknowledgements
+; ?
+;
+
+#=============================================================================
+# 5. OVERALL REFINEMENT & COMPUTING DETAILS
+
+_refine_special_details
+; ?
+;
+_pd_proc_ls_special_details
+; ?
+;
+
+# The following items are used to identify the programs used.
+_computing_molecular_graphics     ?
+_computing_publication_material   ?
+
+_refine_ls_weighting_scheme       ?        
+_refine_ls_weighting_details      ?
+_refine_ls_hydrogen_treatment     ?        
+_refine_ls_extinction_method      ?        
+_refine_ls_extinction_coef        ?         
+_refine_ls_number_constraints     ?        
+
+_refine_ls_restrained_S_all       ?        
+_refine_ls_restrained_S_obs       ?
+
+#==============================================================================
+# 6. SAMPLE PREPARATION DATA
+
+# (In the unusual case where multiple samples are used in a single
+#  Rietveld study, this information should be moved into the phase
+#  blocks)
+
+# The following three fields describe the preparation of the material.
+# The cooling rate is in K/min.  The pressure at which the sample was  
+# prepared is in kPa.  The temperature of preparation is in K.
+               
+_pd_prep_cool_rate                N/A        
+_pd_prep_pressure                 101.3        
+_pd_prep_temperature              298         
+
+_pd_char_colour                   ?       # use ICDD colour descriptions
+
+data_QPABAT3_overall
+_pd_proc_info_datetime  2021-08-04T17:27
+_pd_calc_method  "Rietveld Refinement"
+_computing_structure_refinement
+   "GSAS-II (Toby & Von Dreele, J. Appl. Cryst. 46, 544-549, 2013)"
+_refine_ls_number_parameters  31
+_refine_ls_goodness_of_fit_all  1.948
+_refine_ls_shift/su_max  0.0409
+
+# OVERALL WEIGHTED R-FACTOR
+_refine_ls_wR_factor_obs  0.07869
+_refine_ls_matrix_type  full
+# POINTERS TO PHASE AND HISTOGRAM BLOCKS
+loop_   _pd_phase_block_id
+  2021-08-04T17:27|QPABAT3|phase_2|McDougallHamish
+  2021-08-04T17:27|QPABAT3|phase_0|McDougallHamish
+  2021-08-04T17:27|QPABAT3|phase_3|McDougallHamish
+  2021-08-04T17:27|QPABAT3|phase_4|McDougallHamish
+  2021-08-04T17:27|QPABAT3|phase_1|McDougallHamish
+_pd_block_diffractogram_id
+;
+2021-08-04T17:27|QPABAT3|McDougallHamish|PANalytical,Co-EmpyreanII_hist_0
+;
+
+data_QPABAT3_phase_2
+# Information for phase 2
+_pd_block_id  2021-08-04T17:27|QPABAT3|phase_2|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Albite NaAlSi3O8 follows
+_pd_phase_name  "Albite NaAlSi3O8"
+_cell_length_a  8.137
+_cell_length_b  12.785
+_cell_length_c  7.1583
+_cell_angle_alpha  94.26
+_cell_angle_beta   116.6
+_cell_angle_gamma  87.71
+_cell_volume  664.008
+_exptl_crystal_density_diffrn  2.6230
+_symmetry_cell_setting  triclinic
+_symmetry_space_group_name_H-M  "C -1"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -x,-y,-z
+     3  1/2+x,1/2+y,z
+     4  1/2-x,1/2-y,-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Al1    Al3+ 0.00887     0.16846     0.20805     1.000      Uani 0.007      4   
+Si1    Si4+ 0.00375     0.82051     0.23737     1.000      Uani 0.006      4   
+Si2    Si4+ 0.69162     0.11021     0.31466     1.000      Uani 0.006      4   
+Si3    Si4+ 0.68129     0.88190     0.36076     1.000      Uani 0.006      4   
+Na1    Na1+ 0.26799     0.98865     0.14650     1.000      Uani 0.031      4   
+O1     O2-  0.00490     0.13103     0.96660     1.000      Uani 0.012      4   
+O2     O2-  0.59176     0.99756     0.28040     1.000      Uani 0.008      4   
+O3     O2-  0.81230     0.10966     0.19010     1.000      Uani 0.014      4   
+O4     O2-  0.82000     0.85101     0.25870     1.000      Uani 0.018      4   
+O5     O2-  0.01288     0.30238     0.27060     1.000      Uani 0.011      4   
+O6     O2-  0.02329     0.69368     0.22910     1.000      Uani 0.011      4   
+O7     O2-  0.20780     0.10896     0.38900     1.000      Uani 0.011      4   
+O8     O2-  0.18400     0.86817     0.43620     1.000      Uani 0.012      4   
+
+loop_
+   _atom_site_aniso_label
+   _atom_site_aniso_U_11
+   _atom_site_aniso_U_22
+   _atom_site_aniso_U_33
+   _atom_site_aniso_U_12
+   _atom_site_aniso_U_13
+   _atom_site_aniso_U_23
+Al1    0.0074      0.0068      0.0061      -0.0009     0.0031      0.0004      
+Si1    0.0068      0.0065      0.0055      0.0011      0.0030      0.0008      
+Si2    0.0061      0.0055      0.0073      -0.0002     0.0025      0.0004      
+Si3    0.0060      0.0055      0.0074      0.0006      0.0028      0.0009      
+Na1    0.0136      0.0471      0.0315      -0.0050     0.0084      -0.0219     
+O1     0.0164      0.0122      0.0074      -0.0002     0.0067      0.0014      
+O2     0.0074      0.0056      0.0119      0.0003      0.0033      0.0020      
+O3     0.0117      0.0130      0.0162      -0.0040     0.0093      -0.0017     
+O4     0.0134      0.0179      0.0216      0.0046      0.0129      0.0020      
+O5     0.0103      0.0076      0.0150      -0.0020     0.0052      -0.0009     
+O6     0.0101      0.0071      0.0145      0.0022      0.0034      0.0012      
+O7     0.0120      0.0129      0.0080      0.0024      0.0013      0.0015      
+O8     0.0140      0.0140      0.0084      -0.0026     -0.0002     -0.0006     
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Al   4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Na   4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  O    32     ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si   12     ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Al Na O8 Si3"
+_chemical_formula_weight  262.22
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Al1    O1     1.74519      1_555    1_554 yes
+  Al1    O3     1.7429       1_555    1_455 yes
+  Al1    O5     1.73509      1_555    1_555 yes
+  Al1    O7     1.74556      1_555    1_555 yes
+  Si1    O1     1.59985      1_555    2_566 yes
+  Si1    O4     1.59997      1_555    1_455 yes
+  Si1    O6     1.62225      1_555    1_555 yes
+  Si1    O8     1.61907      1_555    1_555 yes
+  Si2    O2     1.63011      1_555    1_545 yes
+  Si2    O3     1.59435      1_555    1_555 yes
+  Si2    O6     1.61836      1_555    3_545 yes
+  Si2    O8     1.6168       1_555    2_666 yes
+  Si3    O2     1.64718      1_555    1_555 yes
+  Si3    O4     1.61975      1_555    1_555 yes
+  Si3    O5     1.59682      1_555    3_555 yes
+  Si3    O7     1.60203      1_555    2_666 yes
+  Na1    O1     2.66887      1_555    1_564 yes
+  Na1    O1     2.53079      1_555    2_566 yes
+  Na1    O2     2.3704       1_555    1_555 yes
+  Na1    O3     2.45321      1_555    2_665 yes
+  Na1    O7     2.43384      1_555    1_565 yes
+  O1     Al1    1.74519      1_555    1_556 yes
+  O1     Si1    1.59985      1_555    2_566 yes
+  O1     Na1    2.66887      1_555    1_546 yes
+  O1     Na1    2.53079      1_555    2_566 yes
+  O2     Si2    1.63011      1_555    1_565 yes
+  O2     Si3    1.64718      1_555    1_555 yes
+  O2     Na1    2.3704       1_555    1_555 yes
+  O3     Al1    1.7429       1_555    1_655 yes
+  O3     Si2    1.59435      1_555    1_555 yes
+  O3     Na1    2.45321      1_555    2_665 yes
+  O4     Si1    1.59997      1_555    1_655 yes
+  O4     Si3    1.61975      1_555    1_555 yes
+  O5     Al1    1.73509      1_555    1_555 yes
+  O5     Si3    1.59682      1_555    3_445 yes
+  O6     Si1    1.62225      1_555    1_555 yes
+  O6     Si2    1.61836      1_555    3_455 yes
+  O7     Al1    1.74556      1_555    1_555 yes
+  O7     Si3    1.60203      1_555    2_666 yes
+  O7     Na1    2.43384      1_555    1_545 yes
+  O8     Si1    1.61907      1_555    1_555 yes
+  O8     Si2    1.6168       1_555    2_666 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Al1    O3     102.836       1_554  1_555    1_455 yes
+  O1     Al1    O5     116.047       1_554  1_555    1_555 yes
+  O3     Al1    O5     112.215       1_455  1_555    1_555 yes
+  O1     Al1    O7     104.004       1_554  1_555    1_555 yes
+  O3     Al1    O7     111.151       1_455  1_555    1_555 yes
+  O5     Al1    O7     110.14        1_555  1_555    1_555 yes
+  O1     Si1    O4     109.433       2_566  1_555    1_455 yes
+  O1     Si1    O6     112.47        2_566  1_555    1_555 yes
+  O4     Si1    O6     108.187       1_455  1_555    1_555 yes
+  O1     Si1    O8     107.176       2_566  1_555    1_555 yes
+  O4     Si1    O8     111.446       1_455  1_555    1_555 yes
+  O6     Si1    O8     108.16        1_555  1_555    1_555 yes
+  O2     Si2    O3     111.144       1_545  1_555    1_555 yes
+  O2     Si2    O6     104.24        1_545  1_555    3_545 yes
+  O3     Si2    O6     112.114       1_555  1_555    3_545 yes
+  O2     Si2    O8     106.97        1_545  1_555    2_666 yes
+  O3     Si2    O8     111.591       1_555  1_555    2_666 yes
+  O6     Si2    O8     110.422       3_545  1_555    2_666 yes
+  O2     Si3    O4     107.269       1_555  1_555    1_555 yes
+  O2     Si3    O5     105.914       1_555  1_555    3_555 yes
+  O4     Si3    O5     110.224       1_555  1_555    3_555 yes
+  O2     Si3    O7     108.565       1_555  1_555    2_666 yes
+  O4     Si3    O7     110.208       1_555  1_555    2_666 yes
+  O5     Si3    O7     114.328       3_555  1_555    2_666 yes
+  Al1    O1     Si1    141.397       1_556  1_555    2_566 yes
+  Si2    O2     Si3    130.019       1_565  1_555    1_555 yes
+  Si2    O2     Na1    120.351       1_565  1_555    1_555 yes
+  Si3    O2     Na1    108.811       1_555  1_555    1_555 yes
+  Al1    O3     Si2    139.461       1_655  1_555    1_555 yes
+  Si1    O4     Si3    161.151       1_655  1_555    1_555 yes
+  Al1    O5     Si3    129.689       1_555  1_555    3_445 yes
+  Si1    O6     Si2    135.676       1_555  1_555    3_455 yes
+  Al1    O7     Si3    133.943       1_555  1_555    2_666 yes
+  Si1    O8     Si2    151.747       1_555  1_555    2_666 yes
+_pd_proc_ls_pref_orient_corr  none
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.111(8), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_QPABAT3_phase_0
+# Information for phase 0
+_pd_block_id  2021-08-04T17:27|QPABAT3|phase_0|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Pyrite FeS2 follows
+_pd_phase_name  "Pyrite FeS2"
+_cell_length_a  5.419411(25)
+_cell_length_b  5.419411(25)
+_cell_length_c  5.419411(25)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  90
+_cell_volume  159.1682(22)
+_exptl_crystal_density_diffrn  5.0063
+_symmetry_cell_setting  cubic
+_symmetry_space_group_name_H-M  "P a -3"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  z,x,y
+     3  y,z,x
+     4  1/2+x,y,1/2-z
+     5  1/2-z,1/2+x,y
+     6  y,1/2-z,1/2+x
+     7  -z,1/2+x,1/2-y
+     8  1/2-y,-z,1/2+x
+     9  1/2+y,1/2-z,-x
+    10  -x,1/2+y,1/2-z
+    11  1/2-z,-x,1/2+y
+    12  1/2+x,1/2-y,-z
+    13  -x,-y,-z
+    14  -z,-x,-y
+    15  -y,-z,-x
+    16  1/2-x,-y,1/2+z
+    17  1/2+z,1/2-x,-y
+    18  -y,1/2+z,1/2-x
+    19  z,1/2-x,1/2+y
+    20  1/2+y,z,1/2-x
+    21  1/2-y,1/2+z,x
+    22  x,1/2-y,1/2+z
+    23  1/2+z,x,1/2-y
+    24  1/2-x,1/2+y,z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Fe1    Fe   0.00000     0.00000     0.00000     1.000      Uiso 0.00508(25) 4   
+S2     S    0.38468(9)  0.38468     0.38468     1.000      Uiso 0.00584(27) 8   
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Fe   4      11.7695    7.3573     3.5222     2.3045     4.7611     0.3072     15.3535    76.8805    1.0369     0.945
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S    8      6.9053     5.2034     1.4379     1.5863     1.4679     22.2151    0.2536     56.172     0.8669     0.2847
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Fe S2"
+_chemical_formula_weight  119.97
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Fe1    S2     2.26435(13)   1_555    4_455 yes
+  Fe1    S2     2.26435(13)   1_555    5_545 yes
+  Fe1    S2     2.26435(13)   1_555    6_554 yes
+  Fe1    S2     2.26435(13)   1_555    7_545 yes
+  Fe1    S2     2.26435(13)   1_555    8_554 yes
+  Fe1    S2     2.2644(4)    1_555    9_455 yes
+  S2     Fe1    2.26435(13)   1_555    4_555 yes
+  S2     Fe1    2.26435(13)   1_555    5_555 yes
+  S2     Fe1    2.2644(4)    1_555    6_555 yes
+  S2     S2     2.1650(6)    1_555   13_666 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.1809(10), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_QPABAT3_phase_3
+# Information for phase 3
+_pd_block_id  2021-08-04T17:27|QPABAT3|phase_3|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Pyrrhotite 4M Fe7S8 follows
+_pd_phase_name  "Pyrrhotite 4M Fe7S8"
+_cell_length_a  11.946(31)
+_cell_length_b  6.857(4)
+_cell_length_c  12.83(3)
+_cell_angle_alpha  90
+_cell_angle_beta   117.25(6)
+_cell_angle_gamma  90
+_cell_volume  934.4(4)
+_exptl_crystal_density_diffrn  4.6023
+_symmetry_cell_setting  monoclinic
+_symmetry_space_group_name_H-M  "C 2/c"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -x,y,1/2-z
+     3  -x,-y,-z
+     4  x,-y,1/2+z
+     5  1/2+x,1/2+y,z
+     6  1/2-x,1/2+y,1/2-z
+     7  1/2-x,1/2-y,-z
+     8  1/2+x,1/2-y,1/2+z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+S1     S    0.01800     0.38330     0.11960     1.000      Uiso 0.010      8   
+S2     S    0.02910     0.11420     0.63900     1.000      Uiso 0.010      8   
+Fe3    Fe   0.10860     0.10250     0.49980     1.000      Uiso 0.010      8   
+S4     S    0.23410     0.13550     0.38260     1.000      Uiso 0.010      8   
+Fe5    Fe   0.24180     0.36600     0.24680     1.000      Uiso 0.010      8   
+S6     S    0.26790     0.13400     0.12360     1.000      Uiso 0.010      8   
+Fe7    Fe   0.38720     0.15000     0.01260     1.000      Uiso 0.010      8   
+Fe8    Fe   0.00000     0.14720     0.25000     1.000      Uiso 0.010      4   
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Fe   28     11.7695    7.3573     3.5222     2.3045     4.7611     0.3072     15.3535    76.8805    1.0369     0.945
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S    32     6.9053     5.2034     1.4379     1.5863     1.4679     22.2151    0.2536     56.172     0.8669     0.2847
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Fe7 S8"
+_chemical_formula_weight  647.41
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  S1     Fe3    2.49393      1_555    2_555 yes
+  S1     Fe5    2.41436      1_555    1_555 yes
+  S1     Fe7    2.38874      1_555    5_455 yes
+  S1     Fe7    2.44361      1_555    7_555 yes
+  S1     Fe8    2.40753      1_555    1_555 yes
+  S2     Fe3    2.37739      1_555    1_555 yes
+  S2     Fe3    2.32434      1_555    3_556 yes
+  S2     Fe5    2.44598      1_555    7_556 yes
+  S2     Fe7    2.36649      1_555    8_456 yes
+  S2     Fe8    2.41154      1_555    3_556 yes
+  Fe3    S1     2.49393      1_555    2_555 yes
+  Fe3    S2     2.37739      1_555    1_555 yes
+  Fe3    S2     2.32434      1_555    3_556 yes
+  Fe3    S6     2.45071      1_555    4_556 yes
+  S4     Fe5    2.38527      1_555    1_555 yes
+  Fe5    S1     2.41436      1_555    1_555 yes
+  Fe5    S2     2.44598      1_555    7_556 yes
+  Fe5    S4     2.38527      1_555    1_555 yes
+  Fe5    S6     2.36183      1_555    1_555 yes
+  S6     Fe3    2.45071      1_555    4_555 yes
+  S6     Fe5    2.36183      1_555    1_555 yes
+  S6     Fe7    2.43526      1_555    1_555 yes
+  S6     Fe7    2.39065      1_555    7_555 yes
+  Fe7    S1     2.38874      1_555    5_545 yes
+  Fe7    S1     2.44361      1_555    7_555 yes
+  Fe7    S2     2.36649      1_555    8_555 yes
+  Fe7    S6     2.43526      1_555    1_555 yes
+  Fe7    S6     2.39065      1_555    7_555 yes
+  Fe8    S1     2.40753      1_555    1_555 yes
+  Fe8    S1     2.40753      1_555    2_555 yes
+  Fe8    S2     2.41154      1_555    3_556 yes
+  Fe8    S2     2.41154      1_555    4_555 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.0305(25), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_QPABAT3_phase_4
+# Information for phase 4
+_pd_block_id  2021-08-04T17:27|QPABAT3|phase_4|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Rutile TiO2 follows
+_pd_phase_name  "Rutile TiO2"
+_cell_length_a  4.5980(13)
+_cell_length_b  4.5980(13)
+_cell_length_c  2.9619(13)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  90
+_cell_volume  62.618(30)
+_exptl_crystal_density_diffrn  4.2376
+_symmetry_cell_setting  tetragonal
+_symmetry_space_group_name_H-M  "P 42/m n m"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  1/2-y,1/2+x,1/2+z
+     3  -x,-y,z
+     4  1/2+y,1/2-x,1/2+z
+     5  1/2-x,1/2+y,1/2+z
+     6  -y,-x,z
+     7  1/2+x,1/2-y,1/2+z
+     8  y,x,z
+     9  -x,-y,-z
+    10  1/2+y,1/2-x,1/2-z
+    11  x,y,-z
+    12  1/2-y,1/2+x,1/2-z
+    13  1/2+x,1/2-y,1/2-z
+    14  y,x,-z
+    15  1/2-x,1/2+y,1/2-z
+    16  -y,-x,-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Ti1    Ti4+ 0.00000     0.00000     0.00000     1.000      Uiso 0.006      2   
+O1     O2-  0.32861     0.32861     0.00000     1.000      Uiso 0.005      4   
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  O    4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Ti   2      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  2
+_chemical_formula_sum  "O2 Ti"
+_chemical_formula_weight  79.9
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Ti1    O1     2.13681      1_555    1_555 yes
+  Ti1    O1     1.85342      1_555    2_544 yes
+  Ti1    O1     1.85342      1_555    2_545 yes
+  Ti1    O1     2.13681      1_555    3_555 yes
+  Ti1    O1     1.85342      1_555    4_454 yes
+  Ti1    O1     1.85342      1_555    4_455 yes
+  O1     Ti1    2.13681      1_555    1_555 yes
+  O1     Ti1    1.85342      1_555    2_554 yes
+  O1     Ti1    1.85342      1_555    2_555 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Ti1    O1     106.075       2_544  1_555    2_545 yes
+  O1     Ti1    O1     73.925        2_544  1_555    4_454 yes
+  O1     Ti1    O1     180           2_545  1_555    4_454 yes
+  O1     Ti1    O1     180           2_544  1_555    4_455 yes
+  O1     Ti1    O1     73.925        2_545  1_555    4_455 yes
+  O1     Ti1    O1     106.075       4_454  1_555    4_455 yes
+  Ti1    O1     Ti1    106.075       2_554  1_555    2_555 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.073(10), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_QPABAT3_phase_1
+# Information for phase 1
+_pd_block_id  2021-08-04T17:27|QPABAT3|phase_1|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Silica SiO2 follows
+_pd_phase_name  "Silica SiO2"
+_cell_length_a  4.9143(5)
+_cell_length_b  4.9143(5)
+_cell_length_c  5.4067(5)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  120
+_cell_volume  113.078(11)
+_exptl_crystal_density_diffrn  2.6470
+_symmetry_cell_setting  trigonal
+_symmetry_space_group_name_H-M  "P 32 2 1"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -y,x-y,2/3+z
+     3  y-x,-x,1/3+z
+     4  y,x,-z
+     5  -x,y-x,2/3-z
+     6  x-y,-y,1/3-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Si1    Si4+ 0.47000     0.00000     0.66670     1.000      Uiso 0.020      3   
+O1     O2-  0.41460     0.26780     0.78543     1.000      Uiso 0.017      6   
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  O    6      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si   3      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  3
+_chemical_formula_sum  "O2 Si"
+_chemical_formula_weight  60.08
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Si1    O1     1.60513      1_555    1_555 yes
+  Si1    O1     1.61166      1_555    2_654 yes
+  Si1    O1     1.6114       1_555    5_656 yes
+  Si1    O1     1.60528      1_555    6_556 yes
+  O1     Si1    1.60513      1_555    1_555 yes
+  O1     Si1    1.61166      1_555    3_665 yes
+  O1     Si1    1.6114       1_555    5_666 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Si1    O1     110.262       1_555  1_555    2_654 yes
+  O1     Si1    O1     108.73        1_555  1_555    5_656 yes
+  O1     Si1    O1     109.698       2_654  1_555    5_656 yes
+  O1     Si1    O1     109.165       1_555  1_555    6_556 yes
+  O1     Si1    O1     108.71        2_654  1_555    6_556 yes
+  O1     Si1    O1     110.268       5_656  1_555    6_556 yes
+  Si1    O1     Si1    143.833       1_555  1_555    3_665 yes
+  Si1    O1     Si1    143.836       1_555  1_555    5_666 yes
+  Si1    O1     Si1    0.009         3_665  1_555    5_666 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.145(6), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_QPABAT3_pwd_0
+_pd_proc_ls_profile_function
+;
+Finger-Cox-Jephcoat function parameters U, V, W, X, Y, SH/L:
+  peak variance(Gauss) = Utan(Th)^2^+Vtan(Th)+W:
+  peak HW(Lorentz) = X/cos(Th)+Ytan(Th); SH/L = S/L+H/L
+  U, V, W in (centideg)^2^, X & Y in centideg
+    0.000, 0.000, 3.345, 2.239, -0.670, 0.034, 
+;
+# Information for histogram 0: PWDR BAT3_Whole_30mm_MonicaHamish_Ruoming_step size 0_BAT3_Whole.xrdml Scan 1
+_pd_block_id
+;
+2021-08-04T17:27|QPABAT3|McDougallHamish|PANalytical,Co-EmpyreanII_hist_0
+;
+# GSAS-II edited template follows Instrument_Template
+#==============================================================================
+# 9. INSTRUMENT CHARACTERIZATION
+
+_exptl_special_details
+; ?
+;
+
+# if regions of the data are excluded, the reason(s) are supplied here:
+_pd_proc_info_excluded_regions
+; ?
+;
+
+# The following item is used to identify the equipment used to record 
+# the powder pattern when the diffractogram was measured at a laboratory 
+# other than the authors' home institution, e.g. when neutron or synchrotron
+# radiation is used.
+
+_pd_instr_location
+; ?
+;
+_pd_calibration_special_details           # description of the method used
+                                          # to calibrate the instrument
+; ?
+;
+
+_diffrn_source                    Co-Ka       
+_diffrn_source_target             Co
+_diffrn_source_type               Graded_Flat
+_diffrn_measurement_device_type   Panalytical_Reflection_Transmission       
+_diffrn_detector                  PIXcel1D       
+_diffrn_detector_type             Empyrean_II       # make or model of detector
+
+_pd_meas_scan_method              ?       # options are 'step', 'cont',
+                                          # 'tof', 'fixed' or
+                                          # 'disp' (= dispersive)
+_pd_meas_special_details
+;  ?
+;
+
+# The following two items identify the program(s) used (if appropriate).
+_computing_data_collection        ?        
+_computing_data_reduction         ?                   
+
+# Describe any processing performed on the data, prior to refinement.
+# For example: a manual Lp correction or a precomputed absorption correction
+_pd_proc_info_data_reduction      ?
+
+# The following item is used for angular dispersive measurements only.
+
+_diffrn_radiation_monochromator   ?        
+
+# The following items are used to define the size of the instrument.
+# Not all distances are appropriate for all instrument types.
+
+_pd_instr_dist_src/mono           ?
+_pd_instr_dist_mono/spec          ?
+_pd_instr_dist_src/spec           ?
+_pd_instr_dist_spec/anal          ?
+_pd_instr_dist_anal/detc          ?
+_pd_instr_dist_spec/detc          ?
+
+# 10. Specimen size and mounting information
+
+# The next three fields give the specimen dimensions in mm.  The equatorial 
+# plane contains the incident and diffracted beam.
+
+_pd_spec_size_axial               ?       # perpendicular to 
+                                          # equatorial plane
+
+_pd_spec_size_equat               ?       # parallel to 
+                                          # scattering vector 
+                                          # in transmission
+
+_pd_spec_size_thick               ?       # parallel to 
+                                          # scattering vector 
+                                          # in reflection
+
+_pd_spec_mounting                         # This field should be
+                                          # used to give details of the 
+                                          # container.
+; ?
+;
+
+_pd_spec_mount_mode               ?       # options are 'reflection' 
+                                          # or 'transmission'
+    
+_pd_spec_shape                    ?       # options are 'cylinder' 
+                                          # 'flat_sheet' or 'irregular'
+
+
+loop_
+     _atom_type_symbol
+     _atom_type_scat_dispersion_real
+     _atom_type_scat_dispersion_imag
+     _atom_type_scat_dispersion_source
+  Al        0.255   0.328   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Fe       -3.332   0.490   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Na        0.167   0.167   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  O         0.063   0.044   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S         0.371   0.733   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si        0.298   0.438   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Ti       -0.063   2.321   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+_diffrn_radiation_type  K\a~1,2~
+loop_
+   _diffrn_radiation_wavelength
+   _diffrn_radiation_wavelength_wt
+   _diffrn_radiation_wavelength_id
+  1.78892         1.0             1     
+  1.79278         0.5000          2     
+
+# PHASE TABLE
+loop_
+   _pd_phase_id
+   _pd_phase_block_id
+   _pd_phase_mass_%
+  2  2021-08-04T17:27|QPABAT3|phase_2|McDougallHamish  0.0851(21)
+  0  2021-08-04T17:27|QPABAT3|phase_0|McDougallHamish  0.8094(27)
+  3  2021-08-04T17:27|QPABAT3|phase_3|McDougallHamish  0.0350(12)
+  4  2021-08-04T17:27|QPABAT3|phase_4|McDougallHamish  0.0106(7)
+  1  2021-08-04T17:27|QPABAT3|phase_1|McDougallHamish  0.0598(8)
+loop_
+   _gsas_proc_phase_R_F_factor
+   _gsas_proc_phase_R_Fsqd_factor
+   _gsas_proc_phase_id
+   _gsas_proc_phase_block_id
+    0.06873  0.15034  2  2021-08-04T17:27|QPABAT3|phase_2|McDougallHamish
+    0.01682  0.03546  0  2021-08-04T17:27|QPABAT3|phase_0|McDougallHamish
+    0.06246  0.11208  3  2021-08-04T17:27|QPABAT3|phase_3|McDougallHamish
+    0.04014  0.07367  4  2021-08-04T17:27|QPABAT3|phase_4|McDougallHamish
+    0.03350  0.06031  1  2021-08-04T17:27|QPABAT3|phase_1|McDougallHamish
+_pd_proc_ls_prof_R_factor     0.05965
+_pd_proc_ls_prof_wR_factor    0.07869
+_gsas_proc_ls_prof_R_B_factor   0.06432
+_gsas_proc_ls_prof_wR_B_factor  0.08293
+_pd_proc_ls_prof_wR_expected  0.04055
+_diffrn_radiation_probe  x-ray
+_diffrn_radiation_polarisn_ratio  0.7000
+_pd_proc_ls_background_function
+;
+Background function: "chebyschev-1" function with 7 terms:
+    374.6(12), -373.9(18), 291.7(17), -139.4(15), 84.2(14), -23.2(11), 
+    6.1(10), 
+;
+_diffrn_ambient_temperature  300
+_diffrn_ambient_pressure  100
+
+# STRUCTURE FACTOR TABLE
+loop_
+   _pd_refln_phase_id
+   _refln_index_h
+   _refln_index_k
+   _refln_index_l
+   _refln_F_squared_meas
+   _refln_F_squared_calc
+   _refln_phase_calc
+   _refln_d_spacing
+   _gsas_i100_meas
+  0  1    1    1    953.6319   888.7034   0.0     3.12890  23.43  
+  0  2    0    0    6373.5500  6318.1937  -0.0    2.70971  86.79  
+  0  2    1    0    3566.6358  3423.9852  0.0     2.42363  76.70  
+  0  2    1    1    1783.6764  1744.8963  -180.0  2.21247  63.21  
+  0  2    2    0    3315.4690  3397.1649  -0.0    1.91605  43.35  
+  0  2    2    1    39.3742    36.6182    -0.0    1.80647  0.91   
+  0  3    1    1    5292.3725  5439.4706  -0.0    1.63401  100.00 
+  0  2    2    2    2393.7744  2433.4337  0.0     1.56445  13.87  
+  0  3    0    2    3112.5363  3118.1042  -0.0    1.50307  25.12  
+  0  3    1    2    606.2251   622.4613   0.0     1.44840  9.17   
+  0  3    2    1    1632.1432  1675.8561  180.0   1.44840  24.70  
+  0  4    0    0    364.7901   382.5763   -180.0  1.35485  1.24   
+  0  3    2    2    37.1980    39.3408    -0.0    1.31440  0.49   
+  0  4    1    0    96.3551    101.9055   -0.0    1.31440  0.63   
+  0  4    1    1    60.6080    55.2470    180.0   1.27737  0.77   
+  0  3    3    1    584.2468   600.2920   -0.0    1.24330  7.20   
+  0  4    0    2    952.5246   959.8730   0.0     1.21182  5.76   
+  0  4    2    0    952.5246   959.8730   0.0     1.21182  5.76   
+  0  4    1    2    1.2517     1.3214     -0.0    1.18261  0.01   
+  0  4    2    1    1360.1940  1435.9676  -180.0  1.18261  16.24  
+  0  3    3    2    753.7695   735.2189   0.0     1.15542  8.95   
+  0  4    2    2    1114.6756  1102.4674  0.0     1.10623  13.35  
+  0  4    3    0    122.9460   123.8227   -0.0    1.08388  0.75   
+  0  4    1    3    59.8256    67.5814    -180.0  1.06283  0.74   
+  0  4    3    1    22.2210    25.1017    0.0     1.06283  0.28   
+  0  3    3    3    1858.0757  1712.9917  -0.0    1.04297  7.94   
+  0  5    1    1    3720.1705  3429.6886  -0.0    1.04297  47.70  
+  1  1    0    0    275.0958   238.6947   180.0   4.25587  0.52   
+  1  1    0    1    636.9922   612.7021   120.0   3.34414  0.74   
+  1  1    0    -1   1527.2812  1469.0424  -120.0  3.34414  1.76   
+  1  1    1    0    308.5001   325.9565   -154.8  2.45713  0.19   
+  1  1    0    -2   90.0390    91.7616    -60.0   2.28191  0.05   
+  1  1    0    2    266.2259   271.3193   -120.0  2.28191  0.14   
+  1  1    1    1    85.0881    89.1200    84.9    2.23696  0.08   
+  1  2    0    0    275.7651   268.8947   0.0     2.12793  0.12   
+  1  2    0    -1   74.9098    70.9920    60.0    1.98009  0.03   
+  1  2    0    1    192.5013   182.4334   -60.0   1.98009  0.07   
+  1  1    1    2    511.5978   527.1769   9.6     1.81828  0.33   
+  1  0    0    3    68.8060    63.7751    0.0     1.80223  0.01   
+  1  2    0    2    82.3512    74.0105    60.0    1.67207  0.02   
+  1  2    0    -2   367.9443   330.6781   120.0   1.67207  0.10   
+  1  1    0    -3   177.1482   170.2804   180.0   1.65956  0.05   
+  1  1    0    3    4.5379     4.3619     0.0     1.65956  0.00   
+  1  2    1    0    15.3764    14.6768    -31.6   1.60857  0.01   
+  1  2    1    -1   306.5110   304.2732   96.0    1.54178  0.14   
+  1  2    1    1    239.6923   237.9424   -108.8  1.54178  0.11   
+  1  1    1    3    120.9267   117.1794   115.5   1.45323  0.05   
+  1  3    0    0    53.6608    63.4236    180.0   1.41862  0.01   
+  1  2    1    -2   324.1279   312.8922   -123.7  1.38236  0.12   
+  1  2    1    2    112.2637   108.3721   146.6   1.38236  0.04   
+  1  2    0    -3   214.1492   196.0323   -0.0    1.37527  0.04   
+  1  2    0    3    890.1879   814.8785   0.0     1.37527  0.17   
+  1  3    0    -1   657.5973   641.0877   -120.0  1.37218  0.12   
+  1  3    0    1    2.2450     2.1887     -60.0   1.37218  0.00   
+  1  1    0    -4   84.8637    73.1913    -120.0  1.28826  0.01   
+  1  1    0    4    355.3450   306.4700   120.0   1.28826  0.06   
+  1  3    0    -2   173.9706   157.0421   120.0   1.25617  0.03   
+  1  3    0    2    370.2963   334.2640   -120.0  1.25617  0.06   
+  1  2    2    0    263.6336   264.4146   -17.2   1.22856  0.04   
+  1  2    1    -3   50.9106    53.9241    177.4   1.20008  0.02   
+  1  2    1    3    218.8440   231.7979   -133.8  1.20008  0.07   
+  1  2    2    1    72.0811    76.2373    87.4    1.19802  0.02   
+  1  1    1    4    238.9946   236.8237   -16.4   1.18431  0.08   
+  1  3    1    0    258.8220   267.3717   121.0   1.18037  0.08   
+  1  3    1    -1   156.4601   140.4949   -21.5   1.15320  0.05   
+  1  3    1    1    42.3482    38.0270    20.3    1.15320  0.01   
+  1  2    0    -4   2.3144     2.2786     -120.0  1.14095  0.00   
+  1  2    0    4    55.4309    54.5722    120.0   1.14095  0.01   
+  1  2    2    2    3.2199     4.0621     -26.6   1.11848  0.00   
+  1  3    0    -3   10.3118    8.3593     -0.0    1.11471  0.00   
+  1  3    0    3    63.4349    51.4234    -180.0  1.11471  0.01   
+  1  3    1    -2   215.8521   218.2199   -10.1   1.08175  0.07   
+  1  3    1    2    83.1443    84.0564    62.7    1.08175  0.03   
+  1  4    0    0    80.3057    101.3482   0.0     1.06397  0.01   
+  1  1    0    -5   262.6261   242.0269   120.0   1.04804  0.05   
+  1  1    0    5    75.0118    69.1282    -120.0  1.04804  0.01   
+  1  4    0    -1   23.1559    20.4749    60.0    1.04395  0.00   
+  1  4    0    1    230.8402   204.1133   120.0   1.04395  0.04   
+  1  2    1    4    122.1357   152.0260   -130.5  1.03483  0.04   
+  1  2    1    -4   4.7801     5.9499     31.3    1.03483  0.00   
+  2  0    2    -1   20.4335    16.5792    0.0     4.66174  0.00   
+  2  0    2    1    4.3112     1.8371     180.0   4.37623  0.00   
+  2  2    0    -1   23726.5316 21037.4763 -0.0    4.02732  0.12   
+  2  1    -1   1    3276.9945  3767.3897  -0.0    3.85265  0.02   
+  2  1    1    1    9435.9706  10390.3834 0.0     3.77565  0.06   
+  2  1    3    0    6547.1186  5886.9121  180.0   3.68167  0.03   
+  2  1    3    -1   5012.8781  4505.3267  0.0     3.66562  0.02   
+  2  1    -3   0    11374.5196 11675.3013 180.0   3.65766  0.05   
+  2  2    0    0    1.6818     2.5781     0.0     3.63776  0.00   
+  2  1    1    -2   5647.9628  4328.5159  0.0     3.50520  0.03   
+  2  2    2    -1   3076.9341  1650.0035  180.0   3.48122  0.01   
+  2  1    -3   -1   49.4079    12.1276    0.0     3.43616  0.00   
+  2  1    -1   -2   6027.1007  5251.4578  0.0     3.37264  0.03   
+  2  2    -2   -1   343.9506   364.8637   0.0     3.33313  0.00   
+  2  2    0    -2   27092.4669 26655.4799 -180.0  3.21484  0.10   
+  2  0    0    2    38628.3382 37071.8044 -180.0  3.19393  0.17   
+  2  0    4    0    26101.0770 25362.8195 180.0   3.18733  0.08   
+  2  2    2    0    13112.2326 13873.6743 180.0   3.16977  0.04   
+  2  2    -2   0    14725.5156 14946.6082 -180.0  3.14934  0.05   
+  2  1    -3   1    12734.4390 11175.2497 -180.0  2.96418  0.04   
+  2  2    2    -2   7782.9054  7187.5067  0.0     2.95504  0.02   
+  2  0    2    -2   5344.1407  5310.5610  0.0     2.93060  0.02   
+  2  0    4    -1   8131.5223  8585.7945  0.0     2.92677  0.02   
+  2  1    3    1    7360.4421  6897.0276  180.0   2.86133  0.02   
+  2  1    3    -2   2000.6337  1923.0466  -0.0    2.83885  0.01   
+  2  2    -2   -2   143.1037   183.4547   -0.0    2.79276  0.00   
+  2  0    2    2    157.6877   191.6414   0.0     2.78600  0.00   
+  2  0    4    1    332.3521   387.5360   -0.0    2.78271  0.00   
+  2  2    0    1    100.4575   109.5836   -0.0    2.68712  0.00   
+  2  3    1    -1   431.4697   431.0071   -180.0  2.66293  0.00   
+  2  1    -3   -2   6607.0063  6171.6319  -0.0    2.63839  0.02   
+  2  3    -1   -1   37.5914    33.5476    -180.0  2.62530  0.00   
+  2  2    4    -1   14422.6270 12550.4891 -180.0  2.55995  0.03   
+  2  3    1    -2   2660.9934  1812.0722  180.0   2.53704  0.01   
+  2  1    -1   2    972.0915   667.2869   180.0   2.51139  0.00   
+  2  2    -2   1    2054.9148  1686.7859  -180.0  2.49495  0.00   
+  2  3    -1   -2   533.5367   451.5613   180.0   2.48043  0.00   
+  2  1    1    2    111.3007   110.2849   180.0   2.46610  0.00   
+  2  2    2    1    1302.9890  1367.0046  -180.0  2.45771  0.00   
+  2  2    -4   -1   9545.1070  10453.7459 -180.0  2.44277  0.02   
+  2  1    5    -1   4179.2302  4093.1663  -0.0    2.42941  0.01   
+  2  1    5    0    57.7340    64.0884    180.0   2.41202  0.00   
+  2  2    4    0    3528.0535  3944.1458  -0.0    2.40628  0.01   
+  2  1    -5   0    2025.2183  2230.8323  180.0   2.40074  0.00   
+  2  2    -4   0    2017.9225  2079.3222  -0.0    2.38844  0.00   
+  2  3    1    0    1550.2269  1565.2946  -0.0    2.38575  0.00   
+  2  3    -1   0    2107.0828  2090.0863  -0.0    2.37918  0.00   
+  2  2    0    -3   7.2396     7.3701     180.0   2.35133  0.00   
+  2  2    4    -2   2.9509     2.9331     0.0     2.34729  0.00   
+  2  1    1    -3   109.8434   110.8373   -0.0    2.33656  0.00   
+  2  0    4    -2   1187.7021  884.3144   -180.0  2.33087  0.00   
+  2  3    3    -1   16745.1147 9809.7794  180.0   2.31766  0.03   
+  2  1    -5   -1   1758.5917  1044.9800  0.0     2.31526  0.00   
+  2  1    -1   -3   2341.8407  2291.2470  -0.0    2.27750  0.01   
+  2  2    2    -3   189.5033   155.6865   -0.0    2.26146  0.00   
+  2  3    3    -2   18.1198    15.9172    0.0     2.25070  0.00   
+  2  3    -3   -1   2864.8502  2703.2457  -180.0  2.24518  0.00   
+  2  1    -3   2    813.3962   824.7896   -0.0    2.22556  0.00   
+  2  0    4    2    2000.7742  2085.0250  0.0     2.18812  0.00   
+  2  2    -4   -2   1373.1665  1431.8638  0.0     2.18799  0.00   
+  2  1    -5   1    3892.8343  4194.8986  180.0   2.18493  0.01   
+  2  2    -2   -3   1643.5006  1851.4932  0.0     2.15451  0.00   
+  2  1    5    -2   299.6445   312.7232   -180.0  2.15169  0.00   
+  2  3    1    -3   190.7957   204.6119   0.0     2.13824  0.00   
+  2  3    -3   -2   477.8601   512.1941   180.0   2.13724  0.00   
+  2  1    3    2    166.3478   174.4523   -180.0  2.13433  0.00   
+  2  0    0    3    461.7157   454.6548   -0.0    2.12929  0.00   
+  2  0    6    0    11087.5489 11042.6256 -0.0    2.12489  0.02   
+  2  1    3    -3   643.1052   674.2906   -180.0  2.11876  0.00   
+  2  1    5    1    4511.3977  4734.7647  180.0   2.11595  0.01   
+  2  3    3    0    1417.1647  1496.6439  -180.0  2.11318  0.00   
+  2  3    -3   0    174.8168   182.7827   -180.0  2.09956  0.00   
+  2  3    -1   -3   1918.9184  2416.5634  0.0     2.08973  0.00   
+  2  2    -4   1    7689.8989  8370.0925  180.0   2.07604  0.01   
+  2  0    2    -3   272.9768   286.8930   -180.0  2.05903  0.00   
+  2  0    6    -1   77.2644    83.9001    -0.0    2.05549  0.00   
+  2  2    4    1    2706.7994  2723.1302  180.0   2.03350  0.00   
+  2  4    0    -2   1394.1408  1673.8545  -0.0    2.01366  0.00   
+  2  1    -5   -2   905.6539   976.2191   -0.0    2.00557  0.00   
+  2  4    0    -1   2624.4957  3207.5402  -0.0    2.00025  0.00   
+  2  2    0    2    713.4040   914.6787   0.0     1.99827  0.00   
+  2  1    -3   -3   1638.1937  2006.9284  -0.0    1.99351  0.00   
+  2  0    2    3    1348.9533  1320.4879  0.0     1.98235  0.00   
+  2  0    6    1    5021.8002  4760.1395  0.0     1.97919  0.01   
+  2  3    -1   1    2022.4513  1778.1424  0.0     1.97162  0.00   
+  2  3    3    -3   845.7463   747.2487   -180.0  1.97003  0.00   
+  2  3    1    1    1018.7966  1049.8991  0.0     1.96352  0.00   
+  2  2    4    -3   203.6082   210.6125   -180.0  1.96339  0.00   
+  2  4    2    -2   1501.5548  1505.1300  0.0     1.94723  0.00   
+  2  2    -2   2    4187.1277  4434.5615  -0.0    1.92633  0.01   
+  2  4    2    -1   186.1111   195.3738   0.0     1.92397  0.00   
+  2  2    6    -1   25.1538    25.7092    -0.0    1.91781  0.00   
+  2  4    -2   -2   15013.6630 14612.2943 -0.0    1.89414  0.02   
+  2  4    -2   -1   86.2608    83.9894    180.0   1.89341  0.00   
+  2  3    5    -1   3542.4830  3253.1319  -180.0  1.88804  0.00   
+  2  2    2    2    12237.5261 11147.4650 -0.0    1.88782  0.02   
+  2  3    -3   -3   360.9007   242.1347   -0.0    1.86184  0.00   
+  2  3    5    -2   221.0097   151.7748   -180.0  1.86122  0.00   
+  2  4    0    -3   15555.3971 17227.6438 -180.0  1.84958  0.02   
+  2  2    -6   -1   530.7776   630.1904   -180.0  1.84310  0.00   
+  2  1    -5   2    27.8720    32.7906    -180.0  1.84286  0.00   
+  2  2    6    0    5534.6608  5973.8074  -0.0    1.84084  0.01   
+  2  2    6    -2   2877.3334  2234.4122  -180.0  1.83281  0.00   
+  2  1    -1   3    2909.2733  2403.8627  -180.0  1.82957  0.00   
+  2  2    -6   0    13306.5004 11170.3478 0.0     1.82883  0.01   
+  2  2    -4   -3   413.3319   351.5785   -0.0    1.82817  0.00   
+  2  0    4    -3   7434.2691  6600.1943  180.0   1.82454  0.01   
+  2  3    -5   -1   598.6795   547.0575   -180.0  1.82305  0.00   
+  2  0    6    -2   10255.2730 9376.7847  -180.0  1.82300  0.01   
+  2  4    0    0    16481.2842 16544.7345 -0.0    1.81888  0.02   
+  2  3    -3   1    1287.1322  1388.1619  -0.0    1.81269  0.00   
+  2  4    2    -3   1807.8317  1698.2109  -0.0    1.80678  0.00   
+  2  1    1    3    14201.7356 13204.6231 -180.0  1.80269  0.02   
+  2  3    3    1    584.6137   659.8672   -0.0    1.79396  0.00   
+  2  1    5    -3   30.6095    36.9138    180.0   1.79152  0.00   
+  2  1    7    -1   315.7516   370.2527   -180.0  1.78554  0.00   
+  2  2    0    -4   25021.5072 29304.7955 0.0     1.78457  0.03   
+  2  1    7    0    1805.8089  1186.7943  -0.0    1.76994  0.00   
+  2  3    5    0    552.4616   192.4714   -180.0  1.76391  0.00   
+  2  1    -7   0    5474.4712  1861.7091  0.0     1.76369  0.00   
+  2  1    5    2    5372.4966  1478.1411  -180.0  1.75728  0.01   
+  2  3    -5   -2   865.3719   292.8600   -180.0  1.75539  0.00   
+  2  2    2    -4   11044.6510 5374.4235  180.0   1.75260  0.01   
+  2  4    2    0    6620.3539  3240.2714  180.0   1.75255  0.01   
+  2  3    -5   0    1.1376     0.6787     -180.0  1.75073  0.00   
+  2  4    -2   -3   2050.1894  1498.9920  -180.0  1.74735  0.00   
+  2  4    -2   0    1893.2370  1478.3757  -180.0  1.74562  0.00   
+  2  4    4    -2   13783.9990 11156.5991 -180.0  1.74061  0.01   
+  2  3    1    -4   15.0473    11.6942    0.0     1.73791  0.00   
+  2  1    1    -4   1212.3837  931.5858   180.0   1.73044  0.00   
+  2  0    4    3    1746.1070  1649.4123  180.0   1.72108  0.00   
+  2  1    -7   -1   575.8025   544.5769   -0.0    1.72100  0.00   
+  2  2    -4   2    5379.7933  5111.9528  -180.0  1.72066  0.01   
+  2  0    6    2    4224.1980  4043.0244  180.0   1.71979  0.00   
+  2  2    -6   -2   6010.3220  5843.5104  180.0   1.71808  0.01   
+  2  1    -3   3    3987.0349  3889.7621  0.0     1.71755  0.00   
+  2  4    4    -1   3518.0361  3425.3612  -0.0    1.71605  0.00   
+  2  3    -1   -4   30.8027    26.3196    -0.0    1.70384  0.00   
+  2  3    5    -3   2183.8957  1781.5059  180.0   1.70048  0.00   
+  2  1    -1   -4   1362.1175  1087.2281  180.0   1.69839  0.00   
+  2  2    -2   -4   6715.4253  6607.2640  -0.0    1.68632  0.01   
+  2  2    -6   1    115.0334   111.8094   180.0   1.68403  0.00   
+  2  1    -7   1    1256.0119  1037.6002  0.0     1.67991  0.00   
+  2  1    7    -2   3574.8147  3014.1863  0.0     1.67337  0.00   
+  2  4    -4   -1   3675.5651  3113.5342  -0.0    1.67328  0.00   
+  2  1    -5   -3   332.7621   322.6770   -180.0  1.66739  0.00   
+  2  2    4    2    7130.3335  6980.1241  -180.0  1.66673  0.01   
+  2  4    -4   -2   3055.7728  2996.9232  -180.0  1.66656  0.00   
+  2  1    3    3    607.7784   605.4945   0.0     1.65314  0.00   
+  2  3    3    -4   464.1250   474.5918   180.0   1.65084  0.00   
+  2  2    6    1    14.8049    15.0623    180.0   1.64996  0.00   
+  2  4    4    -3   80.9860    81.5092    0.0     1.64497  0.00   
+  2  1    3    -4   1274.4571  1267.0308  -180.0  1.64299  0.00   
+  2  2    6    -3   429.2751   438.3802   0.0     1.63845  0.00   
+  2  1    7    1    950.3428   959.6711   0.0     1.63566  0.00   
+  2  5    1    -2   59.1926    62.3555    -180.0  1.62122  0.00   
+  2  2    4    -4   6.9916     6.6299     0.0     1.60885  0.00   
+  2  3    -1   2    251.7843   237.1891   -180.0  1.60779  0.00   
+  2  4    0    -4   27.3435    25.5451    0.0     1.60742  0.00   
+  2  5    -1   -2   119.4990   104.4782   -0.0    1.60481  0.00   
+  2  3    1    2    5.0772     3.3755     -180.0  1.59704  0.00   
+  2  0    0    4    2591.6518  1719.5025  -0.0    1.59697  0.00   
+  2  0    8    0    6445.1147  4104.7411  -0.0    1.59366  0.00   
+  2  3    -5   -3   7551.4786  7048.0684  -180.0  1.58673  0.01   
+  2  4    2    -4   5386.5992  5767.4424  -180.0  1.58523  0.00   
+  2  4    4    0    73.4284    80.5872    180.0   1.58489  0.00   
+  2  3    -5   1    3115.8482  3541.7994  0.0     1.57987  0.00   
+  2  1    -7   -2   101.2926   106.0592   180.0   1.57566  0.00   
+  2  4    -4   0    947.4899   972.7791   180.0   1.57467  0.00   
+  2  4    0    1    1295.0410  1313.3627  0.0     1.57405  0.00   
+  2  0    2    -4   6869.8910  6835.8768  -180.0  1.57267  0.01   
+  2  5    1    -1   1854.5946  1838.8969  0.0     1.57223  0.00   
+  2  5    1    -3   4.6693     4.5305     0.0     1.57056  0.00   
+  2  0    8    -1   5279.3672  5105.5113  -180.0  1.56971  0.00   
+  2  3    -3   -4   226.3807   222.0271   -180.0  1.56739  0.00   
+  2  1    -3   -4   1155.6177  1168.3240  -180.0  1.56437  0.00   
+  2  5    -1   -1   3476.1490  3532.8589  -0.0    1.56314  0.00   
+  2  3    5    1    6320.1099  6630.5027  -0.0    1.55930  0.01   
+  2  2    0    3    1681.3360  1763.6711  -180.0  1.55911  0.00   
+  2  4    -4   -3   636.3388   668.2938   0.0     1.55805  0.00   
+  2  0    6    -3   49.3813    50.4752    180.0   1.55391  0.00   
+  2  5    -1   -3   3177.4605  3177.9812  180.0   1.54983  0.00   
+  2  5    3    -2   1781.8573  1684.3120  0.0     1.53962  0.00   
+  2  3    7    -1   303.4207   255.3064   -0.0    1.53554  0.00   
+  2  4    -2   -4   5048.7194  4566.3850  180.0   1.53333  0.00   
+  2  4    -2   1    369.1985   360.2122   -0.0    1.53138  0.00   
+  2  2    -2   3    3958.9580  3884.5431  0.0     1.52972  0.00   
+  2  1    -5   3    131.1026   114.2358   180.0   1.52775  0.00   
+  2  0    2    4    2355.2911  1999.2534  180.0   1.52655  0.00   
+  2  3    7    -2   1666.5176  1417.6951  180.0   1.52649  0.00   
+  2  4    2    1    64.6394    55.0425    -0.0    1.52494  0.00   
+  2  0    8    1    64.2081    53.4117    0.0     1.52385  0.00   
+  2  3    -3   2    856.5190   713.5252   0.0     1.52351  0.00   
+  2  2    -6   -3   1287.9993  972.3599   180.0   1.52111  0.00   
+  2  1    -7   2    2643.0487  2092.8268  180.0   1.51406  0.00   
+  2  2    -4   -4   4067.2876  3475.0688  -180.0  1.51008  0.00   
+  2  2    8    -1   9396.6043  8932.7653  0.0     1.50687  0.01   
+  2  5    3    -3   10945.5097 11216.4371 -0.0    1.50125  0.01   
+  2  2    2    3    248.1712   261.4234   0.0     1.49966  0.00   
+  2  5    -3   -2   1197.6906  1283.3165  0.0     1.49852  0.00   
+  2  4    6    -2   1522.9594  1643.4734  -180.0  1.49804  0.00   
+  2  3    3    2    2582.1913  2828.3266  0.0     1.49651  0.00   
+  2  5    3    -1   1294.7838  1375.8687  180.0   1.49230  0.00   
+  2  1    7    -3   924.3756   963.7100   -0.0    1.49138  0.00   
+  2  3    5    -4   966.3690   976.7543   0.0     1.48741  0.00   
+  2  3    -7   -1   4.1124     4.1505     -180.0  1.48641  0.00   
+  2  2    -6   2    2117.0368  2225.9899  -180.0  1.48209  0.00   
+  2  1    5    -4   529.1086   569.2303   -0.0    1.48061  0.00   
+  2  4    4    -4   881.0438   936.8644   -0.0    1.47752  0.00   
+  2  4    6    -1   2293.1724  2425.3077  -0.0    1.47727  0.00   
+  2  2    8    -2   2039.2569  2036.6290  -0.0    1.46947  0.00   
+  2  5    -3   -1   2258.8354  2250.7625  180.0   1.46932  0.00   
+  2  0    4    -4   1647.0945  1799.2981  0.0     1.46530  0.00   
+  2  2    8    0    15209.8348 17372.8918 180.0   1.46378  0.01   
+  2  0    8    -2   2343.0482  2670.5014  0.0     1.46338  0.00   
+  2  3    7    0    1221.2445  1344.4772  -0.0    1.46164  0.00   
+  2  0    6    3    9583.0747  9727.2084  -180.0  1.45874  0.01   
+  2  2    -8   -1   280.2527   277.6153   0.0     1.45806  0.00   
+  2  2    -8   0    15572.0028 14971.6548 -180.0  1.45572  0.01   
+  2  1    5    3    87.4077    84.4701    0.0     1.45352  0.00   
+  2  3    -7   0    1883.2745  1874.7884  -0.0    1.45113  0.00   
+  2  5    -3   -3   3914.2348  3973.0050  -0.0    1.44873  0.00   
+  2  1    7    2    329.2853   339.6716   180.0   1.44736  0.00   
+  2  5    1    0    453.9278   468.7582   0.0     1.44694  0.00   
+  2  5    -1   0    267.6661   282.6566   0.0     1.44450  0.00   
+  2  3    -7   -2   385.4776   407.5222   -180.0  1.44435  0.00   
+  2  5    1    -4   355.7039   376.0669   -0.0    1.44434  0.00   
+  2  4    6    -3   4549.2620  4799.2632  180.0   1.44037  0.00   
+  2  3    7    -3   2022.6721  2066.9126  0.0     1.43858  0.00   
+  2  4    -6   -1   13832.8092 13974.0377 -0.0    1.43651  0.01   
+  2  1    -1   4    1870.0717  1747.7612  -0.0    1.43156  0.00   
+  2  2    6    2    15218.6694 14127.5120 -180.0  1.43067  0.01   
+  2  4    -6   -2   11185.6388 11494.7453 -180.0  1.42772  0.01   
+  2  3    1    -5   47.3409    54.5453    0.0     1.42498  0.00   
+  2  2    -4   3    8045.4257  9304.7725  -0.0    1.42492  0.01   
+  2  5    -1   -4   5237.2907  6191.0063  0.0     1.42367  0.00   
+  2  2    0    -5   452.3974   530.6717   -0.0    1.41970  0.00   
+  2  2    6    -4   3525.1793  4109.1661  -0.0    1.41942  0.00   
+  2  4    -4   1    1736.6725  2328.2327  -180.0  1.41643  0.00   
+  2  1    1    4    7280.8753  9765.5200  -0.0    1.41417  0.01   
+  2  2    2    -5   112.4555   102.1798   180.0   1.40774  0.00   
+  2  4    4    1    4065.2686  4251.1055  -180.0  1.40628  0.00   
+  2  1    9    -1   326.3669   313.3806   180.0   1.40427  0.00   
+  2  3    -1   -5   518.4931   559.2035   180.0   1.40173  0.00   
+  2  5    5    -2   107.6280   121.8591   180.0   1.39689  0.00   
+  2  4    -4   -4   306.8289   333.7965   -180.0  1.39638  0.00   
+  2  5    3    -4   10454.5520 10290.7248 -180.0  1.39407  0.01   
+  2  0    4    4    582.9121   603.2489   180.0   1.39300  0.00   
+  2  1    9    0    5771.3979  6061.3448  -180.0  1.39244  0.00   
+  2  0    8    2    811.5302   841.8614   -0.0    1.39135  0.00   
+  2  1    -7   -3   8.4310     8.6161     0.0     1.39082  0.00   
+  2  2    -8   -2   397.3245   389.1003   0.0     1.38958  0.00   
+  2  1    -9   0    5145.2035  5032.6219  -180.0  1.38852  0.00   
+  2  3    -5   -4   724.3311   712.8918   180.0   1.38828  0.00   
+  2  1    -5   -4   12.0757    12.2841    -0.0    1.38705  0.00   
+  2  4    6    0    6750.9811  6881.9956  0.0     1.38694  0.00   
+  2  2    -8   1    2663.9577  2583.5813  -0.0    1.38353  0.00   
+  2  3    -5   2    115.2140   107.7060   180.0   1.38139  0.00   
+  2  1    -3   4    12478.0081 11498.8556 180.0   1.38001  0.01   
+  2  3    3    -5   654.3535   601.2645   -0.0    1.37984  0.00   
+  2  5    3    0    2247.3467  2064.1961  180.0   1.37983  0.00   
+  2  2    4    3    8731.9459  7682.9819  -0.0    1.37735  0.01   
+  2  4    -6   0    3276.0861  2929.6322  0.0     1.37669  0.00   
+  2  5    -3   0    1960.6102  1846.9850  -180.0  1.37349  0.00   
+  2  4    0    -5   10209.7478 9852.1453  -0.0    1.37263  0.01   
+  2  5    5    -3   1049.9923  1000.1841  -0.0    1.37203  0.00   
+  2  1    1    -5   65.3771    51.8333    180.0   1.36876  0.00   
+  2  2    8    -3   1261.0357  897.0709   0.0     1.36740  0.00   
+  2  2    -2   -5   1057.6844  890.9937   -180.0  1.36475  0.00   
+  2  1    -9   -1   2714.8817  2521.2414  180.0   1.36346  0.00   
+  2  4    2    -5   11174.3226 11335.5971 180.0   1.36264  0.01   
+  2  2    8    1    3283.2599  3611.9875  -180.0  1.35827  0.00   
+  2  5    5    -1   820.3367   870.4892   -180.0  1.35737  0.00   
+  2  4    -6   -3   3793.9878  4126.3352  180.0   1.35385  0.00   
+  2  3    -7   1    517.9960   576.4772   0.0     1.35312  0.00   
+  2  1    9    -2   13299.4479 16147.0686 0.0     1.35152  0.01   
+  2  6    0    -2   13809.8083 16981.3924 180.0   1.35133  0.01   
+  2  1    -9   1    2951.8488  3741.5161  -0.0    1.35032  0.00   
+  2  1    -1   -5   8547.1481  10683.9602 -0.0    1.34891  0.01   
+  2  3    5    2    172.6770   209.3398   0.0     1.34817  0.00   
+  2  5    -5   -2   485.2567   568.7530   180.0   1.34647  0.00   
+  2  4    0    2    17071.2909 20266.7951 180.0   1.34356  0.01   
+  2  6    0    -3   363.4278   424.9852   0.0     1.34244  0.00   
+  2  3    -7   -3   866.0162   987.1236   180.0   1.34218  0.00   
+  2  5    -3   -4   17.6076    19.4544    -0.0    1.34037  0.00   
+  2  3    7    1    525.4114   545.2034   0.0     1.33504  0.00   
+  2  1    3    4    296.4809   303.9072   180.0   1.33473  0.00   
+  2  2    4    -5   2110.7646  2138.1647  -0.0    1.33359  0.00   
+  2  6    2    -2   5222.0638  7470.5514  0.0     1.33146  0.00   
+  2  3    -1   3    405.2430   551.6386   -0.0    1.32984  0.00   
+  2  5    -5   -1   2229.9348  3077.6343  -180.0  1.32879  0.00   
+  2  1    -7   3    626.8304   845.5145   -180.0  1.32789  0.00   
+  2  1    3    -5   9610.3784  12956.3684 180.0   1.32785  0.01   
+  2  4    6    -4   904.2649   1219.1637  0.0     1.32754  0.00   
+  2  6    2    -3   4.3860     6.0091     -0.0    1.32656  0.00   
+  2  4    -2   -5   2612.1161  3146.4347  0.0     1.32203  0.00   
+  2  1    9    1    848.0411   1105.1306  -0.0    1.32057  0.00   
+  2  4    -2   2    1715.3861  2255.4357  0.0     1.32028  0.00   
+  2  3    1    3    2455.4955  3237.6008  0.0     1.32015  0.00   
+  2  2    -6   -4   86.3716    114.0134   0.0     1.31919  0.00   
+  2  3    -3   -5   1651.9305  2179.7868  180.0   1.31918  0.00   
+  2  0    6    -4   2981.8665  3685.3963  0.0     1.31717  0.00   
+  2  0    8    -3   3921.2657  4546.6333  -0.0    1.31636  0.00   
+  2  6    -2   -2   335.4577   330.6363   180.0   1.31265  0.00   
+  2  4    2    2    653.7713   505.4413   0.0     1.30914  0.00   
+  2  5    -5   -3   8537.1509  6208.9517  0.0     1.30653  0.00   
+  2  3    7    -4   16.4367    11.5530    -180.0  1.30602  0.00   
+  2  6    0    -1   944.2162   635.2341   -0.0    1.30261  0.00   
+  2  6    -2   -3   7764.1238  4797.6968  0.0     1.30107  0.00   
+  2  1    7    -4   1348.3128  816.7390   180.0   1.30069  0.00   
+  2  4    4    -5   1489.2135  839.8412   -180.0  1.29576  0.00   
+  2  5    -1   1    727.4867   560.8179   -180.0  1.29287  0.00   
+  2  5    5    -4   122.0888   102.0732   -0.0    1.29210  0.00   
+  2  5    1    1    253.4839   213.0414   180.0   1.29128  0.00   
+  2  5    1    -5   1537.2202  1297.0866  -180.0  1.28850  0.00   
+  2  1    -9   -2   8248.8036  7594.2794  0.0     1.28440  0.00   
+  2  3    -3   3    4133.9267  3821.2749  180.0   1.28422  0.00   
+  2  2    -6   3    104.2039   97.9036    -0.0    1.28363  0.00   
+  2  3    5    -5   3193.6145  3037.5557  -0.0    1.28334  0.00   
+  2  6    2    -1   2543.1445  2446.8719  180.0   1.28151  0.00   
+  2  4    8    -2   16671.7315 16043.2073 -0.0    1.27998  0.01   
+  2  6    0    -4   5019.2584  4642.8182  0.0     1.27913  0.00   
+  2  1    -5   4    0.3018     0.2762     -0.0    1.27885  0.00   
+  2  0    0    5    1666.2840  1504.7953  0.0     1.27757  0.00   
+  2  2    -8   -3   1192.0850  969.8153   0.0     1.27578  0.00   
+  2  1    -3   -5   2027.3553  1649.0848  -180.0  1.27554  0.00   
+  2  0    10   0    6740.7560  5612.4673  -0.0    1.27493  0.00   
+  2  3    9    -1   692.4670   567.6734   180.0   1.27318  0.00   
+  2  3    9    -2   223.0776   209.3409   0.0     1.27118  0.00   
+  2  6    -2   -1   639.1128   604.9530   -180.0  1.27102  0.00   
+  2  5    -1   -5   3411.0528  3287.3648  -0.0    1.27057  0.00   
+  2  4    -6   1    2211.8769  2157.0193  180.0   1.27033  0.00   
+  2  2    0    4    5479.7524  5970.9564  -0.0    1.26862  0.00   
+  2  6    2    -4   2392.7378  2642.8907  -180.0  1.26852  0.00   
+  2  0    2    -5   3591.3445  4140.6925  180.0   1.26818  0.00   
+  2  2    -8   2    13368.6636 15669.9235 0.0     1.26800  0.01   
+  2  5    5    0    1305.5882  1539.1640  -0.0    1.26791  0.00   
+  2  0    10   -1   765.0279   722.1628   -180.0  1.26570  0.00   
+  2  4    8    -1   149.3735   116.1733   180.0   1.26381  0.00   
+  2  2    -4   -5   47.1676    34.2839    180.0   1.26302  0.00   
+  2  1    -9   2    561.8092   407.6104   0.0     1.26267  0.00   
+  2  6    4    -2   5247.6837  4060.9393  -0.0    1.26012  0.00   
+  2  1    7    3    1800.8293  1423.0605  -180.0  1.25993  0.00   
+  2  5    -5   0    1545.2396  1251.7915  -0.0    1.25974  0.00   
+  2  4    6    1    41.6794    35.4122    180.0   1.25938  0.00   
+  2  6    4    -3   6544.6023  5742.7030  -180.0  1.25904  0.00   
+  2  3    3    3    38.5511    34.1056    0.0     1.25855  0.00   
+  2  2    -2   4    2998.9627  2630.4316  180.0   1.25569  0.00   
+  2  5    3    -5   9068.6357  7849.9862  180.0   1.25548  0.01   
+  2  1    9    -3   565.3264   446.4585   -180.0  1.25310  0.00   
+  2  4    -4   2    3313.6249  2913.1494  0.0     1.24747  0.00   
+  2  4    8    -3   1696.4876  1591.0184  -180.0  1.24643  0.00   
+  2  5    -3   1    155.9899   154.1169   -180.0  1.24419  0.00   
+  2  4    -6   -4   4710.1568  4649.8078  0.0     1.24074  0.00   
+  2  1    5    -5   21.1823    20.8490    -0.0    1.24058  0.00   
+  2  6    -2   -4   119.3123   116.0421   -0.0    1.24022  0.00   
+  2  5    3    1    903.2639   865.0651   -180.0  1.23993  0.00   
+  2  0    6    4    4698.1018  4402.8269  -0.0    1.23960  0.00   
+  2  0    8    3    2787.3167  2523.8232  0.0     1.23892  0.00   
+  2  5    7    -2   55.7379    48.4702    -180.0  1.23815  0.00   
+  2  0    2    5    7.3252     6.1649     -0.0    1.23770  0.00   
+  2  3    -9   -1   2399.2078  1878.7146  -180.0  1.23697  0.00   
+  2  0    10   1    93.8140    69.0195    180.0   1.23540  0.00   
+  2  2    8    -4   0.9174     0.6712     -0.0    1.23509  0.00   
+  2  2    2    4    276.8933   202.3679   180.0   1.23305  0.00   
+  2  2    10   -1   898.4176   674.5837   -0.0    1.23266  0.00   
+  2  2    6    3    717.5582   591.5126   -0.0    1.23202  0.00   
+  2  4    -8   -1   1786.9839  1660.8265  180.0   1.22975  0.00   
+  2  4    4    2    7383.3269  7216.8110  -0.0    1.22886  0.00   
+  2  6    -4   -2   7549.9953  7429.0559  0.0     1.22874  0.00   
+  2  4    -4   -5   5903.1771  5935.8119  180.0   1.22833  0.00   
+  2  3    9    0    205.0691   207.1256   180.0   1.22722  0.00   
+  2  2    8    2    15157.8048 16367.8700 -0.0    1.22501  0.01   
+  2  3    -7   2    4.1002     4.4310     -180.0  1.22493  0.00   
+  2  5    7    -3   716.7797   701.3947   180.0   1.22357  0.00   
+  2  5    -5   -4   490.9404   527.2945   -180.0  1.22255  0.00   
+  2  2    6    -5   86.0337    93.3157    -0.0    1.22244  0.00   
+  2  3    9    -3   3585.7199  3989.5508  -0.0    1.22187  0.00   
+  2  4    -8   -2   14062.1437 15576.6760 0.0     1.22139  0.01   
+  2  1    5    4    2945.8456  2923.6151  -180.0  1.22003  0.00   
+  2  3    -9   0    66.8726    63.1939    -0.0    1.21922  0.00   
+  2  6    -4   -3   1.7630     1.6171     -180.0  1.21643  0.00   
+  2  6    4    -1   10.7334    10.2523    180.0   1.21473  0.00   
+  2  2    10   -2   3345.0589  3195.8904  -180.0  1.21471  0.00   
+  2  3    -7   -4   9.8847     9.5153     0.0     1.21279  0.00   
+  2  6    0    0    13522.0172 13100.2263 0.0     1.21259  0.01   
+  2  1    9    2    1805.9473  1749.7864  0.0     1.21259  0.00   
+  2  0    4    -5   53.0493    51.4047    -180.0  1.21258  0.00   
+  2  1    -7   -4   694.3890   673.8718   0.0     1.21254  0.00   
+  2  6    4    -4   201.5775   199.9465   0.0     1.21185  0.00   
+  2  0    10   -2   2470.6217  2393.1814  180.0   1.21068  0.00   
+  2  3    -9   -2   2.4743     2.4088     0.0     1.20966  0.00   
+  2  5    7    -1   987.7116   919.5910   -0.0    1.20764  0.00   
+  2  5    -3   -5   1792.8974  1669.4106  -180.0  1.20756  0.00   
+  2  2    10   0    12.6542    11.8619    180.0   1.20601  0.00   
+  2  3    -5   -5   5525.3532  5223.5291  -0.0    1.20426  0.00   
+  2  4    8    0    2102.7255  2036.1638  -180.0  1.20314  0.00   
+  2  2    -10  0    1179.3977  1234.3417  180.0   1.20037  0.00   
+  2  2    -10  -1   1849.2743  1881.5821  0.0     1.19900  0.00   
+  2  2    -4   4    0.0041     0.0043     180.0   1.19841  0.00   
+  2  3    -5   3    4986.1911  5149.8089  -180.0  1.19827  0.00   
+  2  6    -4   -1   3858.0233  4013.4094  180.0   1.19705  0.00   
+  2  4    -8   0    1891.7268  1701.7086  -180.0  1.19422  0.00   
+  2  4    6    -5   6203.8886  5356.2972  -0.0    1.19366  0.00   
+  2  6    2    0    7449.2883  6359.8747  -180.0  1.19287  0.00   
+  2  3    1    -6   201.6447   172.0799   180.0   1.19278  0.00   
+  2  3    7    2    247.9747   210.6961   180.0   1.19262  0.00   
+  2  6    -2   0    2214.1788  1825.4606  -180.0  1.18959  0.00   
+  2  5    -7   -2   291.5197   235.2689   -180.0  1.18926  0.00   
+  2  5    5    -5   634.2807   652.0282   -0.0    1.18202  0.00   
+  2  6    0    -5   1842.6634  1859.8386  -0.0    1.18139  0.00   
+  2  5    -7   -1   1133.5424  1170.6276  -0.0    1.17956  0.00   
+  2  3    -1   -6   10285.3736 10651.6340 0.0     1.17652  0.01   
+  2  1    -9   -3   3339.5608  3479.3329  -0.0    1.17569  0.00   
+  2  4    0    -6   666.9598   694.8770   -180.0  1.17567  0.00   
+  2  6    2    -5   662.4733   690.4314   180.0   1.17553  0.00   
+  2  4    8    -4   4869.1600  5262.2410  180.0   1.17365  0.00   
+  2  1    -1   5    40.8453    44.3347    0.0     1.17349  0.00   
+  2  2    0    -6   2961.1502  3262.2227  -180.0  1.17258  0.00   
+  2  4    2    -6   716.6555   785.7923   0.0     1.17185  0.00   
+  2  4    -8   -3   467.9272   512.5086   -0.0    1.17167  0.00   
+  2  1    -5   -5   4947.1446  5414.4867  -180.0  1.17131  0.00   
+  2  3    3    -6   3199.6081  3178.6335  180.0   1.16840  0.00   
+  2  5    7    -4   5997.9488  5932.4007  0.0     1.16833  0.00   
+  2  2    2    -6   450.7999   444.4424   0.0     1.16828  0.00   
+  2  0    8    -4   6757.6219  6734.2463  -180.0  1.16544  0.00   
+  2  3    5    3    8783.9808  9033.3981  -180.0  1.16397  0.01   
+  2  6    -4   -4   1298.5140  1331.0105  -180.0  1.16381  0.00   
+  2  3    7    -5   1153.8836  1180.8749  180.0   1.16377  0.00   
+  2  3    -9   1    27.3301    24.5109    -0.0    1.16177  0.00   
+  2  1    1    5    2217.6245  1984.2370  0.0     1.16142  0.00   
+  2  2    -10  1    456.9839   408.7012   -180.0  1.16134  0.00   
+  2  0    4    5    4220.1782  3674.6390  -180.0  1.16082  0.00   
+  2  6    6    -3   679.4929   572.9928   0.0     1.16041  0.00   
+  2  5    -5   1    9.8168     8.2052     180.0   1.16017  0.00   
+  2  7    1    -3   391.3171   326.8856   180.0   1.15995  0.00   
+  2  2    4    4    400.5101   334.7388   180.0   1.15990  0.00   
+  2  0    10   2    2316.3656  1953.1670  -180.0  1.15916  0.00   
+  2  5    -7   -3   16.4520    13.9221    0.0     1.15905  0.00   
+  2  6    6    -2   1243.0456  1062.5954  180.0   1.15883  0.00   
+  2  2    -10  -2   1032.8432  927.1428   -180.0  1.15763  0.00   
+  2  2    10   -3   507.7390   456.9863   180.0   1.15752  0.00   
+  2  1    -7   4    8682.8102  7894.1741  -0.0    1.15699  0.00   
+  2  1    11   -1   184.6374   172.4013   -0.0    1.15488  0.00   
+  2  5    5    1    16.0717    14.5872    180.0   1.15443  0.00   
+  2  4    0    3    430.2888   372.8509   -0.0    1.15214  0.00   
+  2  7    -1   -3   223.5957   190.7937   -0.0    1.15103  0.00   
+  2  1    -9   3    458.2758   390.2848   -180.0  1.15086  0.00   
+  2  7    1    -2   499.7933   417.6649   180.0   1.14957  0.00   
+  2  6    -2   -5   3.6630     3.3422     180.0   1.14818  0.00   
+  2  2    -8   -4   1350.5900  1241.1393  -0.0    1.14713  0.00   
+  2  3    9    1    906.3456   840.9132   -180.0  1.14703  0.00   
+  2  1    -3   5    139.4796   131.0137   -0.0    1.14691  0.00   
+  2  4    -6   2    895.5178   884.2580   -180.0  1.14653  0.00   
+  2  1    11   0    651.7144   673.8595   0.0     1.14593  0.00   
+  2  3    -9   -3   6577.6780  6842.7549  -0.0    1.14539  0.00   
+  2  1    -11  0    49.8798    56.5171    180.0   1.14326  0.00   
+  2  7    -1   -2   228.7923   258.5173   180.0   1.14319  0.00   
+  2  2    10   1    1962.7644  2221.3310  -180.0  1.14260  0.00   
+  2  2    -6   -5   7301.3763  8280.7099  -0.0    1.14253  0.00   
+  2  5    -1   2    0.2221     0.2523     -180.0  1.14237  0.00   
+  2  4    -2   -6   159.5567   159.9954   -0.0    1.14109  0.00   
+  2  5    7    0    1592.3624  1584.2307  0.0     1.14103  0.00   
+  2  3    9    -4   3759.4257  3452.1120  -180.0  1.13977  0.00   
+  2  4    -2   3    742.8000   675.3480   180.0   1.13965  0.00   
+  2  2    -8   3    1081.3938  940.5804   180.0   1.13923  0.00   
+  2  5    1    2    179.2079   151.0052   180.0   1.13897  0.00   
+  2  2    -2   -6   557.1492   457.5743   180.0   1.13875  0.00   
+  2  5    1    -6   112.9885   92.8501    180.0   1.13644  0.00   
+  2  6    4    0    11722.6974 9886.1889  -180.0  1.13618  0.01   
+  2  1    9    -4   7250.8869  6387.1239  180.0   1.13575  0.00   
+  2  7    1    -4   109.0622   104.3489   0.0     1.13318  0.00   
+  2  5    -7   0    569.1070   561.3250   0.0     1.13270  0.00   
+  2  6    4    -5   3667.0037  3560.8356  -0.0    1.13225  0.00   
+  2  7    3    -3   1899.4783  1752.7599  180.0   1.13164  0.00   
+  2  1    7    -5   2087.6189  1876.4532  -0.0    1.13113  0.00   
+  2  4    4    -6   79.0412    74.0198    180.0   1.13073  0.00   
+  2  6    -4   0    9432.9423  8996.3605  -180.0  1.13052  0.00   
+  2  1    1    -6   13.2830    12.7255    180.0   1.13041  0.00   
+  2  4    2    3    28.8503    26.9687    0.0     1.12798  0.00   
+  2  1    11   -2   3810.8048  4054.5939  -180.0  1.12721  0.00   
+  2  2    4    -6   563.2021   617.9103   -180.0  1.12706  0.00   
+  2  1    -11  -1   71.6747    80.5660    180.0   1.12692  0.00   
+  2  0    6    -5   717.7937   825.3110   -0.0    1.12677  0.00   
+  2  0    10   -3   17.9789    25.1309    180.0   1.12560  0.00   
+  2  6    6    -4   755.1372   1116.6065  -0.0    1.12535  0.00   
+  2  4    -8   1    932.8382   1428.0735  -0.0    1.12500  0.00   
+  2  4    6    2    321.4515   491.6513   180.0   1.12497  0.00   
+  2  3    -3   -6   2009.4408  2679.1058  0.0     1.12421  0.00   
+  2  1    -11  1    402.7277   520.4388   180.0   1.12385  0.00   
+  2  3    -1   4    45.8189    62.3074    180.0   1.12290  0.00   
+  2  7    -1   -4   250.1668   340.7362   180.0   1.12266  0.00   
+  2  6    -6   -2   4.3375     5.8815     -0.0    1.12259  0.00   
+  2  5    -1   -6   3142.5200  3679.1020  -180.0  1.12188  0.00   
+  2  6    6    -1   16.2908    18.5196    -180.0  1.12105  0.00   
+  2  7    3    -2   372.3235   466.2613   -180.0  1.11981  0.00   
+  2  5    -5   -5   3020.8735  3254.1700  180.0   1.11710  0.00   
+  2  1    -1   -6   1468.7199  1573.1101  -180.0  1.11699  0.00   
+  2  4    -6   -5   11.9968    12.1624    -180.0  1.11621  0.00   
+  2  5    3    -6   3779.7849  3572.8767  0.0     1.11574  0.00   
+  2  3    1    4    662.4661   557.2568   180.0   1.11489  0.00   
+  2  4    8    1    3619.1460  3030.2470  -0.0    1.11486  0.00   
+  2  1    3    5    262.6216   208.8946   -180.0  1.11404  0.00   
+  2  2    -6   4    2124.4727  1626.0861  -0.0    1.11278  0.00   
+  2  6    -6   -3   11481.6152 9170.8262  180.0   1.11104  0.01   
+  2  5    -3   2    28.8898    23.9804    -180.0  1.11049  0.00   
+  2  3    5    -6   89.1563    75.3696    -0.0    1.11017  0.00   
+  2  1    3    -6   4233.7983  3749.4968  0.0     1.10915  0.00   
+  2  7    3    -4   949.2056   851.8273   -0.0    1.10885  0.00   
+  2  7    -3   -3   8.6953     8.0510     -0.0    1.10731  0.00   
+  2  7    1    -1   585.2187   540.2195   -180.0  1.10485  0.00   
+  2  6    0    1    3045.3685  2851.2916  180.0   1.10441  0.00   
+  2  1    11   1    379.3183   353.4958   0.0     1.10278  0.00   
+  2  7    -3   -2   8.2360     7.6618     -0.0    1.10240  0.00   
+  2  4    10   -2   312.6906   293.9448   -180.0  1.10139  0.00   
+  2  7    -1   -1   597.2087   560.8360   -180.0  1.10125  0.00   
+  2  5    3    2    98.6081    92.4856    -180.0  1.10119  0.00   
+  2  2    8    -5   4059.4603  3728.5603  180.0   1.10077  0.00   
+  2  6    -6   -1   6.9146     6.2337     0.0     1.10033  0.00   
+  2  5    -7   -4   146.2968   136.6182   0.0     1.09716  0.00   
+  2  3    -3   4    154.2543   143.6453   -0.0    1.09706  0.00   
+  2  1    7    4    62.7647    57.0295    -0.0    1.09661  0.00   
+  2  0    8    4    3674.0667  2959.2417  180.0   1.09406  0.00   
+  2  4    -8   -4   4605.3899  3685.4545  -180.0  1.09399  0.00   
+  2  4    -4   3    2776.5977  2186.7268  180.0   1.09385  0.00   
+  2  3    -7   3    2305.4637  1814.2931  0.0     1.09384  0.00   
+  2  1    9    3    392.2940   308.2223   180.0   1.09383  0.00   
+  2  2    -10  2    4.9468     3.3265     -0.0    1.09247  0.00   
+  2  2    8    3    587.7213   379.8198   0.0     1.09126  0.00   
+  2  5    9    -2   2573.4413  1582.6840  -0.0    1.09021  0.00   
+  2  4    10   -1   2.6568     1.7369     -180.0  1.08903  0.00   
+  2  6    -2   1    2.3305     1.5406     -180.0  1.08894  0.00   
+  2  1    -5   5    8449.1403  5646.2565  0.0     1.08884  0.01   
+  2  6    2    1    366.8815   245.3481   -0.0    1.08745  0.00   
+  2  2    -10  -3   908.7302   617.4947   180.0   1.08733  0.00   
+  2  5    7    -5   127.2016   91.0318    -180.0  1.08704  0.00   
+  2  6    -4   -5   454.0248   422.0173   180.0   1.08477  0.00   
+  2  3    -7   -5   3388.8888  3180.2930  0.0     1.08232  0.00   
+  2  5    9    -3   38.8031    37.0056    -180.0  1.08217  0.00   
+  2  4    10   -3   495.1552   496.5346   180.0   1.08176  0.00   
+  2  4    8    -5   382.4621   416.8216   0.0     1.08002  0.00   
+  2  7    -3   -4   436.6102   475.9937   -180.0  1.08002  0.00   
+  2  3    11   -2   1056.4507  1209.7235  180.0   1.07973  0.00   
+  2  3    -9   2    978.3047   1162.0253  -0.0    1.07952  0.00   
+  2  1    -11  -2   406.4566   505.5742   -0.0    1.07909  0.00   
+  2  3    11   -1   2027.2121  2531.9784  -180.0  1.07901  0.00   
+  2  4    -4   -6   52.3491    79.4879    0.0     1.07725  0.00   
+  2  7    3    -1   325.2921   517.9063   0.0     1.07642  0.00   
+  2  7    1    -5   15.9005    25.2106    -0.0    1.07626  0.00   
+  2  5    -3   -6   823.0150   1371.1187  180.0   1.07586  0.00   
+  2  2    10   -4   1701.8956  2842.5457  0.0     1.07584  0.00   
+  2  2    -4   -6   108.5183   186.5753   0.0     1.07568  0.00   
+  2  3    3    4    315.6656   560.4316   180.0   1.07511  0.00   
+  2  1    -11  2    309.6133   558.2780   -180.0  1.07370  0.00   
+  2  7    5    -3   506.3881   928.6481   180.0   1.07351  0.00   
+  2  4    4    3    444.9201   818.8776   180.0   1.07348  0.00   
+  2  1    -3   -6   76.4261    135.6225   180.0   1.07233  0.00   
+  2  6    0    -6   2.3698     4.1780     -180.0  1.07161  0.00   
+  2  1    11   -3   301.5372   540.3856   180.0   1.07008  0.00   
+  2  6    2    -6   53.8093    107.8329   0.0     1.06912  0.00   
+  2  6    -6   -4   247.9032   552.9788   0.0     1.06862  0.00   
+  2  5    9    -1   540.5756   1026.4794  0.0     1.06732  0.00   
+  2  2    6    4    2247.4148  4143.5979  0.0     1.06716  0.00   
+  2  7    -3   -1   100.9311   173.9010   0.0     1.06652  0.00   
+  2  2    0    5    1108.4557  1937.9253  0.0     1.06580  0.00   
+  2  0    6    5    206.7761   358.8678   0.0     1.06561  0.00   
+  2  7    -1   -5   1956.0918  3288.8085  0.0     1.06535  0.00   
+  2  5    5    -6   278.1492   447.2840   -180.0  1.06509  0.00   
+  2  0    0    6    35.8768    53.4823    180.0   1.06464  0.00   
+  2  0    10   3    2205.8772  3276.3246  0.0     1.06463  0.00   
+  2  4    6    -6   27.2103    31.3322    -180.0  1.06282  0.00   
+  2  6    6    -5   379.7096   434.3157   -0.0    1.06260  0.00   
+  2  0    12   0    98.9375    112.6819   180.0   1.06244  0.00   
+  2  4    -10  -1   973.2238   1132.6677  180.0   1.06171  0.00   
+  2  7    5    -2   3783.1903  4496.3914  -180.0  1.06153  0.00   
+  2  0    2    -6   609.0520   748.1993   0.0     1.06104  0.00   
+  2  5    -7   1    801.6337   969.1237   180.0   1.06052  0.00   
+  2  1    -9   -4   1429.9855  1706.8793  -180.0  1.06015  0.00   
+  2  2    -2   5    2793.5777  3313.4198  -180.0  1.05994  0.00   
+  2  3    -9   -4   11.5277    13.6703    -180.0  1.05993  0.00   
+  2  2    6    -6   228.2722   288.6216   -180.0  1.05938  0.00   
+  2  0    12   -1   952.2244   1340.4500  -0.0    1.05892  0.00   
+  2  1    -7   -5   5.2740     7.5059     -180.0  1.05860  0.00   
+  2  1    5    -6   33.3334    47.4061    -180.0  1.05858  0.00   
+  2  2    10   2    919.0598   1237.1699  -0.0    1.05797  0.00   
+  2  3    7    3    9.7727     12.9031    -180.0  1.05758  0.00   
+  2  7    3    -5   1657.7963  2239.1302  -180.0  1.05718  0.00   
+  2  6    6    0    304.7781   461.7745   -0.0    1.05659  0.00   
+  2  7    5    -4   1352.5283  2051.4003  0.0     1.05581  0.00   
+  2  4    -10  -2   2047.8750  3145.7849  0.0     1.05450  0.00   
+  2  5    7    1    24.0462    37.2884    180.0   1.05440  0.00   
+  2  6    8    -3   6368.7008  8866.7538  -0.0    1.05196  0.00   
+  2  3    -11  -1   188.1857   261.5320   -0.0    1.05193  0.00   
+  2  5    -5   2    4079.6880  5387.0808  -180.0  1.05131  0.00   
+  2  3    9    2    673.1254   862.2832   -0.0    1.05108  0.00   
+  2  3    11   -3   547.2633   673.7850   180.0   1.05082  0.00   
+  2  6    -6   0    449.4182   488.9045   -0.0    1.04978  0.00   
+  2  6    8    -2   333.1357   331.3808   0.0     1.04899  0.00   
+  2  3    11   0    414.2802   407.0557   -0.0    1.04881  0.00   
+  2  3    -5   -6   1265.2558  1235.7557  -180.0  1.04872  0.00   
+  2  4    10   0    67.4820    61.4161    -0.0    1.04771  0.00   
+  2  5    -9   -2   2484.6310  2208.3085  -0.0    1.04729  0.00   
+  2  5    9    -4   249.5270   228.7958   -180.0  1.04516  0.00   
+  2  6    -2   -6   1430.5244  1293.5044  -0.0    1.04487  0.00   
+  2  6    -4   1    3497.6169  3160.5795  -0.0    1.04485  0.00   
+  2  3    -5   4    2574.0900  2301.6767  -0.0    1.04377  0.00   
+  2  3    9    -5   1995.9849  1817.7670  180.0   1.04328  0.00   
+  2  1    5    5    1793.1801  1623.2967  -0.0    1.04294  0.00   
+  2  3    -11  0    1562.4200  1387.3612  0.0     1.04270  0.00   
+  2  2    2    5    297.9510   264.3036   0.0     1.04269  0.00   
+  2  5    -9   -1   72.7501    62.5557    0.0     1.04240  0.00   
+  2  6    4    1    1206.9577  1021.8291  -0.0    1.04223  0.00   
+  2  4    -10  0    648.0375   554.7785   -0.0    1.04034  0.00   
+  2  2    12   -1   4559.0261  3828.0670  -180.0  1.03971  0.00   
+  2  0    2    6    1773.6290  1492.8101  0.0     1.03949  0.00   
+  2  7    -5   -3   4171.7955  3517.5593  180.0   1.03943  0.00   
+  2  5    5    2    4826.2104  4324.4718  -180.0  1.03825  0.00   
+  2  4    -8   2    325.0577   298.1823   -0.0    1.03802  0.00   
+  2  6    4    -6   1358.2900  1251.2761  -180.0  1.03798  0.00   
+  2  0    12   1    346.4388   335.8693   -0.0    1.03750  0.00   
+  2  7    -5   -2   1486.1518  1492.9651  -180.0  1.03709  0.00   
+  2  7    1    0    1215.5021  1264.8986  -0.0    1.03656  0.00   
+  2  1    -9   4    2.5467     2.8086     180.0   1.03594  0.00   
+  2  1    11   2    1514.6524  1702.3367  180.0   1.03580  0.00   
+  2  7    -1   0    1515.1319  1823.6465  -0.0    1.03529  0.00   
+  2  4    10   -4   7.4288     9.1218     0.0     1.03486  0.00   
+  2  3    -11  -2   1132.1271  1522.0493  -180.0  1.03326  0.00   
+  3  2    0    -2   21414.3960 11511.4582 0.0     5.27278  0.00   
+  3  1    1    1    11116.1116 5910.6018  -180.0  4.69421  0.00   
+  3  1    1    -2   902.2754   470.8008   -180.0  4.67491  0.00   
+  3  1    1    2    1564.4449  1807.3867  -180.0  3.62744  0.00   
+  3  1    1    -3   5385.6955  6211.3199  180.0   3.61259  0.00   
+  3  0    2    0    4732.3341  1736.6491  180.0   3.42848  0.00   
+  3  3    1    -1   2075.4842  1015.9203  -0.0    3.40848  0.00   
+  3  3    1    -2   5917.9239  3190.0695  180.0   3.40107  0.00   
+  3  0    2    1    4827.9839  5002.8861  -0.0    3.28338  0.00   
+  3  2    0    2    12212.4204 11589.5133 -0.0    3.21994  0.00   
+  3  2    0    -4   5201.5796  4999.3789  180.0   3.19515  0.00   
+  3  3    1    0    2245.2837  2138.5462  0.0     3.14549  0.00   
+  3  3    1    -3   2928.3434  2676.9793  180.0   3.12810  0.00   
+  3  4    0    -2   105431.7486 80997.2126 -180.0  2.98634  0.01   
+  3  2    2    -1   92931.3838 75009.6462 -0.0    2.97342  0.01   
+  3  0    2    2    820.7845   792.3120   0.0     2.93844  0.00   
+  3  2    2    0    1758.8094  1808.4094  0.0     2.88026  0.00   
+  3  2    2    -2   533.5572   529.1465   -0.0    2.87430  0.00   
+  3  1    1    3    2551.1495  2484.3535  -0.0    2.86317  0.00   
+  3  1    1    -4   5877.7627  5798.5977  -0.0    2.85294  0.00   
+  3  0    0    4    10449.9421 10330.1978 -0.0    2.85171  0.00   
+  3  3    1    1    3158.0955  3754.6111  -180.0  2.75830  0.00   
+  3  3    1    -4   2653.5221  3264.4514  -0.0    2.73880  0.00   
+  3  4    0    0    74405.8494 71127.9625 0.0     2.65494  0.00   
+  3  2    2    1    142966.4789 132922.3198 0.0     2.64122  0.01   
+  3  4    0    -4   152282.2474 140723.6400 180.0   2.63639  0.01   
+  3  2    2    -3   72136.0229 66238.5325 -180.0  2.63204  0.01   
+  3  0    2    3    18771.3876 14170.9481 180.0   2.54623  0.00   
+  3  3    1    2    9626.8667  9775.9233  -180.0  2.37575  0.00   
+  3  3    1    -5   5673.1953  5862.9516  -0.0    2.35831  0.00   
+  3  2    2    2    147.7776   143.7322   -180.0  2.34711  0.00   
+  3  2    2    -4   984.8233   881.1199   180.0   2.33745  0.00   
+  3  1    1    4    3432.7522  2963.9032  -0.0    2.33543  0.00   
+  3  1    1    -5   399.8024   299.6580   -0.0    2.32829  0.00   
+  3  4    2    -2   1576.3986  1408.2873  -0.0    2.25186  0.00   
+  3  5    1    -2   2294.7716  2126.0831  180.0   2.24688  0.00   
+  3  5    1    -3   566.6560   539.9081   180.0   2.24334  0.00   
+  3  1    3    0    52.4793    52.4047    0.0     2.23449  0.00   
+  3  1    3    -1   4177.9379  4178.6541  -0.0    2.23379  0.00   
+  3  4    2    -1   898.8724   918.6208   0.0     2.21193  0.00   
+  3  4    2    -3   12508.8351 13301.7968 -0.0    2.20653  0.00   
+  3  0    2    4    887.4687   966.4144   180.0   2.19243  0.00   
+  3  5    1    -1   10063.3153 11534.5287 -0.0    2.16765  0.00   
+  3  5    1    -4   631.3083   710.8237   -180.0  2.15815  0.00   
+  3  1    3    1    940.8918   1030.5591  -0.0    2.15401  0.00   
+  3  1    3    -2   10136.3897 10956.6340 0.0     2.15213  0.00   
+  3  2    0    4    1548.4698  1631.5304  0.0     2.13728  0.00   
+  3  2    0    -6   7042.2070  7207.2063  0.0     2.12516  0.00   
+  3  4    2    0    680.2017   728.5675   -180.0  2.09914  0.00   
+  3  4    2    -4   484.2816   548.8323   -180.0  2.08993  0.00   
+  3  4    0    2    273378.4953 286005.4391 180.0   2.07126  0.01   
+  3  2    2    3    281136.5956 292660.3806 0.0     2.06253  0.02   
+  3  2    2    -5   276479.4024 296975.5561 0.0     2.05380  0.02   
+  3  4    0    -6   281498.7779 302465.0083 -180.0  2.05369  0.01   
+  3  3    1    3    1002.2300  1081.5570  -180.0  2.04859  0.00   
+  3  3    1    -6   149.1826   154.7495   -0.0    2.03421  0.00   
+  3  5    1    0    737.5313   771.8585   180.0   2.02885  0.00   
+  3  5    1    -5   12486.3104 14173.7038 -0.0    2.01590  0.00   
+  3  1    3    2    12327.2426 14004.5535 -0.0    2.01560  0.00   
+  3  1    3    -3   1086.3128  1237.4212  -0.0    2.01304  0.00   
+  3  3    3    -1   7280.2589  7019.6674  -0.0    1.97556  0.00   
+  3  3    3    -2   196.2736   188.0590   0.0     1.97412  0.00   
+  3  6    0    -2   961.7763   972.7095   180.0   1.96408  0.00   
+  3  1    1    5    4414.0047  4613.2866  180.0   1.96089  0.00   
+  3  6    0    -4   16317.2404 17295.8116 -180.0  1.95842  0.00   
+  3  1    1    -6   1473.7332  1561.0393  -0.0    1.95572  0.00   
+  3  4    2    1    19837.5507 20967.6709 -0.0    1.94305  0.00   
+  3  4    2    -5   65.8499    70.9580    180.0   1.93212  0.00   
+  3  3    3    0    9566.5507  9831.0649  180.0   1.92017  0.00   
+  3  3    3    -3   2715.8822  2768.0491  -0.0    1.91620  0.00   
+  3  0    0    6    1796.2202  1706.1315  -0.0    1.90114  0.00   
+  3  0    2    5    96.1068    90.1154    -180.0  1.89931  0.00   
+  3  5    1    1    3527.9753  2503.9377  -180.0  1.86201  0.00   
+  3  1    3    3    3687.6628  3420.0327  0.0     1.85016  0.00   
+  3  5    1    -6   2954.9138  2901.7818  -180.0  1.84802  0.00   
+  3  1    3    -4   511.3939   508.3602   -180.0  1.84739  0.00   
+  3  3    3    1    3529.2065  3294.2444  -0.0    1.82094  0.00   
+  3  3    3    -4   15301.0478 15068.8682 -180.0  1.81530  0.00   
+  3  2    2    4    2028.4991  2004.2303  180.0   1.81372  0.00   
+  3  2    2    -6   117.1101   110.8504   -0.0    1.80630  0.00   
+  3  3    1    4    1204.8589  1171.4647  -0.0    1.78242  0.00   
+  3  4    2    2    817.5488   570.0731   -0.0    1.77285  0.00   
+  3  3    1    -7   1151.9615  721.3829   -180.0  1.77084  0.00   
+  3  6    0    0    55711.1427 33175.6283 180.0   1.76996  0.00   
+  3  4    2    -6   3211.0122  1198.9237  -0.0    1.76179  0.00   
+  3  6    0    -6   5.5520     2.0493     0.0     1.75759  0.00   
+  3  6    2    -3   424184.5169 370441.0875 -180.0  1.72167  0.02   
+  3  0    4    0    384419.1257 348292.1094 -180.0  1.71424  0.01   
+  3  6    2    -2   456.1601   389.9646   -0.0    1.70424  0.00   
+  3  6    2    -4   1867.3112  1561.5622  180.0   1.70053  0.00   
+  3  3    3    2    4318.8444  3598.0817  -0.0    1.69681  0.00   
+  3  0    4    1    3878.8403  3253.6697  -0.0    1.69521  0.00   
+  3  5    1    2    2968.7466  2569.6935  -180.0  1.69204  0.00   
+  3  3    3    -5   11923.6387 10528.9461 0.0     1.69043  0.00   
+  3  1    1    6    814.4200   741.9232   -0.0    1.68509  0.00   
+  3  1    3    4    50.5966    44.8709    -0.0    1.68194  0.00   
+  3  1    1    -7   14149.1562 12427.2990 -180.0  1.68121  0.00   
+  3  1    3    -5   5456.0838  4676.5444  0.0     1.67927  0.00   
+  3  5    1    -7   312.5538   266.1130   -180.0  1.67855  0.00   
+  3  0    2    6    1059.5812  1003.4202  0.0     1.66263  0.00   
+  3  7    1    -3   36.0560    35.5714    180.0   1.65261  0.00   
+  3  6    2    -1   875.3269   866.7608   -180.0  1.65158  0.00   
+  3  7    1    -4   562.8836   558.9000   -0.0    1.65064  0.00   
+  3  5    3    -2   337.8339   336.8105   -180.0  1.64794  0.00   
+  3  2    4    -1   2846.8322  2838.5276  180.0   1.64772  0.00   
+  3  5    3    -3   1236.7780  1233.2068  -180.0  1.64654  0.00   
+  3  6    2    -5   508.0507   506.0292   -180.0  1.64486  0.00   
+  3  0    4    2    613.0233   610.4188   -180.0  1.64169  0.00   
+  3  2    4    0    724.5136   752.2049   -0.0    1.63133  0.00   
+  3  2    4    -2   4263.0263  4454.1899  180.0   1.63025  0.00   
+  3  7    1    -2   3534.4259  3579.8293  180.0   1.62084  0.00   
+  3  5    3    -1   1008.1618  966.8328   0.0     1.61591  0.00   
+  3  7    1    -5   964.0720   919.1461   -0.0    1.61527  0.00   
+  3  5    3    -4   4117.7508  3836.3564  -180.0  1.61196  0.00   
+  3  4    0    4    70013.8111 64411.0665 180.0   1.60997  0.00   
+  3  4    2    3    30.4822    27.4330    180.0   1.60782  0.00   
+  3  2    2    5    43356.7368 37123.7775 -180.0  1.60482  0.00   
+  3  2    2    -7   88242.3118 66522.3216 0.0     1.59865  0.00   
+  3  4    0    -8   49907.3525 36968.9224 0.0     1.59758  0.00   
+  3  4    2    -7   3490.4746  2583.0936  -0.0    1.59751  0.00   
+  3  2    4    1    1954.2254  1921.5460  0.0     1.58398  0.00   
+  3  2    4    -3   1837.2293  1873.5320  0.0     1.58199  0.00   
+  3  2    0    6    28485.2641 28903.5841 -0.0    1.57550  0.00   
+  3  6    2    0    319.0935   317.6202   -0.0    1.57274  0.00   
+  3  2    0    -8   5055.5878  4976.9857  -180.0  1.56869  0.00   
+  3  3    1    5    1765.5374  1738.9888  180.0   1.56823  0.00   
+  3  3    3    3    485.9415   484.2721   0.0     1.56474  0.00   
+  3  6    2    -6   1248.9868  1248.6755  -180.0  1.56405  0.00   
+  3  0    4    3    2894.9749  2911.4288  -0.0    1.56276  0.00   
+  3  7    1    -1   2018.9239  2046.3350  -0.0    1.56077  0.00   
+  3  3    1    -8   1828.2043  1859.5582  0.0     1.55890  0.00   
+  3  3    3    -6   1466.8080  1492.1789  -180.0  1.55830  0.00   
+  3  5    3    0    3714.5163  3763.3472  180.0   1.55589  0.00   
+  3  7    1    -6   3788.1731  3795.1599  -180.0  1.55250  0.00   
+  3  5    3    -5   1427.5998  1407.6720  0.0     1.55003  0.00   
+  3  5    1    3    867.3478   788.0574   0.0     1.53300  0.00   
+  3  1    3    5    8.6855     7.4043     -180.0  1.52460  0.00   
+  3  1    3    -6   1399.1204  1154.4221  0.0     1.52216  0.00   
+  3  5    1    -8   6.5839     5.3533     0.0     1.52075  0.00   
+  3  2    4    2    5064.0420  4247.4670  180.0   1.51316  0.00   
+  3  2    4    -4   2849.5794  2483.9424  -0.0    1.51057  0.00   
+  3  6    0    2    9545.5961  8942.8816  -180.0  1.50640  0.00   
+  3  6    0    -8   4202.7153  4394.2493  -180.0  1.49373  0.00   
+  3  8    0    -4   19344.1354 20182.1370 -0.0    1.49317  0.00   
+  3  4    4    -2   19975.5278 20467.2694 -0.0    1.48671  0.00   
+  3  7    1    0    501.4179   523.5234   0.0     1.48128  0.00   
+  3  6    2    1    485.3539   507.6139   180.0   1.47872  0.00   
+  3  5    3    1    1413.4621  1470.2348  180.0   1.47671  0.00   
+  3  4    4    -1   174.3070   180.4280   180.0   1.47504  0.00   
+  3  1    1    7    8771.6268  9078.3281  -0.0    1.47499  0.00   
+  3  4    4    -3   1619.8728  1668.6989  180.0   1.47344  0.00   
+  3  1    1    -8   7220.6776  7396.8151  0.0     1.47199  0.00   
+  3  0    2    7    2442.3072  2499.6537  180.0   1.47177  0.00   
+  3  7    1    -7   227.6067   232.6283   -180.0  1.47141  0.00   
+  3  5    3    -6   0.1764     0.1794     -180.0  1.46970  0.00   
+  3  0    4    4    569.6465   579.1182   180.0   1.46922  0.00   
+  3  6    2    -7   1068.1953  1085.9553  180.0   1.46910  0.00   
+  3  4    2    4    309.2678   309.1522   -180.0  1.45729  0.00   
+  3  4    2    -8   297.8245   302.7889   -180.0  1.44808  0.00   
+  3  8    0    -2   51383.6797 52401.9841 0.0     1.44751  0.00   
+  3  8    0    -6   38382.9273 39579.0897 -180.0  1.44148  0.00   
+  3  4    4    0    39324.7431 40385.4402 -180.0  1.44013  0.00   
+  3  4    4    -4   53617.8118 54092.8025 0.0     1.43715  0.00   
+  3  3    3    4    4612.0218  4616.8695  -180.0  1.43605  0.00   
+  3  2    2    6    0.8235     0.8056     -180.0  1.43158  0.00   
+  3  3    3    -7   1466.1774  1448.2095  0.0     1.42997  0.00   
+  3  2    4    3    2645.4727  2694.8245  180.0   1.42814  0.00   
+  3  2    2    -8   1720.1754  1820.4529  -0.0    1.42647  0.00   
+  3  0    0    8    248541.2310 266732.7000 -0.0    1.42586  0.00   
+  3  2    4    -5   1534.8714  1669.7327  180.0   1.42524  0.00   
+  3  3    1    6    908.1148   938.8410   180.0   1.39505  0.00   
+  3  7    1    1    49.4546    50.2357    -180.0  1.39164  0.00   
+  3  5    1    4    759.9933   766.8174   0.0     1.39062  0.00   
+  3  5    3    2    445.2257   442.8181   -180.0  1.38751  0.00   
+  3  3    1    -9   712.3840   708.4684   -0.0    1.38746  0.00   
+  3  4    4    1    3650.2476  3621.4810  -0.0    1.38663  0.00   
+  3  1    3    6    3245.9674  3145.7496  0.0     1.38367  0.00   
+  3  4    4    -5   1276.2886  1223.4375  0.0     1.38264  0.00   
+  3  1    3    -7   513.1058   485.6292   -180.0  1.38152  0.00   
+  3  7    1    -8   245.9447   231.7453   0.0     1.38113  0.00   
+  3  5    3    -7   1155.6086  1075.8151  180.0   1.38004  0.00   
+  3  5    1    -9   3411.4183  3167.7891  -0.0    1.37980  0.00   
+  3  6    2    2    277.0658   255.6554   -180.0  1.37915  0.00   
+  3  0    4    5    413.4275   361.1609   -180.0  1.37047  0.00   
+  3  6    2    -8   3.3335     2.8442     0.0     1.36940  0.00   
+  3  8    2    -4   875.5352   740.7113   180.0   1.36897  0.00   
+  3  7    3    -3   3737.2077  3201.7654  -180.0  1.36552  0.00   
+  3  7    3    -4   519.1095   462.9948   -180.0  1.36440  0.00   
+  3  8    2    -3   1907.9255  1927.1532  180.0   1.36048  0.00   
+  3  1    5    0    4289.4752  4360.5263  -180.0  1.36010  0.00   
+  3  1    5    -1   56.1489    57.2215    -0.0    1.35994  0.00   
+  3  8    2    -5   13621.2223 14185.1487 180.0   1.35796  0.00   
+  3  7    3    -2   6086.7146  6979.5720  0.0     1.34743  0.00   
+  3  7    3    -5   2130.0693  2393.9202  180.0   1.34423  0.00   
+  3  1    5    1    6827.5061  7418.3946  0.0     1.34132  0.00   
+  3  1    5    -2   2592.7555  2794.4988  180.0   1.34086  0.00   
+  3  2    4    4    199.4314   204.5780   -180.0  1.33725  0.00   
+  3  2    4    -6   3971.8768  4271.0117  180.0   1.33426  0.00   
+  3  8    2    -2   175.1343   192.6542   0.0     1.33353  0.00   
+  3  8    2    -6   93.8271    116.9879   0.0     1.32881  0.00   
+  3  8    0    0    101797.9870 126956.4224 0.0     1.32747  0.00   
+  3  4    2    5    10613.4848 12813.2310 0.0     1.32420  0.00   
+  3  4    4    2    95928.6146 113768.3425 0.0     1.32061  0.00   
+  3  8    0    -8   121188.9249 139544.0331 -0.0    1.31819  0.00   
+  3  3    3    5    1127.1240  1244.6187  -0.0    1.31675  0.00   
+  3  0    2    8    335.9088   368.2815   180.0   1.31654  0.00   
+  3  4    2    -9   5113.7561  5527.8067  180.0   1.31614  0.00   
+  3  4    4    -6   112012.0708 120592.4792 0.0     1.31602  0.00   
+  3  7    3    -1   1104.3786  1033.4915  180.0   1.31232  0.00   
+  3  3    3    -8   7939.0297  7097.5780  180.0   1.31121  0.00   
+  3  1    1    8    182.7036   157.0067   180.0   1.31026  0.00   
+  3  1    1    -9   907.4581   715.4708   180.0   1.30787  0.00   
+  3  7    3    -6   9707.7829  7551.7571  -0.0    1.30740  0.00   
+  3  1    5    2    2319.2961  1733.2782  180.0   1.30583  0.00   
+  3  1    5    -3   9919.1305  7303.6570  -0.0    1.30514  0.00   
+  3  9    1    -4   1259.5017  843.4711   0.0     1.30157  0.00   
+  3  9    1    -5   397.6969   257.6551   0.0     1.30033  0.00   
+  3  7    1    2    6274.5257  3977.9953  -180.0  1.29932  0.00   
+  3  6    4    -3   3737.4331  2357.3599  -0.0    1.29904  0.00   
+  3  5    3    3    524.3398   335.5156   180.0   1.29569  0.00   
+  3  3    5    -1   936.1025   621.7084   0.0     1.29476  0.00   
+  3  3    5    -2   3231.8197  2187.9867  -0.0    1.29435  0.00   
+  3  6    4    -2   33.1922    25.6015    0.0     1.29151  0.00   
+  3  8    2    -1   11511.2384 8940.5721  180.0   1.29125  0.00   
+  3  4    0    6    23640.0666 18472.0747 180.0   1.29100  0.00   
+  3  6    4    -4   8941.9702  7142.6749  -0.0    1.28989  0.00   
+  3  7    1    -9   163.3159   133.2606   180.0   1.28888  0.00   
+  3  5    3    -8   4214.3345  3486.8639  180.0   1.28826  0.00   
+  3  2    2    7    19291.8709 16125.1270 -0.0    1.28781  0.00   
+  3  9    1    -3   6371.1874  5524.9101  180.0   1.28615  0.00   
+  3  8    2    -7   484.0998   430.5464   -180.0  1.28483  0.00   
+  3  2    2    -9   21809.5918 19765.3570 0.0     1.28355  0.00   
+  3  9    1    -6   204.4634   187.1689   -0.0    1.28257  0.00   
+  3  4    0    -10  22576.2861 20681.0743 -180.0  1.28247  0.00   
+  3  6    2    3    0.4162     0.3823     180.0   1.28086  0.00   
+  3  3    5    0    798.6200   720.5954   -0.0    1.27878  0.00   
+  3  3    5    -3   6795.4325  6036.9196  -0.0    1.27761  0.00   
+  3  0    4    6    135.2271   118.5251   180.0   1.27311  0.00   
+  3  6    2    -9   513.5838   465.8532   180.0   1.27149  0.00   
+  3  6    4    -1   496.0143   481.8202   -180.0  1.26813  0.00   
+  3  6    0    4    7773.0922  7271.9004  180.0   1.26631  0.00   
+  3  5    1    5    5022.1052  4614.0892  180.0   1.26584  0.00   
+  3  6    4    -5   653.5362   581.7999   -180.0  1.26508  0.00   
+  3  7    3    0    945.0706   803.6266   180.0   1.26401  0.00   
+  3  1    3    7    10200.9605 8417.2878  -0.0    1.26009  0.00   
+  3  1    3    -8   3644.9133  3095.0525  180.0   1.25822  0.00   
+  3  7    3    -7   2849.0833  2425.9429  180.0   1.25786  0.00   
+  3  1    5    3    41.2073    35.1503    180.0   1.25746  0.00   
+  3  1    5    -4   3634.1785  3097.6918  180.0   1.25659  0.00   
+  3  5    1    -10  8283.4294  7054.0860  -180.0  1.25642  0.00   
+  3  6    0    -10  139.1037   117.7387   180.0   1.25576  0.00   
+  3  9    1    -2   428.6554   362.7881   0.0     1.25576  0.00   
+  3  3    1    7    1967.0686  1612.5440  -0.0    1.25351  0.00   
+  3  9    1    -7   10808.5076 8760.4984  -180.0  1.25022  0.00   
+  3  3    5    1    9751.7680  8337.3020  0.0     1.24817  0.00   
+  3  4    4    3    19.1671    16.4749    0.0     1.24800  0.00   
+  3  3    1    -10  3401.5186  2988.8915  180.0   1.24727  0.00   
+  3  2    4    5    1284.5115  1150.2934  0.0     1.24659  0.00   
+  3  3    5    -4   1211.2354  1091.6733  -0.0    1.24635  0.00   
+  3  2    4    -7   840.3606   790.3905   0.0     1.24369  0.00   
+  3  4    4    -7   6938.6927  6541.8184  -0.0    1.24316  0.00   
+  3  2    0    8    29.5264    27.7546    -0.0    1.24197  0.00   
+  3  8    2    0    856.7491   733.8837   180.0   1.23792  0.00   
+  3  2    0    -10  2360.2121  2005.6643  180.0   1.23768  0.00   
+  3  6    4    0    16252.9945 14152.7382 -0.0    1.23138  0.00   
+  3  8    2    -8   697.9044   629.1885   180.0   1.23039  0.00   
+  3  6    4    -6   133.7100   129.7138   -180.0  1.22719  0.00   
+  3  9    1    -1   2866.1517  2744.2992  -0.0    1.21345  0.00   
+  3  7    1    3    76.2051    73.2189    180.0   1.20941  0.00   
+  3  3    3    6    884.3587   848.7937   0.0     1.20915  0.00   
+  3  4    2    6    431.2526   411.8660   -0.0    1.20819  0.00   
+  3  7    3    1    2881.3776  2739.7130  180.0   1.20692  0.00   
+  3  9    1    -8   2449.9070  2328.1573  0.0     1.20647  0.00   
+  3  5    3    4    7928.6973  7533.8281  -180.0  1.20626  0.00   
+  3  3    5    2    3937.6745  3741.7581  0.0     1.20594  0.00   
+  3  3    3    -9   986.2601   945.2482   -0.0    1.20420  0.00   
+  3  3    5    -5   50.6910    48.8651    180.0   1.20364  0.00   
+  3  4    2    -10  167.1772   165.7399   -0.0    1.20118  0.00   
+  3  1    5    4    3952.6894  3934.1444  180.0   1.20057  0.00   
+  3  7    3    -8   5.4675     5.4499     0.0     1.20005  0.00   
+  3  1    5    -5   658.0967   655.8926   0.0     1.19960  0.00   
+  3  7    1    -10  8343.4253  8313.3024  -180.0  1.19946  0.00   
+  3  5    3    -9   302.2091   300.8794   180.0   1.19918  0.00   
+  3  10   0    -4   7894.7838  6816.4474  0.0     1.18909  0.00   
+  3  0    2    9    310.8739   269.4917   -0.0    1.18880  0.00   
+  3  5    5    -2   3436.7442  3024.8638  -0.0    1.18802  0.00   
+  3  6    2    4    303.5102   268.0503   180.0   1.18787  0.00   
+  3  5    5    -3   0.1120     0.0999     -0.0    1.18749  0.00   
+  3  10   0    -6   12318.9289 11133.5203 0.0     1.18699  0.00   
+  3  6    4    1    1375.4413  1320.3743  0.0     1.18466  0.00   
+  3  0    4    7    285.5702   286.2759   180.0   1.18107  0.00   
+  3  6    4    -7   1772.6655  1787.3679  0.0     1.17969  0.00   
+  3  8    0    2    30957.0046 31252.4162 180.0   1.17918  0.00   
+  3  6    2    -10  2.1959     2.2169     -0.0    1.17916  0.00   
+  3  1    1    9    120.9508   122.6224   -0.0    1.17794  0.00   
+  3  8    2    1    5759.5931  5839.8036  -180.0  1.17792  0.00   
+  3  1    1    -10  742.9927   763.1313   180.0   1.17600  0.00   
+  3  5    5    -1   7113.8846  7315.0281  -180.0  1.17585  0.00   
+  3  5    5    -4   5343.8311  5558.6385  -0.0    1.17432  0.00   
+  3  4    4    4    32304.3359 33773.1476 0.0     1.17355  0.00   
+  3  8    2    -9   8254.6061  8433.6820  180.0   1.16982  0.00   
+  3  8    0    -10  37722.9316 38320.9165 0.0     1.16945  0.00   
+  3  4    4    -8   28465.5927 28599.6035 -180.0  1.16873  0.00   
+  3  2    2    8    101.1420   100.3642   0.0     1.16772  0.00   
+  3  2    2    -10  575.5699   559.7557   -0.0    1.16414  0.00   
+  3  9    1    0    185.7188   176.0111   180.0   1.16288  0.00   
+  3  2    4    6    15405.0755 13773.8803 180.0   1.16000  0.00   
+  3  5    1    6    55.6677    50.4105    0.0     1.15746  0.00   
+  3  2    4    -8   2662.0533  2415.1534  0.0     1.15727  0.00   
+  3  3    5    3    3415.7078  3130.6548  0.0     1.15568  0.00   
+  3  9    1    -9   619.3920   566.7118   180.0   1.15499  0.00   
+  3  3    5    -6   57.3151    51.5975    -0.0    1.15308  0.00   
+  3  1    3    8    3078.1451  2760.9534  0.0     1.15268  0.00   
+  3  5    5    0    7464.4591  6661.9553  -0.0    1.15210  0.00   
+  3  1    3    -9   1.4977     1.3293     -0.0    1.15105  0.00   
+  3  5    5    -5   9516.5649  8505.8774  -180.0  1.14972  0.00   
+  3  5    1    -11  1683.6378  1515.0613  0.0     1.14930  0.00   
+  3  9    3    -4   444.9553   427.8410   0.0     1.14675  0.00   
+  3  9    3    -5   65.6741    65.0163    -0.0    1.14590  0.00   
+  3  7    3    2    4846.9260  4902.8455  -0.0    1.14521  0.00   
+  3  0    6    0    2524.7656  2603.9725  -0.0    1.14283  0.00   
+  3  10   0    -2   15679.7812 16037.3797 0.0     1.14241  0.00   
+  3  0    0    10   442.2009   424.2167   -0.0    1.14068  0.00   
+  3  1    5    5    5586.0332  5037.9825  -0.0    1.13922  0.00   
+  3  1    5    -6   6065.5115  5303.5881  180.0   1.13821  0.00   
+  3  7    3    -9   5354.7779  4668.6503  180.0   1.13804  0.00   
+  3  0    6    1    1890.3431  1644.7919  180.0   1.13714  0.00   
+  3  10   0    -8   1664.0814  1453.4715  0.0     1.13685  0.00   
+  3  3    1    8    77.6954    68.5405    180.0   1.13637  0.00   
+  3  9    3    -3   1610.5516  1428.7035  -180.0  1.13616  0.00   
+  3  9    3    -6   1979.2860  1859.1319  -0.0    1.13369  0.00   
+  3  6    4    2    2971.2285  2826.8128  0.0     1.13157  0.00   
+  3  3    1    -11  32.5000    30.9644    0.0     1.13117  0.00   
+  3  10   2    -5   6240.2468  6295.3268  0.0     1.12803  0.00   
+  3  6    4    -8   1850.0563  2098.5070  -0.0    1.12617  0.00   
+  3  8    4    -4   3620.2539  4166.4798  -180.0  1.12593  0.00   
+  3  7    1    4    4101.0669  4931.2456  -0.0    1.12480  0.00   
+  3  10   2    -4   7.5285     9.0471     180.0   1.12344  0.00   
+  3  2    6    -1   3000.1617  3545.8942  180.0   1.12246  0.00   
+  3  5    3    5    1682.2340  1969.8973  -180.0  1.12209  0.00   
+  3  10   2    -6   148.8068   172.5193   180.0   1.12167  0.00   
+  3  8    4    -3   2890.8352  3322.6561  -180.0  1.12119  0.00   
+  3  0    6    2    1201.6077  1372.9391  -180.0  1.12055  0.00   
+  3  8    4    -5   907.0053   1032.2056  180.0   1.11978  0.00   
+  3  5    5    1    635.2586   710.5254   0.0     1.11882  0.00   
+  3  2    6    0    5106.0592  5310.1542  180.0   1.11724  0.00   
+  3  2    6    -2   972.7134   991.2840   180.0   1.11689  0.00   
+  3  5    5    -6   2635.4547  2502.1692  0.0     1.11577  0.00   
+  3  7    1    -11  2226.3277  2086.3451  180.0   1.11556  0.00   
+  3  5    3    -10  1709.2901  1596.5822  -0.0    1.11551  0.00   
+  3  8    2    2    132.9741   120.8930   0.0     1.11507  0.00   
+  3  9    3    -2   2227.7323  2022.8077  0.0     1.11505  0.00   
+  3  3    3    7    8426.7329  7160.4504  0.0     1.11347  0.00   
+  3  9    3    -7   2076.6655  1754.2932  -180.0  1.11116  0.00   
+  3  3    3    -10  298.1141   264.2368   -0.0    1.10909  0.00   
+  3  10   2    -3   39057.7856 35198.9394 -180.0  1.10829  0.00   
+  3  9    1    1    4179.0980  3814.8159  -180.0  1.10755  0.00   
+  3  4    2    7    10150.6021 9266.0725  0.0     1.10755  0.00   
+  3  8    2    -10  39.7105    36.6106    0.0     1.10683  0.00   
+  3  8    4    -2   31659.7444 29371.8595 -180.0  1.10597  0.00   
+  3  10   2    -7   37701.5154 35018.3253 0.0     1.10490  0.00   
+  3  8    4    -6   32481.4745 30155.6103 0.0     1.10327  0.00   
+  3  6    2    5    143084.4133 132224.1652 -180.0  1.10215  0.00   
+  3  2    6    1    29926.9844 27586.9951 -180.0  1.10167  0.00   
+  3  4    2    -11  2361.3674  2174.1832  -0.0    1.10148  0.00   
+  3  2    6    -3   32530.1627 29856.1362 0.0     1.10100  0.00   
+  3  3    5    4    76.6017    70.2165    0.0     1.10083  0.00   
+  3  4    4    5    2945.4743  2696.1431  180.0   1.10063  0.00   
+  3  9    1    -10  308.7342   280.7417   0.0     1.09923  0.00   
+  3  3    5    -7   3252.0839  2933.4436  0.0     1.09808  0.00   
+  3  0    4    8    153492.0260 133795.8139 -180.0  1.09621  0.00   
+  3  4    4    -9   154.7213   133.9544   0.0     1.09598  0.00   
+  3  0    6    3    4161.4928  3391.0840  -0.0    1.09446  0.00   
+  3  6    2    -11  186569.8446 149937.5693 -180.0  1.09419  0.00   
+  3  9    3    -1   1268.7356  1115.8244  0.0     1.08511  0.00   
+  3  10   2    -2   940.4470   880.8125   -0.0    1.08382  0.00   
+  3  0    2    10   135.8756   133.8301   0.0     1.08235  0.00   
+  3  7    3    3    6057.5859  5998.1447  180.0   1.08222  0.00   
+  3  8    4    -1   6.3753     6.5222     0.0     1.08149  0.00   
+  3  9    3    -8   15.3424    16.9760    180.0   1.08011  0.00   
+  3  2    4    7    123.7007   143.3393   180.0   1.07946  0.00   
+  3  10   2    -8   253.4574   302.3514   0.0     1.07907  0.00   
+  3  5    5    2    4255.5745  5302.6889  0.0     1.07850  0.00   
+  3  8    4    -7   668.8363   885.8789   -0.0    1.07771  0.00   
+  3  2    6    2    342.7297   478.1936   0.0     1.07700  0.00   
+  3  2    4    -9   929.8904   1302.2259  -180.0  1.07695  0.00   
+  3  1    5    6    5251.1013  7484.8835  180.0   1.07669  0.00   
+  3  2    6    -4   2127.8770  3155.4747  -0.0    1.07607  0.00   
+  3  1    5    -7   7362.8557  11172.4404 0.0     1.07568  0.00   
+  3  6    4    3    983.3377   1518.6342  -180.0  1.07536  0.00   
+  3  7    3    -10  7836.1505  12279.4341 0.0     1.07507  0.00   
+  3  5    5    -7   10.4878    16.5024    0.0     1.07498  0.00   
+  3  6    0    6    533.7628   881.0224   180.0   1.07331  0.00   
+  3  11   1    -5   94.1775    157.4610   180.0   1.07181  0.00   
+  3  11   1    -6   3.3812     5.7108     -180.0  1.07097  0.00   
+  3  6    4    -9   477.1930   817.7360   -180.0  1.06980  0.00   
+  3  1    1    10   1509.8494  2600.5368  -180.0  1.06948  0.00   
+  3  4    0    8    13552.5087 23545.6846 -0.0    1.06864  0.00   
+  3  7    5    -3   771.8114   1330.2343  -180.0  1.06807  0.00   
+  3  1    1    -11  24.5615    42.0897    0.0     1.06788  0.00   
+  3  7    5    -4   99.6129    168.4965   180.0   1.06754  0.00   
+  3  4    6    -2   1481.6256  2484.1220  -180.0  1.06734  0.00   
+  3  2    2    9    15161.6332 24387.2566 -0.0    1.06652  0.00   
+  3  6    0    -12  2005.7953  2937.0147  -180.0  1.06505  0.00   
+  3  5    1    7    2505.8511  3266.5087  0.0     1.06351  0.00   
+  3  2    2    -11  16131.4338 21014.7437 -180.0  1.06350  0.00   
+  3  11   1    -4   3981.0800  5130.8036  0.0     1.06330  0.00   
+  3  4    6    -1   1.5808     2.0095     -0.0    1.06300  0.00   
+  3  4    0    -12  22566.2817 28294.4853 -180.0  1.06258  0.00   
+  3  4    6    -3   2257.8470  2820.0151  180.0   1.06240  0.00   
+  3  10   0    0    662.6688   823.5252   0.0     1.06197  0.00   
+  3  11   1    -7   53.1843    66.4369    -180.0  1.06083  0.00   
+  3  0    6    4    1334.7621  1667.5861  0.0     1.06081  0.00   
+  3  1    3    9    1255.1516  1610.5703  0.0     1.05949  0.00   
+  3  7    5    -2   1.2698     1.6367     -0.0    1.05935  0.00   
+  3  1    3    -10  1769.1447  2357.4609  0.0     1.05808  0.00   
+  3  7    5    -5   2897.0825  3882.9000  -180.0  1.05779  0.00   
+  3  5    1    -12  1513.2851  2096.8219  -180.0  1.05643  0.00   
+  3  10   0    -10  3325.4762  4670.5595  0.0     1.05456  0.00   
+  3  8    2    3    17282.3496 22586.4647 180.0   1.05224  0.00   
+  3  10   2    -1   45516.5536 58072.3330 0.0     1.05185  0.00   
+  3  9    1    2    115.5673   132.8636   -0.0    1.05041  0.00   
+  3  4    6    0    1456.0676  1588.0055  0.0     1.04971  0.00   
+  3  8    4    0    57574.4703 62169.3866 -180.0  1.04957  0.00   
+  3  4    6    -4   1153.1348  1168.0135  0.0     1.04855  0.00   
+  3  9    3    0    2336.8164  2359.8361  0.0     1.04850  0.00   
+  3  7    1    5    1076.8673  1024.8294  0.0     1.04685  0.00   
+  3  11   1    -3   29.2948    27.5849    180.0   1.04608  0.00   
+  3  10   2    -9   71621.2424 67433.1239 0.0     1.04607  0.00   
+  3  2    6    3    59949.6074 55749.7605 -180.0  1.04504  0.00   
+  3  8    4    -8   72761.2238 67597.9465 -180.0  1.04497  0.00   
+  3  5    3    6    1516.2982  1400.3734  -180.0  1.04452  0.00   
+  3  3    5    5    3953.8144  3639.2065  -0.0    1.04425  0.00   
+  3  8    2    -11  5.2939     4.8681     0.0     1.04417  0.00   
+  3  2    6    -5   61153.9020 56063.5788 -180.0  1.04390  0.00   
+  3  9    3    -9   547.2838   493.6028   -180.0  1.04270  0.00   
+  3  11   1    -8   5985.6648  5353.4363  0.0     1.04216  0.00   
+  3  7    5    -1   5209.2788  4651.6452  -180.0  1.04203  0.00   
+  3  9    1    -11  5549.8809  4955.5220  180.0   1.04203  0.00   
+  3  3    5    -8   429.1373   381.5611   -0.0    1.04148  0.00   
+  3  7    5    -6   22.9256    20.5764    180.0   1.03956  0.00   
+  3  5    3    -11  180.4017   166.7784   -0.0    1.03851  0.00   
+  3  7    1    -12  608.6499   564.9155   -180.0  1.03841  0.00   
+  3  3    1    9    1052.5079  984.5971   -180.0  1.03823  0.00   
+  3  8    0    4    2635.4088  2830.6748  -0.0    1.03563  0.00   
+  3  3    1    -12  834.7617   960.8990   0.0     1.03384  0.00   
+  3  5    5    3    1203.2535  1391.0003  -180.0  1.03365  0.00   
+  4  1    1    0    1554.5603  1523.1929  -0.0    3.25125  0.08   
+  4  1    0    1    437.9567   356.4613   -0.0    2.48998  0.03   
+  4  2    0    0    305.6561   291.8090   -0.0    2.29898  0.01   
+  4  1    1    1    272.1481   288.4667   180.0   2.18953  0.01   
+  4  2    1    0    214.1767   230.0704   0.0     2.05627  0.01   
+  4  2    1    1    949.2630   879.7935   -0.0    1.68912  0.05   
+  4  2    2    0    792.3184   872.5279   -0.0    1.62563  0.01   
+  4  0    0    2    1309.2159  1394.0051  -0.0    1.48094  0.01   
+  4  3    1    0    282.3887   273.7934   -0.0    1.45400  0.01   
+  4  2    2    1    78.9627    88.9749    180.0   1.42509  0.00   
+  4  3    0    1    1136.3619  1183.6304  -0.0    1.36121  0.02   
+  4  1    1    2    505.8513   598.3989   -0.0    1.34771  0.01   
+  4  3    1    1    1.2445     0.8897     0.0     1.30521  0.00   
+  4  3    2    0    0.8997     0.7519     180.0   1.27525  0.00   
+  4  2    0    2    211.1670   203.6183   -0.0    1.24499  0.00   
+  4  2    1    2    62.6601    62.9745    0.0     1.20171  0.00   
+  4  3    2    1    175.1624   188.7646   -0.0    1.17129  0.01   
+  4  4    0    0    264.4570   227.1319   -0.0    1.14949  0.00   
+  4  4    1    0    70.6931    62.4730    180.0   1.11517  0.00   
+  4  2    2    2    520.8392   440.1237   -0.0    1.09477  0.01   
+  4  3    3    0    764.6751   737.9443   -0.0    1.08375  0.01   
+  4  4    1    1    400.6362   360.8859   -0.0    1.04365  0.01   
+  4  3    1    2    180.9715   174.6004   -0.0    1.03753  0.01   
+_reflns_number_total  1177
+_reflns_d_resolution_low    5.273
+_reflns_d_resolution_high   1.033
+
+# POWDER DATA TABLE
+_pd_meas_2theta_range_min  10.01313
+_pd_meas_2theta_range_max  119.99238
+_pd_meas_2theta_range_inc  0.02626
+_pd_proc_2theta_range_min  9.99428
+_pd_proc_2theta_range_max  119.97353
+_pd_proc_2theta_range_inc  0.02626
+_pd_proc_number_of_points  4189
+
+loop_
+   _pd_meas_intensity_total
+   _pd_calc_intensity_total
+   _pd_proc_intensity_bkg_calc
+   _pd_proc_ls_weight
+  2914         0            0           0         
+  2902         0            0           0         
+  2836         0            0           0         
+  3001         0            0           0         
+  2863         0            0           0         
+  2859         0            0           0         
+  2962         0            0           0         
+  2923         0            0           0         
+  2909         0            0           0         
+  2898         0            0           0         
+  2857         0            0           0         
+  2910         0            0           0         
+  2903         0            0           0         
+  2861         0            0           0         
+  2844         0            0           0         
+  2859         0            0           0         
+  2897         0            0           0         
+  2828         0            0           0         
+  2824         0            0           0         
+  2786         0            0           0         
+  2844         0            0           0         
+  2757         0            0           0         
+  2754         0            0           0         
+  2803         0            0           0         
+  2680         0            0           0         
+  2799         0            0           0         
+  2714         0            0           0         
+  2825         0            0           0         
+  2779         0            0           0         
+  2838         0            0           0         
+  2771         0            0           0         
+  2745         0            0           0         
+  2766         0            0           0         
+  2652         0            0           0         
+  2725         0            0           0         
+  2723         0            0           0         
+  2738         0            0           0         
+  2668         0            0           0         
+  2726         0            0           0         
+  2605         0            0           0         
+  2688         0            0           0         
+  2680         0            0           0         
+  2555         0            0           0         
+  2583         0            0           0         
+  2683         0            0           0         
+  2651         0            0           0         
+  2635         0            0           0         
+  2653         0            0           0         
+  2674         0            0           0         
+  2615         0            0           0         
+  2590         0            0           0         
+  2723         0            0           0         
+  2565         0            0           0         
+  2609         0            0           0         
+  2597         0            0           0         
+  2631         0            0           0         
+  2588         0            0           0         
+  2662         0            0           0         
+  2627         0            0           0         
+  2646         0            0           0         
+  2596         0            0           0         
+  2541         0            0           0         
+  2535         0            0           0         
+  2592         0            0           0         
+  2517         0            0           0         
+  2541         0            0           0         
+  2613         0            0           0         
+  2497         0            0           0         
+  2700         0            0           0         
+  2510         0            0           0         
+  2448         0            0           0         
+  2361         0            0           0         
+  2535         0            0           0         
+  2395         0            0           0         
+  2493         0            0           0         
+  2511         0            0           0         
+  2506         0            0           0         
+  2499         0            0           0         
+  2405         0            0           0         
+  2478         0            0           0         
+  2485         0            0           0         
+  2409         0            0           0         
+  2442         0            0           0         
+  2487         0            0           0         
+  2410         0            0           0         
+  2419         0            0           0         
+  2410         0            0           0         
+  2371         0            0           0         
+  2441         0            0           0         
+  2532         0            0           0         
+  2406         0            0           0         
+  2349         0            0           0         
+  2437         0            0           0         
+  2343         0            0           0         
+  2393         0            0           0         
+  2380         0            0           0         
+  2356         0            0           0         
+  2330         0            0           0         
+  2349         0            0           0         
+  2409         0            0           0         
+  2230         0            0           0         
+  2314         0            0           0         
+  2354         0            0           0         
+  2316         0            0           0         
+  2306         0            0           0         
+  2270         0            0           0         
+  2271         0            0           0         
+  2259         0            0           0         
+  2244         0            0           0         
+  2251         0            0           0         
+  2273         0            0           0         
+  2373         0            0           0         
+  2307         0            0           0         
+  2292         0            0           0         
+  2267         0            0           0         
+  2273         0            0           0         
+  2215         0            0           0         
+  2274         0            0           0         
+  2164         0            0           0         
+  2275         0            0           0         
+  2332         0            0           0         
+  2216         0            0           0         
+  2255         0            0           0         
+  2266         0            0           0         
+  2204         0            0           0         
+  2295         0            0           0         
+  2220         0            0           0         
+  2204         0            0           0         
+  2233         0            0           0         
+  2241         0            0           0         
+  2241         0            0           0         
+  2221         0            0           0         
+  2246         0            0           0         
+  2232         0            0           0         
+  2249         0            0           0         
+  2197         0            0           0         
+  2278         0            0           0         
+  2147         0            0           0         
+  2170         0            0           0         
+  2156         0            0           0         
+  2195         0            0           0         
+  2152         0            0           0         
+  2075         0            0           0         
+  2167         0            0           0         
+  2170         0            0           0         
+  2183         0            0           0         
+  2122         0            0           0         
+  2079         0            0           0         
+  2099         0            0           0         
+  2129         0            0           0         
+  2136         0            0           0         
+  2118         0            0           0         
+  2107         0            0           0         
+  1988         0            0           0         
+  2024         0            0           0         
+  2025         0            0           0         
+  2070         0            0           0         
+  2076         0            0           0         
+  2078         0            0           0         
+  2036         0            0           0         
+  1987         0            0           0         
+  2053         0            0           0         
+  2071         0            0           0         
+  1997         0            0           0         
+  1948         0            0           0         
+  2056         0            0           0         
+  1986         0            0           0         
+  2043         0            0           0         
+  2025         0            0           0         
+  1978         0            0           0         
+  1947         0            0           0         
+  1996         0            0           0         
+  2004         0            0           0         
+  1944         0            0           0         
+  2025         0            0           0         
+  1953         0            0           0         
+  1840         0            0           0         
+  2023         0            0           0         
+  2042         0            0           0         
+  1917         0            0           0         
+  1982         0            0           0         
+  1898         0            0           0         
+  1860         0            0           0         
+  2023         0            0           0         
+  1993         0            0           0         
+  1918         0            0           0         
+  1930         0            0           0         
+  1934         0            0           0         
+  1951         0            0           0         
+  1867         0            0           0         
+  1820         0            0           0         
+  1934         0            0           0         
+  1852         0            0           0         
+  1910         0            0           0         
+  1906         0            0           0         
+  1872         0            0           0         
+  1832         0            0           0         
+  1878         0            0           0         
+  1803         0            0           0         
+  1875         0            0           0         
+  1860         0            0           0         
+  1849         0            0           0         
+  1835         0            0           0         
+  1890         0            0           0         
+  1868         0            0           0         
+  1820         0            0           0         
+  1885         0            0           0         
+  1839         0            0           0         
+  1785         0            0           0         
+  1819         0            0           0         
+  1872         0            0           0         
+  1852         0            0           0         
+  1811         0            0           0         
+  1809         0            0           0         
+  1726         0            0           0         
+  1772         0            0           0         
+  1764         0            0           0         
+  1788         0            0           0         
+  1784         0            0           0         
+  1772         0            0           0         
+  1823         0            0           0         
+  1763         0            0           0         
+  1793         0            0           0         
+  1709         0            0           0         
+  1765         0            0           0         
+  1813         0            0           0         
+  1794         0            0           0         
+  1781         0            0           0         
+  1796         0            0           0         
+  1851         0            0           0         
+  1802         0            0           0         
+  1808         0            0           0         
+  1799         0            0           0         
+  1769         0            0           0         
+  1773         0            0           0         
+  1720         0            0           0         
+  1717         0            0           0         
+  1622         0            0           0         
+  1696         0            0           0         
+  1754         0            0           0         
+  1727         0            0           0         
+  1606         0            0           0         
+  1702         0            0           0         
+  1697         0            0           0         
+  1635         0            0           0         
+  1619         0            0           0         
+  1567         0            0           0         
+  1713         0            0           0         
+  1666         0            0           0         
+  1668         0            0           0         
+  1586         0            0           0         
+  1718         0            0           0         
+  1618         0            0           0         
+  1586         0            0           0         
+  1657         0            0           0         
+  1561         0            0           0         
+  1626         0            0           0         
+  1650         0            0           0         
+  1694         0            0           0         
+  1654         0            0           0         
+  1627         0            0           0         
+  1584         0            0           0         
+  1617         0            0           0         
+  1661         0            0           0         
+  1620         0            0           0         
+  1600         0            0           0         
+  1609         0            0           0         
+  1645         0            0           0         
+  1656         0            0           0         
+  1623         0            0           0         
+  1540         0            0           0         
+  1552         0            0           0         
+  1556         0            0           0         
+  1569         0            0           0         
+  1584         0            0           0         
+  1579         0            0           0         
+  1568         0            0           0         
+  1526         0            0           0         
+  1578         0            0           0         
+  1576         0            0           0         
+  1548         0            0           0         
+  1547         0            0           0         
+  1531         0            0           0         
+  1540         0            0           0         
+  1492         0            0           0         
+  1531         0            0           0         
+  1532         0            0           0         
+  1532         0            0           0         
+  1447         0            0           0         
+  1498         0            0           0         
+  1506         0            0           0         
+  1401         0            0           0         
+  1517         0            0           0         
+  1476         0            0           0         
+  1476         0            0           0         
+  1485         0            0           0         
+  1486         0            0           0         
+  1460         0            0           0         
+  1414         0            0           0         
+  1506         0            0           0         
+  1531         0            0           0         
+  1507         0            0           0         
+  1413         0            0           0         
+  1519         0            0           0         
+  1568         0            0           0         
+  1445         0            0           0         
+  1456         0            0           0         
+  1547         0            0           0         
+  1515         0            0           0         
+  1401         0            0           0         
+  1440         0            0           0         
+  1442         0            0           0         
+  1464         0            0           0         
+  1374         0            0           0         
+  1400         0            0           0         
+  1423         0            0           0         
+  1447         0            0           0         
+  1427         0            0           0         
+  1436         0            0           0         
+  1497         0            0           0         
+  1467         0            0           0         
+  1423         0            0           0         
+  1452         0            0           0         
+  1371         0            0           0         
+  1436         0            0           0         
+  1380         0            0           0         
+  1370         0            0           0         
+  1379         0            0           0         
+  1430         0            0           0         
+  1444         0            0           0         
+  1440         0            0           0         
+  1349         0            0           0         
+  1406         0            0           0         
+  1445         0            0           0         
+  1433         0            0           0         
+  1494         0            0           0         
+  1443         0            0           0         
+  1376         0            0           0         
+  1423         0            0           0         
+  1363         0            0           0         
+  1383         0            0           0         
+  1361         0            0           0         
+  1375         0            0           0         
+  1340         0            0           0         
+  1341         0            0           0         
+  1431         0            0           0         
+  1346         0            0           0         
+  1303         0            0           0         
+  1335         0            0           0         
+  1306         0            0           0         
+  1368         0            0           0         
+  1259         0            0           0         
+  1341         0            0           0         
+  1357         0            0           0         
+  1268         0            0           0         
+  1301         0            0           0         
+  1184         0            0           0         
+  1330         0            0           0         
+  1305         0            0           0         
+  1338         0            0           0         
+  1298         1339.74811   1293.12403  0.000770416 
+  1311         1336.07289   1290.54505  0.000762777 
+  1331         1330.89718   1287.97109  0.000751315 
+  1273         1324.69679   1285.40215  0.000785546 
+  1330         1318.00854   1282.83822  0.00075188 
+  1262         1311.27978   1280.27928  0.000792393 
+  1215         1304.80589   1277.72535  0.000823045 
+  1305         1298.73794   1275.17639  0.000766284 
+  1259         1293.12477   1272.63242  0.000794281 
+  1258         1287.95464   1270.09341  0.000794913 
+  1319         1283.18602   1267.55936  0.00075815 
+  1317         1278.76746   1265.03027  0.000759301 
+  1248         1274.6472    1262.50613  0.000801282 
+  1271         1270.77779   1259.98692  0.000786782 
+  1214         1267.11818   1257.47265  0.000823723 
+  1281         1263.63358   1254.96329  0.00078064 
+  1187         1260.29494   1252.45886  0.00084246 
+  1289         1257.07846   1249.95932  0.000775795 
+  1252         1253.96461   1247.46469  0.000798722 
+  1295         1250.95      1244.97495  0.000772201 
+  1308         1247.99639   1242.4901   0.000764526 
+  1272         1245.10572   1240.01012  0.000786164 
+  1240         1242.2786    1237.53501  0.000806452 
+  1247         1239.48914   1235.06476  0.000801925 
+  1179         1236.74073   1232.59937  0.000848176 
+  1237         1234.02994   1230.13882  0.000808407 
+  1266         1231.34961   1227.68311  0.000789889 
+  1280         1228.69778   1225.23222  0.00078125 
+  1158         1226.07151   1222.78617  0.000863558 
+  1269         1223.46833   1220.34492  0.000788022 
+  1263         1220.88702   1217.90849  0.000791766 
+  1296         1218.32395   1215.47685  0.000771605 
+  1275         1215.77848   1213.05001  0.000784314 
+  1216         1213.24971   1210.62795  0.000822368 
+  1238         1210.73557   1208.21067  0.000807754 
+  1177         1208.23553   1205.79815  0.000849618 
+  1188         1205.7487    1203.3904   0.000841751 
+  1162         1203.27432   1200.98741  0.000860585 
+  1164         1200.81174   1198.58916  0.000859107 
+  1257         1198.36039   1196.19564  0.000795545 
+  1185         1195.91976   1193.80687  0.000843882 
+  1195         1193.48942   1191.42281  0.00083682 
+  1193         1191.069     1189.04347  0.000838223 
+  1185         1188.65817   1186.66884  0.000843882 
+  1175         1186.25665   1184.29892  0.000851064 
+  1216         1183.86422   1181.93368  0.000822368 
+  1146         1181.48068   1179.57314  0.0008726 
+  1200         1179.10586   1177.21727  0.000833333 
+  1164         1176.73965   1174.86607  0.000859107 
+  1177         1174.38195   1172.51954  0.000849618 
+  1148         1172.03269   1170.17767  0.00087108 
+  1146         1169.69187   1167.84044  0.0008726 
+  1142         1167.35946   1165.50786  0.000875657 
+  1186         1165.03552   1163.17991  0.00084317 
+  1163         1162.72011   1160.85659  0.000859845 
+  1101         1160.41333   1158.53789  0.000908265 
+  1166         1158.11532   1156.2238   0.000857633 
+  1163         1155.82627   1153.91431  0.000859845 
+  1162         1153.54641   1151.60943  0.000860585 
+  1141         1151.27602   1149.30913  0.000876424 
+  1181         1149.01543   1147.01341  0.00084674 
+  1179         1146.76506   1144.72228  0.000848176 
+  1116         1144.52538   1142.4357   0.000896057 
+  1176         1142.29696   1140.15369  0.00085034 
+  1135         1140.08048   1137.87624  0.000881057 
+  1169         1137.87672   1135.60333  0.000855432 
+  1123         1135.68663   1133.33496  0.000890472 
+  1143         1133.51132   1131.07112  0.000874891 
+  1172         1131.35574   1128.8118   0.000853242 
+  1136         1129.21422   1126.557    0.000880282 
+  1094         1127.09226   1124.30671  0.000914077 
+  1118         1124.99393   1122.06093  0.000894454 
+  1102         1122.91834   1119.81963  0.000907441 
+  1105         1120.87061   1117.58283  0.000904977 
+  1100         1118.85474   1115.35051  0.000909091 
+  1103         1116.87566   1113.12266  0.000906618 
+  1094         1114.93942   1110.89927  0.000914077 
+  1070         1113.05331   1108.68035  0.000934579 
+  1134         1111.22639   1106.46588  0.000881834 
+  1087         1109.46968   1104.25585  0.000919963 
+  1163         1107.79641   1102.05026  0.000859845 
+  1086         1106.22293   1099.8491   0.00092081 
+  1064         1104.76759   1097.65236  0.00093985 
+  1089         1103.45173   1095.46004  0.000918274 
+  1111         1102.29889   1093.27213  0.00090009 
+  1093         1101.33218   1091.08862  0.000914913 
+  1068         1100.56802   1088.9095   0.00093633 
+  1099         1100.00919   1086.73477  0.000909918 
+  1139         1099.62888   1084.56442  0.000877963 
+  1086         1099.35125   1082.39845  0.00092081 
+  1085         1099.03619   1080.23684  0.000921659 
+  1111         1098.48095   1078.07959  0.00090009 
+  1032         1097.45746   1075.92669  0.000968992 
+  1108         1095.78476   1073.77814  0.000902527 
+  1089         1093.39907   1071.63392  0.000918274 
+  1085         1090.37777   1069.49403  0.000921659 
+  1090         1086.9044    1067.35847  0.000917431 
+  1103         1083.18965   1065.22723  0.000906618 
+  1043         1079.37369   1063.10029  0.000958773 
+  1086         1075.5081    1060.97766  0.00092081 
+  1031         1071.68413   1058.85932  0.000969932 
+  1054         1067.99187   1056.74527  0.000948767 
+  999          1064.49415   1054.6355   0.001001001 
+  1061         1061.2153    1052.53001  0.000942507 
+  1067         1058.13624   1050.42879  0.000937207 
+  1069         1055.22511   1048.33182  0.000935454 
+  1036         1052.45214   1046.23911  0.000965251 
+  1047         1049.79282   1044.15065  0.00095511 
+  992          1047.22735   1042.06642  0.001008065 
+  1001         1044.73994   1039.98643  0.000999001 
+  1102         1042.31785   1037.91066  0.000907441 
+  1055         1039.95091   1035.83911  0.000947867 
+  1029         1037.63052   1033.77178  0.000971817 
+  1028         1035.35008   1031.70865  0.000972763 
+  1003         1033.10402   1029.64972  0.000997009 
+  1071         1030.88791   1027.59498  0.000933707 
+  966          1028.69801   1025.54442  0.001035197 
+  981          1026.53134   1023.49804  0.001019368 
+  1033         1024.3854    1021.45583  0.000968054 
+  988          1022.25816   1019.41779  0.001012146 
+  993          1020.14792   1017.3839   0.001007049 
+  1019         1018.14403   1015.35417  0.000981354 
+  988          1016.06432   1013.32857  0.001012146 
+  1006         1013.99802   1011.30711  0.000994036 
+  1035         1011.98981   1009.28979  0.000966184 
+  1006         1009.94826   1007.27658  0.000994036 
+  1060         1007.91805   1005.26749  0.000943396 
+  977          1005.91287   1003.26252  0.001023541 
+  1014         1003.90407   1001.26164  0.000986193 
+  1017         1001.90545   999.26486   0.000983284 
+  1006         999.92389    997.27217   0.000994036 
+  1069         997.94504    995.28356   0.000935454 
+  1067         995.97588    993.29902   0.000937207 
+  1100         994.01636    991.31856   0.000909091 
+  1101         992.06646    989.34216   0.000908265 
+  1063         990.12627    987.36981   0.000940734 
+  1019         988.22049    985.40151   0.000981354 
+  1043         986.30021    983.43725   0.000958773 
+  933          984.41428    981.47703   0.001071811 
+  999          982.51485    979.52084   0.001001001 
+  987          980.62626    977.56867   0.001013171 
+  1010         978.7549     975.62051   0.000990099 
+  962          976.88943    973.67636   0.001039501 
+  942          975.03636    971.73622   0.001061571 
+  962          973.19642    969.80007   0.001039501 
+  1001         971.37731    967.8679    0.000999001 
+  987          969.56639    965.93972   0.001013171 
+  946          967.7717     964.01552   0.001057082 
+  970          965.99819    962.09528   0.001030928 
+  926          964.24095    960.17901   0.001079914 
+  957          962.50595    958.26669   0.001044932 
+  964          960.79643    956.35832   0.001037344 
+  953          959.11617    954.4539    0.001049318 
+  970          957.46752    952.5534    0.001030928 
+  945          955.85383    950.65684   0.001058201 
+  902          954.2568     948.7642    0.001108647 
+  946          952.69103    946.87548   0.001057082 
+  974          951.17069    944.99067   0.001026694 
+  1015         949.70162    943.10976   0.000985222 
+  978          948.29978    941.23274   0.001022495 
+  949          946.97649    939.35962   0.001053741 
+  954          945.74523    937.49038   0.001048218 
+  863          944.62357    935.62501   0.001158749 
+  992          943.63488    933.76352   0.001008065 
+  920          942.81016    931.90589   0.001086957 
+  916          942.19049    930.05212   0.001091703 
+  947          941.83165    928.2022    0.001055966 
+  938          941.81018    926.35612   0.001066098 
+  904          942.23301    924.51389   0.001106195 
+  974          943.25408    922.67548   0.001026694 
+  948          945.10012    920.8409    0.001054852 
+  956          948.1152     919.01014   0.001046025 
+  940          952.84536    917.18319   0.00106383 
+  970          960.21481    915.36005   0.001030928 
+  991          971.97228    913.5407    0.001009082 
+  943          991.85012    911.72515   0.001060445 
+  1055         1027.84474   909.91339   0.000947867 
+  1150         1094.51275   908.10541   0.000869565 
+  1158         1210.42254   906.3012    0.000863558 
+  1268         1373.22387   904.50076   0.000788644 
+  1471         1487.35548   902.70408   0.00067981 
+  1517         1459.86291   900.91115   0.000659196 
+  1485         1360.09641   899.12198   0.000673401 
+  1316         1220.98904   897.33654   0.000759878 
+  1136         1100.1977    895.55485   0.000880282 
+  1006         1023.39176   893.77688   0.000994036 
+  963          978.87629    892.00263   0.001038422 
+  834          952.68243    890.23211   0.001199041 
+  873          936.04833    888.46529   0.001145475 
+  961          924.49161    886.70218   0.001040583 
+  913          915.87734    884.94276   0.00109529 
+  918          909.12932    883.18704   0.001089325 
+  884          903.63842    881.43501   0.001131222 
+  904          899.02831    879.68665   0.001106195 
+  907          895.05508    877.94197   0.001102536 
+  945          891.5546     876.20095   0.001058201 
+  926          888.4134     874.4636    0.001079914 
+  872          885.55141    872.7299    0.001146789 
+  886          882.9109     870.99984   0.001128668 
+  877          880.44944    869.27343   0.001140251 
+  879          878.13568    867.55066   0.001137656 
+  858          875.94619    865.83151   0.001165501 
+  887          873.86331    864.11599   0.001127396 
+  878          871.87393    862.40409   0.001138952 
+  847          869.9684     860.6958    0.001180638 
+  854          868.13979    858.99111   0.00117096 
+  906          866.3836     857.29002   0.001103753 
+  834          864.69736    855.59253   0.001199041 
+  783          863.08035    853.89862   0.001277139 
+  832          861.53383    852.20829   0.001201923 
+  854          860.0608     850.52154   0.00117096 
+  828          858.66637    848.83835   0.001207729 
+  897          857.35843    847.15873   0.001114827 
+  873          856.14624    845.48266   0.001145475 
+  876          855.04386    843.81015   0.001141553 
+  822          854.06932    842.14117   0.001216545 
+  849          853.24637    840.47574   0.001177856 
+  829          852.6058     838.81383   0.001206273 
+  908          852.1894     837.15546   0.001101322 
+  871          852.05277    835.5006    0.001148106 
+  844          852.27194    833.84925   0.001184834 
+  913          852.9525     832.20142   0.00109529 
+  882          854.24325    830.55708   0.001133787 
+  841          856.36009    828.91624   0.001189061 
+  884          859.62583    827.27889   0.001131222 
+  829          864.54319    825.64503   0.001206273 
+  905          871.95378    824.01464   0.001104972 
+  916          883.3824     822.38772   0.001091703 
+  898          901.7003     820.76427   0.001113586 
+  1012         932.09819    819.14428   0.000988142 
+  1075         982.79533    817.52774   0.000930233 
+  1125         1063.66523   815.91465   0.000888889 
+  1269         1175.72417   814.305     0.000788022 
+  1327         1278.53585   812.69879   0.00075358 
+  1390         1299.41738   811.09601   0.000719424 
+  1237         1247.3362    809.49665   0.000808407 
+  1105         1156.98596   807.90071   0.000904977 
+  1070         1054.3597    806.30818   0.000934579 
+  875          972.78303    804.71906   0.001142857 
+  866          918.52236    803.13334   0.001154734 
+  829          884.1274     801.55101   0.001206273 
+  826          861.99224    799.97207   0.001210654 
+  831          847.01857    798.39651   0.001203369 
+  853          836.24162    796.82433   0.001172333 
+  883          828.04761    795.25553   0.001132503 
+  838          821.54479    793.69008   0.001193317 
+  842          816.20723    792.128     0.001187648 
+  817          811.70444    790.56927   0.00122399 
+  777          807.81652    789.01388   0.001287001 
+  832          804.3922     787.46184   0.001201923 
+  793          801.3246     785.91314   0.001261034 
+  773          798.53978    784.36776   0.001293661 
+  750          795.9762     782.82571   0.001333333 
+  768          793.59823    781.28698   0.001302083 
+  829          791.36901    779.75156   0.001206273 
+  776          789.26564    778.21945   0.00128866 
+  766          787.27329    776.69064   0.001305483 
+  754          785.37524    775.16512   0.00132626 
+  778          783.56362    773.6429    0.001285347 
+  789          781.83109    772.12396   0.001267427 
+  778          780.17386    770.60829   0.001285347 
+  774          778.59037    769.0959    0.00129199 
+  766          777.08161    767.58678   0.001305483 
+  768          775.65163    766.08092   0.001302083 
+  776          774.30739    764.57831   0.00128866 
+  741          773.0608     763.07895   0.001349528 
+  755          771.92951    761.58284   0.001324503 
+  728          770.93967    760.08996   0.001373626 
+  745          770.13012    758.60032   0.001342282 
+  716          769.55919    757.11391   0.001396648 
+  788          769.3179     755.63071   0.001269036 
+  760          769.55696    754.15073   0.001315789 
+  798          770.5454     752.67396   0.001253133 
+  796          772.78906    751.2004    0.001256281 
+  769          777.21307    749.73003   0.00130039 
+  748          785.32026    748.26286   0.001336898 
+  800          799.04671    746.79888   0.00125   
+  829          819.21771    745.33807   0.001206273 
+  824          839.82402    743.88045   0.001213592 
+  831          846.30369    742.42599   0.001203369 
+  820          837.42313    740.9747    0.001219512 
+  811          821.00695    739.52657   0.001233046 
+  818          800.51613    738.08159   0.001222494 
+  746          782.69647    736.63976   0.001340483 
+  740          770.34733    735.20107   0.001351351 
+  724          762.44544    733.76553   0.001381215 
+  785          757.46603    732.33311   0.001273885 
+  748          754.34134    730.90382   0.001336898 
+  732          752.46929    729.47765   0.00136612 
+  760          751.5746     728.05459   0.001315789 
+  752          751.604      726.63464   0.001329787 
+  767          752.66774    725.2178    0.001303781 
+  729          755.06035    723.80406   0.001371742 
+  758          759.37699    722.39341   0.001319261 
+  713          766.7826     720.98585   0.001402525 
+  746          779.48104    719.58136   0.001340483 
+  796          801.22353    718.17996   0.001256281 
+  811          837.28096    716.78163   0.001233046 
+  906          891.81019    715.38636   0.001103753 
+  916          955.51734    713.99415   0.001091703 
+  942          990.18696    712.605     0.001061571 
+  1007         976.34617    711.2189    0.000993049 
+  925          937.70535    709.83584   0.001081081 
+  867          883.68259    708.45582   0.001153403 
+  852          830.64624    707.07883   0.001173709 
+  829          791.84972    705.70487   0.001206273 
+  720          766.61231    704.33394   0.001388889 
+  751          750.50378    702.96602   0.001331558 
+  744          739.91902    701.60111   0.001344086 
+  688          732.58884    700.2392    0.001453488 
+  743          727.23395    698.8803    0.001345895 
+  710          723.16408    697.5244    0.001408451 
+  671          719.99928    696.17148   0.001490313 
+  726          717.52138    694.82155   0.00137741 
+  663          715.60519    693.47459   0.001508296 
+  686          714.18665    692.13062   0.001457726 
+  681          713.24881    690.78961   0.001468429 
+  679          712.81911    689.45156   0.001472754 
+  688          712.97603    688.11647   0.001453488 
+  693          713.86973    686.78434   0.001443001 
+  708          715.77203    685.45515   0.001412429 
+  698          719.18555    684.1289    0.001432665 
+  729          725.03825    682.80559   0.001371742 
+  713          734.9264     681.48521   0.001402525 
+  799          751.22053    680.16776   0.001251564 
+  804          776.38398    678.85323   0.001243781 
+  801          809.02575    677.54162   0.001248439 
+  841          836.06431    676.23291   0.001189061 
+  905          846.50701    674.92711   0.001104972 
+  919          852.43713    673.62421   0.001088139 
+  921          862.86726    672.32421   0.001085776 
+  920          883.66321    671.0271    0.001086957 
+  1038         914.42258    669.73286   0.000963391 
+  1024         948.93332    668.44151   0.000976562 
+  1059         971.42912    667.15304   0.000944287 
+  982          953.69582    665.86743   0.00101833 
+  848          910.85206    664.58468   0.001179245 
+  771          859.90888    663.3048    0.001297017 
+  760          807.10164    662.02776   0.001315789 
+  730          765.3311     660.75358   0.001369863 
+  681          737.34113    659.48223   0.001468429 
+  668          719.47861    658.21373   0.001497006 
+  679          707.95688    656.94806   0.001472754 
+  658          700.2135     655.68521   0.001519757 
+  687          694.69849    654.42519   0.001455604 
+  722          690.51273    653.16798   0.001385042 
+  704          687.09362    651.91359   0.001420455 
+  670          684.06928    650.662     0.001492537 
+  680          681.17501    649.41322   0.001470588 
+  628          678.25827    648.16723   0.001592357 
+  710          675.22769    646.92403   0.001408451 
+  661          672.10952    645.68362   0.001512859 
+  635          668.969      644.44599   0.001574803 
+  643          665.88827    643.21114   0.00155521 
+  672          662.94492    641.97906   0.001488095 
+  645          660.17302    640.74974   0.001550388 
+  645          657.59861    639.52319   0.001550388 
+  678          655.22173    638.29939   0.001474926 
+  641          653.03025    637.07835   0.001560062 
+  613          651.00686    635.86004   0.001631321 
+  613          649.13334    634.64449   0.001631321 
+  637          647.3927     633.43166   0.001569859 
+  610          645.77056    632.22157   0.001639344 
+  629          644.2556     631.0142    0.001589825 
+  635          642.83948    629.80956   0.001574803 
+  601          641.51706    628.60763   0.001663894 
+  668          640.28659    627.40841   0.001497006 
+  619          639.14977    626.2119    0.001615509 
+  651          638.11252    625.01809   0.001536098 
+  623          637.186      623.82697   0.001605136 
+  616          636.38811    622.63855   0.001623377 
+  658          635.74651    621.45281   0.001519757 
+  664          635.30327    620.26975   0.001506024 
+  644          635.12272    619.08937   0.001552795 
+  633          635.30771    617.91167   0.001579779 
+  647          636.03297    616.73662   0.001545595 
+  573          637.61737    615.56424   0.001745201 
+  628          640.65875    614.39452   0.001592357 
+  622          646.21188    613.22745   0.001607717 
+  590          655.88163    612.06302   0.001694915 
+  668          671.43258    610.90124   0.001497006 
+  702          692.30012    609.74209   0.001424501 
+  744          709.19038    608.58558   0.001344086 
+  747          710.00411    607.43169   0.001338688 
+  779          700.43885    606.28043   0.001283697 
+  720          686.3643     605.13178   0.001388889 
+  665          669.61156    603.98575   0.001503759 
+  656          656.70007    602.84232   0.00152439 
+  664          650.40595    601.7015    0.001506024 
+  696          649.44067    600.56328   0.001436782 
+  667          649.46474    599.42764   0.00149925 
+  641          646.06853    598.2946    0.001560062 
+  671          640.59179    597.16414   0.001490313 
+  677          634.23092    596.03626   0.001477105 
+  681          627.26864    594.91096   0.001468429 
+  672          621.39255    593.78822   0.001488095 
+  679          617.15846    592.66805   0.001472754 
+  680          614.20992    591.55044   0.001470588 
+  655          612.1162     590.43539   0.001526718 
+  694          610.57461    589.32288   0.001440922 
+  679          609.40491    588.21292   0.001472754 
+  667          608.50983    587.1055    0.00149925 
+  783          607.83973    586.00062   0.001277139 
+  681          607.36995    584.89827   0.001468429 
+  673          607.08449    583.79844   0.001485884 
+  758          606.95881    582.70114   0.001319261 
+  710          606.94679    581.60635   0.001408451 
+  742          607.05491    580.51408   0.001347709 
+  696          607.29476    579.42431   0.001436782 
+  645          607.67914    578.33705   0.001550388 
+  600          608.23536    577.25228   0.001666667 
+  662          609.0008     576.17001   0.001510574 
+  594          610.00153    575.09023   0.001683502 
+  654          611.26249    574.01293   0.001529052 
+  658          612.8009     572.93812   0.001519757 
+  659          614.62976    571.86577   0.001517451 
+  667          616.76676    570.7959    0.00149925 
+  716          619.25253    569.7285    0.001396648 
+  674          622.17761    568.66355   0.00148368 
+  666          625.71331    567.60106   0.001501502 
+  655          630.14861    566.54102   0.001526718 
+  682          635.95432    565.48343   0.001466276 
+  652          643.90813    564.42829   0.001533742 
+  677          655.29302    563.37558   0.001477105 
+  641          672.08525    562.3253    0.001560062 
+  725          696.83828    561.27745   0.00137931 
+  752          731.12541    560.23203   0.001329787 
+  746          769.47732    559.18903   0.001340483 
+  818          796.86969    558.14844   0.001222494 
+  810          813.82431    557.11026   0.001234568 
+  815          834.22969    556.07449   0.001226994 
+  893          863.67785    555.04112   0.001119821 
+  1006         916.98048    554.01014   0.000994036 
+  1082         1021.10046   552.98156   0.000924214 
+  1296         1220.73833   551.95537   0.000771605 
+  1570         1590.91118   550.93156   0.000636943 
+  2117         2215.93234   549.91013   0.000472367 
+  2729         3030.63789   548.89107   0.000366435 
+  3520         3470.79488   547.87438   0.000284091 
+  3744         3236.74217   546.86006   0.000267094 
+  3048         2871.75657   545.8481    0.000328084 
+  2378         2363.70242   544.83849   0.000420521 
+  1869         1765.30811   543.83123   0.000535045 
+  1302         1326.26895   542.82633   0.000768049 
+  890          1061.31409   541.82376   0.001123596 
+  758          908.14554    540.82354   0.001319261 
+  695          816.53281    539.82564   0.001438849 
+  681          757.69663    538.83008   0.001468429 
+  662          717.28556    537.83684   0.001510574 
+  615          688.20899    536.84592   0.001626016 
+  650          666.63864    535.85732   0.001538462 
+  684          650.29912    534.87103   0.001461988 
+  634          637.74985    533.88705   0.001577287 
+  605          628.04529    532.90537   0.001652893 
+  602          620.55072    531.92599   0.00166113 
+  583          614.82834    530.9489    0.001715266 
+  616          610.57119    529.9741    0.001623377 
+  599          607.54511    529.00159   0.001669449 
+  622          605.58247    528.03135   0.001607717 
+  624          604.55976    527.0634    0.001602564 
+  574          604.4068     526.09771   0.00174216 
+  589          605.14605    525.1343    0.001697793 
+  580          606.92107    524.17314   0.001724138 
+  609          610.04069    523.21425   0.001642036 
+  607          615.03052    522.25761   0.001647446 
+  597          622.71821    521.30322   0.001675042 
+  591          634.35678    520.35108   0.001692047 
+  600          651.76624    519.40117   0.001666667 
+  652          677.41213    518.45351   0.001533742 
+  681          714.17118    517.50808   0.001468429 
+  703          763.85646    516.56487   0.001422475 
+  781          822.46401    515.62389   0.00128041 
+  852          873.28224    514.68513   0.001173709 
+  914          894.16521    513.74859   0.001094092 
+  972          882.80551    512.81426   0.001028807 
+  885          851.64069    511.88213   0.001129944 
+  853          808.36778    510.95221   0.001172333 
+  808          762.82448    510.02449   0.001237624 
+  767          725.81936    509.09896   0.001303781 
+  714          701.75426    508.17562   0.00140056 
+  715          690.66393    507.25447   0.001398601 
+  732          692.29981    506.3355    0.00136612 
+  713          708.37321    505.4187    0.001402525 
+  760          743.55245    504.50408   0.001315789 
+  811          805.03775    503.59163   0.001233046 
+  909          897.11029    502.68134   0.00110011 
+  1013         999.15995    501.77322   0.000987167 
+  1028         1050.17616   500.86724   0.000972763 
+  1066         1039.55951   499.96343   0.000938086 
+  1017         1017.41258   499.06176   0.000983284 
+  963          991.32447    498.16223   0.001038422 
+  922          980.90592    497.26484   0.001084599 
+  1001         1026.4237    496.36959   0.000999001 
+  1097         1147.48985   495.47647   0.000911577 
+  1388         1326.50988   494.58547   0.000720461 
+  1520         1471.73219   493.6966    0.000657895 
+  1676         1516.95425   492.80985   0.000596659 
+  1632         1515.76944   491.92521   0.000612745 
+  1568         1441.72556   491.04268   0.000637755 
+  1345         1289.63066   490.16226   0.000743494 
+  1134         1144.89018   489.28394   0.000881834 
+  975          1028.43333   488.40772   0.001025641 
+  931          946.32423    487.53359   0.001074114 
+  802          911.21299    486.66156   0.001246883 
+  801          908.99504    485.7916    0.001248439 
+  872          901.09129    484.92373   0.001146789 
+  875          875.3286     484.05794   0.001142857 
+  819          851.38398    483.19422   0.001221001 
+  781          829.17787    482.33257   0.00128041 
+  835          813.86805    481.47299   0.001197605 
+  833          821.54114    480.61546   0.00120048 
+  882          859.1525     479.75999   0.001133787 
+  890          921.89752    478.90658   0.001123596 
+  910          985.2692     478.05522   0.001098901 
+  978          1032.71626   477.2059    0.001022495 
+  1055         1093.51175   476.35862   0.000947867 
+  1181         1196.06219   475.51338   0.00084674 
+  1442         1385.52407   474.67017   0.000693481 
+  1910         1787.99994   473.82899   0.00052356 
+  2691         2621.7082    472.98983   0.000371609 
+  3777         4094.15497   472.1527    0.00026476 
+  5386         5788.2775    471.31758   0.000185667 
+  6796         6004.59737   470.48447   0.000147145 
+  6118         5160.743     469.65338   0.000163452 
+  4857         4547.00614   468.82428   0.000205888 
+  4023         3529.01462   467.99719   0.000248571 
+  2906         2381.24963   467.1721    0.000344116 
+  1676         1627.28524   466.349     0.000596659 
+  1190         1212.96009   465.52789   0.000840336 
+  958          989.95683    464.70876   0.001043841 
+  803          859.61081    463.89161   0.00124533 
+  738          774.79842    463.07644   0.001355014 
+  689          715.394      462.26325   0.001451379 
+  658          671.85717    461.45202   0.001519757 
+  637          638.88808    460.64276   0.001569859 
+  598          613.24848    459.83546   0.001672241 
+  587          592.86244    459.03012   0.001703578 
+  582          576.34124    458.22673   0.001718213 
+  584          562.73064    457.42529   0.001712329 
+  563          551.3552     456.62579   0.001776199 
+  606          541.72719    455.82824   0.001650165 
+  572          533.48637    455.03263   0.001748252 
+  616          526.36289    454.23895   0.001623377 
+  504          520.15065    453.4472    0.001984127 
+  554          514.69209    452.65737   0.001805054 
+  511          509.85816    451.86947   0.001956947 
+  537          505.55241    451.08349   0.001862197 
+  591          501.69574    450.29942   0.001692047 
+  555          498.22606    449.51726   0.001801802 
+  571          495.0896     448.73701   0.001751313 
+  535          492.24548    447.95867   0.001869159 
+  543          489.65957    447.18222   0.001841621 
+  506          487.30383    446.40767   0.001976285 
+  558          485.15522    445.63501   0.001792115 
+  489          483.19525    444.86423   0.00204499 
+  521          481.40883    444.09535   0.001919386 
+  515          479.78412    443.32834   0.001941748 
+  532          478.31196    442.56321   0.001879699 
+  494          476.98579    441.79995   0.002024291 
+  484          475.80138    441.03856   0.002066116 
+  507          474.75794    440.27903   0.001972387 
+  498          473.85356    439.52137   0.002008032 
+  481          473.09197    438.76556   0.002079002 
+  471          472.47839    438.01161   0.002123142 
+  487          472.02196    437.25951   0.002053388 
+  504          471.73144    436.50925   0.001984127 
+  509          471.62275    435.76084   0.001964637 
+  436          471.71488    435.01427   0.002293578 
+  469          472.03985    434.26953   0.002132196 
+  446          472.61175    433.52662   0.002242152 
+  458          473.47583    432.78554   0.002183406 
+  503          474.67765    432.04628   0.001988072 
+  451          476.27679    431.30885   0.002217295 
+  487          478.32178    430.57323   0.002053388 
+  508          480.91663    429.83942   0.001968504 
+  503          484.13662    429.10742   0.001988072 
+  489          488.09207    428.37723   0.00204499 
+  516          492.88009    427.64884   0.001937984 
+  461          498.58857    426.92225   0.002169197 
+  554          505.26747    426.19745   0.001805054 
+  556          512.89098    425.47444   0.001798561 
+  604          521.32029    424.75322   0.001655629 
+  580          530.29452    424.03379   0.001724138 
+  575          539.46905    423.31613   0.00173913 
+  637          548.5183     422.60025   0.001569859 
+  655          557.23537    421.88614   0.001526718 
+  584          565.56081    421.1738    0.001712329 
+  652          573.55523    420.46323   0.001533742 
+  672          581.43283    419.75441   0.001488095 
+  672          589.78812    419.04736   0.001488095 
+  675          600.0097     418.34206   0.001481481 
+  682          614.55582    417.63851   0.001466276 
+  671          636.23004    416.93671   0.001490313 
+  727          663.59403    416.23665   0.001375516 
+  725          681.72545    415.53833   0.00137931 
+  651          678.0335     414.84174   0.001536098 
+  691          669.16841    414.14689   0.001447178 
+  687          663.84793    413.45377   0.001455604 
+  678          650.08917    412.76238   0.001474926 
+  595          622.12274    412.0727    0.001680672 
+  583          591.26613    411.38475   0.001715266 
+  574          566.29292    410.69851   0.00174216 
+  621          542.85324    410.01398   0.001610306 
+  498          521.46317    409.33116   0.002008032 
+  536          506.54346    408.65004   0.001865672 
+  481          499.04907    407.97063   0.002079002 
+  505          498.91228    407.29291   0.001980198 
+  487          506.9795     406.61689   0.002053388 
+  566          524.79949    405.94255   0.001766784 
+  571          551.43155    405.2699    0.001751313 
+  604          577.71282    404.59894   0.001655629 
+  619          593.28823    403.92965   0.001615509 
+  568          592.86895    403.26205   0.001760563 
+  562          575.3337     402.59611   0.001779359 
+  552          550.84988    401.93184   0.001811594 
+  486          524.56341    401.26924   0.002057613 
+  459          497.43035    400.60831   0.002178649 
+  509          474.99341    399.94903   0.001964637 
+  429          459.27664    399.2914    0.002331002 
+  449          448.77553    398.63543   0.002227171 
+  392          441.66363    397.98111   0.00255102 
+  397          437.2376     397.32843   0.002518892 
+  397          433.52357    396.67739   0.002518892 
+  418          430.65905    396.02799   0.002392344 
+  394          428.38898    395.38023   0.002538071 
+  425          426.86031    394.73409   0.002352941 
+  414          425.38869    394.08959   0.002415459 
+  446          424.21071    393.44671   0.002242152 
+  423          423.2921     392.80545   0.002364066 
+  412          422.60629    392.16581   0.002427184 
+  376          422.14343    391.52778   0.002659574 
+  421          421.89924    390.89136   0.002375297 
+  399          421.87682    390.25655   0.002506266 
+  419          422.08465    389.62335   0.002386635 
+  446          422.55142    388.99174   0.002242152 
+  428          423.33691    388.36173   0.002336449 
+  399          424.55935    387.73332   0.002506266 
+  435          426.43316    387.1065    0.002298851 
+  455          429.3704     386.48126   0.002197802 
+  468          434.11273    385.85761   0.002136752 
+  441          441.87622    385.23554   0.002267574 
+  470          454.30703    384.61505   0.00212766 
+  431          472.58225    383.99613   0.002320186 
+  477          493.45157    383.37878   0.002096436 
+  530          504.41918    382.763     0.001886792 
+  520          499.96661    382.14878   0.001923077 
+  529          491.54012    381.53612   0.001890359 
+  524          481.802      380.92502   0.001908397 
+  482          467.54244    380.31547   0.002074689 
+  439          453.41952    379.70748   0.002277904 
+  442          443.21782    379.10103   0.002262443 
+  386          436.96618    378.49612   0.002590674 
+  443          433.93737    377.89276   0.002257336 
+  417          433.65721    377.29093   0.002398082 
+  446          435.41804    376.69064   0.002242152 
+  459          436.68004    376.09188   0.002178649 
+  431          434.43282    375.49465   0.002320186 
+  429          430.38744    374.89894   0.002331002 
+  390          426.57929    374.30475   0.002564103 
+  458          422.09413    373.71208   0.002183406 
+  432          417.2642     373.12093   0.002314815 
+  418          413.36755    372.53128   0.002392344 
+  451          410.6298     371.94315   0.002217295 
+  398          408.77402    371.35652   0.002512563 
+  453          407.51556    370.77139   0.002207506 
+  365          406.65416    370.18776   0.002739726 
+  378          406.06869    369.60563   0.002645503 
+  425          405.68978    369.02499   0.002352941 
+  417          405.47794    368.44583   0.002398082 
+  403          405.41029    367.86817   0.00248139 
+  391          405.47406    367.29198   0.002557545 
+  360          405.6633     366.71727   0.002777778 
+  391          405.97859    366.14405   0.002557545 
+  413          406.42691    365.57229   0.002421308 
+  406          407.0259     365.002     0.002463054 
+  413          407.80739    364.43318   0.002421308 
+  377          408.8207     363.86583   0.00265252 
+  346          410.12564    363.29993   0.002890173 
+  408          411.73848    362.73549   0.00245098 
+  394          413.50048    362.17251   0.002538071 
+  433          415.25369    361.61097   0.002309469 
+  404          417.29654    361.05089   0.002475248 
+  355          419.79387    360.49225   0.002816901 
+  440          422.30216    359.93505   0.002272727 
+  390          424.44867    359.37929   0.002564103 
+  457          426.08264    358.82496   0.002188184 
+  412          427.38952    358.27207   0.002427184 
+  394          428.82862    357.7206    0.002538071 
+  414          430.47197    357.17056   0.002415459 
+  438          432.34927    356.62195   0.002283105 
+  457          434.73476    356.07475   0.002188184 
+  407          437.77314    355.52897   0.002457002 
+  445          441.42589    354.98461   0.002247191 
+  469          445.66831    354.44165   0.002132196 
+  473          450.48307    353.9001    0.002114165 
+  424          455.87693    353.35996   0.002358491 
+  458          461.87271    352.82122   0.002183406 
+  439          468.51101    352.28387   0.002277904 
+  424          475.85673    351.74793   0.002358491 
+  418          484.01215    351.21337   0.002392344 
+  465          493.12293    350.6802    0.002150538 
+  488          503.38793    350.14842   0.00204918 
+  482          515.02635    349.61802   0.002074689 
+  469          528.33145    349.089     0.002132196 
+  467          543.64492    348.56136   0.002141328 
+  515          561.37422    348.0351    0.001941748 
+  516          582.01013    347.5102    0.001937984 
+  495          606.18215    346.98667   0.002020202 
+  528          634.69429    346.46451   0.001893939 
+  536          668.62433    345.94371   0.001865672 
+  595          709.43419    345.42426   0.001680672 
+  606          759.1158     344.90618   0.001650165 
+  623          820.45547    344.38945   0.001605136 
+  766          897.40921    343.87406   0.001305483 
+  820          995.7045     343.36003   0.001219512 
+  969          1123.94841   342.84733   0.001031992 
+  1089         1295.50764   342.33598   0.000918274 
+  1380         1532.01515   341.82597   0.000724638 
+  1748         1871.27945   341.31729   0.000572082 
+  2408         2389.1615    340.80995   0.000415282 
+  3443         3265.28254   340.30393   0.000290444 
+  5128         4926.9824    339.79924   0.000195008 
+  8262         8164.648     339.29587   0.000121036 
+  13150        13761.20791  338.79383   0.000076046 
+  19182        20214.86043  338.2931    0.000052132 
+  23442        20971.3483   337.79368   0.000042658 
+  20351        17225.52722  337.29558   0.000049138 
+  15322        15310.66588  336.79879   0.000065266 
+  13256        13473.80612  336.3033    0.000075438 
+  10616        9421.81586   335.80912   0.000094197 
+  5968         5875.16883   335.31623   0.00016756 
+  3130         3748.45655   334.82464   0.000319489 
+  2108         2604.36157   334.33435   0.000474383 
+  1659         1974.0745    333.84535   0.000602773 
+  1327         1589.45636   333.35764   0.00075358 
+  1150         1331.48374   332.87121   0.000869565 
+  1072         1148.13879   332.38607   0.000932836 
+  929          1012.85615   331.9022    0.001076426 
+  842          910.08706    331.41961   0.001187648 
+  783          830.26648    330.9383    0.001277139 
+  715          767.23937    330.45826   0.001398601 
+  707          716.73312    329.97948   0.001414427 
+  679          675.77902    329.50198   0.001472754 
+  612          642.36581    329.02573   0.001633987 
+  609          615.03225    328.55075   0.001642036 
+  623          592.67929    328.07702   0.001605136 
+  542          574.51005    327.60454   0.001845018 
+  558          559.96231    327.13332   0.001792115 
+  518          548.65744    326.66335   0.001930502 
+  509          540.34763    326.19462   0.001964637 
+  545          534.78558    325.72714   0.001834862 
+  533          531.45918    325.26089   0.001876173 
+  526          529.65743    324.79589   0.001901141 
+  541          529.417      324.33212   0.001848429 
+  523          531.02175    323.86958   0.001912046 
+  512          534.16099    323.40827   0.001953125 
+  535          538.5775     322.94818   0.001869159 
+  581          544.4831     322.48932   0.00172117 
+  601          552.14982    322.03168   0.001663894 
+  598          561.80582    321.57526   0.001672241 
+  569          573.71652    321.12005   0.001757469 
+  654          588.14858    320.66606   0.001529052 
+  621          605.3704     320.21327   0.001610306 
+  621          625.5887     319.7617    0.001610306 
+  708          648.44148    319.31132   0.001412429 
+  683          670.33437    318.86215   0.001464129 
+  717          681.00355    318.41418   0.0013947 
+  679          675.50044    317.9674    0.001472754 
+  693          662.80041    317.52182   0.001443001 
+  689          646.50766    317.07743   0.001451379 
+  589          623.22848    316.63423   0.001697793 
+  593          595.44897    316.19221   0.001686341 
+  615          568.05007    315.75137   0.001626016 
+  578          542.66749    315.31171   0.001730104 
+  551          519.4257     314.87323   0.001814882 
+  549          498.27582    314.43593   0.001821494 
+  518          479.23938    313.9998    0.001930502 
+  481          462.29834    313.56483   0.002079002 
+  449          447.36091    313.13103   0.002227171 
+  478          434.30054    312.6984    0.00209205 
+  405          422.94602    312.26693   0.002469136 
+  387          413.09154    311.83661   0.002583979 
+  410          404.53014    311.40745   0.002439024 
+  393          397.07067    310.97945   0.002544529 
+  366          390.542      310.55259   0.00273224 
+  367          384.80636    310.12689   0.002724796 
+  399          379.74092    309.70232   0.002506266 
+  385          375.24399    309.27891   0.002597403 
+  394          371.23532    308.85663   0.002538071 
+  355          368.15174    308.43548   0.002816901 
+  365          364.92735    308.01548   0.002739726 
+  370          362.01923    307.5966    0.002702703 
+  374          359.38396    307.17885   0.002673797 
+  369          357.25509    306.76223   0.002710027 
+  365          355.09465    306.34674   0.002739726 
+  355          353.14172    305.93237   0.002816901 
+  330          351.37427    305.51911   0.003030303 
+  395          349.78431    305.10697   0.002531646 
+  399          348.36496    304.69595   0.002506266 
+  359          347.11575    304.28603   0.002785515 
+  372          346.03792    303.87723   0.002688172 
+  370          345.14228    303.46953   0.002702703 
+  359          344.44666    303.06294   0.002785515 
+  374          343.98225    302.65744   0.002673797 
+  399          343.79318    302.25305   0.002506266 
+  380          343.9543     301.84975   0.002631579 
+  334          344.58511    301.44754   0.002994012 
+  359          345.88988    301.04643   0.002785515 
+  374          348.24483    300.6464    0.002673797 
+  380          352.33913    300.24746   0.002631579 
+  357          359.35154    299.8496    0.00280112 
+  392          370.99337    299.45282   0.00255102 
+  366          388.96053    299.05712   0.00273224 
+  389          411.93342    298.66249   0.002570694 
+  431          428.75156    298.26894   0.002320186 
+  484          426.9666     297.87646   0.002066116 
+  443          416.45085    297.48505   0.002257336 
+  394          408.31904    297.0947    0.002538071 
+  403          397.95207    296.70541   0.00248139 
+  401          382.63772    296.31719   0.002493766 
+  384          368.58592    295.93002   0.002604167 
+  348          358.80624    295.54391   0.002873563 
+  394          352.63363    295.15885   0.002538071 
+  332          348.82343    294.77485   0.003012048 
+  370          346.48776    294.39189   0.002702703 
+  385          345.20899    294.00997   0.002597403 
+  364          344.93943    293.6291    0.002747253 
+  356          345.74348    293.24927   0.002808989 
+  381          347.09281    292.87048   0.002624672 
+  365          346.9862     292.49273   0.002739726 
+  368          344.3921     292.116     0.002717391 
+  393          341.35838    291.74031   0.002544529 
+  364          338.86715    291.36565   0.002747253 
+  339          335.9173     290.99201   0.002949853 
+  337          332.64198    290.6194    0.002967359 
+  363          329.86303    290.2478    0.002754821 
+  378          327.89655    289.87723   0.002645503 
+  351          326.5795     289.50767   0.002849003 
+  372          325.73289    289.13913   0.002688172 
+  360          325.24841    288.77159   0.002777778 
+  336          325.07656    288.40507   0.00297619 
+  365          325.23627    288.03955   0.002739726 
+  354          325.80122    287.67504   0.002824859 
+  362          326.88128    287.31153   0.002762431 
+  358          328.53934    286.94902   0.002793296 
+  349          330.43817    286.5875    0.00286533 
+  369          331.59254    286.22698   0.002710027 
+  352          331.84063    285.86745   0.002840909 
+  340          332.23856    285.50892   0.002941176 
+  360          333.09937    285.15137   0.002777778 
+  329          334.06806    284.7948    0.003039514 
+  343          335.44356    284.43922   0.002915452 
+  356          337.92157    284.08462   0.002808989 
+  355          342.0356     283.73099   0.002816901 
+  411          348.34059    283.37835   0.00243309 
+  315          357.3891     283.02667   0.003174603 
+  414          368.98787    282.67597   0.002415459 
+  367          381.54577    282.32623   0.002724796 
+  421          394.55691    281.97747   0.002375297 
+  421          407.67008    281.62966   0.002375297 
+  483          416.02288    281.28282   0.002070393 
+  455          415.50102    280.93694   0.002197802 
+  440          409.60106    280.59201   0.002272727 
+  410          402.74372    280.24804   0.002439024 
+  455          394.89118    279.90502   0.002197802 
+  409          385.86747    279.56295   0.002444988 
+  417          377.46101    279.22183   0.002398082 
+  348          370.79902    278.88165   0.002873563 
+  369          366.22508    278.54242   0.002710027 
+  390          363.8792     278.20413   0.002564103 
+  386          363.33382    277.86678   0.002590674 
+  388          364.0327     277.53036   0.00257732 
+  411          365.92417    277.19488   0.00243309 
+  380          369.16986    276.86033   0.002631579 
+  360          373.90007    276.52671   0.002777778 
+  384          380.32961    276.19402   0.002604167 
+  413          388.73939    275.86225   0.002421308 
+  395          400.28149    275.53141   0.002531646 
+  369          417.1835     275.20148   0.002710027 
+  432          444.1184     274.87248   0.002314815 
+  483          487.45404    274.54439   0.002070393 
+  547          551.30319    274.21721   0.001828154 
+  595          618.00085    273.89095   0.001680672 
+  621          635.39183    273.56559   0.001610306 
+  569          612.33464    273.24114   0.001757469 
+  579          602.96175    272.9176    0.001727116 
+  564          606.06255    272.59496   0.00177305 
+  568          593.56042    272.27322   0.001760563 
+  555          577.90533    271.95238   0.001801802 
+  545          578.95363    271.63244   0.001834862 
+  568          599.46738    271.31338   0.001760563 
+  620          636.95279    270.99522   0.001612903 
+  619          684.43077    270.67795   0.001615509 
+  646          730.41631    270.36157   0.001547988 
+  672          777.4442     270.04607   0.001488095 
+  785          840.58828    269.73146   0.001273885 
+  877          926.66516    269.41772   0.001140251 
+  938          1038.74086   269.10487   0.001066098 
+  1103         1192.18644   268.79289   0.000906618 
+  1366         1414.41857   268.48178   0.000732064 
+  1726         1747.67021   268.17155   0.000579374 
+  2353         2278.72292   267.86219   0.000424989 
+  3459         3217.51768   267.55369   0.000289101 
+  5416         5031.50846   267.24606   0.000184638 
+  8479         8448.33676   266.9393    0.000117938 
+  13686        13746.48704  266.63339   0.000073067 
+  18605        17864.59147  266.32834   0.000053749 
+  19049        15981.36983  266.02416   0.000052496 
+  14684        12707.55432  265.72082   0.000068101 
+  11637        11794.70584  265.41834   0.000085933 
+  11042        10975.51973  265.11671   0.000090563 
+  8873         7947.39383   264.81593   0.000112701 
+  5435         5006.94188   264.51599   0.000183993 
+  2827         3186.42441   264.2169    0.000353732 
+  1864         2198.48526   263.91865   0.000536481 
+  1345         1658.65325   263.62124   0.000743494 
+  1136         1335.06392   263.32467   0.000880282 
+  961          1122.56987   263.02893   0.001040583 
+  840          973.89052    262.73403   0.001190476 
+  795          862.0553     262.43996   0.001257862 
+  734          773.89719    262.14672   0.001362398 
+  656          705.9138     261.85431   0.00152439 
+  583          653.01102    261.56272   0.001715266 
+  589          607.10499    261.27195   0.001697793 
+  534          565.46811    260.98201   0.001872659 
+  495          530.57759    260.69289   0.002020202 
+  465          502.42842    260.40458   0.002150538 
+  435          478.81926    260.11709   0.002298851 
+  460          458.91041    259.83041   0.002173913 
+  441          443.25138    259.54454   0.002267574 
+  426          431.87297    259.25948   0.002347418 
+  402          423.72796    258.97523   0.002487562 
+  409          416.35959    258.69178   0.002444988 
+  410          408.43795    258.40914   0.002439024 
+  416          400.31215    258.12729   0.002403846 
+  371          392.40404    257.84625   0.002695418 
+  385          385.5278     257.566     0.002597403 
+  365          380.03377    257.28654   0.002739726 
+  402          374.89031    257.00788   0.002487562 
+  385          367.98085    256.73001   0.002597403 
+  376          359.87282    256.45293   0.002659574 
+  342          352.85553    256.17663   0.002923977 
+  334          347.06395    255.90112   0.002994012 
+  344          341.10787    255.62639   0.002906977 
+  330          334.90323    255.35245   0.003030303 
+  313          329.3056     255.07928   0.003194888 
+  338          324.54959    254.80688   0.00295858 
+  324          320.50017    254.53527   0.00308642 
+  344          317.01745    254.26442   0.002906977 
+  291          313.97247    253.99435   0.003436426 
+  299          311.29253    253.72504   0.003344482 
+  260          308.90714    253.4565    0.003846154 
+  302          306.75544    253.18873   0.003311258 
+  284          304.77588    252.92172   0.003521127 
+  307          302.91134    252.65546   0.003257329 
+  302          301.10296    252.38997   0.003311258 
+  289          299.35719    252.12524   0.003460208 
+  284          297.654      251.86126   0.003521127 
+  298          295.98532    251.59803   0.003355705 
+  324          294.39086    251.33555   0.00308642 
+  274          292.86097    251.07383   0.003649635 
+  265          291.42272    250.81285   0.003773585 
+  297          290.09863    250.55261   0.003367003 
+  286          288.90167    250.29312   0.003496503 
+  308          287.83614    250.03437   0.003246753 
+  283          286.9092     249.77636   0.003533569 
+  290          286.14284    249.51909   0.003448276 
+  299          285.54428    249.26255   0.003344482 
+  287          285.12777    249.00675   0.003484321 
+  263          284.91533    248.75168   0.003802281 
+  254          284.895      248.49734   0.003937008 
+  274          284.9874     248.24372   0.003649635 
+  268          285.20333    247.99084   0.003731343 
+  292          285.78016    247.73867   0.003424658 
+  290          286.80526    247.48723   0.003448276 
+  305          287.68452    247.23651   0.003278689 
+  290          287.52495    246.98651   0.003448276 
+  312          286.82755    246.73723   0.003205128 
+  308          286.6649     246.48866   0.003246753 
+  329          287.21597    246.2408    0.003039514 
+  308          288.31418    245.99366   0.003246753 
+  329          290.65869    245.74722   0.003039514 
+  317          295.54618    245.50149   0.003154574 
+  359          304.2357     245.25647   0.002785515 
+  417          317.267      245.01215   0.002398082 
+  373          331.38823    244.76853   0.002680965 
+  432          337.29476    244.52561   0.002314815 
+  403          332.74555    244.28339   0.00248139 
+  392          326.41387    244.04187   0.00255102 
+  398          321.8569     243.80104   0.002512563 
+  384          315.58548    243.5609    0.002604167 
+  364          306.26286    243.32146   0.002747253 
+  338          297.36376    243.0827    0.00295858 
+  303          290.80262    242.84463   0.00330033 
+  336          286.84825    242.60725   0.00297619 
+  304          285.14032    242.37055   0.003289474 
+  302          285.27367    242.13453   0.003311258 
+  316          287.03453    241.89919   0.003164557 
+  243          290.2726     241.66453   0.004115226 
+  303          294.47292    241.43055   0.00330033 
+  321          298.19791    241.19724   0.003115265 
+  300          299.68508    240.9646    0.003333333 
+  277          298.97325    240.73263   0.003610108 
+  287          297.69258    240.50134   0.003484321 
+  276          296.61024    240.27071   0.003623188 
+  287          295.36024    240.04074   0.003484321 
+  302          294.08683    239.81144   0.003311258 
+  309          293.81778    239.58281   0.003236246 
+  263          295.62368    239.35483   0.003802281 
+  303          300.66634    239.12751   0.00330033 
+  307          311.10199    238.90085   0.003257329 
+  313          331.00239    238.67484   0.003194888 
+  365          366.12911    238.44949   0.002739726 
+  423          419.00395    238.22478   0.002364066 
+  441          468.49569    238.00073   0.002267574 
+  480          467.98654    237.77733   0.002083333 
+  427          437.39656    237.55457   0.00234192 
+  437          422.80297    237.33245   0.00228833 
+  378          419.89139    237.11098   0.002645503 
+  361          397.78125    236.89015   0.002770083 
+  349          361.91527    236.66996   0.00286533 
+  362          333.98327    236.45041   0.002762431 
+  300          316.18381    236.23149   0.003333333 
+  313          304.22938    236.01321   0.003194888 
+  312          296.0534     235.79556   0.003205128 
+  323          290.76866    235.57853   0.003095975 
+  294          287.5089     235.36214   0.003401361 
+  322          285.62541    235.14638   0.00310559 
+  294          284.70652    234.93124   0.003401361 
+  314          284.50194    234.71673   0.003184713 
+  290          284.83597    234.50284   0.003448276 
+  289          285.49623    234.28956   0.003460208 
+  297          286.29232    234.07691   0.003367003 
+  292          287.3006     233.86488   0.003424658 
+  309          288.65933    233.65346   0.003236246 
+  324          290.35508    233.44265   0.00308642 
+  294          292.31729    233.23246   0.003401361 
+  320          294.60215    233.02287   0.003125  
+  316          297.33148    232.8139    0.003164557 
+  284          300.61413    232.60553   0.003521127 
+  341          304.5923     232.39777   0.002932551 
+  311          309.49963    232.19061   0.003215434 
+  326          315.67882    231.98405   0.003067485 
+  362          323.40762    231.7781    0.002762431 
+  334          332.19914    231.57274   0.002994012 
+  337          340.05833    231.36798   0.002967359 
+  373          346.41654    231.16382   0.002680965 
+  350          354.45359    230.96025   0.002857143 
+  365          367.18724    230.75727   0.002739726 
+  387          386.28248    230.55488   0.002583979 
+  396          413.36767    230.35308   0.002525253 
+  418          446.20818    230.15187   0.002392344 
+  424          466.02476    229.95125   0.002358491 
+  483          463.83755    229.75121   0.002070393 
+  455          463.27619    229.55175   0.002197802 
+  449          475.17545    229.35287   0.002227171 
+  473          490.0588     229.15457   0.002114165 
+  454          498.98287    228.95685   0.002202643 
+  497          511.36281    228.75971   0.002012072 
+  555          534.3378     228.56314   0.001801802 
+  539          569.17471    228.36714   0.001855288 
+  606          616.37073    228.17172   0.001650165 
+  632          677.37438    227.97686   0.001582278 
+  777          756.66667    227.78257   0.001287001 
+  864          862.59425    227.58885   0.001157407 
+  982          1007.6789    227.3957    0.00101833 
+  1207         1212.34096   227.2031    0.0008285 
+  1528         1515.84332   227.01107   0.00065445 
+  2119         2006.6729    226.8196    0.000471921 
+  3146         2897.41604   226.62869   0.000317864 
+  5073         4623.2985    226.43834   0.000197122 
+  8118         7772.86421   226.24854   0.000123183 
+  12432        12257.58915  226.05929   0.000080438 
+  15362        14704.47088  225.8706    0.000065096 
+  14148        12242.94837  225.68246   0.000070681 
+  10495        9533.90525   225.49487   0.000095283 
+  8691         9009.5804    225.30782   0.000115062 
+  8594         9038.92869   225.12132   0.00011636 
+  7493         7064.75459   224.93537   0.000133458 
+  4685         4560.03892   224.74996   0.000213447 
+  2597         2884.71697   224.56509   0.00038506 
+  1602         1953.08065   224.38076   0.00062422 
+  1084         1448.08973   224.19697   0.000922509 
+  914          1151.21381   224.01372   0.001094092 
+  737          957.30286    223.831     0.001356852 
+  681          821.76727    223.64882   0.001468429 
+  598          723.12493    223.46717   0.001672241 
+  529          649.65773    223.28605   0.001890359 
+  525          594.39499    223.10546   0.001904762 
+  484          553.11141    222.9254    0.002066116 
+  459          523.21985    222.74586   0.002178649 
+  503          502.88601    222.56685   0.001988072 
+  455          489.80493    222.38836   0.002197802 
+  485          480.09351    222.2104    0.002061856 
+  508          469.26125    222.03295   0.001968504 
+  497          455.61041    221.85603   0.002012072 
+  416          441.12206    221.67962   0.002403846 
+  436          427.49941    221.50373   0.002293578 
+  420          410.96258    221.32835   0.002380952 
+  366          391.34118    221.15348   0.00273224 
+  337          372.65999    220.97913   0.002967359 
+  335          356.80935    220.80529   0.002985075 
+  325          342.72263    220.63196   0.003076923 
+  297          329.8071     220.45913   0.003367003 
+  313          319.02722    220.28681   0.003194888 
+  329          310.51417    220.11499   0.003039514 
+  298          303.79889    219.94368   0.003355705 
+  277          298.40557    219.77287   0.003610108 
+  300          293.97984    219.60255   0.003333333 
+  277          290.27306    219.43274   0.003610108 
+  266          287.10495    219.26342   0.003759398 
+  274          284.336      219.0946    0.003649635 
+  254          281.84731    218.92628   0.003937008 
+  272          279.5489     218.75844   0.003676471 
+  254          277.38109    218.5911    0.003937008 
+  281          275.32375    218.42425   0.003558719 
+  282          273.38483    218.25788   0.003546099 
+  248          271.59363    218.09201   0.004032258 
+  246          269.99843    217.92661   0.004065041 
+  270          268.67704    217.76171   0.003703704 
+  257          267.75063    217.59728   0.003891051 
+  257          267.39599    217.43334   0.003891051 
+  260          267.83661    217.26988   0.003846154 
+  263          269.23601    217.10689   0.003802281 
+  245          271.22776    216.94439   0.004081633 
+  252          272.18396    216.78236   0.003968254 
+  267          270.92274    216.6208    0.003745318 
+  250          268.89393    216.45972   0.004     
+  284          267.23436    216.2991    0.003521127 
+  270          265.55874    216.13896   0.003703704 
+  264          263.11451    215.97929   0.003787879 
+  273          260.25481    215.82009   0.003663004 
+  262          257.67023    215.66135   0.003816794 
+  242          255.50466    215.50307   0.004132231 
+  254          253.80666    215.34526   0.003937008 
+  276          252.58976    215.18791   0.003623188 
+  252          251.84417    215.03102   0.003968254 
+  205          251.58426    214.8746    0.004878049 
+  240          251.8689     214.71862   0.004166667 
+  265          252.74352    214.56311   0.003773585 
+  256          254.07784    214.40805   0.00390625 
+  261          255.50476    214.25345   0.003831418 
+  231          257.01034    214.09929   0.004329004 
+  252          259.2966     213.94559   0.003968254 
+  260          263.09279    213.79234   0.003846154 
+  272          269.28057    213.63954   0.003676471 
+  284          279.92639    213.48718   0.003521127 
+  288          298.68002    213.33527   0.003472222 
+  331          329.2825     213.18381   0.003021148 
+  387          368.75419    213.03278   0.002583979 
+  391          393.32455    212.8822    0.002557545 
+  427          387.67851    212.73206   0.00234192 
+  433          379.22866    212.58236   0.002309469 
+  367          377.66199    212.4331    0.002724796 
+  369          371.52463    212.28427   0.002710027 
+  351          351.84108    212.13588   0.002849003 
+  314          329.29864    211.98793   0.003184713 
+  290          313.26868    211.8404    0.003448276 
+  322          300.82572    211.69331   0.00310559 
+  279          291.69047    211.54665   0.003584229 
+  272          287.35571    211.40041   0.003676471 
+  289          285.71459    211.2546    0.003460208 
+  304          282.23012    211.10922   0.003289474 
+  256          277.11707    210.96427   0.00390625 
+  265          272.75904    210.81974   0.003773585 
+  257          268.91811    210.67563   0.003891051 
+  261          264.38117    210.53194   0.003831418 
+  252          258.94859    210.38867   0.003968254 
+  259          254.03193    210.24582   0.003861004 
+  241          249.91184    210.10339   0.004149378 
+  261          246.52164    209.96137   0.003831418 
+  247          244.0813     209.81977   0.004048583 
+  230          242.52004    209.67858   0.004347826 
+  230          241.62138    209.5378    0.004347826 
+  262          241.21117    209.39744   0.003816794 
+  271          241.17983    209.25748   0.003690037 
+  228          241.44434    209.11793   0.004385965 
+  251          241.87207    208.97879   0.003984064 
+  249          242.32415    208.84006   0.004016064 
+  242          242.87635    208.70173   0.004132231 
+  200          243.69525    208.5638    0.005     
+  238          244.85779    208.42628   0.004201681 
+  253          246.39854    208.28915   0.003952569 
+  234          248.46636    208.15243   0.004273504 
+  262          251.36066    208.0161    0.003816794 
+  241          255.29385    207.88018   0.004149378 
+  218          259.84515    207.74465   0.004587156 
+  259          263.22983    207.60951   0.003861004 
+  256          264.33185    207.47476   0.00390625 
+  239          265.02261    207.34041   0.0041841 
+  257          266.91345    207.20645   0.003891051 
+  242          269.71888    207.07288   0.004132231 
+  259          272.35413    206.9397    0.003861004 
+  256          274.99732    206.80691   0.00390625 
+  270          278.74466    206.6745    0.003703704 
+  301          284.22641    206.54248   0.003322259 
+  325          291.86927    206.41084   0.003076923 
+  323          302.25045    206.27959   0.003095975 
+  311          316.1085     206.14871   0.003215434 
+  303          333.60748    206.01822   0.00330033 
+  327          351.97968    205.88811   0.003058104 
+  330          364.79495    205.75837   0.003030303 
+  351          371.72121    205.62901   0.002849003 
+  346          379.33797    205.50003   0.002890173 
+  391          390.12409    205.37142   0.002557545 
+  381          401.15235    205.24318   0.002624672 
+  407          409.04094    205.11532   0.002457002 
+  426          415.44805    204.98783   0.002347418 
+  429          423.0509     204.8607    0.002331002 
+  429          432.55677    204.73395   0.002331002 
+  445          443.75429    204.60756   0.002247191 
+  497          456.16599    204.48154   0.002012072 
+  450          469.18309    204.35588   0.002222222 
+  524          482.13768    204.23059   0.001908397 
+  491          494.49192    204.10566   0.00203666 
+  523          506.06801    203.9811    0.001912046 
+  510          517.16042    203.85689   0.001960784 
+  519          528.30167    203.73304   0.001926782 
+  485          539.74895    203.60955   0.002061856 
+  575          551.13187    203.48642   0.00173913 
+  528          560.9253     203.36365   0.001893939 
+  529          566.4958     203.24123   0.001890359 
+  530          566.48261    203.11916   0.001886792 
+  584          561.638      202.99745   0.001712329 
+  549          552.7306     202.87608   0.001821494 
+  502          539.45583    202.75507   0.001992032 
+  454          521.47034    202.63441   0.002202643 
+  442          499.76792    202.51409   0.002262443 
+  407          476.04071    202.39412   0.002457002 
+  389          451.6339     202.2745    0.002570694 
+  399          427.48155    202.15522   0.002506266 
+  377          404.34617    202.03629   0.00265252 
+  379          382.84719    201.9177    0.002638522 
+  337          363.38345    201.79945   0.002967359 
+  333          346.11055    201.68154   0.003003003 
+  324          331.01429    201.56397   0.00308642 
+  330          317.96642    201.44674   0.003030303 
+  303          306.79752    201.32984   0.00330033 
+  280          297.32648    201.21328   0.003571429 
+  310          289.44212    201.09706   0.003225806 
+  284          283.10929    200.98117   0.003521127 
+  270          278.38692    200.86561   0.003703704 
+  265          275.35882    200.75039   0.003773585 
+  261          273.77203    200.63549   0.003831418 
+  284          272.09412    200.52093   0.003521127 
+  269          268.21567    200.40669   0.003717472 
+  275          263.02226    200.29278   0.003636364 
+  246          258.71889    200.1792    0.004065041 
+  257          255.71678    200.06594   0.003891051 
+  264          252.85225    199.953     0.003787879 
+  238          249.22044    199.84039   0.004201681 
+  255          245.56188    199.7281    0.003921569 
+  254          242.59281    199.61614   0.003937008 
+  245          240.38024    199.50449   0.004081633 
+  244          238.7851     199.39316   0.004098361 
+  225          237.67265    199.28215   0.004444444 
+  208          236.95323    199.17146   0.004807692 
+  248          236.57084    199.06108   0.004032258 
+  244          236.49074    198.95101   0.004098361 
+  216          236.68446    198.84126   0.00462963 
+  236          237.12531    198.73183   0.004237288 
+  237          237.79689    198.6227    0.004219409 
+  208          238.70479    198.51389   0.004807692 
+  251          239.86785    198.40538   0.003984064 
+  234          241.18587    198.29718   0.004273504 
+  243          241.62203    198.1893    0.004115226 
+  235          240.87538    198.08171   0.004255319 
+  232          238.94797    197.97444   0.004310345 
+  216          237.10288    197.86746   0.00462963 
+  204          235.59649    197.76079   0.004901961 
+  213          234.42846    197.65443   0.004694836 
+  230          233.02152    197.54836   0.004347826 
+  254          231.8215     197.4426    0.003937008 
+  252          231.23544    197.33713   0.003968254 
+  225          230.85552    197.23197   0.004444444 
+  204          230.15849    197.1271    0.004901961 
+  238          229.78333    197.02252   0.004201681 
+  238          230.66094    196.91825   0.004201681 
+  226          233.03997    196.81426   0.004424779 
+  247          236.07513    196.71057   0.004048583 
+  222          237.68098    196.60718   0.004504505 
+  225          236.91123    196.50407   0.004444444 
+  236          235.36945    196.40126   0.004237288 
+  207          234.27805    196.29873   0.004830918 
+  218          234.15429    196.19649   0.004587156 
+  223          234.56395    196.09454   0.004484305 
+  214          235.05154    195.99288   0.004672897 
+  240          234.95421    195.8915    0.004166667 
+  230          232.91235    195.79041   0.004347826 
+  203          229.97116    195.6896    0.004926108 
+  224          228.05501    195.58908   0.004464286 
+  240          227.52643    195.48883   0.004166667 
+  221          227.48771    195.38887   0.004524887 
+  226          227.12014    195.28919   0.004424779 
+  226          227.02166    195.18978   0.004424779 
+  202          228.07663    195.09066   0.004950495 
+  209          230.84195    194.99181   0.004784689 
+  215          236.06202    194.89323   0.004651163 
+  256          245.09579    194.79493   0.00390625 
+  270          259.85462    194.69691   0.003703704 
+  294          282.18365    194.59916   0.003401361 
+  348          312.03288    194.50168   0.002873563 
+  331          336.00188    194.40447   0.003021148 
+  344          331.61153    194.30754   0.002906977 
+  323          311.55944    194.21087   0.003095975 
+  318          298.02568    194.11447   0.003144654 
+  296          295.77438    194.01834   0.003378378 
+  295          293.89379    193.92248   0.003389831 
+  279          280.84053    193.82688   0.003584229 
+  259          264.33887    193.73154   0.003861004 
+  262          252.38279    193.63647   0.003816794 
+  266          245.56115    193.54167   0.003759398 
+  255          241.23533    193.44712   0.003921569 
+  244          237.52136    193.35284   0.004098361 
+  255          234.38798    193.25882   0.003921569 
+  241          232.20806    193.16506   0.004149378 
+  231          231.02826    193.07155   0.004329004 
+  240          230.21663    192.9783    0.004166667 
+  227          229.56485    192.88531   0.004405286 
+  234          229.36275    192.79258   0.004273504 
+  232          229.62913    192.7001    0.004310345 
+  240          229.66988    192.60787   0.004166667 
+  217          228.98264    192.5159    0.004608295 
+  233          228.29397    192.42418   0.004291845 
+  232          228.18727    192.33271   0.004310345 
+  207          228.50671    192.24149   0.004830918 
+  225          228.64621    192.15052   0.004444444 
+  221          228.35897    192.0598    0.004524887 
+  224          228.01698    191.96933   0.004464286 
+  210          227.86799    191.87911   0.004761905 
+  214          227.93393    191.78913   0.004672897 
+  225          228.18964    191.69939   0.004444444 
+  223          228.61945    191.6099    0.004484305 
+  220          229.24123    191.52066   0.004545455 
+  238          230.10204    191.43165   0.004201681 
+  238          231.28188    191.34289   0.004201681 
+  244          232.89099    191.25437   0.004098361 
+  215          235.05108    191.16609   0.004651163 
+  232          237.78167    191.07805   0.004310345 
+  263          240.65931    190.99024   0.003802281 
+  222          242.76399    190.90268   0.004504505 
+  284          244.08415    190.81535   0.003521127 
+  248          245.56795    190.72825   0.004032258 
+  247          247.62229    190.6414    0.004048583 
+  246          249.94655    190.55477   0.004065041 
+  234          251.95775    190.46838   0.004273504 
+  249          253.66423    190.38222   0.004016064 
+  248          255.52372    190.29629   0.004032258 
+  243          257.76226    190.2106    0.004115226 
+  249          260.43079    190.12513   0.004016064 
+  249          263.55668    190.03989   0.004016064 
+  271          267.19318    189.95488   0.003690037 
+  247          271.42626    189.8701    0.004048583 
+  281          276.3729     189.78555   0.003558719 
+  265          282.17075    189.70122   0.003773585 
+  275          288.98628    189.61711   0.003636364 
+  277          297.02019    189.53323   0.003610108 
+  271          306.53042    189.44958   0.003690037 
+  292          317.86578    189.36614   0.003424658 
+  321          331.51879    189.28293   0.003115265 
+  325          348.17183    189.19994   0.003076923 
+  333          368.74488    189.11717   0.003003003 
+  377          394.2966     189.03461   0.00265252 
+  428          425.40066    188.95228   0.002336449 
+  472          460.97527    188.87016   0.002118644 
+  470          500.66939    188.78826   0.00212766 
+  559          549.70933    188.70658   0.001788909 
+  592          615.52793    188.62511   0.001689189 
+  697          705.54323    188.54386   0.00143472 
+  711          829.82891    188.46282   0.00140647 
+  876          1007.60555   188.38199   0.001141553 
+  1237         1282.57998   188.30138   0.000808407 
+  1720         1756.32376   188.22097   0.000581395 
+  2677         2651.22059   188.14078   0.000373552 
+  4458         4335.17499   188.0608    0.000224316 
+  7047         7080.5261    187.98102   0.000141904 
+  9338         9841.56504   187.90146   0.000107089 
+  9587         9474.10254   187.8221    0.000104308 
+  7274         6981.83651   187.74295   0.000137476 
+  5347         5447.50551   187.664     0.000187021 
+  5149         5437.35515   187.58526   0.000194212 
+  5649         6025.11801   187.50672   0.000177022 
+  5003         5291.97287   187.42839   0.00019988 
+  3532         3599.896     187.35026   0.000283126 
+  2138         2290.20968   187.27233   0.000467727 
+  1318         1525.44001   187.19461   0.000758725 
+  930          1109.56043   187.11708   0.001075269 
+  790          872.45488    187.03976   0.001265823 
+  698          722.53189    186.96263   0.001432665 
+  566          619.3274     186.8857    0.001766784 
+  492          544.50105    186.80897   0.00203252 
+  496          488.41565    186.73244   0.002016129 
+  422          445.30276    186.6561    0.002369668 
+  387          411.51793    186.57996   0.002583979 
+  387          384.66879    186.50401   0.002583979 
+  378          363.16139    186.42825   0.002645503 
+  348          345.94998    186.35269   0.002873563 
+  345          332.43526    186.27732   0.002898551 
+  390          322.41601    186.20215   0.002564103 
+  349          316.10835    186.12716   0.00286533 
+  328          314.08333    186.05236   0.00304878 
+  327          316.82578    185.97776   0.003058104 
+  301          322.84449    185.90334   0.003322259 
+  320          325.31668    185.82911   0.003125  
+  313          318.02496    185.75507   0.003194888 
+  313          307.17261    185.68121   0.003194888 
+  328          301.0743     185.60754   0.00304878 
+  294          301.78529    185.53406   0.003401361 
+  284          306.42379    185.46076   0.003521127 
+  287          311.21071    185.38764   0.003484321 
+  311          315.21955    185.31471   0.003215434 
+  277          312.59443    185.24196   0.003610108 
+  315          299.35521    185.16939   0.003174603 
+  316          284.36459    185.097     0.003164557 
+  287          274.93306    185.02479   0.003484321 
+  262          270.65194    184.95276   0.003816794 
+  287          265.7853     184.88091   0.003484321 
+  261          256.15306    184.80924   0.003831418 
+  245          245.02202    184.73775   0.004081633 
+  265          235.87047    184.66643   0.003773585 
+  288          229.18316    184.59529   0.003472222 
+  218          224.37457    184.52432   0.004587156 
+  250          220.82631    184.45353   0.004     
+  234          218.08739    184.38291   0.004273504 
+  225          215.8799     184.31247   0.004444444 
+  226          214.0355     184.2422    0.004424779 
+  233          212.45565    184.1721    0.004291845 
+  241          211.07943    184.10217   0.004149378 
+  244          209.86602    184.03241   0.004098361 
+  236          208.78693    183.96282   0.004237288 
+  225          207.82384    183.8934    0.004444444 
+  208          206.95782    183.82415   0.004807692 
+  220          206.17995    183.75507   0.004545455 
+  213          205.48228    183.68616   0.004694836 
+  234          204.85966    183.61741   0.004273504 
+  240          203.99623    183.54883   0.004166667 
+  222          203.51814    183.48041   0.004504505 
+  221          203.11055    183.41216   0.004524887 
+  202          202.77893    183.34407   0.004950495 
+  198          202.37637    183.27614   0.005050505 
+  216          202.23205    183.20838   0.00462963 
+  235          202.20909    183.14078   0.004255319 
+  229          202.31886    183.07334   0.004366812 
+  205          202.50897    183.00606   0.004878049 
+  222          202.59756    182.93894   0.004504505 
+  229          202.45938    182.87199   0.004366812 
+  184          202.25594    182.80519   0.005434783 
+  200          202.20053    182.73854   0.005     
+  209          202.35719    182.67206   0.004784689 
+  196          202.66419    182.60573   0.005102041 
+  226          203.06219    182.53956   0.004424779 
+  214          203.65755    182.47354   0.004672897 
+  219          204.65753    182.40768   0.00456621 
+  208          206.2973     182.34198   0.004807692 
+  227          208.92964    182.27642   0.004405286 
+  232          213.14582    182.21102   0.004310345 
+  247          219.83719    182.14578   0.004048583 
+  257          230.03976    182.08068   0.003891051 
+  259          243.92736    182.01574   0.003861004 
+  260          257.43257    181.95094   0.003846154 
+  217          260.96575    181.8863    0.004608295 
+  241          253.2851     181.8218    0.004149378 
+  209          244.60737    181.75746   0.004784689 
+  216          240.88302    181.69326   0.00462963 
+  209          241.14858    181.62921   0.004784689 
+  199          239.93667    181.56531   0.005025126 
+  220          234.21898    181.50155   0.004545455 
+  209          227.92658    181.43794   0.004784689 
+  214          224.3033     181.37447   0.004672897 
+  213          223.70366    181.31115   0.004694836 
+  215          225.31364    181.24797   0.004651163 
+  214          226.31397    181.18494   0.004672897 
+  222          223.87329    181.12205   0.004504505 
+  211          219.88618    181.0593    0.004739336 
+  220          217.18788    180.99669   0.004545455 
+  196          216.43681    180.93422   0.005102041 
+  229          216.52775    180.8719    0.004366812 
+  203          215.65147    180.80971   0.004926108 
+  226          214.18125    180.74766   0.004424779 
+  219          213.7901     180.68575   0.00456621 
+  224          215.185      180.62398   0.004464286 
+  254          218.11597    180.56235   0.003937008 
+  249          221.70223    180.50085   0.004016064 
+  236          226.12504    180.43949   0.004237288 
+  265          233.27814    180.37827   0.003773585 
+  253          244.1897     180.31718   0.003952569 
+  287          256.53724    180.25622   0.003484321 
+  260          263.88981    180.1954    0.003846154 
+  309          263.04728    180.13471   0.003236246 
+  249          260.68046    180.07416   0.004016064 
+  278          263.89043    180.01373   0.003597122 
+  302          274.14438    179.95344   0.003311258 
+  304          287.75735    179.89328   0.003289474 
+  326          298.26606    179.83325   0.003067485 
+  297          304.39254    179.77336   0.003367003 
+  308          309.39376    179.71359   0.003246753 
+  349          317.1965     179.65394   0.00286533 
+  396          337.37964    179.59443   0.002525253 
+  419          379.80431    179.53505   0.002386635 
+  462          451.15226    179.47579   0.002164502 
+  535          545.92028    179.41666   0.001869159 
+  582          612.59091    179.35766   0.001718213 
+  547          579.67276    179.29878   0.001828154 
+  523          496.30357    179.24002   0.001912046 
+  405          442.65       179.18139   0.002469136 
+  432          433.90499    179.12289   0.002314815 
+  372          446.38181    179.06451   0.002688172 
+  385          428.2746     179.00625   0.002597403 
+  357          374.18821    178.94811   0.00280112 
+  301          323.07541    178.8901    0.003322259 
+  233          288.82062    178.83221   0.004291845 
+  265          269.31685    178.77443   0.003773585 
+  249          261.28863    178.71678   0.004016064 
+  223          262.07926    178.65925   0.004484305 
+  313          273.91407    178.60184   0.003194888 
+  290          302.17331    178.54454   0.003448276 
+  387          351.55417    178.48737   0.002583979 
+  409          403.51395    178.43031   0.002444988 
+  433          399.81298    178.37337   0.002309469 
+  381          355.61136    178.31654   0.002624672 
+  334          330.50471    178.25983   0.002994012 
+  358          338.09264    178.20324   0.002793296 
+  383          365.11474    178.14676   0.002610966 
+  392          370.14676    178.0904    0.00255102 
+  345          333.46037    178.03415   0.002898551 
+  288          293.10036    177.97801   0.003472222 
+  277          268.39907    177.92199   0.003610108 
+  266          257.03968    177.86608   0.003759398 
+  235          250.1288     177.81028   0.004255319 
+  249          240.23863    177.7546    0.004016064 
+  227          228.70071    177.69902   0.004405286 
+  260          219.36114    177.64356   0.003846154 
+  233          213.05507    177.5882    0.004291845 
+  202          209.18332    177.53296   0.004950495 
+  221          206.91158    177.47782   0.004524887 
+  189          205.36688    177.42279   0.005291005 
+  184          204.11121    177.36787   0.005434783 
+  197          203.36278    177.31306   0.005076142 
+  199          203.34782    177.25835   0.005025126 
+  194          204.10651    177.20376   0.005154639 
+  184          205.61327    177.14926   0.005434783 
+  206          207.973      177.09488   0.004854369 
+  224          211.81297    177.0406    0.004464286 
+  198          218.2655     176.98642   0.005050505 
+  247          228.90429    176.93235   0.004048583 
+  206          245.70112    176.87838   0.004854369 
+  256          269.93857    176.82451   0.00390625 
+  253          297.63094    176.77075   0.003952569 
+  307          312.85376    176.71709   0.003257329 
+  270          303.25595    176.66353   0.003703704 
+  250          283.4321     176.61007   0.004     
+  245          270.29138    176.55671   0.004081633 
+  257          267.18103    176.50346   0.003891051 
+  257          267.49081    176.4503    0.003891051 
+  235          259.94134    176.39725   0.004255319 
+  227          244.02523    176.34429   0.004405286 
+  218          228.33369    176.29143   0.004587156 
+  208          216.7529     176.23867   0.004807692 
+  179          209.02999    176.186     0.005586592 
+  200          204.04733    176.13344   0.005     
+  220          200.8411     176.08097   0.004545455 
+  194          198.76395    176.0286    0.005154639 
+  178          197.43192    175.97632   0.005617978 
+  215          196.63377    175.92414   0.004651163 
+  180          196.2595     175.87205   0.005555556 
+  192          196.25865    175.82006   0.005208333 
+  207          196.61351    175.76816   0.004830918 
+  222          197.29068    175.71635   0.004504505 
+  199          198.0897     175.66464   0.005025126 
+  148          198.45233    175.61302   0.006756757 
+  221          198.02484    175.5615    0.004524887 
+  219          197.30815    175.51006   0.00456621 
+  187          196.83758    175.45872   0.005347594 
+  208          196.76739    175.40747   0.004807692 
+  223          196.98364    175.3563    0.004484305 
+  213          197.25553    175.30523   0.004694836 
+  199          197.65374    175.25425   0.005025126 
+  216          198.24713    175.20336   0.00462963 
+  228          198.34152    175.15255   0.004385965 
+  223          197.35431    175.10184   0.004484305 
+  227          196.04898    175.05121   0.004405286 
+  265          195.27784    175.00067   0.003773585 
+  275          195.23906    174.95022   0.003636364 
+  292          195.67057    174.89985   0.003424658 
+  287          196.08702    174.84957   0.003484321 
+  268          196.52998    174.79938   0.003731343 
+  315          197.44079    174.74927   0.003174603 
+  318          198.61262    174.69924   0.003144654 
+  315          199.35313    174.6493    0.003174603 
+  289          200.00406    174.59945   0.003460208 
+  260          201.65805    174.54968   0.003846154 
+  289          205.0356     174.49999   0.003460208 
+  298          210.54016    174.45039   0.003355705 
+  244          217.46248    174.40086   0.004098361 
+  294          222.43369    174.35142   0.003401361 
+  257          221.39076    174.30206   0.003891051 
+  241          216.32372    174.25279   0.004149378 
+  231          212.20649    174.20359   0.004329004 
+  231          211.02921    174.15448   0.004329004 
+  243          212.13171    174.10544   0.004115226 
+  230          212.92429    174.05648   0.004347826 
+  226          211.59046    174.00761   0.004424779 
+  204          209.28631    173.95881   0.004901961 
+  200          207.18677    173.91009   0.005     
+  210          205.82271    173.86145   0.004761905 
+  185          205.03304    173.81289   0.005405405 
+  223          204.74536    173.7644    0.004484305 
+  212          205.53072    173.71599   0.004716981 
+  243          207.672      173.66766   0.004115226 
+  225          211.47667    173.61941   0.004444444 
+  243          217.33786    173.57123   0.004115226 
+  206          224.34541    173.52312   0.004854369 
+  234          228.78432    173.47509   0.004273504 
+  220          226.85837    173.42714   0.004545455 
+  228          221.58199    173.37926   0.004385965 
+  214          217.84383    173.33145   0.004672897 
+  217          217.10217    173.28372   0.004608295 
+  221          218.22072    173.23606   0.004524887 
+  227          218.24097    173.18848   0.004405286 
+  238          215.69948    173.14096   0.004201681 
+  241          212.61566    173.09352   0.004149378 
+  253          210.64208    173.04615   0.003952569 
+  220          210.01049    172.99885   0.004545455 
+  220          210.5166     172.95162   0.004545455 
+  227          211.971      172.90446   0.004405286 
+  233          214.27249    172.85738   0.004291845 
+  214          217.33847    172.81036   0.004672897 
+  221          220.8796     172.76341   0.004524887 
+  254          224.36569    172.71653   0.003937008 
+  265          227.84811    172.66972   0.003773585 
+  232          232.00521    172.62298   0.004310345 
+  272          237.26027    172.57631   0.003676471 
+  268          243.70779    172.5297    0.003731343 
+  272          251.1999     172.48317   0.003676471 
+  284          259.5346     172.4367    0.003521127 
+  299          269.00095    172.39029   0.003344482 
+  311          279.6076     172.34395   0.003215434 
+  330          291.51752    172.29768   0.003030303 
+  306          304.61258    172.25148   0.003267974 
+  305          318.74904    172.20533   0.003278689 
+  341          333.78075    172.15926   0.002932551 
+  375          349.20102    172.11325   0.002666667 
+  360          362.65961    172.0673    0.002777778 
+  342          371.01722    172.02142   0.002923977 
+  395          374.29689    171.9756    0.002531646 
+  399          375.78032    171.92984   0.002506266 
+  364          377.94492    171.88415   0.002747253 
+  368          378.50759    171.83852   0.002717391 
+  378          374.14779    171.79295   0.002645503 
+  350          365.69148    171.74744   0.002857143 
+  358          355.17016    171.70199   0.002793296 
+  344          344.29053    171.65661   0.002906977 
+  322          334.42737    171.61129   0.00310559 
+  310          324.38403    171.56602   0.003225806 
+  306          313.3703     171.52082   0.003267974 
+  296          302.36303    171.47568   0.003378378 
+  285          291.70307    171.4306    0.003508772 
+  305          281.50183    171.38557   0.003278689 
+  281          272.1858     171.34061   0.003558719 
+  269          263.80965    171.2957    0.003717472 
+  254          256.21542    171.25086   0.003937008 
+  273          249.29413    171.20607   0.003663004 
+  262          243.01891    171.16133   0.003816794 
+  239          237.40212    171.11666   0.0041841 
+  221          232.45524    171.07204   0.004524887 
+  227          228.17278    171.02748   0.004405286 
+  239          224.53119    170.98298   0.0041841 
+  242          221.49929    170.93853   0.004132231 
+  220          219.04629    170.89414   0.004545455 
+  206          217.14971    170.8498    0.004854369 
+  225          215.82782    170.80552   0.004444444 
+  232          215.14787    170.76129   0.004310345 
+  231          215.17847    170.71712   0.004329004 
+  221          215.82509    170.673     0.004524887 
+  232          216.53403    170.62894   0.004310345 
+  224          216.72778    170.58493   0.004464286 
+  221          216.83608    170.54097   0.004524887 
+  256          217.28749    170.49707   0.00390625 
+  220          217.71773    170.45322   0.004545455 
+  219          218.0959     170.40942   0.00456621 
+  202          218.72766    170.36567   0.004950495 
+  252          219.71712    170.32198   0.003968254 
+  256          221.41748    170.27833   0.00390625 
+  261          224.03365    170.23474   0.003831418 
+  224          227.54759    170.1912    0.004464286 
+  258          232.40226    170.14771   0.003875969 
+  280          239.43446    170.10427   0.003571429 
+  246          249.50685    170.06088   0.004065041 
+  291          263.54333    170.01754   0.003436426 
+  298          282.36302    169.97425   0.003355705 
+  331          305.75965    169.93101   0.003021148 
+  336          330.38258    169.88782   0.00297619 
+  350          348.27593    169.84468   0.002857143 
+  359          352.26165    169.80158   0.002785515 
+  380          345.3232     169.75854   0.002631579 
+  339          337.28893    169.71554   0.002949853 
+  315          333.57204    169.67259   0.003174603 
+  318          330.84348    169.62968   0.003144654 
+  323          322.71278    169.58683   0.003095975 
+  306          308.0553     169.54402   0.003267974 
+  272          290.72122    169.50125   0.003676471 
+  267          275.29391    169.45854   0.003745318 
+  247          263.41861    169.41587   0.004048583 
+  264          253.53187    169.37324   0.003787879 
+  253          244.35682    169.33066   0.003952569 
+  192          236.82943    169.28813   0.005208333 
+  239          231.5155     169.24564   0.0041841 
+  234          227.84655    169.20319   0.004273504 
+  255          224.99678    169.16079   0.003921569 
+  223          222.80955    169.11843   0.004484305 
+  248          221.53257    169.07612   0.004032258 
+  208          221.27907    169.03385   0.004807692 
+  252          222.08481    168.99163   0.003968254 
+  277          223.99414    168.94944   0.003610108 
+  252          227.28731    168.9073    0.003968254 
+  280          232.97447    168.8652    0.003571429 
+  284          242.77376    168.82315   0.003521127 
+  284          258.55454    168.78114   0.003521127 
+  302          280.95921    168.73916   0.003311258 
+  308          307.57505    168.69723   0.003246753 
+  346          325.36892    168.65535   0.002890173 
+  305          315.45233    168.6135    0.003278689 
+  303          292.60943    168.57169   0.00330033 
+  291          278.2875     168.52992   0.003436426 
+  308          276.41337    168.4882    0.003246753 
+  310          283.5837     168.44651   0.003225806 
+  283          290.74943    168.40487   0.003533569 
+  287          287.1856     168.36326   0.003484321 
+  295          278.63133    168.32169   0.003389831 
+  259          270.68144    168.28016   0.003861004 
+  246          261.19125    168.23867   0.004065041 
+  240          251.924      168.19722   0.004166667 
+  244          246.10843    168.15581   0.004098361 
+  235          244.34328    168.11444   0.004255319 
+  254          245.46615    168.0731    0.003937008 
+  250          246.92202    168.0318    0.004     
+  228          246.77048    167.99054   0.004385965 
+  274          246.79697    167.94932   0.003649635 
+  265          249.93421    167.90813   0.003773585 
+  291          257.7527     167.86698   0.003436426 
+  268          269.35946    167.82586   0.003731343 
+  282          277.21787    167.78478   0.003546099 
+  248          273.32348    167.74374   0.004032258 
+  302          265.20334    167.70274   0.003311258 
+  257          261.00747    167.66177   0.003891051 
+  250          261.96234    167.62083   0.004     
+  270          267.17334    167.57993   0.003703704 
+  259          271.86914    167.53907   0.003861004 
+  285          271.37259    167.49824   0.003508772 
+  274          268.95573    167.45744   0.003649635 
+  265          268.35128    167.41668   0.003773585 
+  282          270.17787    167.37595   0.003546099 
+  281          273.53728    167.33526   0.003558719 
+  272          277.79292    167.2946    0.003676471 
+  264          282.94356    167.25397   0.003787879 
+  284          289.08199    167.21338   0.003521127 
+  284          296.0608     167.17281   0.003521127 
+  294          303.76533    167.13229   0.003401361 
+  349          312.28314    167.09179   0.00286533 
+  308          321.76743    167.05133   0.003246753 
+  334          332.74385    167.0109    0.002994012 
+  337          345.00274    166.9705    0.002967359 
+  353          358.92464    166.93013   0.002832861 
+  321          374.71474    166.88979   0.003115265 
+  404          392.80641    166.84949   0.002475248 
+  393          413.73904    166.80921   0.002544529 
+  426          438.09698    166.76897   0.002347418 
+  450          466.60592    166.72876   0.002222222 
+  443          500.23207    166.68858   0.002257336 
+  577          539.50468    166.64843   0.001733102 
+  633          585.55125    166.6083    0.001579779 
+  704          640.71188    166.56821   0.001420455 
+  792          708.50154    166.52815   0.001262626 
+  864          793.20353    166.48812   0.001157407 
+  881          900.64953    166.44812   0.001135074 
+  989          1039.24277   166.40814   0.001011122 
+  1109         1221.81061   166.3682    0.000901713 
+  1329         1469.32903   166.32828   0.000752445 
+  1636         1818.02451   166.28839   0.000611247 
+  2262         2337.52202   166.24853   0.000442087 
+  3142         3182.12204   166.2087    0.000318269 
+  4985         4696.83829   166.1689    0.000200602 
+  8015         7519.4636    166.12912   0.000124766 
+  12936        12411.16961  166.08937   0.000077304 
+  18532        18953.91899  166.04965   0.000053961 
+  21445        22000.73393  166.00996   0.000046631 
+  17527        17630.32384  165.97029   0.000057055 
+  11970        12128.29711  165.93065   0.000083542 
+  8892         9262.67735   165.89104   0.000112461 
+  9094         9207.20202   165.85145   0.000109963 
+  10694        11162.37404  165.81189   0.00009351 
+  11296        12432.86107  165.77235   0.000088527 
+  9550         10096.00332  165.73285   0.000104712 
+  6121         6646.61094   165.69336   0.000163372 
+  3675         4215.84611   165.65391   0.000272109 
+  2404         2815.49999   165.61447   0.000415973 
+  1745         2042.41945   165.57507   0.000573066 
+  1317         1590.98042   165.53568   0.000759301 
+  1136         1300.69548   165.49633   0.000880282 
+  898          1098.13743   165.457     0.001113586 
+  812          947.58894    165.41769   0.001231527 
+  749          830.59545    165.3784    0.001335113 
+  684          737.93381    165.33914   0.001461988 
+  623          664.29503    165.29991   0.001605136 
+  549          605.4328     165.2607    0.001821494 
+  468          557.40873    165.22151   0.002136752 
+  504          516.66721    165.18235   0.001984127 
+  442          480.92478    165.1432    0.002262443 
+  443          449.48696    165.10409   0.002257336 
+  394          422.25604    165.06499   0.002538071 
+  371          398.91305    165.02592   0.002695418 
+  349          378.92368    164.98687   0.00286533 
+  380          361.73144    164.94784   0.002631579 
+  325          346.85452    164.90884   0.003076923 
+  354          333.88917    164.86986   0.002824859 
+  294          322.52581    164.8309    0.003401361 
+  321          312.53159    164.79196   0.003115265 
+  318          303.72234    164.75304   0.003144654 
+  307          295.94892    164.71415   0.003257329 
+  288          289.09279    164.67527   0.003472222 
+  278          283.05468    164.63642   0.003597122 
+  295          277.75402    164.59759   0.003389831 
+  299          273.11753    164.55878   0.003344482 
+  291          269.08113    164.51999   0.003436426 
+  263          265.58955    164.48122   0.003802281 
+  285          262.61168    164.44247   0.003508772 
+  261          260.15668    164.40374   0.003831418 
+  271          258.30549    164.36504   0.003690037 
+  245          257.18507    164.32635   0.004081633 
+  266          256.74652    164.28768   0.003759398 
+  261          256.05151    164.24903   0.003831418 
+  235          253.66406    164.2104    0.004255319 
+  258          250.32711    164.17179   0.003875969 
+  235          247.43755    164.1332    0.004255319 
+  235          245.43171    164.09463   0.004255319 
+  254          244.24757    164.05608   0.003937008 
+  275          243.39691    164.01755   0.003636364 
+  225          241.92139    163.97904   0.004444444 
+  245          239.7126     163.94054   0.004081633 
+  230          237.53137    163.90206   0.004347826 
+  284          235.75754    163.86361   0.003521127 
+  258          234.44533    163.82517   0.003875969 
+  261          233.54187    163.78674   0.003831418 
+  245          232.96574    163.74834   0.004081633 
+  218          232.63463    163.70995   0.004587156 
+  225          232.49235    163.67158   0.004444444 
+  267          232.50243    163.63323   0.003745318 
+  264          232.62348    163.5949    0.003787879 
+  269          232.83717    163.55658   0.003717472 
+  264          233.15663    163.51828   0.003787879 
+  241          233.52194    163.48      0.004149378 
+  274          233.49764    163.44174   0.003649635 
+  260          232.36538    163.40349   0.003846154 
+  291          230.38507    163.36526   0.003436426 
+  278          228.63219    163.32704   0.003597122 
+  262          227.75627    163.28884   0.003816794 
+  281          227.79419    163.25066   0.003558719 
+  303          227.84563    163.21249   0.00330033 
+  261          226.05706    163.17434   0.003831418 
+  264          222.15733    163.13621   0.003787879 
+  241          218.03067    163.09809   0.004149378 
+  259          214.94504    163.05999   0.003861004 
+  227          213.11909    163.0219    0.004405286 
+  254          212.24117    162.98383   0.003937008 
+  243          211.55431    162.94577   0.004115226 
+  232          210.60082    162.90773   0.004310345 
+  256          210.04908    162.8697    0.00390625 
+  238          210.76142    162.83169   0.004201681 
+  237          213.21459    162.79369   0.004219409 
+  243          217.4046     162.75571   0.004115226 
+  220          222.03048    162.71774   0.004545455 
+  240          224.56369    162.67979   0.004166667 
+  220          224.81338    162.64185   0.004545455 
+  210          224.15598    162.60393   0.004761905 
+  204          222.15246    162.56602   0.004901961 
+  191          219.55897    162.52812   0.005235602 
+  201          218.03718    162.49024   0.004975124 
+  215          217.21524    162.45237   0.004651163 
+  214          216.16928    162.41451   0.004672897 
+  216          215.29266    162.37667   0.00462963 
+  194          214.51518    162.33884   0.005154639 
+  201          213.61146    162.30103   0.004975124 
+  209          213.30915    162.26323   0.004784689 
+  200          213.53215    162.22544   0.005     
+  207          213.42979    162.18767   0.004830918 
+  190          212.28525    162.14991   0.005263158 
+  203          211.60986    162.11216   0.004926108 
+  208          212.04881    162.07442   0.004807692 
+  202          213.66174    162.0367    0.004950495 
+  215          216.21035    161.99899   0.004651163 
+  224          219.11365    161.96129   0.004464286 
+  204          222.24646    161.9236    0.004901961 
+  222          225.87939    161.88593   0.004504505 
+  230          230.77544    161.84827   0.004347826 
+  231          236.97602    161.81062   0.004329004 
+  247          244.46508    161.77298   0.004048583 
+  234          253.25967    161.73536   0.004273504 
+  283          261.80438    161.69774   0.003533569 
+  255          267.52567    161.66014   0.003921569 
+  267          271.7494     161.62255   0.003745318 
+  285          278.25342    161.58497   0.003508772 
+  289          289.1115     161.54741   0.003460208 
+  328          304.61601    161.50985   0.00304878 
+  356          323.61054    161.47231   0.002808989 
+  326          345.06887    161.43477   0.003067485 
+  383          371.97901    161.39725   0.002610966 
+  428          411.34025    161.35974   0.002336449 
+  473          472.86492    161.32224   0.002114165 
+  600          574.05763    161.28475   0.001666667 
+  807          753.23285    161.24727   0.001239157 
+  1105         1084.86234   161.20981   0.000904977 
+  1711         1670.73729   161.17235   0.000584454 
+  2501         2522.72257   161.1349    0.00039984 
+  2970         3133.44924   161.09747   0.0003367 
+  2600         2741.30896   161.06004   0.000384615 
+  1933         1951.16615   161.02262   0.000517331 
+  1517         1435.49265   160.98522   0.000659196 
+  1361         1283.45634   160.94782   0.000734754 
+  1488         1441.53191   160.91044   0.000672043 
+  1590         1754.17147   160.87306   0.000628931 
+  1686         1774.98359   160.8357    0.00059312 
+  1291         1363.47126   160.79834   0.000774593 
+  907          944.79984    160.761     0.001102536 
+  621          674.46176    160.72366   0.001610306 
+  495          518.11643    160.68633   0.002020202 
+  400          426.5486     160.64902   0.0025    
+  336          369.46332    160.61171   0.00297619 
+  314          331.66353    160.57441   0.003184713 
+  288          305.84281    160.53712   0.003472222 
+  277          287.54691    160.49984   0.003610108 
+  278          272.88008    160.46257   0.003597122 
+  254          259.5257     160.42531   0.003937008 
+  259          247.73664    160.38806   0.003861004 
+  253          238.00075    160.35081   0.003952569 
+  214          230.19627    160.31358   0.004672897 
+  223          224.01503    160.27635   0.004484305 
+  209          219.16422    160.23913   0.004784689 
+  191          215.4221     160.20192   0.005235602 
+  210          212.66667    160.16472   0.004761905 
+  226          210.85326    160.12753   0.004424779 
+  233          209.91439    160.09035   0.004291845 
+  202          209.45016    160.05317   0.004950495 
+  194          208.46085    160.01601   0.005154639 
+  200          206.40887    159.97885   0.005     
+  198          204.1727     159.9417    0.005050505 
+  199          202.63519    159.90456   0.005025126 
+  197          202.06153    159.86742   0.005076142 
+  193          202.41716    159.8303    0.005181347 
+  217          203.42165    159.79318   0.004608295 
+  208          204.63794    159.75607   0.004807692 
+  226          206.26499    159.71897   0.004424779 
+  220          209.25078    159.68187   0.004545455 
+  210          214.76133    159.64479   0.004761905 
+  234          224.59202    159.60771   0.004273504 
+  276          241.97437    159.57064   0.003623188 
+  265          271.87572    159.53357   0.003773585 
+  335          319.25575    159.49652   0.002985075 
+  377          379.09042    159.45947   0.00265252 
+  422          413.07636    159.42243   0.002369668 
+  335          384.39215    159.3854    0.002985075 
+  319          332.21108    159.34837   0.003134796 
+  275          296.53688    159.31135   0.003636364 
+  267          284.58992    159.27434   0.003745318 
+  301          292.78808    159.23733   0.003322259 
+  327          309.95189    159.20034   0.003058104 
+  247          309.59051    159.16334   0.004048583 
+  307          281.86253    159.12636   0.003257329 
+  259          250.41067    159.08938   0.003861004 
+  250          228.01529    159.05241   0.004     
+  209          214.19414    159.01545   0.004784689 
+  213          205.91231    158.9785    0.004694836 
+  227          201.01659    158.94155   0.004405286 
+  226          198.4537     158.9046    0.004424779 
+  231          197.73678    158.86767   0.004329004 
+  205          198.2589     158.83074   0.004878049 
+  212          198.56466    158.79382   0.004716981 
+  204          197.23856    158.7569    0.004901961 
+  202          195.08518    158.71999   0.004950495 
+  181          193.66331    158.68309   0.005524862 
+  195          193.59885    158.64619   0.005128205 
+  178          194.93925    158.6093    0.005617978 
+  208          197.31631    158.57242   0.004807692 
+  173          199.21123    158.53554   0.005780347 
+  195          198.64829    158.49867   0.005128205 
+  180          196.15469    158.4618    0.005555556 
+  177          193.96733    158.42494   0.005649718 
+  186          193.25118    158.38809   0.005376344 
+  237          194.11587    158.35125   0.004219409 
+  226          196.06708    158.31441   0.004424779 
+  220          197.46023    158.27757   0.004545455 
+  207          196.44938    158.24074   0.004830918 
+  167          193.8553     158.20392   0.005988024 
+  188          191.65386    158.1671    0.005319149 
+  197          190.63044    158.13029   0.005076142 
+  215          190.72247    158.09349   0.004651163 
+  182          191.39701    158.05669   0.005494505 
+  189          191.68932    158.0199    0.005291005 
+  181          191.16912    157.98311   0.005524862 
+  189          190.53561    157.94633   0.005291005 
+  217          190.39385    157.90956   0.004608295 
+  217          190.65727    157.87279   0.004608295 
+  205          190.90692    157.83602   0.004878049 
+  216          191.02171    157.79926   0.00462963 
+  181          191.17921    157.76251   0.005524862 
+  220          191.57908    157.72576   0.004545455 
+  225          192.35015    157.68902   0.004444444 
+  186          193.48133    157.65229   0.005376344 
+  205          194.82329    157.61556   0.004878049 
+  212          196.21125    157.57883   0.004716981 
+  190          197.72035    157.54211   0.005263158 
+  207          199.55463    157.5054    0.004830918 
+  248          201.84709    157.46869   0.004032258 
+  231          204.686      157.43199   0.004329004 
+  214          208.13599    157.39529   0.004672897 
+  224          212.12385    157.3586    0.004464286 
+  233          216.21392    157.32191   0.004291845 
+  235          219.91999    157.28523   0.004255319 
+  249          223.65742    157.24855   0.004016064 
+  255          228.21664    157.21188   0.003921569 
+  232          234.07149    157.17522   0.004310345 
+  264          241.50621    157.13856   0.003787879 
+  291          250.71579    157.1019    0.003436426 
+  286          261.62033    157.06525   0.003496503 
+  340          273.67758    157.02861   0.002941176 
+  312          286.236      156.99197   0.003205128 
+  354          300.02509    156.95534   0.002824859 
+  314          317.40285    156.91871   0.003184713 
+  364          340.61978    156.88208   0.002747253 
+  353          371.66323    156.84546   0.002832861 
+  428          412.57487    156.80885   0.002336449 
+  490          465.01437    156.77224   0.002040816 
+  542          531.59057    156.73564   0.001845018 
+  563          622.79133    156.69904   0.001776199 
+  807          762.81342    156.66245   0.001239157 
+  1087         999.95108    156.62586   0.000919963 
+  1524         1431.41692   156.58928   0.000656168 
+  2450         2215.82676   156.5527    0.000408163 
+  3627         3495.43941   156.51613   0.00027571 
+  4915         4966.44388   156.47956   0.000203459 
+  5148         5221.57826   156.443     0.00019425 
+  4000         3974.89696   156.40644   0.00025   
+  2706         2739.89439   156.36988   0.000369549 
+  2097         2090.26313   156.33334   0.000476872 
+  2061         2000.07245   156.29679   0.000485201 
+  2292         2370.98358   156.26026   0.0004363 
+  2714         2929.56295   156.22372   0.00036846 
+  2733         2907.51301   156.1872    0.000365898 
+  2039         2172.1547    156.15067   0.000490436 
+  1404         1455.54612   156.11415   0.000712251 
+  932          996.2045     156.07764   0.001072961 
+  674          733.74525    156.04113   0.00148368 
+  539          582.951      156.00463   0.001855288 
+  468          489.93399    155.96813   0.002136752 
+  408          427.11617    155.93164   0.00245098 
+  358          381.40272    155.89515   0.002793296 
+  318          347.06334    155.85867   0.003144654 
+  311          320.86931    155.82219   0.003215434 
+  273          300.46267    155.78572   0.003663004 
+  265          284.43991    155.74925   0.003773585 
+  258          271.84098    155.71278   0.003875969 
+  235          261.551      155.67633   0.004255319 
+  239          252.67709    155.63987   0.0041841 
+  230          244.87038    155.60342   0.004347826 
+  230          237.87069    155.56698   0.004347826 
+  239          231.5706     155.53054   0.0041841 
+  211          225.93622    155.49411   0.004739336 
+  217          221.11276    155.45768   0.004608295 
+  209          217.22037    155.42126   0.004784689 
+  236          214.17599    155.38484   0.004237288 
+  212          211.71547    155.34842   0.004716981 
+  208          209.57615    155.31202   0.004807692 
+  204          207.6704     155.27561   0.004901961 
+  203          205.87764    155.23921   0.004926108 
+  216          203.99245    155.20282   0.00462963 
+  202          201.99123    155.16643   0.004950495 
+  207          200.14693    155.13005   0.004830918 
+  201          198.66455    155.09367   0.004975124 
+  183          197.60226    155.0573    0.005464481 
+  201          196.97123    155.02093   0.004975124 
+  182          196.75231    154.98456   0.005494505 
+  190          196.88085    154.94821   0.005263158 
+  204          197.41281    154.91185   0.004901961 
+  193          198.63386    154.87551   0.005181347 
+  211          200.75856    154.83916   0.004739336 
+  221          203.56405    154.80283   0.004524887 
+  181          206.28166    154.76649   0.005524862 
+  213          208.2341     154.73017   0.004694836 
+  203          208.89339    154.69384   0.004926108 
+  206          207.76375    154.65753   0.004854369 
+  201          205.41175    154.62121   0.004975124 
+  169          203.22503    154.58491   0.00591716 
+  244          202.07156    154.54861   0.004098361 
+  162          201.91859    154.51231   0.00617284 
+  199          202.38298    154.47602   0.005025126 
+  208          202.86466    154.43973   0.004807692 
+  190          202.20343    154.40345   0.005263158 
+  197          199.68565    154.36718   0.005076142 
+  199          196.25221    154.33091   0.005025126 
+  191          193.25234    154.29465   0.005235602 
+  192          191.21175    154.25839   0.005208333 
+  193          190.10943    154.22213   0.005181347 
+  194          189.70449    154.18589   0.005154639 
+  166          189.52027    154.14964   0.006024096 
+  199          189.02042    154.11341   0.005025126 
+  189          188.21811    154.07717   0.005291005 
+  197          187.52016    154.04095   0.005076142 
+  175          187.13844    154.00473   0.005714286 
+  184          187.10019    153.96851   0.005434783 
+  196          187.40666    153.9323    0.005102041 
+  167          188.10197    153.8961    0.005988024 
+  201          189.27596    153.8599    0.004975124 
+  183          191.00062    153.82371   0.005464481 
+  179          193.0767     153.78752   0.005586592 
+  192          194.65079    153.75134   0.005208333 
+  192          194.80906    153.71516   0.005208333 
+  203          194.08823    153.67899   0.004926108 
+  197          193.66206    153.64283   0.005076142 
+  207          194.10085    153.60667   0.004830918 
+  213          195.55996    153.57052   0.004694836 
+  205          198.04955    153.53437   0.004878049 
+  222          201.36083    153.49823   0.004504505 
+  207          205.16659    153.4621    0.004830918 
+  221          209.63391    153.42597   0.004524887 
+  186          215.27226    153.38985   0.005376344 
+  198          222.67758    153.35373   0.005050505 
+  211          231.4144     153.31762   0.004739336 
+  213          237.57197    153.28151   0.004694836 
+  241          237.15121    153.24541   0.004149378 
+  200          232.7338     153.20932   0.005     
+  200          229.27893    153.17323   0.005     
+  229          228.74021    153.13715   0.004366812 
+  204          230.95743    153.10108   0.004901961 
+  243          235.30134    153.06501   0.004115226 
+  214          240.3209     153.02895   0.004672897 
+  251          243.92784    152.99289   0.003984064 
+  257          246.68377    152.95684   0.003891051 
+  236          251.02109    152.9208    0.004237288 
+  240          256.94452    152.88476   0.004166667 
+  231          261.4199     152.84873   0.004329004 
+  271          263.30469    152.81271   0.003690037 
+  256          265.74225    152.77669   0.00390625 
+  304          271.69632    152.74068   0.003289474 
+  295          282.40443    152.70468   0.003389831 
+  318          297.98059    152.66868   0.003144654 
+  325          316.47107    152.63269   0.003076923 
+  342          333.02158    152.59671   0.002923977 
+  359          345.82869    152.56073   0.002785515 
+  395          360.40416    152.52476   0.002531646 
+  398          382.18885    152.48879   0.002512563 
+  447          412.97264    152.45284   0.002237136 
+  508          450.42799    152.41689   0.001968504 
+  467          487.29004    152.38094   0.002141328 
+  493          524.31845    152.34501   0.002028398 
+  545          573.83415    152.30908   0.001834862 
+  681          648.12404    152.27315   0.001468429 
+  728          760.39871    152.23724   0.001373626 
+  955          932.24063    152.20133   0.00104712 
+  1275         1210.44769   152.16543   0.000784314 
+  1832         1695.21159   152.12954   0.000545852 
+  2810         2568.98222   152.09365   0.000355872 
+  4229         4055.82486   152.05777   0.000236463 
+  5910         6070.77164   152.0219    0.000169205 
+  6693         7209.71754   151.98603   0.00014941 
+  5942         6029.21881   151.95018   0.000168294 
+  3992         4163.24617   151.91432   0.000250501 
+  2840         2932.122     151.87848   0.000352113 
+  2476         2449.28476   151.84265   0.000403877 
+  2655         2604.25833   151.80682   0.000376648 
+  3135         3275.21585   151.771     0.000318979 
+  3660         3976.72248   151.73519   0.000273224 
+  3358         3684.26534   151.69938   0.000297796 
+  2424         2638.13901   151.66359   0.000412541 
+  1629         1744.60169   151.6278    0.000613874 
+  1125         1188.2665    151.59202   0.000888889 
+  816          871.90869    151.55624   0.00122549 
+  667          689.91699    151.52048   0.00149925 
+  566          577.02863    151.48472   0.001766784 
+  506          501.24306    151.44897   0.001976285 
+  443          447.65708    151.41323   0.002257336 
+  386          408.56982    151.3775    0.002590674 
+  347          379.22157    151.34177   0.002881844 
+  331          355.97988    151.30606   0.003021148 
+  300          336.27595    151.27035   0.003333333 
+  292          319.68736    151.23465   0.003424658 
+  317          306.55753    151.19896   0.003154574 
+  326          296.54085    151.16327   0.003067485 
+  279          288.93284    151.1276    0.003584229 
+  277          283.61338    151.09193   0.003610108 
+  287          280.66524    151.05627   0.003484321 
+  265          279.13971    151.02062   0.003773585 
+  289          276.61627    150.98498   0.003460208 
+  267          270.23423    150.94935   0.003745318 
+  226          260.71602    150.91373   0.004424779 
+  215          251.36224    150.87811   0.004651163 
+  268          243.91165    150.84251   0.003731343 
+  248          238.83092    150.80691   0.004032258 
+  254          236.04134    150.77133   0.003937008 
+  240          234.73764    150.73575   0.004166667 
+  242          233.17537    150.70018   0.004132231 
+  225          230.45163    150.66462   0.004444444 
+  228          228.1317     150.62907   0.004385965 
+  222          227.95445    150.59353   0.004504505 
+  222          230.32143    150.55799   0.004504505 
+  274          234.43437    150.52247   0.003649635 
+  229          238.10516    150.48696   0.004366812 
+  247          237.70292    150.45145   0.004048583 
+  260          232.93166    150.41596   0.003846154 
+  265          228.10953    150.38047   0.003773585 
+  245          226.38647    150.345     0.004081633 
+  251          228.56894    150.30953   0.003984064 
+  241          234.17855    150.27408   0.004149378 
+  239          241.12694    150.23863   0.0041841 
+  250          244.91977    150.2032    0.004     
+  216          242.62624    150.16777   0.00462963 
+  234          237.72552    150.13236   0.004273504 
+  253          234.68633    150.09695   0.003952569 
+  259          235.09397    150.06155   0.003861004 
+  230          238.69878    150.02617   0.004347826 
+  229          243.57207    149.99079   0.004366812 
+  231          245.72521    149.95543   0.004329004 
+  201          242.76372    149.92007   0.004975124 
+  231          236.93334    149.88473   0.004329004 
+  200          230.40533    149.8494    0.005     
+  223          223.82858    149.81407   0.004484305 
+  197          218.51083    149.77876   0.005076142 
+  210          215.11075    149.74346   0.004761905 
+  198          212.6359     149.70817   0.005050505 
+  184          209.59829    149.67289   0.005434783 
+  182          206.19519    149.63762   0.005494505 
+  198          203.40164    149.60236   0.005050505 
+  191          201.27323    149.56711   0.005235602 
+  220          199.90423    149.53188   0.004545455 
+  180          199.28614    149.49665   0.005555556 
+  217          198.6366     149.46144   0.004608295 
+  194          197.13939    149.42623   0.005154639 
+  182          193.68025    149.39104   0.005494505 
+  180          189.265      149.35586   0.005555556 
+  172          186.24938    149.32069   0.005813953 
+  154          185.36902    149.28554   0.006493506 
+  167          186.14976    149.25039   0.005988024 
+  196          187.38812    149.21526   0.005102041 
+  170          188.26284    149.18014   0.005882353 
+  208          188.96585    149.14503   0.004807692 
+  193          189.86658    149.10993   0.005181347 
+  172          191.86765    149.07484   0.005813953 
+  176          194.04469    149.03977   0.005681818 
+  160          193.20811    149.0047    0.00625   
+  172          188.69361    148.96965   0.005813953 
+  167          183.25189    148.93462   0.005988024 
+  141          178.93112    148.89959   0.007092199 
+  174          176.42721    148.86458   0.005747126 
+  170          175.72731    148.82957   0.005882353 
+  174          176.25084    148.79459   0.005747126 
+  177          176.50335    148.75961   0.005649718 
+  161          174.83506    148.72465   0.00621118 
+  149          171.70206    148.6897    0.006711409 
+  178          168.63547    148.65476   0.005617978 
+  183          166.30754    148.61983   0.005464481 
+  164          164.72988    148.58492   0.006097561 
+  169          163.75976    148.55002   0.00591716 
+  175          163.2896     148.51513   0.005714286 
+  177          163.27077    148.48026   0.005649718 
+  175          163.70715    148.4454    0.005714286 
+  156          164.6415     148.41055   0.006410256 
+  181          166.02182    148.37572   0.005524862 
+  150          167.27441    148.3409    0.006666667 
+  155          167.28816    148.30609   0.006451613 
+  157          165.90504    148.2713    0.006369427 
+  146          164.22973    148.23652   0.006849315 
+  161          163.03932    148.20175   0.00621118 
+  155          162.47133    148.167     0.006451613 
+  177          162.41013    148.13226   0.005649718 
+  173          162.66986    148.09754   0.005780347 
+  173          162.86559    148.06283   0.005780347 
+  182          162.48501    148.02813   0.005494505 
+  142          161.63169    147.99345   0.007042254 
+  154          160.81974    147.95878   0.006493506 
+  164          160.19376    147.92413   0.006097561 
+  151          159.5941     147.88949   0.006622517 
+  170          158.97473    147.85487   0.005882353 
+  155          158.44458    147.82026   0.006451613 
+  164          158.08271    147.78566   0.006097561 
+  137          157.90002    147.75108   0.00729927 
+  145          157.8772     147.71651   0.006896552 
+  158          157.97518    147.68196   0.006329114 
+  177          158.11519    147.64743   0.005649718 
+  142          158.23797    147.6129    0.007042254 
+  144          158.40397    147.5784    0.006944444 
+  139          158.7159     147.54391   0.007194245 
+  139          159.23247    147.50943   0.007194245 
+  173          159.95551    147.47497   0.005780347 
+  144          160.88945    147.44053   0.006944444 
+  157          162.12213    147.4061    0.006369427 
+  176          163.92653    147.37168   0.005681818 
+  174          166.66653    147.33728   0.005747126 
+  170          170.59067    147.3029    0.005882353 
+  207          175.35982    147.26853   0.004830918 
+  172          179.25882    147.23418   0.005813953 
+  174          180.35071    147.19985   0.005747126 
+  197          179.55676    147.16553   0.005076142 
+  163          179.1607     147.13122   0.006134969 
+  174          179.33281    147.09694   0.005747126 
+  167          179.05924    147.06267   0.005988024 
+  165          178.37534    147.02841   0.006060606 
+  167          178.12189    146.99417   0.005988024 
+  194          177.82594    146.95995   0.005154639 
+  169          176.8112     146.92575   0.00591716 
+  169          175.83953    146.89156   0.00591716 
+  179          175.92362    146.85739   0.005586592 
+  180          176.95032    146.82323   0.005555556 
+  196          178.24309    146.7891    0.005102041 
+  196          179.51042    146.75498   0.005102041 
+  165          180.2965     146.72087   0.006060606 
+  182          180.27886    146.68679   0.005494505 
+  196          180.47189    146.65272   0.005102041 
+  166          181.57505    146.61867   0.006024096 
+  175          182.54261    146.58463   0.005714286 
+  190          182.20887    146.55062   0.005263158 
+  161          181.48792    146.51662   0.00621118 
+  181          181.68187    146.48263   0.005524862 
+  192          182.91311    146.44867   0.005208333 
+  174          185.19514    146.41473   0.005747126 
+  193          189.41125    146.3808    0.005181347 
+  209          196.65245    146.34689   0.004784689 
+  201          207.79812    146.313     0.004975124 
+  235          224.37205    146.27912   0.004255319 
+  247          249.26075    146.24527   0.004048583 
+  296          282.52618    146.21143   0.003378378 
+  310          308.56985    146.17761   0.003225806 
+  278          301.76448    146.14381   0.003597122 
+  255          272.99594    146.11003   0.003921569 
+  274          249.11703    146.07627   0.003649635 
+  244          238.74426    146.04253   0.004098361 
+  228          241.05457    146.0088    0.004385965 
+  274          252.50231    145.9751    0.003649635 
+  253          266.82319    145.94141   0.003952569 
+  270          273.96585    145.90775   0.003703704 
+  280          264.14604    145.8741    0.003571429 
+  265          245.63643    145.84047   0.003773585 
+  268          232.41001    145.80686   0.003731343 
+  257          228.26156    145.77327   0.003891051 
+  252          231.4451     145.7397    0.003968254 
+  248          238.08884    145.70615   0.004032258 
+  246          245.74025    145.67262   0.004065041 
+  269          257.43976    145.63911   0.003717472 
+  314          279.65185    145.60562   0.003184713 
+  354          314.85705    145.57215   0.002824859 
+  370          347.79908    145.5387    0.002702703 
+  363          346.19664    145.50527   0.002754821 
+  341          314.60177    145.47186   0.002932551 
+  333          285.05898    145.43847   0.003003003 
+  287          270.67953    145.40511   0.003484321 
+  285          273.56812    145.37176   0.003508772 
+  281          294.39424    145.33843   0.003558719 
+  328          331.4816     145.30512   0.00304878 
+  381          369.38396    145.27184   0.002624672 
+  311          372.15637    145.23858   0.003215434 
+  319          331.51       145.20533   0.003134796 
+  287          283.48317    145.17211   0.003484321 
+  259          249.51382    145.13891   0.003861004 
+  241          231.13227    145.10573   0.004149378 
+  233          225.10699    145.07257   0.004291845 
+  200          228.0755     145.03944   0.005     
+  220          234.81342    145.00632   0.004545455 
+  213          235.00854    144.97323   0.004694836 
+  233          222.33236    144.94016   0.004291845 
+  213          205.56114    144.90711   0.004694836 
+  207          192.45255    144.87408   0.004830918 
+  198          183.89106    144.84108   0.005050505 
+  196          178.55126    144.8081    0.005102041 
+  207          175.15019    144.77514   0.004830918 
+  240          173.0434     144.7422    0.004166667 
+  194          171.96722    144.70928   0.005154639 
+  182          171.7951     144.67639   0.005494505 
+  177          172.47718    144.64352   0.005649718 
+  180          174.0077     144.61068   0.005555556 
+  200          176.32175    144.57785   0.005     
+  189          179.36438    144.54505   0.005291005 
+  195          183.46475    144.51227   0.005128205 
+  186          189.1624     144.47952   0.005376344 
+  222          196.53086    144.44679   0.004504505 
+  205          205.01178    144.41408   0.004878049 
+  182          213.08199    144.3814    0.005494505 
+  205          219.09175    144.34874   0.004878049 
+  217          223.93185    144.3161    0.004608295 
+  206          228.50927    144.28349   0.004854369 
+  216          231.16799    144.2509    0.00462963 
+  227          230.15161    144.21833   0.004405286 
+  259          226.33525    144.18579   0.003861004 
+  224          222.17737    144.15327   0.004464286 
+  226          219.09024    144.12078   0.004424779 
+  209          216.93751    144.08831   0.004784689 
+  197          215.99276    144.05587   0.005076142 
+  186          216.59093    144.02345   0.005376344 
+  189          217.32128    143.99106   0.005291005 
+  191          216.14312    143.95869   0.005235602 
+  222          213.25189    143.92634   0.004504505 
+  213          210.85462    143.89402   0.004694836 
+  198          211.19497    143.86173   0.005050505 
+  205          216.64828    143.82946   0.004878049 
+  233          230.92281    143.79721   0.004291845 
+  293          260.02919    143.765     0.003412969 
+  298          310.95544    143.7328    0.003355705 
+  363          381.1761     143.70064   0.002754821 
+  407          426.64264    143.66849   0.002457002 
+  393          392.76775    143.63638   0.002544529 
+  352          326.98814    143.60429   0.002840909 
+  293          279.26829    143.57222   0.003412969 
+  240          255.70339    143.54019   0.004166667 
+  267          252.91847    143.50818   0.003745318 
+  258          269.53338    143.47619   0.003875969 
+  320          304.09376    143.44423   0.003125  
+  338          340.17826    143.4123    0.00295858 
+  325          341.29538    143.38039   0.003076923 
+  264          310.89384    143.34851   0.003787879 
+  223          276.89094    143.31666   0.004484305 
+  208          250.77994    143.28484   0.004807692 
+  205          234.67579    143.25304   0.004878049 
+  203          227.14113    143.22127   0.004926108 
+  208          226.83799    143.18953   0.004807692 
+  207          231.98878    143.15781   0.004830918 
+  197          238.19568    143.12612   0.005076142 
+  210          239.99107    143.09446   0.004761905 
+  214          235.9207     143.06283   0.004672897 
+  215          228.66087    143.03122   0.004651163 
+  190          220.64054    142.99964   0.005263158 
+  210          212.97566    142.96809   0.004761905 
+  202          206.91724    142.93657   0.004950495 
+  195          203.22899    142.90508   0.005128205 
+  196          200.98582    142.87361   0.005102041 
+  178          199.00913    142.84218   0.005617978 
+  185          197.317      142.81077   0.005405405 
+  203          196.92831    142.77939   0.004926108 
+  208          198.13909    142.74804   0.004807692 
+  205          201.00639    142.71672   0.004878049 
+  208          205.20677    142.68543   0.004807692 
+  184          207.95185    142.65416   0.005434783 
+  186          205.05126    142.62293   0.005376344 
+  203          197.07062    142.59172   0.004926108 
+  145          188.72188    142.56055   0.006896552 
+  171          182.56513    142.5294    0.005847953 
+  185          178.85265    142.49829   0.005405405 
+  166          177.42827    142.4672    0.006024096 
+  184          178.01443    142.43614   0.005434783 
+  180          179.35768    142.40512   0.005555556 
+  136          178.9511     142.37412   0.007352941 
+  179          175.44999    142.34315   0.005586592 
+  141          170.72627    142.31222   0.007092199 
+  174          166.57233    142.28131   0.005747126 
+  162          163.34677    142.25043   0.00617284 
+  179          160.87378    142.21959   0.005586592 
+  153          159.01968    142.18878   0.006535948 
+  160          157.67245    142.15799   0.00625   
+  172          156.70825    142.12724   0.005813953 
+  149          156.02626    142.09652   0.006711409 
+  144          155.58797    142.06583   0.006944444 
+  166          155.30905    142.03517   0.006024096 
+  166          155.21392    142.00454   0.006024096 
+  150          155.31259    141.97395   0.006666667 
+  151          155.62626    141.94338   0.006622517 
+  148          156.16037    141.91285   0.006756757 
+  146          156.84883    141.88235   0.006849315 
+  175          157.57346    141.85188   0.005714286 
+  171          158.34281    141.82144   0.005847953 
+  162          159.2967     141.79104   0.00617284 
+  154          160.35476    141.76067   0.006493506 
+  183          161.13927    141.73033   0.005464481 
+  182          161.67281    141.70002   0.005494505 
+  159          162.55333    141.66974   0.006289308 
+  161          164.26302    141.6395    0.00621118 
+  150          166.84907    141.60929   0.006666667 
+  141          169.75533    141.57912   0.007092199 
+  160          171.70045    141.54897   0.00625   
+  142          171.90687    141.51886   0.007042254 
+  166          171.29642    141.48879   0.006024096 
+  161          171.05019    141.45874   0.00621118 
+  161          171.83382    141.42873   0.00621118 
+  171          174.00564    141.39876   0.005847953 
+  180          177.76766    141.36882   0.005555556 
+  167          183.1353     141.33891   0.005988024 
+  162          189.40902    141.30903   0.00617284 
+  178          195.3801     141.27919   0.005617978 
+  193          199.75688    141.24939   0.005181347 
+  191          200.23883    141.21961   0.005235602 
+  188          196.19756    141.18988   0.005319149 
+  179          190.6459     141.16017   0.005586592 
+  158          186.2977     141.13051   0.006329114 
+  162          183.98116    141.10087   0.00617284 
+  169          183.53792    141.07127   0.00591716 
+  165          184.4644     141.04171   0.006060606 
+  166          186.15385    141.01218   0.006024096 
+  181          187.36456    140.98269   0.005524862 
+  169          186.54659    140.95323   0.00591716 
+  174          184.05768    140.92381   0.005747126 
+  164          181.56556    140.89442   0.006097561 
+  169          180.01955    140.86507   0.00591716 
+  185          179.60465    140.83576   0.005405405 
+  161          180.26881    140.80648   0.00621118 
+  201          181.92335    140.77724   0.004975124 
+  177          184.34391    140.74803   0.005649718 
+  186          186.95844    140.71886   0.005376344 
+  191          189.17541    140.68973   0.005235602 
+  186          191.29395    140.66063   0.005376344 
+  197          194.06145    140.63157   0.005076142 
+  166          197.67527    140.60255   0.006024096 
+  173          201.45676    140.57356   0.005780347 
+  205          204.18989    140.54461   0.004878049 
+  190          205.51879    140.5157    0.005263158 
+  175          206.31097    140.48682   0.005714286 
+  171          206.90575    140.45798   0.005847953 
+  184          207.22985    140.42918   0.005434783 
+  197          208.02044    140.40042   0.005076142 
+  178          210.09106    140.3717    0.005617978 
+  195          213.57435    140.34301   0.005128205 
+  185          217.8341     140.31436   0.005405405 
+  196          221.72555    140.28575   0.005102041 
+  175          224.84608    140.25718   0.005714286 
+  208          228.0502     140.22864   0.004807692 
+  232          232.32947    140.20015   0.004310345 
+  255          240.02559    140.17169   0.003921569 
+  218          256.28523    140.14327   0.004587156 
+  270          287.93649    140.11489   0.003703704 
+  298          339.71856    140.08655   0.003355705 
+  386          397.40483    140.05825   0.002590674 
+  392          406.01749    140.02999   0.00255102 
+  342          353.08096    140.00176   0.002923977 
+  290          295.49768    139.97358   0.003448276 
+  249          257.54099    139.94543   0.004016064 
+  211          238.17587    139.91733   0.004739336 
+  228          233.79057    139.88927   0.004385965 
+  263          243.05974    139.86124   0.003802281 
+  242          264.66193    139.83326   0.004132231 
+  284          285.26799    139.80531   0.003521127 
+  282          275.97498    139.77741   0.003546099 
+  242          243.13531    139.74954   0.004132231 
+  209          213.69675    139.72172   0.004784689 
+  208          194.38667    139.69394   0.004807692 
+  172          182.79272    139.6662    0.005813953 
+  165          175.79896    139.6385    0.006060606 
+  171          171.29575    139.61084   0.005847953 
+  186          168.11784    139.58322   0.005376344 
+  194          165.71356    139.55564   0.005154639 
+  160          163.93139    139.52811   0.00625   
+  182          162.77485    139.50061   0.005494505 
+  159          162.27       139.47316   0.006289308 
+  159          162.45607    139.44575   0.006289308 
+  169          163.31414    139.41838   0.00591716 
+  188          164.48512    139.39105   0.005319149 
+  172          164.93976    139.36377   0.005813953 
+  180          163.75408    139.33653   0.005555556 
+  179          161.49441    139.30933   0.005586592 
+  176          159.29753    139.28217   0.005681818 
+  170          157.68371    139.25506   0.005882353 
+  179          156.71869    139.22798   0.005586592 
+  143          156.35042    139.20095   0.006993007 
+  135          156.56216    139.17397   0.007407407 
+  158          156.93628    139.14703   0.006329114 
+  164          156.99369    139.12013   0.006097561 
+  169          156.22701    139.09327   0.00591716 
+  169          155.36168    139.06646   0.00591716 
+  143          154.70252    139.03969   0.006993007 
+  152          154.38526    139.01297   0.006578947 
+  187          154.48788    138.98629   0.005347594 
+  174          155.13312    138.95965   0.005747126 
+  167          156.21876    138.93306   0.005988024 
+  159          157.0224     138.90651   0.006289308 
+  168          156.85589    138.88001   0.005952381 
+  161          155.5509     138.85355   0.00621118 
+  177          153.95403    138.82713   0.005649718 
+  157          152.65283    138.80076   0.006369427 
+  163          151.79021    138.77444   0.006134969 
+  149          151.36789    138.74816   0.006711409 
+  151          151.3763     138.72193   0.006622517 
+  160          151.68832    138.69574   0.00625   
+  151          151.91993    138.66959   0.006622517 
+  177          151.61718    138.6435    0.005649718 
+  170          150.81588    138.61744   0.005882353 
+  149          149.92817    138.59144   0.006711409 
+  158          149.24421    138.56548   0.006329114 
+  167          148.84327    138.53957   0.005988024 
+  172          148.70306    138.5137    0.005813953 
+  154          148.74505    138.48788   0.006493506 
+  166          148.81112    138.4621    0.006024096 
+  170          148.73124    138.43637   0.005882353 
+  147          148.53236    138.41069   0.006802721 
+  164          148.37384    138.38506   0.006097561 
+  143          148.34874    138.35947   0.006993007 
+  185          148.48291    138.33393   0.005405405 
+  152          148.78397    138.30844   0.006578947 
+  167          149.2553     138.283     0.005988024 
+  150          149.86912    138.2576    0.006666667 
+  148          150.50615    138.23225   0.006756757 
+  155          150.99314    138.20695   0.006451613 
+  138          151.33252    138.18169   0.007246377 
+  149          151.69447    138.15649   0.006711409 
+  152          152.19385    138.13133   0.006578947 
+  155          152.86275    138.10622   0.006451613 
+  151          153.69933    138.08116   0.006622517 
+  148          154.73749    138.05615   0.006756757 
+  173          156.0918     138.03119   0.005780347 
+  166          157.93862    138.00627   0.006024096 
+  174          160.55771    137.98141   0.005747126 
+  168          164.4988     137.95659   0.005952381 
+  217          170.65846    137.93183   0.004608295 
+  178          180.07647    137.90711   0.005617978 
+  182          192.96392    137.88244   0.005494505 
+  227          205.4593     137.85783   0.004405286 
+  209          207.84424    137.83326   0.004784689 
+  189          198.11365    137.80874   0.005291005 
+  212          186.07115    137.78427   0.004716981 
+  204          177.55443    137.75986   0.004901961 
+  162          173.22441    137.73549   0.00617284 
+  194          172.56775    137.71117   0.005154639 
+  182          175.2484     137.68691   0.005494505 
+  188          180.93811    137.66269   0.005319149 
+  177          187.77982    137.63853   0.005649718 
+  176          191.029      137.61442   0.005681818 
+  189          189.10724    137.59036   0.005291005 
+  213          186.41398    137.56635   0.004694836 
+  195          184.76722    137.54239   0.005128205 
+  177          182.53566    137.51848   0.005649718 
+  180          179.11103    137.49462   0.005555556 
+  186          175.69341    137.47082   0.005376344 
+  184          172.89719    137.44707   0.005434783 
+  169          170.75139    137.42337   0.00591716 
+  155          169.67901    137.39973   0.006451613 
+  159          170.10497    137.37613   0.006289308 
+  173          172.00148    137.35259   0.005780347 
+  201          174.63244    137.3291    0.004975124 
+  166          176.6932     137.30567   0.006024096 
+  181          177.9059     137.28228   0.005524862 
+  168          179.60836    137.25895   0.005952381 
+  197          182.7641     137.23568   0.005076142 
+  181          186.74951    137.21245   0.005524862 
+  179          189.47557    137.18929   0.005586592 
+  185          189.6015     137.16617   0.005405405 
+  186          188.789      137.14311   0.005376344 
+  197          189.18437    137.1201    0.005076142 
+  200          192.39217    137.09715   0.005     
+  194          201.20664    137.07425   0.005154639 
+  212          219.58972    137.0514    0.004716981 
+  261          250.34556    137.02861   0.003831418 
+  274          286.07126    137.00588   0.003649635 
+  314          296.06477    136.9832    0.003184713 
+  259          268.08888    136.96057   0.003861004 
+  247          233.81003    136.938     0.004048583 
+  230          210.44016    136.91549   0.004347826 
+  231          198.27338    136.89303   0.004329004 
+  217          194.81067    136.87062   0.004608295 
+  213          198.58701    136.84827   0.004694836 
+  232          209.14657    136.82598   0.004310345 
+  249          223.53586    136.80375   0.004016064 
+  233          228.7597     136.78157   0.004291845 
+  203          214.38307    136.75944   0.004926108 
+  191          194.21573    136.73737   0.005235602 
+  177          179.40874    136.71536   0.005649718 
+  192          170.65365    136.69341   0.005208333 
+  177          165.94524    136.67151   0.005649718 
+  191          163.39649    136.64967   0.005235602 
+  150          161.87195    136.62789   0.006666667 
+  192          160.78247    136.60616   0.005208333 
+  161          159.83935    136.58449   0.00621118 
+  157          159.29091    136.56288   0.006369427 
+  157          159.55135    136.54133   0.006369427 
+  166          160.64874    136.51983   0.006024096 
+  162          162.14094    136.49839   0.00617284 
+  184          163.31755    136.47701   0.005434783 
+  162          163.82816    136.45569   0.00617284 
+  178          164.57179    136.43443   0.005617978 
+  160          166.76683    136.41323   0.00625   
+  181          171.19925    136.39208   0.005524862 
+  181          177.97836    136.371     0.005524862 
+  177          186.00486    136.34997   0.005649718 
+  180          192.78497    136.329     0.005555556 
+  161          195.52988    136.30809   0.00621118 
+  182          192.42447    136.28724   0.005494505 
+  171          184.98954    136.26645   0.005847953 
+  148          177.1826     136.24572   0.006756757 
+  136          171.53672    136.22505   0.007352941 
+  159          168.72266    136.20444   0.006289308 
+  171          168.50121    136.18389   0.005847953 
+  202          170.09288    136.1634    0.004950495 
+  160          172.03959    136.14297   0.00625   
+  159          172.65226    136.12261   0.006289308 
+  146          170.74326    136.1023    0.006849315 
+  160          166.52472    136.08205   0.00625   
+  144          161.73727    136.06187   0.006944444 
+  161          157.76732    136.04174   0.00621118 
+  155          154.9335     136.02168   0.006451613 
+  158          153.05831    136.00168   0.006329114 
+  182          151.88687    135.98174   0.005494505 
+  145          151.19962    135.96186   0.006896552 
+  158          150.78777    135.94205   0.006329114 
+  154          150.49604    135.92229   0.006493506 
+  174          150.31567    135.9026    0.005747126 
+  162          150.35103    135.88297   0.00617284 
+  146          150.7081     135.86341   0.006849315 
+  144          151.47306    135.8439    0.006944444 
+  158          152.74076    135.82446   0.006329114 
+  185          154.61837    135.80509   0.005405405 
+  166          157.14128    135.78577   0.006024096 
+  177          160.00305    135.76652   0.005649718 
+  196          162.39037    135.74733   0.005102041 
+  161          163.72796    135.72821   0.00621118 
+  178          164.38197    135.70915   0.005617978 
+  160          164.73587    135.69016   0.00625   
+  146          164.54412    135.67122   0.006849315 
+  170          164.02773    135.65236   0.005882353 
+  167          164.14814    135.63355   0.005988024 
+  188          165.67827    135.61482   0.005319149 
+  159          169.04414    135.59614   0.006289308 
+  174          174.57755    135.57753   0.005747126 
+  192          182.85703    135.55899   0.005208333 
+  192          195.0562     135.54051   0.005208333 
+  190          211.66498    135.5221    0.005263158 
+  239          227.85676    135.50375   0.0041841 
+  250          231.88148    135.48547   0.004     
+  207          221.47451    135.46725   0.004830918 
+  218          206.76886    135.4491    0.004587156 
+  192          193.7462     135.43102   0.005208333 
+  213          184.38102    135.413     0.004694836 
+  191          179.41612    135.39505   0.005235602 
+  204          178.86957    135.37717   0.004901961 
+  208          182.4987     135.35935   0.004807692 
+  180          189.03081    135.3416    0.005555556 
+  199          193.77695    135.32392   0.005025126 
+  177          191.39307    135.3063    0.005649718 
+  202          184.12596    135.28875   0.004950495 
+  175          176.3905     135.27127   0.005714286 
+  163          169.84523    135.25386   0.006134969 
+  174          165.00456    135.23651   0.005747126 
+  183          161.79448    135.21923   0.005464481 
+  153          159.83191    135.20202   0.006535948 
+  177          158.74533    135.18488   0.005649718 
+  162          158.27306    135.16781   0.00617284 
+  164          158.2364     135.1508    0.006097561 
+  195          158.50456    135.13387   0.005128205 
+  171          158.99948    135.117     0.005847953 
+  197          159.71877    135.10021   0.005076142 
+  174          160.69719    135.08348   0.005747126 
+  163          161.97175    135.06682   0.006134969 
+  169          163.59108    135.05023   0.00591716 
+  166          165.61998    135.03371   0.006024096 
+  162          168.14665    135.01726   0.00617284 
+  197          171.26548    135.00088   0.005076142 
+  171          175.00414    134.98458   0.005847953 
+  212          179.17988    134.96834   0.004716981 
+  194          183.48684    134.95217   0.005154639 
+  182          188.09196    134.93607   0.005494505 
+  197          193.67708    134.92005   0.005076142 
+  208          200.7903     134.90409   0.004807692 
+  213          209.83986    134.88821   0.004694836 
+  214          221.62252    134.8724    0.004672897 
+  247          237.42304    134.85666   0.004048583 
+  263          258.99987    134.84099   0.003802281 
+  282          289.22601    134.82539   0.003546099 
+  333          333.96322    134.80987   0.003003003 
+  397          405.79745    134.79441   0.002518892 
+  550          528.28014    134.77903   0.001818182 
+  758          735.15998    134.76373   0.001319261 
+  1006         1050.35924   134.74849   0.000994036 
+  1324         1395.59917   134.73333   0.000755287 
+  1366         1473.39379   134.71824   0.000732064 
+  1047         1192.01164   134.70322   0.00095511 
+  836          860.71042    134.68828   0.001196172 
+  634          634.82736    134.67341   0.001577287 
+  517          512.93259    134.65862   0.001934236 
+  485          468.65882    134.6439    0.002061856 
+  477          488.16709    134.62925   0.002096436 
+  556          572.69441    134.61468   0.001798561 
+  685          719.76809    134.60018   0.001459854 
+  781          859.18573    134.58575   0.00128041 
+  722          831.79307    134.57141   0.001385042 
+  635          657.6661     134.55713   0.001574803 
+  448          490.40642    134.54293   0.002232143 
+  366          377.83867    134.52881   0.00273224 
+  319          309.1098     134.51476   0.003134796 
+  271          267.35852    134.50079   0.003690037 
+  237          240.72216    134.48689   0.004219409 
+  222          222.54189    134.47307   0.004504505 
+  209          209.58088    134.45932   0.004784689 
+  205          199.99154    134.44565   0.004878049 
+  200          192.67746    134.43206   0.005     
+  173          187.19267    134.41854   0.005780347 
+  191          183.0297     134.40511   0.005235602 
+  191          179.30571    134.39174   0.005235602 
+  196          175.40802    134.37846   0.005102041 
+  182          171.51501    134.36525   0.005494505 
+  169          167.91437    134.35212   0.00591716 
+  177          164.73896    134.33907   0.005649718 
+  164          162.11378    134.32609   0.006097561 
+  174          160.05873    134.31319   0.005747126 
+  165          158.50584    134.30038   0.006060606 
+  159          157.36705    134.28763   0.006289308 
+  184          156.50413    134.27497   0.005434783 
+  167          155.74031    134.26239   0.005988024 
+  172          155.0106     134.24988   0.005813953 
+  167          154.42035    134.23746   0.005988024 
+  167          154.06606    134.22511   0.005988024 
+  177          153.94477    134.21284   0.005649718 
+  164          153.97122    134.20066   0.006097561 
+  166          154.04039    134.18855   0.006024096 
+  165          154.10867    134.17652   0.006060606 
+  166          154.19122    134.16457   0.006024096 
+  164          154.30256    134.15271   0.006097561 
+  140          154.52944    134.14092   0.007142857 
+  157          155.0388     134.12921   0.006369427 
+  139          155.96764    134.11758   0.007194245 
+  160          157.45645    134.10604   0.00625   
+  160          159.68887    134.09458   0.00625   
+  189          162.91406    134.08319   0.005291005 
+  183          167.44808    134.07189   0.005464481 
+  177          173.74454    134.06067   0.005649718 
+  158          182.44339    134.04953   0.006329114 
+  215          193.84271    134.03848   0.004651163 
+  224          205.98832    134.02751   0.004464286 
+  186          212.94061    134.01661   0.005376344 
+  212          209.02729    134.00581   0.004716981 
+  179          197.73414    133.99508   0.005586592 
+  189          186.50855    133.98444   0.005291005 
+  192          178.74052    133.97388   0.005208333 
+  180          174.76035    133.9634    0.005555556 
+  153          174.06715    133.95301   0.006535948 
+  173          176.33349    133.9427    0.005780347 
+  179          181.33069    133.93247   0.005586592 
+  202          187.92615    133.92233   0.004950495 
+  194          193.16145    133.91227   0.005154639 
+  182          194.25962    133.9023    0.005494505 
+  186          192.64927    133.89241   0.005376344 
+  171          190.52668    133.88261   0.005847953 
+  173          186.88424    133.87289   0.005780347 
+  180          180.9305     133.86325   0.005555556 
+  156          174.535      133.85371   0.006410256 
+  175          169.56523    133.84424   0.005714286 
+  193          166.53616    133.83486   0.005181347 
+  184          165.2845     133.82557   0.005434783 
+  181          165.59037    133.81637   0.005524862 
+  168          167.42231    133.80725   0.005952381 
+  174          170.73202    133.79821   0.005747126 
+  166          174.90641    133.78927   0.006024096 
+  152          178.66541    133.78041   0.006578947 
+  153          181.31876    133.77164   0.006535948 
+  175          183.19036    133.76295   0.005714286 
+  158          183.96057    133.75435   0.006329114 
+  181          182.40044    133.74584   0.005524862 
+  167          178.62944    133.73742   0.005988024 
+  166          174.66031    133.72908   0.006024096 
+  150          172.01081    133.72083   0.006666667 
+  165          170.847      133.71268   0.006060606 
+  186          170.54117    133.7046    0.005376344 
+  155          170.62622    133.69662   0.006451613 
+  194          171.24705    133.68873   0.005154639 
+  172          172.40552    133.68093   0.005813953 
+  184          173.49524    133.67321   0.005434783 
+  178          173.62776    133.66559   0.005617978 
+  157          172.65463    133.65805   0.006369427 
+  168          171.53461    133.6506    0.005952381 
+  173          171.10739    133.64325   0.005780347 
+  170          171.51225    133.63598   0.005882353 
+  196          172.45475    133.62881   0.005102041 
+  180          173.67763    133.62172   0.005555556 
+  188          175.29068    133.61473   0.005319149 
+  180          177.53789    133.60782   0.005555556 
+  179          180.57356    133.60101   0.005586592 
+  204          184.50735    133.59429   0.004901961 
+  194          189.48453    133.58766   0.005154639 
+  184          195.71118    133.58112   0.005434783 
+  219          203.4573     133.57468   0.00456621 
+  207          213.01346    133.56832   0.004830918 
+  232          224.61189    133.56206   0.004310345 
+  246          238.60783    133.55589   0.004065041 
+  270          256.12601    133.54982   0.003703704 
+  277          279.30871    133.54383   0.003610108 
+  334          311.24787    133.53794   0.002994012 
+  404          356.84233    133.53215   0.002475248 
+  448          425.16464    133.52644   0.002232143 
+  536          533.55925    133.52083   0.001865672 
+  757          712.6898     133.51532   0.001321004 
+  1108         1007.15805   133.5099    0.000902527 
+  1460         1456.46909   133.50457   0.000684932 
+  1757         1987.82486   133.49933   0.000569152 
+  1997         2211.76384   133.4942    0.000500751 
+  1775         1863.85513   133.48915   0.00056338 
+  1321         1345.98713   133.4842    0.000757002 
+  961          961.94884    133.47935   0.001040583 
+  792          738.08325    133.47459   0.001262626 
+  666          634.02048    133.46993   0.001501502 
+  632          619.62654    133.46536   0.001582278 
+  782          688.15552    133.46089   0.001278772 
+  823          848.13668    133.45652   0.001215067 
+  1040         1083.40882   133.45224   0.000961538 
+  1162         1245.20511   133.44806   0.000860585 
+  1069         1126.72051   133.44398   0.000935454 
+  785          850.66559    133.43999   0.001273885 
+  637          615.88385    133.4361    0.001569859 
+  496          462.28177    133.43231   0.002016129 
+  384          369.36852    133.42861   0.002604167 
+  320          313.04425    133.42502   0.003125  
+  304          276.77737    133.42152   0.003289474 
+  270          251.53447    133.41812   0.003703704 
+  247          233.07471    133.41482   0.004048583 
+  204          219.20271    133.41161   0.004901961 
+  193          208.63988    133.40851   0.005181347 
+  205          200.51768    133.40551   0.004878049 
+  194          194.26009    133.4026    0.005154639 
+  191          189.49813    133.39979   0.005235602 
+  197          185.99285    133.39709   0.005076142 
+  210          183.54745    133.39448   0.004761905 
+  187          181.92114    133.39198   0.005347594 
+  192          180.86931    133.38957   0.005208333 
+  181          180.07183    133.38727   0.005524862 
+  176          178.86792    133.38506   0.005681818 
+  177          176.85012    133.38296   0.005649718 
+  185          174.57691    133.38096   0.005405405 
+  177          172.7612     133.37905   0.005649718 
+  188          171.53648    133.37726   0.005319149 
+  172          170.69624    133.37556   0.005813953 
+  167          170.24583    133.37396   0.005988024 
+  160          170.45038    133.37247   0.00625   
+  166          171.48127    133.37108   0.006024096 
+  178          173.2567     133.36979   0.005617978 
+  191          175.46148    133.36861   0.005235602 
+  161          177.94362    133.36753   0.00621118 
+  189          181.43577    133.36655   0.005291005 
+  181          187.46141    133.36567   0.005524862 
+  192          197.51764    133.3649    0.005208333 
+  220          212.04005    133.36424   0.004545455 
+  207          227.52408    133.36367   0.004830918 
+  237          233.64229    133.36322   0.004219409 
+  225          224.67642    133.36286   0.004444444 
+  189          210.13102    133.36261   0.005291005 
+  212          198.93845    133.36247   0.004716981 
+  186          193.04836    133.36243   0.005376344 
+  198          191.9345     133.3625    0.005050505 
+  197          195.0343     133.36267   0.005076142 
+  182          201.40567    133.36295   0.005494505 
+  195          208.51618    133.36334   0.005128205 
+  214          213.25079    133.36383   0.004672897 
+  195          213.86155    133.36443   0.005128205 
+  174          207.97924    133.36513   0.005747126 
+  172          197.31137    133.36594   0.005813953 
+  211          186.98545    133.36686   0.004739336 
+  161          179.39156    133.36789   0.00621118 
+  182          174.75666    133.36902   0.005494505 
+  177          172.65255    133.37027   0.005649718 
+  193          172.44911    133.37162   0.005181347 
+  188          172.96431    133.37308   0.005319149 
+  167          172.42815    133.37464   0.005988024 
+  154          170.31714    133.37632   0.006493506 
+  168          168.17067    133.37811   0.005952381 
+  145          167.08291    133.38      0.006896552 
+  173          166.96681    133.38201   0.005780347 
+  169          167.38431    133.38412   0.00591716 
+  155          168.07758    133.38634   0.006451613 
+  171          168.72761    133.38868   0.005847953 
+  196          168.98528    133.39112   0.005102041 
+  171          168.97586    133.39368   0.005847953 
+  189          168.73355    133.39635   0.005291005 
+  165          167.7754     133.39912   0.006060606 
+  153          166.15159    133.40201   0.006535948 
+  169          164.6378     133.40501   0.00591716 
+  179          163.80431    133.40812   0.005586592 
+  180          163.74036    133.41135   0.005555556 
+  201          164.27206    133.41468   0.004975124 
+  166          165.15097    133.41813   0.006024096 
+  181          166.08642    133.42169   0.005524862 
+  182          166.94188    133.42537   0.005494505 
+  170          167.83892    133.42916   0.005882353 
+  169          168.70222    133.43306   0.00591716 
+  167          169.30458    133.43707   0.005988024 
+  174          169.7407     133.4412    0.005747126 
+  163          170.19125    133.44544   0.006134969 
+  193          170.66998    133.4498    0.005181347 
+  192          171.27633    133.45427   0.005208333 
+  194          172.20474    133.45886   0.005154639 
+  205          173.5753     133.46356   0.004878049 
+  194          175.42176    133.46838   0.005154639 
+  181          177.75198    133.47331   0.005524862 
+  200          180.5859     133.47836   0.005     
+  193          183.96114    133.48352   0.005181347 
+  185          187.92857    133.4888    0.005405405 
+  204          192.51695    133.4942    0.004901961 
+  216          197.72965    133.49971   0.00462963 
+  217          203.66459    133.50534   0.004608295 
+  210          210.61454    133.51109   0.004761905 
+  253          218.99772    133.51695   0.003952569 
+  254          229.3105     133.52294   0.003937008 
+  247          242.2092     133.52904   0.004048583 
+  241          258.64945    133.53526   0.004149378 
+  290          280.05026    133.54159   0.003448276 
+  321          308.43264    133.54805   0.003115265 
+  342          346.33486    133.55463   0.002923977 
+  402          395.92061    133.56132   0.002487562 
+  434          456.4504     133.56813   0.002304147 
+  588          527.24599    133.57507   0.00170068 
+  618          624.60634    133.58212   0.001618123 
+  743          786.7328     133.58929   0.001345895 
+  1117         1067.81707   133.59658   0.000895255 
+  1475         1534.61171   133.604     0.000677966 
+  2065         2222.9946    133.61153   0.000484262 
+  2637         2941.41011   133.61919   0.000379219 
+  2695         3081.73098   133.62697   0.000371058 
+  2235         2491.11547   133.63487   0.000447427 
+  1674         1785.89947   133.64289   0.000597372 
+  1297         1286.63854   133.65103   0.00077101 
+  970          993.22665    133.65929   0.001030928 
+  874          849.92711    133.66768   0.001144165 
+  862          821.8821     133.67619   0.001160093 
+  901          903.13751    133.68483   0.001109878 
+  1125         1107.36148   133.69358   0.000888889 
+  1335         1429.96344   133.70246   0.000749064 
+  1474         1736.7919    133.71147   0.000678426 
+  1450         1715.74349   133.7206    0.000689655 
+  1223         1357.47474   133.72985   0.000817661 
+  914          977.47291    133.73923   0.001094092 
+  671          708.35262    133.74873   0.001490313 
+  575          540.61953    133.75836   0.00173913 
+  462          439.95768    133.76811   0.002164502 
+  416          379.28281    133.77799   0.002403846 
+  357          342.25256    133.78799   0.00280112 
+  297          319.28583    133.79812   0.003367003 
+  296          302.13692    133.80838   0.003378378 
+  303          284.06698    133.81876   0.00330033 
+  259          265.80948    133.82927   0.003861004 
+  242          251.15905    133.83991   0.004132231 
+  227          241.005      133.85068   0.004405286 
+  223          233.96592    133.86157   0.004484305 
+  239          227.73481    133.87259   0.0041841 
+  210          220.92813    133.88374   0.004761905 
+  213          214.13598    133.89502   0.004694836 
+  195          208.12538    133.90642   0.005128205 
+  214          202.74592    133.91796   0.004672897 
+  204          197.88818    133.92962   0.004901961 
+  189          193.96969    133.94142   0.005291005 
+  189          191.3832     133.95334   0.005291005 
+  191          190.24791    133.9654    0.005235602 
+  170          190.45321    133.97758   0.005882353 
+  209          191.51374    133.9899    0.004784689 
+  192          192.43323    134.00234   0.005208333 
+  191          192.29308    134.01492   0.005235602 
+  185          191.0581     134.02763   0.005405405 
+  170          189.372      134.04047   0.005882353 
+  194          187.87859    134.05344   0.005154639 
+  182          186.85917    134.06654   0.005494505 
+  174          186.28235    134.07978   0.005747126 
+  181          186.08053    134.09315   0.005524862 
+  174          186.56908    134.10665   0.005747126 
+  196          188.04804    134.12029   0.005102041 
+  181          190.20062    134.13406   0.005524862 
+  173          191.98505    134.14796   0.005780347 
+  196          191.90052    134.162     0.005102041 
+  160          189.56296    134.17617   0.00625   
+  182          185.96497    134.19048   0.005494505 
+  179          182.55362    134.20492   0.005586592 
+  202          180.04999    134.21949   0.004950495 
+  156          178.46235    134.23421   0.006410256 
+  167          177.59157    134.24905   0.005988024 
+  160          177.47645    134.26404   0.00625   
+  166          178.26465    134.27916   0.006024096 
+  213          179.87453    134.29441   0.004694836 
+  171          181.83875    134.30981   0.005847953 
+  157          183.44166    134.32534   0.006369427 
+  183          183.71503    134.34101   0.005464481 
+  182          181.96867    134.35681   0.005494505 
+  188          178.40032    134.37276   0.005319149 
+  178          174.26161    134.38884   0.005617978 
+  187          170.65837    134.40506   0.005347594 
+  164          167.98692    134.42142   0.006097561 
+  169          166.247      134.43792   0.00591716 
+  169          165.35463    134.45456   0.00591716 
+  167          165.26149    134.47133   0.005988024 
+  172          165.96755    134.48825   0.005813953 
+  162          167.44238    134.50531   0.00617284 
+  181          169.43047    134.52251   0.005524862 
+  162          171.28894    134.53985   0.00617284 
+  184          172.25631    134.55733   0.005434783 
+  171          171.94997    134.57495   0.005847953 
+  181          170.70248    134.59271   0.005524862 
+  147          169.54151    134.61062   0.006802721 
+  186          169.37604    134.62867   0.005376344 
+  180          170.51442    134.64686   0.005555556 
+  151          172.59325    134.66519   0.006622517 
+  156          174.4141     134.68367   0.006410256 
+  166          174.52731    134.70229   0.006024096 
+  188          172.87413    134.72105   0.005319149 
+  155          170.75278    134.73996   0.006451613 
+  151          169.13121    134.75901   0.006622517 
+  185          168.04139    134.77821   0.005405405 
+  161          167.23941    134.79755   0.00621118 
+  153          166.89742    134.81703   0.006535948 
+  184          167.40771    134.83667   0.005434783 
+  160          168.98738    134.85644   0.00625   
+  181          171.5381     134.87637   0.005524862 
+  191          174.45083    134.89644   0.005235602 
+  172          176.63986    134.91666   0.005813953 
+  148          177.49684    134.93702   0.006756757 
+  188          177.39516    134.95753   0.005319149 
+  186          176.78407    134.97819   0.005376344 
+  192          176.00478    134.999     0.005208333 
+  190          175.5746     135.01995   0.005263158 
+  205          175.87244    135.04106   0.004878049 
+  188          177.01585    135.06231   0.005319149 
+  169          179.02511    135.08371   0.00591716 
+  212          181.89226    135.10526   0.004716981 
+  205          185.45055    135.12696   0.004878049 
+  208          189.41011    135.14881   0.004807692 
+  224          193.6968     135.17081   0.004464286 
+  193          198.60471    135.19297   0.005181347 
+  215          204.55064    135.21527   0.004651163 
+  217          211.97768    135.23772   0.004608295 
+  255          221.56649    135.26033   0.003921569 
+  264          234.15612    135.28308   0.003787879 
+  256          250.67185    135.30599   0.00390625 
+  285          272.31213    135.32906   0.003508772 
+  317          300.96398    135.35227   0.003154574 
+  356          340.79197    135.37564   0.002808989 
+  431          401.33226    135.39916   0.002320186 
+  539          500.18337    135.42283   0.001855288 
+  694          664.15979    135.44666   0.001440922 
+  1007         924.01371    135.47065   0.000993049 
+  1209         1279.54013   135.49479   0.00082713 
+  1349         1584.06417   135.51908   0.00074129 
+  1462         1547.56307   135.54353   0.000683995 
+  1151         1220.09363   135.56813   0.00086881 
+  907          891.49129    135.59289   0.001102536 
+  727          667.39399    135.61781   0.001375516 
+  586          537.26514    135.64288   0.001706485 
+  535          473.94456    135.66811   0.001869159 
+  487          460.3639     135.6935    0.002053388 
+  571          493.19495    135.71904   0.001751313 
+  653          579.35315    135.74474   0.001531394 
+  760          723.757      135.7706    0.001315789 
+  838          891.92345    135.79662   0.001193317 
+  873          955.78738    135.8228    0.001145475 
+  786          828.16638    135.84914   0.001272265 
+  641          632.6712     135.87563   0.001560062 
+  516          476.93836    135.90229   0.001937984 
+  418          374.88187    135.92911   0.002392344 
+  355          312.17063    135.95608   0.002816901 
+  303          274.13755    135.98322   0.00330033 
+  280          250.92892    136.01052   0.003571429 
+  252          236.93995    136.03798   0.003968254 
+  263          228.57747    136.0656    0.003802281 
+  267          221.93037    136.09339   0.003745318 
+  222          213.37557    136.12134   0.004504505 
+  197          203.42129    136.14944   0.005076142 
+  206          194.59826    136.17772   0.004854369 
+  213          187.78959    136.20615   0.004694836 
+  201          182.63343    136.23475   0.004975124 
+  183          178.50335    136.26352   0.005464481 
+  208          174.9518     136.29245   0.004807692 
+  167          171.83304    136.32154   0.005988024 
+  178          169.15226    136.3508    0.005617978 
+  154          166.92232    136.38022   0.006493506 
+  166          165.11645    136.40981   0.006024096 
+  165          163.70464    136.43957   0.006060606 
+  163          162.69122    136.46949   0.006134969 
+  168          162.09596    136.49958   0.005952381 
+  175          161.90201    136.52984   0.005714286 
+  186          161.99329    136.56026   0.005376344 
+  158          162.08698    136.59085   0.006329114 
+  166          161.88155    136.62161   0.006024096 
+  169          161.37217    136.65254   0.00591716 
+  190          160.81535    136.68364   0.005263158 
+  140          160.46692    136.7149    0.007142857 
+  153          160.51707    136.74634   0.006535948 
+  133          161.03059    136.77795   0.007518797 
+  186          161.83412    136.80972   0.005376344 
+  183          162.40559    136.84167   0.005464481 
+  150          162.09156    136.87379   0.006666667 
+  148          160.89829    136.90608   0.006756757 
+  176          159.47871    136.93854   0.005681818 
+  143          158.29306    136.97117   0.006993007 
+  161          157.44475    137.00398   0.00621118 
+  151          156.98385    137.03695   0.006622517 
+  137          156.98882    137.07011   0.00729927 
+  146          157.54762    137.10343   0.006849315 
+  182          158.76675    137.13693   0.005494505 
+  139          160.6025     137.1706    0.007194245 
+  155          163.20592    137.20445   0.006451613 
+  176          166.07266    137.23847   0.005681818 
+  176          168.38043    137.27267   0.005681818 
+  148          169.06781    137.30704   0.006756757 
+  163          167.63385    137.34159   0.006134969 
+  154          164.96643    137.37631   0.006493506 
+  153          162.48623    137.41122   0.006535948 
+  171          161.01432    137.4463    0.005847953 
+  146          160.77967    137.48155   0.006849315 
+  156          161.66225    137.51699   0.006410256 
+  168          163.00711    137.5526    0.005952381 
+  145          163.84111    137.58839   0.006896552 
+  169          163.7641     137.62436   0.00591716 
+  165          163.67265    137.66051   0.006060606 
+  156          164.0606     137.69684   0.006410256 
+  164          164.40906    137.73334   0.006097561 
+  149          164.00494    137.77003   0.006711409 
+  150          162.75913    137.8069    0.006666667 
+  173          161.15121    137.84395   0.005780347 
+  142          159.74648    137.88118   0.007042254 
+  160          158.83463    137.9186    0.00625   
+  168          158.41236    137.95619   0.005952381 
+  166          158.16414    137.99397   0.006024096 
+  165          157.56615    138.03193   0.006060606 
+  166          156.57301    138.07008   0.006024096 
+  165          155.72883    138.10841   0.006060606 
+  183          155.41455    138.14692   0.005464481 
+  159          155.67105    138.18562   0.006289308 
+  155          156.35484    138.2245    0.006451613 
+  179          157.30445    138.26357   0.005586592 
+  169          158.57233    138.30282   0.00591716 
+  166          160.38851    138.34226   0.006024096 
+  196          162.82363    138.38188   0.005102041 
+  159          165.45391    138.4217    0.006289308 
+  195          167.26287    138.46169   0.005128205 
+  151          167.36712    138.50188   0.006622517 
+  159          165.77507    138.54226   0.006289308 
+  179          163.05199    138.58282   0.005586592 
+  157          160.0356     138.62357   0.006369427 
+  154          157.474      138.66451   0.006493506 
+  170          155.68399    138.70564   0.005882353 
+  151          154.68853    138.74696   0.006622517 
+  154          154.42812    138.78847   0.006493506 
+  139          154.84483    138.83017   0.007194245 
+  161          155.84045    138.87206   0.00621118 
+  151          157.14002    138.91415   0.006622517 
+  179          158.20426    138.95642   0.005586592 
+  146          158.7769     138.99889   0.006849315 
+  173          158.44838    139.04155   0.005780347 
+  172          157.70715    139.0844    0.005813953 
+  145          156.97613    139.12745   0.006896552 
+  153          156.60508    139.17069   0.006535948 
+  155          156.64326    139.21412   0.006451613 
+  159          156.86017    139.25775   0.006289308 
+  169          156.96606    139.30157   0.00591716 
+  150          156.97248    139.34559   0.006666667 
+  132          157.11369    139.38981   0.007575758 
+  171          157.52078    139.43422   0.005847953 
+  177          158.2472     139.47883   0.005649718 
+  168          159.29587    139.52363   0.005952381 
+  158          160.56534    139.56864   0.006329114 
+  146          161.75424    139.61384   0.006849315 
+  145          162.19259    139.65923   0.006896552 
+  160          161.51593    139.70483   0.00625   
+  159          159.96376    139.75063   0.006289308 
+  163          158.36093    139.79662   0.006134969 
+  147          157.0083     139.84282   0.006802721 
+  149          155.9739     139.88921   0.006711409 
+  165          155.32095    139.93581   0.006060606 
+  163          155.04836    139.98261   0.006134969 
+  145          155.12241    140.02961   0.006896552 
+  166          155.50911    140.07681   0.006024096 
+  187          156.14431    140.12421   0.005347594 
+  156          156.9045     140.17182   0.006410256 
+  168          157.49946    140.21963   0.005952381 
+  160          157.67159    140.26764   0.00625   
+  163          157.60463    140.31586   0.006134969 
+  163          157.65722    140.36428   0.006134969 
+  180          157.81476    140.41291   0.005555556 
+  151          157.69271    140.46174   0.006622517 
+  155          157.05792    140.51078   0.006451613 
+  140          156.09947    140.56002   0.007142857 
+  167          155.14029    140.60947   0.005988024 
+  147          154.42298    140.65913   0.006802721 
+  168          154.07436    140.709     0.005952381 
+  128          154.13148    140.75907   0.0078125 
+  144          154.58686    140.80935   0.006944444 
+  158          155.39163    140.85984   0.006329114 
+  154          156.4297     140.91054   0.006493506 
+  140          157.52101    140.96145   0.007142857 
+  129          158.44509    141.01257   0.007751938 
+  148          159.02067    141.0639    0.006756757 
+  159          159.22762    141.11544   0.006289308 
+  148          159.14172    141.16719   0.006756757 
+  144          158.69679    141.21915   0.006944444 
+  162          157.86529    141.27133   0.00617284 
+  146          156.89498    141.32372   0.006849315 
+  154          156.09513    141.37632   0.006493506 
+  152          155.64767    141.42913   0.006578947 
+  157          155.594      141.48216   0.006369427 
+  144          155.88091    141.53541   0.006944444 
+  142          156.39445    141.58887   0.007042254 
+  123          157.0372     141.64254   0.008130081 
+  154          157.77624    141.69643   0.006493506 
+  144          158.62125    141.75054   0.006944444 
+  157          159.39334    141.80486   0.006369427 
+  169          159.61883    141.8594    0.00591716 
+  187          159.00692    141.91416   0.005347594 
+  149          157.86714    141.96913   0.006711409 
+  151          156.69956    142.02432   0.006622517 
+  159          155.78066    142.07974   0.006289308 
+  159          155.1829     142.13537   0.006289308 
+  139          154.88796    142.19122   0.007194245 
+  167          154.85342    142.24729   0.005988024 
+  161          155.03489    142.30359   0.00621118 
+  144          155.39097    142.3601    0.006944444 
+  152          155.86787    142.41684   0.006578947 
+  154          156.35708    142.4738    0.006493506 
+  143          156.68977    142.53098   0.006993007 
+  154          156.7536     142.58838   0.006493506 
+  156          156.6518     142.64601   0.006410256 
+  150          156.60532    142.70386   0.006666667 
+  145          156.73938    142.76193   0.006896552 
+  156          157.02368    142.82024   0.006410256 
+  165          157.35952    142.87876   0.006060606 
+  131          157.77764    142.93751   0.007633588 
+  151          158.42614    142.99649   0.006622517 
+  161          159.409      143.0557    0.00621118 
+  151          160.74443    143.11513   0.006622517 
+  169          162.15999    143.17479   0.00591716 
+  161          163.64279    143.23468   0.00621118 
+  155          164.56503    143.2948    0.006451613 
+  154          164.79699    143.35514   0.006493506 
+  167          164.76615    143.41572   0.005988024 
+  151          165.00443    143.47652   0.006622517 
+  171          165.76979    143.53756   0.005847953 
+  144          167.02883    143.59883   0.006944444 
+  156          168.54394    143.66033   0.006410256 
+  188          170.04258    143.72206   0.005319149 
+  185          171.51892    143.78402   0.005405405 
+  159          173.20911    143.84622   0.006289308 
+  162          175.43712    143.90865   0.00617284 
+  189          177.63624    143.97132   0.005291005 
+  189          178.62232    144.03421   0.005291005 
+  207          177.61661    144.09735   0.004830918 
+  165          175.45822    144.16072   0.006060606 
+  181          173.46904    144.22432   0.005524862 
+  176          172.24844    144.28816   0.005681818 
+  193          171.85845    144.35224   0.005181347 
+  182          172.17159    144.41656   0.005494505 
+  169          172.96647    144.48111   0.00591716 
+  175          174.02369    144.54591   0.005714286 
+  214          175.27628    144.61094   0.004672897 
+  162          176.71156    144.67621   0.00617284 
+  208          178.18694    144.74172   0.004807692 
+  201          179.43415    144.80747   0.004975124 
+  193          180.15294    144.87346   0.005181347 
+  213          180.46222    144.9397    0.004694836 
+  204          181.01217    145.00617   0.004901961 
+  177          182.3043     145.07289   0.005649718 
+  209          184.44611    145.13985   0.004784689 
+  201          187.2111     145.20705   0.004975124 
+  219          189.96277    145.2745    0.00456621 
+  203          191.92447    145.34219   0.004926108 
+  214          192.99426    145.41013   0.004672897 
+  196          193.86194    145.47831   0.005102041 
+  209          195.16295    145.54674   0.004784689 
+  213          197.17629    145.61542   0.004694836 
+  208          200.05553    145.68434   0.004807692 
+  204          203.9557     145.75351   0.004901961 
+  242          208.99902    145.82293   0.004132231 
+  231          215.21369    145.8926    0.004329004 
+  243          222.44163    145.96251   0.004115226 
+  230          230.38452    146.03268   0.004347826 
+  245          238.96394    146.10309   0.004081633 
+  275          248.45647    146.17376   0.003636364 
+  272          259.39752    146.24467   0.003676471 
+  311          272.78737    146.31584   0.003215434 
+  302          290.10301    146.38726   0.003311258 
+  316          313.16724    146.45894   0.003164557 
+  345          344.43088    146.53087   0.002898551 
+  445          387.9349     146.60305   0.002247191 
+  443          450.90511    146.67548   0.002257336 
+  547          546.51284    146.74817   0.001828154 
+  759          697.22642    146.82112   0.001317523 
+  980          936.27509    146.89432   0.001020408 
+  1292         1299.95466   146.96778   0.000773994 
+  1612         1782.31559   147.04149   0.000620347 
+  1966         2197.32302   147.11546   0.000508647 
+  2012         2182.42035   147.18969   0.000497018 
+  1753         1760.76078   147.26418   0.000570451 
+  1277         1297.42166   147.33893   0.000783085 
+  1023         960.08228    147.41394   0.000977517 
+  855          748.86564    147.48921   0.001169591 
+  677          628.85446    147.56474   0.001477105 
+  702          571.21674    147.64053   0.001424501 
+  645          561.06178    147.71658   0.001550388 
+  680          597.28525    147.79289   0.001470588 
+  758          689.77096    147.86947   0.001319261 
+  876          852.3968     147.94631   0.001141553 
+  1073         1076.8446    148.02342   0.000931966 
+  1101         1260.62996   148.10079   0.000908265 
+  1098         1223.71267   148.17842   0.000910747 
+  942          994.83856    148.25632   0.001061571 
+  784          754.98057    148.33449   0.00127551 
+  616          579.5252     148.41293   0.001623377 
+  503          465.14729    148.49163   0.001988072 
+  417          392.93636    148.5706    0.002398082 
+  362          346.70681    148.64983   0.002762431 
+  300          315.78926    148.72934   0.003333333 
+  302          293.98311    148.80912   0.003311258 
+  275          277.81867    148.88916   0.003636364 
+  292          265.30998    148.96948   0.003424658 
+  258          255.35494    149.05007   0.003875969 
+  250          247.35366    149.13093   0.004     
+  256          240.88587    149.21207   0.00390625 
+  222          235.57762    149.29347   0.004504505 
+  235          231.08003    149.37515   0.004255319 
+  232          226.98975    149.45711   0.004310345 
+  240          222.93887    149.53934   0.004166667 
+  236          218.88631    149.62184   0.004237288 
+  214          215.06474    149.70462   0.004672897 
+  219          211.66099    149.78768   0.00456621 
+  242          208.72006    149.87101   0.004132231 
+  194          206.20936    149.95463   0.005154639 
+  223          204.07818    150.03852   0.004484305 
+  209          202.28363    150.12268   0.004784689 
+  203          200.79075    150.20713   0.004926108 
+  186          199.56066    150.29186   0.005376344 
+  187          198.54662    150.37687   0.005347594 
+  198          197.6882     150.46216   0.005050505 
+  197          196.88166    150.54773   0.005076142 
+  209          196.00834    150.63359   0.004784689 
+  200          195.08657    150.71972   0.005     
+  191          194.27825    150.80615   0.005235602 
+  218          193.7212     150.89285   0.004587156 
+  203          193.46255    150.97984   0.004926108 
+  200          193.48946    151.06712   0.005     
+  186          193.75694    151.15468   0.005376344 
+  183          194.20681    151.24252   0.005464481 
+  200          194.7961     151.33066   0.005     
+  213          195.51033    151.41908   0.004694836 
+  207          196.3466     151.50779   0.004830918 
+  197          197.30884    151.59679   0.005076142 
+  194          198.41561    151.68608   0.005154639 
+  221          199.70288    151.77566   0.004524887 
+  199          201.22245    151.86553   0.005025126 
+  205          203.03246    151.95569   0.004878049 
+  219          205.17331    152.04615   0.00456621 
+  198          207.62137    152.13689   0.005050505 
+  202          210.23051    152.22793   0.004950495 
+  179          212.71587    152.31927   0.005586592 
+  201          214.76522    152.4109    0.004975124 
+  229          216.26264    152.50282   0.004366812 
+  218          217.33052    152.59504   0.004587156 
+  228          217.98936    152.68755   0.004385965 
+  220          217.79767    152.78037   0.004545455 
+  230          216.16603    152.87347   0.004347826 
+  196          213.16687    152.96688   0.005102041 
+  204          209.60896    153.06059   0.004901961 
+  222          206.2323     153.1546    0.004504505 
+  242          203.58598    153.2489    0.004132231 
+  225          201.64227    153.34351   0.004444444 
+  222          200.28465    153.43842   0.004504505 
+  219          199.30385    153.53363   0.00456621 
+  204          198.46638    153.62914   0.004901961 
+  262          197.61865    153.72496   0.003816794 
+  203          196.75417    153.82108   0.004926108 
+  220          195.90126    153.9175    0.004545455 
+  201          194.90569    154.01423   0.004975124 
+  194          193.42759    154.11127   0.005154639 
+  242          191.3044     154.20861   0.004132231 
+  211          188.74536    154.30626   0.004739336 
+  202          186.24949    154.40421   0.004950495 
+  200          184.07422    154.50248   0.005     
+  198          182.32878    154.60105   0.005050505 
+  204          180.99266    154.69994   0.004901961 
+  215          179.95895    154.79913   0.004651163 
+  185          179.07613    154.89864   0.005405405 
+  210          178.26878    154.99845   0.004761905 
+  173          177.61967    155.09858   0.005780347 
+  192          177.27434    155.19903   0.005208333 
+  202          177.33258    155.29978   0.004950495 
+  187          177.81243    155.40085   0.005347594 
+  217          178.58498    155.50224   0.004608295 
+  180          179.25753    155.60394   0.005555556 
+  184          179.26705    155.70595   0.005434783 
+  194          178.41366    155.80829   0.005154639 
+  184          177.11303    155.91094   0.005434783 
+  192          175.8909     156.01391   0.005208333 
+  178          174.99531    156.1172    0.005617978 
+  189          174.43096    156.22081   0.005291005 
+  180          174.11237    156.32473   0.005555556 
+  207          173.97872    156.42898   0.004830918 
+  213          174.00189    156.53355   0.004694836 
+  170          174.16324    156.63845   0.005882353 
+  208          174.48451    156.74366   0.004807692 
+  177          175.00532    156.8492    0.005649718 
+  184          175.67384    156.95507   0.005434783 
+  177          176.28083    157.06126   0.005649718 
+  182          176.60908    157.16777   0.005494505 
+  188          176.71313    157.27461   0.005319149 
+  155          176.87874    157.38178   0.006451613 
+  185          177.35545    157.48928   0.005405405 
+  204          178.28047    157.5971    0.004901961 
+  184          179.74692    157.70526   0.005434783 
+  187          181.86736    157.81374   0.005347594 
+  205          184.82148    157.92255   0.004878049 
+  167          188.92914    158.0317    0.005988024 
+  193          194.79606    158.14118   0.005181347 
+  179          203.50589    158.25099   0.005586592 
+  233          216.71775    158.36113   0.004291845 
+  243          236.35572    158.47161   0.004115226 
+  248          262.82838    158.58242   0.004032258 
+  291          289.15077    158.69357   0.003436426 
+  267          296.9144     158.80505   0.003745318 
+  265          279.55245    158.91687   0.003773585 
+  232          254.33888    159.02903   0.004310345 
+  228          234.15247    159.14152   0.004385965 
+  222          221.25151    159.25436   0.004504505 
+  215          214.50868    159.36753   0.004651163 
+  225          212.64625    159.48105   0.004444444 
+  239          214.9806     159.5949    0.0041841 
+  227          221.48591    159.7091    0.004405286 
+  286          232.71257    159.82364   0.003496503 
+  239          249.48449    159.93853   0.0041841 
+  274          271.25993    160.05375   0.003649635 
+  282          292.2905     160.16933   0.003546099 
+  287          300.86217    160.28524   0.003484321 
+  283          289.08578    160.40151   0.003533569 
+  282          264.47528    160.51812   0.003546099 
+  231          240.59124    160.63508   0.004329004 
+  216          222.92581    160.75239   0.00462963 
+  237          211.29584    160.87004   0.004219409 
+  209          204.28017    160.98805   0.004784689 
+  211          200.66002    161.1064    0.004739336 
+  189          199.64646    161.22511   0.005291005 
+  227          200.79324    161.34417   0.004405286 
+  210          203.84948    161.46358   0.004761905 
+  198          208.56662    161.58335   0.005050505 
+  219          213.85486    161.70347   0.00456621 
+  196          216.62425    161.82395   0.005102041 
+  209          213.88339    161.94478   0.004784689 
+  180          207.08597    162.06597   0.005555556 
+  194          199.72839    162.18751   0.005154639 
+  195          193.55114    162.30941   0.005128205 
+  180          188.87957    162.43168   0.005555556 
+  181          185.56021    162.5543    0.005524862 
+  192          183.31172    162.67728   0.005208333 
+  173          181.86295    162.80062   0.005780347 
+  182          180.99766    162.92432   0.005494505 
+  171          180.54644    163.04839   0.005847953 
+  174          180.37036    163.17282   0.005747126 
+  174          180.36069    163.29762   0.005747126 
+  176          180.44642    163.42278   0.005681818 
+  169          180.60398    163.5483    0.00591716 
+  174          180.84901    163.67419   0.005747126 
+  180          181.17482    163.80045   0.005555556 
+  180          181.52917    163.92708   0.005555556 
+  162          181.90072    164.05407   0.00617284 
+  181          182.34919    164.18144   0.005524862 
+  187          182.8865     164.30917   0.005347594 
+  188          183.3443     164.43728   0.005319149 
+  147          183.41758    164.56575   0.006802721 
+  163          182.98711    164.6946    0.006134969 
+  160          182.27561    164.82383   0.00625   
+  185          181.56723    164.95343   0.005405405 
+  185          180.97812    165.0834    0.005405405 
+  181          180.50435    165.21375   0.005524862 
+  163          180.1497     165.34447   0.006134969 
+  170          179.95391    165.47557   0.005882353 
+  162          179.95475    165.60705   0.00617284 
+  160          180.1706     165.73891   0.00625   
+  172          180.59862    165.87115   0.005813953 
+  165          181.21177    166.00377   0.006060606 
+  190          181.92406    166.13677   0.005263158 
+  181          182.52282    166.27016   0.005524862 
+  172          182.70217    166.40392   0.005813953 
+  164          182.32551    166.53807   0.006097561 
+  170          181.59174    166.67261   0.005882353 
+  181          180.8083     166.80752   0.005524862 
+  171          180.14123    166.94283   0.005847953 
+  150          179.617      167.07852   0.006666667 
+  153          179.22025    167.2146    0.006535948 
+  149          178.9372     167.35107   0.006711409 
+  191          178.75638    167.48793   0.005235602 
+  178          178.67537    167.62518   0.005617978 
+  157          178.69961    167.76282   0.006369427 
+  171          178.82802    167.90085   0.005847953 
+  169          179.03844    168.03927   0.00591716 
+  187          179.27571    168.17809   0.005347594 
+  181          179.46232    168.3173    0.005524862 
+  148          179.55117    168.45691   0.006756757 
+  156          179.57652    168.59692   0.006410256 
+  176          179.61899    168.73732   0.005681818 
+  180          179.73608    168.87811   0.005555556 
+  173          179.94116    169.01931   0.005780347 
+  165          180.21071    169.16091   0.006060606 
+  186          180.49627    169.3029    0.005376344 
+  171          180.75892    169.4453    0.005847953 
+  177          181.00876    169.5881    0.005649718 
+  170          181.28756    169.7313    0.005882353 
+  200          181.62679    169.8749    0.005     
+  161          182.03601    170.01891   0.00621118 
+  170          182.5106     170.16333   0.005882353 
+  171          183.04155    170.30815   0.005847953 
+  158          183.61686    170.45338   0.006329114 
+  174          184.21675    170.59901   0.005747126 
+  165          184.83186    170.74506   0.006060606 
+  150          185.49784    170.89151   0.006666667 
+  190          186.28417    171.03837   0.005263158 
+  170          187.25412    171.18565   0.005882353 
+  188          188.44728    171.33334   0.005319149 
+  186          189.87437    171.48144   0.005376344 
+  178          191.4884     171.62995   0.005617978 
+  155          193.0987     171.77888   0.006451613 
+  184          194.33359    171.92823   0.005434783 
+  179          194.88942    172.07799   0.005586592 
+  214          194.87827    172.22817   0.004672897 
+  181          194.72263    172.37876   0.005524862 
+  188          194.76903    172.52978   0.005319149 
+  170          195.16625    172.68122   0.005882353 
+  195          195.94804    172.83307   0.005128205 
+  176          197.10581    172.98535   0.005681818 
+  182          198.57211    173.13805   0.005494505 
+  185          200.19565    173.29118   0.005405405 
+  171          201.83725    173.44473   0.005847953 
+  167          203.45641    173.5987    0.005988024 
+  172          205.04933    173.7531    0.005813953 
+  212          206.6407     173.90793   0.004716981 
+  191          208.30766    174.06318   0.005235602 
+  174          210.07257    174.21887   0.005747126 
+  190          211.93111    174.37498   0.005263158 
+  184          214.04127    174.53153   0.005434783 
+  189          216.80535    174.6885    0.005291005 
+  237          220.60062    174.84591   0.004219409 
+  210          225.27119    175.00376   0.004761905 
+  206          230.27178    175.16203   0.004854369 
+  238          236.19816    175.32075   0.004201681 
+  244          245.39801    175.47989   0.004098361 
+  251          260.75782    175.63948   0.003984064 
+  290          284.99622    175.7995    0.003448276 
+  307          318.98154    175.95996   0.003257329 
+  336          355.02566    176.12087   0.00297619 
+  350          369.84716    176.28221   0.002857143 
+  357          349.24492    176.44399   0.00280112 
+  315          313.04089    176.60622   0.003174603 
+  261          281.75694    176.76889   0.003831418 
+  249          260.4133     176.932     0.004016064 
+  259          247.55363    177.09557   0.003861004 
+  249          240.67173    177.25957   0.004016064 
+  214          237.34665    177.42403   0.004672897 
+  243          235.78371    177.58893   0.004115226 
+  222          235.69713    177.75428   0.004504505 
+  235          238.1692     177.92008   0.004255319 
+  228          244.71053    178.08633   0.004385965 
+  234          256.60003    178.25304   0.004273504 
+  291          273.41123    178.42019   0.003436426 
+  260          288.69292    178.5878    0.003846154 
+  295          289.74401    178.75587   0.003389831 
+  252          275.07889    178.92439   0.003968254 
+  235          256.76469    179.09337   0.004255319 
+  231          242.01733    179.2628    0.004329004 
+  243          231.52062    179.4327    0.004115226 
+  235          224.27311    179.60305   0.004255319 
+  235          219.35315    179.77387   0.004255319 
+  199          216.00298    179.94514   0.005025126 
+  213          213.58237    180.11688   0.004694836 
+  191          211.6761     180.28908   0.005235602 
+  189          210.11271    180.46175   0.005291005 
+  188          208.84735    180.63488   0.005319149 
+  204          207.90325    180.80848   0.004901961 
+  198          207.33647    180.98254   0.005050505 
+  204          207.16527    181.15708   0.004901961 
+  197          207.31574    181.33208   0.005076142 
+  213          207.62653    181.50755   0.004694836 
+  195          207.89676    181.6835    0.005128205 
+  196          207.98427    181.85991   0.005102041 
+  221          207.88251    182.0368    0.004524887 
+  206          207.6926     182.21417   0.004854369 
+  180          207.4858     182.39201   0.005555556 
+  225          207.24126    182.57032   0.004444444 
+  202          206.96899    182.74912   0.004950495 
+  208          206.75615    182.92839   0.004807692 
+  181          206.65683    183.10814   0.005524862 
+  189          206.67681    183.28837   0.005291005 
+  196          206.84726    183.46908   0.005102041 
+  205          207.21299    183.65027   0.004878049 
+  192          207.75511    183.83195   0.005208333 
+  190          208.35061    184.01411   0.005263158 
+  206          208.83901    184.19676   0.004854369 
+  211          209.1826     184.37989   0.004739336 
+  200          209.51423    184.56351   0.005     
+  196          209.99753    184.74762   0.005102041 
+  225          210.70482    184.93221   0.004444444 
+  186          211.60263    185.1173    0.005376344 
+  209          212.59324    185.30288   0.004784689 
+  209          213.55643    185.48895   0.004784689 
+  203          214.34822    185.67552   0.004926108 
+  202          214.86639    185.86258   0.004950495 
+  206          215.18886    186.05013   0.004854369 
+  182          215.52356    186.23818   0.005494505 
+  213          216.03471    186.42673   0.004694836 
+  188          216.76879    186.61578   0.005319149 
+  190          217.68312    186.80533   0.005263158 
+  235          218.71334    186.99537   0.004255319 
+  228          219.85308    187.18592   0.004385965 
+  195          221.16783    187.37698   0.005128205 
+  180          222.73881    187.56853   0.005555556 
+  203          224.63216    187.76059   0.004926108 
+  223          226.9011     187.95316   0.004484305 
+  205          229.57955    188.14623   0.004878049 
+  213          232.63868    188.33982   0.004694836 
+  238          235.90647    188.53391   0.004201681 
+  214          239.00744    188.72851   0.004672897 
+  219          241.45254    188.92362   0.00456621 
+  238          242.99031    189.11924   0.004201681 
+  226          243.8974     189.31538   0.004424779 
+  200          244.62572    189.51203   0.005     
+  225          245.27589    189.7092    0.004444444 
+  213          245.65153    189.90689   0.004694836 
+  236          245.70617    190.10509   0.004237288 
+  230          245.67489    190.30381   0.004347826 
+  213          245.83821    190.50305   0.004694836 
+  222          246.3745     190.70281   0.004504505 
+  270          247.37802    190.90309   0.003703704 
+  213          248.88815    191.1039    0.004694836 
+  233          250.90036    191.30523   0.004291845 
+  250          253.35156    191.50708   0.004     
+  249          255.96324    191.70947   0.004016064 
+  211          258.67504    191.91238   0.004739336 
+  253          261.16005    192.11581   0.003952569 
+  248          263.5125     192.31978   0.004032258 
+  251          266.0339     192.52428   0.003984064 
+  303          268.91324    192.72931   0.00330033 
+  248          272.16058    192.93487   0.004032258 
+  275          275.82304    193.14097   0.003636364 
+  282          280.15922    193.3476    0.003546099 
+  273          285.6122     193.55477   0.003663004 
+  294          292.59477    193.76247   0.003401361 
+  330          300.87642    193.97072   0.003030303 
+  358          308.60233    194.1795    0.002793296 
+  314          312.64392    194.38882   0.003184713 
+  325          312.42714    194.59869   0.003076923 
+  307          310.661      194.8091    0.003257329 
+  348          309.88112    195.02005   0.002873563 
+  339          310.8618     195.23155   0.002949853 
+  341          313.4619     195.4436    0.002932551 
+  381          317.42782    195.65619   0.002624672 
+  353          322.67291    195.86933   0.002832861 
+  357          329.22499    196.08302   0.00280112 
+  356          337.13979    196.29726   0.002808989 
+  370          346.5067     196.51206   0.002702703 
+  372          357.50325    196.7274    0.002688172 
+  379          370.40505    196.9433    0.002638522 
+  422          385.41188    197.15976   0.002369668 
+  384          402.19861    197.37677   0.002604167 
+  408          419.62708    197.59434   0.00245098 
+  456          437.01021    197.81247   0.002192982 
+  495          455.68117    198.03116   0.002020202 
+  500          477.82769    198.25042   0.002     
+  529          505.00487    198.47023   0.001890359 
+  554          538.27218    198.69061   0.001805054 
+  629          578.77438    198.91155   0.001589825 
+  708          628.29275    199.13306   0.001412429 
+  765          689.78125    199.35513   0.00130719 
+  835          767.7132     199.57778   0.001197605 
+  978          868.43234    199.80099   0.001022495 
+  1082         1001.11245   200.02477   0.000924214 
+  1305         1179.52207   200.24913   0.000766284 
+  1615         1426.80304   200.47406   0.000619195 
+  1952         1784.14217   200.69956   0.000512295 
+  2544         2319.16369   200.92564   0.000393082 
+  3227         3124.78684   201.15229   0.000309885 
+  4555         4293.74713   201.37953   0.000219539 
+  5752         5800.83138   201.60734   0.000173853 
+  6933         7181.31089   201.83573   0.000144238 
+  7226         7460.85658   202.0647    0.000138389 
+  6570         6383.5693    202.29426   0.000152207 
+  5370         4856.78334   202.5244    0.00018622 
+  4111         3576.45568   202.75512   0.00024325 
+  3311         2681.67167   202.98643   0.000302024 
+  2616         2102.35019   203.21833   0.000382263 
+  2219         1745.61056   203.45082   0.000450653 
+  1934         1540.91379   203.6839    0.000517063 
+  1841         1445.72207   203.91756   0.000543183 
+  1840         1442.86888   204.15182   0.000543478 
+  1800         1538.54116   204.38668   0.000555556 
+  2062         1759.70667   204.62212   0.000484966 
+  2437         2148.41003   204.85817   0.000410341 
+  2843         2738.86127   205.09481   0.000351741 
+  3425         3470.53012   205.33205   0.000291971 
+  3870         4011.37322   205.56989   0.000258398 
+  3764         3891.74044   205.80833   0.000265675 
+  3290         3197.38283   206.04737   0.000303951 
+  2803         2418.02274   206.28702   0.000356761 
+  2180         1805.01365   206.52727   0.000458716 
+  1762         1378.33187   206.76812   0.000567537 
+  1398         1092.68945   207.00959   0.000715308 
+  1211         901.40646    207.25166   0.000825764 
+  958          769.79794    207.49434   0.001043841 
+  825          675.41903    207.73763   0.001212121 
+  760          604.72107    207.98154   0.001315789 
+  690          549.99017    208.22606   0.001449275 
+  568          506.79394    208.47119   0.001760563 
+  546          472.35742    208.71694   0.001831502 
+  522          444.75258    208.9633    0.001915709 
+  468          422.53995    209.21029   0.002136752 
+  460          404.58117    209.45789   0.002173913 
+  447          389.8706     209.70611   0.002237136 
+  411          377.48706    209.95496   0.00243309 
+  402          366.74509    210.20443   0.002487562 
+  391          357.31349    210.45453   0.002557545 
+  364          349.06344    210.70525   0.002747253 
+  357          341.80444    210.9566    0.00280112 
+  323          335.19524    211.20858   0.003095975 
+  362          328.85103    211.46118   0.002762431 
+  316          322.5381     211.71442   0.003164557 
+  343          316.25925    211.9683    0.002915452 
+  310          310.21867    212.2228    0.003225806 
+  302          304.71745    212.47794   0.003311258 
+  273          299.97893    212.73372   0.003663004 
+  302          296.06349    212.99013   0.003311258 
+  290          292.94366    213.24719   0.003448276 
+  318          290.58931    213.50488   0.003144654 
+  306          288.93449    213.76322   0.003267974 
+  275          287.82791    214.0222    0.003636364 
+  276          287.12784    214.28183   0.003623188 
+  287          286.84744    214.5421    0.003484321 
+  305          287.18919    214.80301   0.003278689 
+  273          288.44129    215.06458   0.003663004 
+  241          290.8268     215.32679   0.004149378 
+  308          294.38069    215.58966   0.003246753 
+  286          298.50871    215.85318   0.003496503 
+  296          301.11517    216.11735   0.003378378 
+  277          299.32339    216.38218   0.003610108 
+  282          292.97569    216.64766   0.003546099 
+  268          285.01178    216.9138    0.003731343 
+  268          277.89491    217.1806    0.003731343 
+  280          272.41791    217.44806   0.003571429 
+  264          268.5417     217.71619   0.003787879 
+  244          266.04249    217.98497   0.004098361 
+  247          264.70536    218.25442   0.004048583 
+  249          264.36416    218.52454   0.004016064 
+  268          264.92253    218.79532   0.003731343 
+  240          266.39036    219.06678   0.004166667 
+  232          268.89414    219.3389    0.004310345 
+  265          272.66754    219.61169   0.003773585 
+  236          277.92739    219.88516   0.004237288 
+  258          284.27143    220.1593    0.003875969 
+#--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--#
+
+
+# start Validation Reply Form
+vrf_PLAT741_QPABAT3_phase_1 # for all atoms in 1_quartz
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+vrf_PLAT741_QPABAT3_phase_3 # for all atoms in 3_pyrrhotite
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+vrf_PLAT741_QPABAT3_phase_4 # for all atoms in 4_rutile
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+vrf_PLAT741_QPABAT3_phase_2 # for all atoms in 2_albite
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT155_QPABAT3_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT141_QPABAT3_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT142_QPABAT3_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT143_QPABAT3_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT144_QPABAT3_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT145_QPABAT3_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT146_QPABAT3_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT151_QPABAT3_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+# end Validation Reply Form

--- a/data/hamish/vb5042sup4.cif
+++ b/data/hamish/vb5042sup4.cif
@@ -1,0 +1,6667 @@
+
+data_QPABAT1ug3_publ
+_audit_creation_method  "created in GSAS-II"
+_audit_creation_date  2021-08-04T17:21
+_audit_author_name  "McDougall, Hamish"
+_audit_update_record
+   "2021-08-04T17:21  Initial software-generated CIF"
+_pd_block_id  2021-08-04T17:21|QPABAT1ug3|McDougallHamish|Overall
+# GSAS-II edited template follows Publication_Template
+#=============================================================================
+# this information describes the project, paper etc. for the CIF             #
+# Acta Cryst. Section C papers and editorial correspondence is generated     #
+# from the information in this section                                       #
+#                                                                            #
+#   (from)   CIF submission form for Rietveld refinements (Acta Cryst. C)    #
+#                                                 Version 14 December 1998   #
+#=============================================================================
+# 1. SUBMISSION DETAILS
+
+_publ_contact_author_name            "Suzanne Neville; Vanessa Peterson; Christophe Didier"   # Name of author for correspondence
+_publ_contact_author_address             # Address of author for correspondence
+; ?
+;
+_publ_contact_author_email           "s.neville@unsw.edu.au; vanessa.peterson@ansto.gov.au; drchristophedidier@gmail.com"
+_publ_contact_author_fax             ?
+_publ_contact_author_phone           ?
+
+_publ_contact_letter
+; ?
+;
+   
+_publ_requested_journal              ?
+_publ_requested_coeditor_name        ?
+_publ_requested_category             ?   # Acta C: one of CI/CM/CO/FI/FM/FO
+
+#==============================================================================
+
+# 2. PROCESSING SUMMARY (IUCr Office Use Only)
+
+_journal_data_validation_number      ?
+
+_journal_date_recd_electronic        ?
+_journal_date_to_coeditor            ?
+_journal_date_from_coeditor          ?
+_journal_date_accepted               ?
+_journal_date_printers_first         ?
+_journal_date_printers_final         ?
+_journal_date_proofs_out             ?
+_journal_date_proofs_in              ?
+_journal_coeditor_name               ?
+_journal_coeditor_code               ?
+_journal_coeditor_notes
+; ?
+;
+_journal_techeditor_code             ?
+_journal_techeditor_notes
+; ?
+;
+_journal_coden_ASTM                  ?
+_journal_name_full                   ?
+_journal_year                        ?
+_journal_volume                      ?
+_journal_issue                       ?
+_journal_page_first                  ?
+_journal_page_last                   ?
+_journal_paper_category              ?
+_journal_suppl_publ_number           ?
+_journal_suppl_publ_pages            ?
+
+#==============================================================================
+
+# 3. TITLE AND AUTHOR LIST
+
+_publ_section_title
+; ?
+;
+_publ_section_title_footnote
+; ?
+;         
+ 
+# The loop structure below should contain the names and addresses of all 
+# authors, in the required order of publication. Repeat as necessary.
+
+loop_
+	_publ_author_name
+        _publ_author_footnote
+	_publ_author_address
+ ?                                   #<--'Last name, first name' 
+; ?
+;
+; ?
+;
+
+#==============================================================================
+
+# 4. TEXT
+
+_publ_section_synopsis
+;  ?
+;
+_publ_section_abstract                         
+; ?
+;          
+_publ_section_comment                          
+; ?
+;
+_publ_section_exptl_prep      # Details of the preparation of the sample(s)
+                              # should be given here. 
+; ?
+;
+_publ_section_exptl_refinement                  
+; ?
+;
+_publ_section_references
+; ?
+;
+_publ_section_figure_captions
+; ?
+;
+_publ_section_acknowledgements
+; ?
+;
+
+#=============================================================================
+# 5. OVERALL REFINEMENT & COMPUTING DETAILS
+
+_refine_special_details
+; ?
+;
+_pd_proc_ls_special_details
+; ?
+;
+
+# The following items are used to identify the programs used.
+_computing_molecular_graphics     ?
+_computing_publication_material   ?
+
+_refine_ls_weighting_scheme       ?        
+_refine_ls_weighting_details      ?
+_refine_ls_hydrogen_treatment     ?        
+_refine_ls_extinction_method      ?        
+_refine_ls_extinction_coef        ?         
+_refine_ls_number_constraints     ?        
+
+_refine_ls_restrained_S_all       ?        
+_refine_ls_restrained_S_obs       ?
+
+#==============================================================================
+# 6. SAMPLE PREPARATION DATA
+
+# (In the unusual case where multiple samples are used in a single
+#  Rietveld study, this information should be moved into the phase
+#  blocks)
+
+# The following three fields describe the preparation of the material.
+# The cooling rate is in K/min.  The pressure at which the sample was  
+# prepared is in kPa.  The temperature of preparation is in K.
+               
+_pd_prep_cool_rate                N/A        
+_pd_prep_pressure                 101.3        
+_pd_prep_temperature              298           
+
+_pd_char_colour                   ?       # use ICDD colour descriptions
+
+data_QPABAT1ug3_overall
+_pd_proc_info_datetime  2021-08-04T17:21
+_pd_calc_method  "Rietveld Refinement"
+_computing_structure_refinement
+   "GSAS-II (Toby & Von Dreele, J. Appl. Cryst. 46, 544-549, 2013)"
+_refine_ls_number_parameters  28
+_refine_ls_goodness_of_fit_all  8.337
+_refine_ls_shift/su_max  0.6046
+
+# OVERALL WEIGHTED R-FACTOR
+_refine_ls_wR_factor_obs  0.32290
+_refine_ls_matrix_type  full
+# POINTERS TO PHASE AND HISTOGRAM BLOCKS
+loop_   _pd_phase_block_id
+  2021-08-04T17:21|QPABAT1ug3|phase_2|McDougallHamish
+  2021-08-04T17:21|QPABAT1ug3|phase_0|McDougallHamish
+  2021-08-04T17:21|QPABAT1ug3|phase_3|McDougallHamish
+  2021-08-04T17:21|QPABAT1ug3|phase_1|McDougallHamish
+  2021-08-04T17:21|QPABAT1ug3|phase_4|McDougallHamish
+_pd_block_diffractogram_id
+;
+2021-08-04T17:21|QPABAT1ug3|McDougallHamish|PANalytical,Co-EmpyreanII_hist_0
+;
+
+data_QPABAT1ug3_phase_2
+# Information for phase 2
+_pd_block_id  2021-08-04T17:21|QPABAT1ug3|phase_2|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Albite NaAlSi3O8 follows
+_pd_phase_name  "Albite NaAlSi3O8"
+_cell_length_a  8.137
+_cell_length_b  12.785
+_cell_length_c  7.1583
+_cell_angle_alpha  94.26
+_cell_angle_beta   116.6
+_cell_angle_gamma  87.71
+_cell_volume  664.008
+_exptl_crystal_density_diffrn  2.6230
+_symmetry_cell_setting  triclinic
+_symmetry_space_group_name_H-M  "C -1"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -x,-y,-z
+     3  1/2+x,1/2+y,z
+     4  1/2-x,1/2-y,-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Al1    Al3+ 0.00887     0.16846     0.20805     1.000      Uani 0.007      4   
+Si1    Si4+ 0.00375     0.82051     0.23737     1.000      Uani 0.006      4   
+Si2    Si4+ 0.69162     0.11021     0.31466     1.000      Uani 0.006      4   
+Si3    Si4+ 0.68129     0.88190     0.36076     1.000      Uani 0.006      4   
+Na1    Na1+ 0.26799     0.98865     0.14650     1.000      Uani 0.031      4   
+O1     O2-  0.00490     0.13103     0.96660     1.000      Uani 0.012      4   
+O2     O2-  0.59176     0.99756     0.28040     1.000      Uani 0.008      4   
+O3     O2-  0.81230     0.10966     0.19010     1.000      Uani 0.014      4   
+O4     O2-  0.82000     0.85101     0.25870     1.000      Uani 0.018      4   
+O5     O2-  0.01288     0.30238     0.27060     1.000      Uani 0.011      4   
+O6     O2-  0.02329     0.69368     0.22910     1.000      Uani 0.011      4   
+O7     O2-  0.20780     0.10896     0.38900     1.000      Uani 0.011      4   
+O8     O2-  0.18400     0.86817     0.43620     1.000      Uani 0.012      4   
+
+loop_
+   _atom_site_aniso_label
+   _atom_site_aniso_U_11
+   _atom_site_aniso_U_22
+   _atom_site_aniso_U_33
+   _atom_site_aniso_U_12
+   _atom_site_aniso_U_13
+   _atom_site_aniso_U_23
+Al1    0.0074      0.0068      0.0061      -0.0009     0.0031      0.0004      
+Si1    0.0068      0.0065      0.0055      0.0011      0.0030      0.0008      
+Si2    0.0061      0.0055      0.0073      -0.0002     0.0025      0.0004      
+Si3    0.0060      0.0055      0.0074      0.0006      0.0028      0.0009      
+Na1    0.0136      0.0471      0.0315      -0.0050     0.0084      -0.0219     
+O1     0.0164      0.0122      0.0074      -0.0002     0.0067      0.0014      
+O2     0.0074      0.0056      0.0119      0.0003      0.0033      0.0020      
+O3     0.0117      0.0130      0.0162      -0.0040     0.0093      -0.0017     
+O4     0.0134      0.0179      0.0216      0.0046      0.0129      0.0020      
+O5     0.0103      0.0076      0.0150      -0.0020     0.0052      -0.0009     
+O6     0.0101      0.0071      0.0145      0.0022      0.0034      0.0012      
+O7     0.0120      0.0129      0.0080      0.0024      0.0013      0.0015      
+O8     0.0140      0.0140      0.0084      -0.0026     -0.0002     -0.0006     
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Al   4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Na   4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  O    32     ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si   12     ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Al Na O8 Si3"
+_chemical_formula_weight  262.22
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Al1    O1     1.74519      1_555    1_554 yes
+  Al1    O3     1.7429       1_555    1_455 yes
+  Al1    O5     1.73509      1_555    1_555 yes
+  Al1    O7     1.74556      1_555    1_555 yes
+  Si1    O1     1.59985      1_555    2_566 yes
+  Si1    O4     1.59997      1_555    1_455 yes
+  Si1    O6     1.62225      1_555    1_555 yes
+  Si1    O8     1.61907      1_555    1_555 yes
+  Si2    O2     1.63011      1_555    1_545 yes
+  Si2    O3     1.59435      1_555    1_555 yes
+  Si2    O6     1.61836      1_555    3_545 yes
+  Si2    O8     1.6168       1_555    2_666 yes
+  Si3    O2     1.64718      1_555    1_555 yes
+  Si3    O4     1.61975      1_555    1_555 yes
+  Si3    O5     1.59682      1_555    3_555 yes
+  Si3    O7     1.60203      1_555    2_666 yes
+  Na1    O1     2.66887      1_555    1_564 yes
+  Na1    O1     2.53079      1_555    2_566 yes
+  Na1    O2     2.3704       1_555    1_555 yes
+  Na1    O3     2.45321      1_555    2_665 yes
+  Na1    O7     2.43384      1_555    1_565 yes
+  O1     Al1    1.74519      1_555    1_556 yes
+  O1     Si1    1.59985      1_555    2_566 yes
+  O1     Na1    2.66887      1_555    1_546 yes
+  O1     Na1    2.53079      1_555    2_566 yes
+  O2     Si2    1.63011      1_555    1_565 yes
+  O2     Si3    1.64718      1_555    1_555 yes
+  O2     Na1    2.3704       1_555    1_555 yes
+  O3     Al1    1.7429       1_555    1_655 yes
+  O3     Si2    1.59435      1_555    1_555 yes
+  O3     Na1    2.45321      1_555    2_665 yes
+  O4     Si1    1.59997      1_555    1_655 yes
+  O4     Si3    1.61975      1_555    1_555 yes
+  O5     Al1    1.73509      1_555    1_555 yes
+  O5     Si3    1.59682      1_555    3_445 yes
+  O6     Si1    1.62225      1_555    1_555 yes
+  O6     Si2    1.61836      1_555    3_455 yes
+  O7     Al1    1.74556      1_555    1_555 yes
+  O7     Si3    1.60203      1_555    2_666 yes
+  O7     Na1    2.43384      1_555    1_545 yes
+  O8     Si1    1.61907      1_555    1_555 yes
+  O8     Si2    1.6168       1_555    2_666 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Al1    O3     102.836       1_554  1_555    1_455 yes
+  O1     Al1    O5     116.047       1_554  1_555    1_555 yes
+  O3     Al1    O5     112.215       1_455  1_555    1_555 yes
+  O1     Al1    O7     104.004       1_554  1_555    1_555 yes
+  O3     Al1    O7     111.151       1_455  1_555    1_555 yes
+  O5     Al1    O7     110.14        1_555  1_555    1_555 yes
+  O1     Si1    O4     109.433       2_566  1_555    1_455 yes
+  O1     Si1    O6     112.47        2_566  1_555    1_555 yes
+  O4     Si1    O6     108.187       1_455  1_555    1_555 yes
+  O1     Si1    O8     107.176       2_566  1_555    1_555 yes
+  O4     Si1    O8     111.446       1_455  1_555    1_555 yes
+  O6     Si1    O8     108.16        1_555  1_555    1_555 yes
+  O2     Si2    O3     111.144       1_545  1_555    1_555 yes
+  O2     Si2    O6     104.24        1_545  1_555    3_545 yes
+  O3     Si2    O6     112.114       1_555  1_555    3_545 yes
+  O2     Si2    O8     106.97        1_545  1_555    2_666 yes
+  O3     Si2    O8     111.591       1_555  1_555    2_666 yes
+  O6     Si2    O8     110.422       3_545  1_555    2_666 yes
+  O2     Si3    O4     107.269       1_555  1_555    1_555 yes
+  O2     Si3    O5     105.914       1_555  1_555    3_555 yes
+  O4     Si3    O5     110.224       1_555  1_555    3_555 yes
+  O2     Si3    O7     108.565       1_555  1_555    2_666 yes
+  O4     Si3    O7     110.208       1_555  1_555    2_666 yes
+  O5     Si3    O7     114.328       3_555  1_555    2_666 yes
+  Al1    O1     Si1    141.397       1_556  1_555    2_566 yes
+  Si2    O2     Si3    130.019       1_565  1_555    1_555 yes
+  Si2    O2     Na1    120.351       1_565  1_555    1_555 yes
+  Si3    O2     Na1    108.811       1_555  1_555    1_555 yes
+  Al1    O3     Si2    139.461       1_655  1_555    1_555 yes
+  Si1    O4     Si3    161.151       1_655  1_555    1_555 yes
+  Al1    O5     Si3    129.689       1_555  1_555    3_445 yes
+  Si1    O6     Si2    135.676       1_555  1_555    3_455 yes
+  Al1    O7     Si3    133.943       1_555  1_555    2_666 yes
+  Si1    O8     Si2    151.747       1_555  1_555    2_666 yes
+_pd_proc_ls_pref_orient_corr  none
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.233(12), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_QPABAT1ug3_phase_0
+# Information for phase 0
+_pd_block_id  2021-08-04T17:21|QPABAT1ug3|phase_0|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Pyrite FeS2 follows
+_pd_phase_name  "Pyrite FeS2"
+_cell_length_a  5.41945(8)
+_cell_length_b  5.41945(8)
+_cell_length_c  5.41945(8)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  90
+_cell_volume  159.171(7)
+_exptl_crystal_density_diffrn  5.0062
+_symmetry_cell_setting  cubic
+_symmetry_space_group_name_H-M  "P a -3"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  z,x,y
+     3  y,z,x
+     4  1/2+x,y,1/2-z
+     5  1/2-z,1/2+x,y
+     6  y,1/2-z,1/2+x
+     7  -z,1/2+x,1/2-y
+     8  1/2-y,-z,1/2+x
+     9  1/2+y,1/2-z,-x
+    10  -x,1/2+y,1/2-z
+    11  1/2-z,-x,1/2+y
+    12  1/2+x,1/2-y,-z
+    13  -x,-y,-z
+    14  -z,-x,-y
+    15  -y,-z,-x
+    16  1/2-x,-y,1/2+z
+    17  1/2+z,1/2-x,-y
+    18  -y,1/2+z,1/2-x
+    19  z,1/2-x,1/2+y
+    20  1/2+y,z,1/2-x
+    21  1/2-y,1/2+z,x
+    22  x,1/2-y,1/2+z
+    23  1/2+z,x,1/2-y
+    24  1/2-x,1/2+y,z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Fe1    Fe   0.00000     0.00000     0.00000     1.000      Uiso 0.010      4   
+S2     S    0.3903(4)   0.3903      0.3903      1.000      Uiso 0.010      8   
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Fe   4      11.7695    7.3573     3.5222     2.3045     4.7611     0.3072     15.3535    76.8805    1.0369     0.945
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S    8      6.9053     5.2034     1.4379     1.5863     1.4679     22.2151    0.2536     56.172     0.8669     0.2847
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Fe S2"
+_chemical_formula_weight  119.97
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Fe1    S2     2.2761(6)    1_555    4_455 yes
+  Fe1    S2     2.2761(6)    1_555    5_545 yes
+  Fe1    S2     2.2761(6)    1_555    6_554 yes
+  Fe1    S2     2.2761(6)    1_555    7_545 yes
+  Fe1    S2     2.2761(6)    1_555    8_554 yes
+  Fe1    S2     2.2761(22)   1_555    9_455 yes
+  S2     Fe1    2.2761(6)    1_555    4_555 yes
+  S2     Fe1    2.2761(6)    1_555    5_555 yes
+  S2     Fe1    2.2761(22)   1_555    6_555 yes
+  S2     S2     2.0604(28)   1_555   13_666 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.373(14), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_QPABAT1ug3_phase_3
+# Information for phase 3
+_pd_block_id  2021-08-04T17:21|QPABAT1ug3|phase_3|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Pyrrhotite 4M Fe7S8 follows
+_pd_phase_name  "Pyrrhotite 4M Fe7S8"
+_cell_length_a  11.922(23)
+_cell_length_b  6.870(4)
+_cell_length_c  12.810(27)
+_cell_angle_alpha  90
+_cell_angle_beta   117.18(5)
+_cell_angle_gamma  90
+_cell_volume  933.3(5)
+_exptl_crystal_density_diffrn  4.6074
+_symmetry_cell_setting  monoclinic
+_symmetry_space_group_name_H-M  "C 2/c"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -x,y,1/2-z
+     3  -x,-y,-z
+     4  x,-y,1/2+z
+     5  1/2+x,1/2+y,z
+     6  1/2-x,1/2+y,1/2-z
+     7  1/2-x,1/2-y,-z
+     8  1/2+x,1/2-y,1/2+z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+S1     S    0.01800     0.38330     0.11960     1.000      Uiso 0.010      8   
+S2     S    0.02910     0.11420     0.63900     1.000      Uiso 0.010      8   
+Fe3    Fe   0.10860     0.10250     0.49980     1.000      Uiso 0.010      8   
+S4     S    0.23410     0.13550     0.38260     1.000      Uiso 0.010      8   
+Fe5    Fe   0.24180     0.36600     0.24680     1.000      Uiso 0.010      8   
+S6     S    0.26790     0.13400     0.12360     1.000      Uiso 0.010      8   
+Fe7    Fe   0.38720     0.15000     0.01260     1.000      Uiso 0.010      8   
+Fe8    Fe   0.00000     0.14720     0.25000     1.000      Uiso 0.010      4   
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Fe   28     11.7695    7.3573     3.5222     2.3045     4.7611     0.3072     15.3535    76.8805    1.0369     0.945
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S    32     6.9053     5.2034     1.4379     1.5863     1.4679     22.2151    0.2536     56.172     0.8669     0.2847
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Fe7 S8"
+_chemical_formula_weight  647.41
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  S1     Fe3    2.49599      1_555    2_555 yes
+  S1     Fe5    2.41181      1_555    1_555 yes
+  S1     Fe7    2.39059      1_555    5_455 yes
+  S1     Fe7    2.4384       1_555    7_555 yes
+  S1     Fe8    2.40718      1_555    1_555 yes
+  S2     Fe3    2.37236      1_555    1_555 yes
+  S2     Fe3    2.32514      1_555    3_556 yes
+  S2     Fe5    2.44312      1_555    7_556 yes
+  S2     Fe7    2.36762      1_555    8_456 yes
+  S2     Fe8    2.41196      1_555    3_556 yes
+  Fe3    S1     2.49599      1_555    2_555 yes
+  Fe3    S2     2.37236      1_555    1_555 yes
+  Fe3    S2     2.32514      1_555    3_556 yes
+  Fe3    S6     2.4516       1_555    4_556 yes
+  S4     Fe5    2.38493      1_555    1_555 yes
+  Fe5    S1     2.41181      1_555    1_555 yes
+  Fe5    S2     2.44312      1_555    7_556 yes
+  Fe5    S4     2.38493      1_555    1_555 yes
+  Fe5    S6     2.36141      1_555    1_555 yes
+  S6     Fe3    2.4516       1_555    4_555 yes
+  S6     Fe5    2.36141      1_555    1_555 yes
+  S6     Fe7    2.42983      1_555    1_555 yes
+  S6     Fe7    2.39126      1_555    7_555 yes
+  Fe7    S1     2.39059      1_555    5_545 yes
+  Fe7    S1     2.4384       1_555    7_555 yes
+  Fe7    S2     2.36762      1_555    8_555 yes
+  Fe7    S6     2.42983      1_555    1_555 yes
+  Fe7    S6     2.39126      1_555    7_555 yes
+  Fe8    S1     2.40718      1_555    1_555 yes
+  Fe8    S1     2.40718      1_555    2_555 yes
+  Fe8    S2     2.41196      1_555    3_556 yes
+  Fe8    S2     2.41196      1_555    4_555 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.15(6), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_QPABAT1ug3_phase_1
+# Information for phase 1
+_pd_block_id  2021-08-04T17:21|QPABAT1ug3|phase_1|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Quartz SiO2 follows
+_pd_phase_name  "Quartz SiO2"
+_cell_length_a  4.9161(6)
+_cell_length_b  4.9161(6)
+_cell_length_c  5.4061(5)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  120
+_cell_volume  113.147(14)
+_exptl_crystal_density_diffrn  2.6454
+_symmetry_cell_setting  trigonal
+_symmetry_space_group_name_H-M  "P 32 2 1"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -y,x-y,2/3+z
+     3  y-x,-x,1/3+z
+     4  y,x,-z
+     5  -x,y-x,2/3-z
+     6  x-y,-y,1/3-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Si1    Si4+ 0.47000     0.00000     0.66670     1.000      Uani 0.006      3   
+O1     O2-  0.41460     0.26780     0.78543     1.000      Uani 0.011      6   
+
+loop_
+   _atom_site_aniso_label
+   _atom_site_aniso_U_11
+   _atom_site_aniso_U_22
+   _atom_site_aniso_U_33
+   _atom_site_aniso_U_12
+   _atom_site_aniso_U_13
+   _atom_site_aniso_U_23
+Si1    0.0073      0.0059      0.0053      0.0029      0.0003      0.0006      
+O1     0.0120      0.0105      0.0118      0.0065      -0.0029     -0.0040     
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  O    6      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si   3      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  3
+_chemical_formula_sum  "O2 Si"
+_chemical_formula_weight  60.08
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Si1    O1     1.60559      1_555    1_555 yes
+  Si1    O1     1.61184      1_555    2_654 yes
+  Si1    O1     1.61158      1_555    5_656 yes
+  Si1    O1     1.60574      1_555    6_556 yes
+  O1     Si1    1.60559      1_555    1_555 yes
+  O1     Si1    1.61184      1_555    3_665 yes
+  O1     Si1    1.61158      1_555    5_666 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Si1    O1     110.252       1_555  1_555    2_654 yes
+  O1     Si1    O1     108.753       1_555  1_555    5_656 yes
+  O1     Si1    O1     109.678       2_654  1_555    5_656 yes
+  O1     Si1    O1     109.158       1_555  1_555    6_556 yes
+  O1     Si1    O1     108.733       2_654  1_555    6_556 yes
+  O1     Si1    O1     110.258       5_656  1_555    6_556 yes
+  Si1    O1     Si1    143.831       1_555  1_555    3_665 yes
+  Si1    O1     Si1    143.835       1_555  1_555    5_666 yes
+  Si1    O1     Si1    0.009         3_665  1_555    5_666 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.37(6), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_QPABAT1ug3_phase_4
+# Information for phase 4
+_pd_block_id  2021-08-04T17:21|QPABAT1ug3|phase_4|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Rutile TiO2 follows
+_pd_phase_name  "Rutile TiO2"
+_cell_length_a  4.746(8)
+_cell_length_b  4.746(8)
+_cell_length_c  2.892(7)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  90
+_cell_volume  65.14(17)
+_exptl_crystal_density_diffrn  4.0737
+_symmetry_cell_setting  tetragonal
+_symmetry_space_group_name_H-M  "P 42/m n m"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  1/2-y,1/2+x,1/2+z
+     3  -x,-y,z
+     4  1/2+y,1/2-x,1/2+z
+     5  1/2-x,1/2+y,1/2+z
+     6  -y,-x,z
+     7  1/2+x,1/2-y,1/2+z
+     8  y,x,z
+     9  -x,-y,-z
+    10  1/2+y,1/2-x,1/2-z
+    11  x,y,-z
+    12  1/2-y,1/2+x,1/2-z
+    13  1/2+x,1/2-y,1/2-z
+    14  y,x,-z
+    15  1/2-x,1/2+y,1/2-z
+    16  -y,-x,-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Ti1    Ti4+ 0.00000     0.00000     0.00000     1.000      Uani 0.006      2   
+O1     O2-  0.30493     0.30493     0.00000     1.000      Uani 0.006      4   
+
+loop_
+   _atom_site_aniso_label
+   _atom_site_aniso_U_11
+   _atom_site_aniso_U_22
+   _atom_site_aniso_U_33
+   _atom_site_aniso_U_12
+   _atom_site_aniso_U_13
+   _atom_site_aniso_U_23
+Ti1    0.0070      0.0070      0.0047      -0.0002     0.0000      0.0000      
+O1     0.0060      0.0060      0.0045      -0.0019     0.0000      0.0000      
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  O    4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Ti   2      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  2
+_chemical_formula_sum  "O2 Ti"
+_chemical_formula_weight  79.9
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Ti1    O1     2.0466       1_555    1_555 yes
+  Ti1    O1     1.95063      1_555    2_544 yes
+  Ti1    O1     1.95063      1_555    2_545 yes
+  Ti1    O1     2.0466       1_555    3_555 yes
+  Ti1    O1     1.95063      1_555    4_454 yes
+  Ti1    O1     1.95063      1_555    4_455 yes
+  O1     Ti1    2.0466       1_555    1_555 yes
+  O1     Ti1    1.95063      1_555    2_554 yes
+  O1     Ti1    1.95063      1_555    2_555 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Ti1    O1     95.681        2_544  1_555    2_545 yes
+  O1     Ti1    O1     84.319        2_544  1_555    4_454 yes
+  O1     Ti1    O1     180           2_545  1_555    4_454 yes
+  O1     Ti1    O1     180           2_544  1_555    4_455 yes
+  O1     Ti1    O1     84.319        2_545  1_555    4_455 yes
+  O1     Ti1    O1     95.681        4_454  1_555    4_455 yes
+  Ti1    O1     Ti1    95.681        2_554  1_555    2_555 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.100, 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_QPABAT1ug3_pwd_0
+_pd_proc_ls_profile_function
+;
+Finger-Cox-Jephcoat function parameters U, V, W, X, Y, SH/L:
+  peak variance(Gauss) = Utan(Th)^2^+Vtan(Th)+W:
+  peak HW(Lorentz) = X/cos(Th)+Ytan(Th); SH/L = S/L+H/L
+  U, V, W in (centideg)^2^, X & Y in centideg
+    0.000, 0.000, 3.345, 2.239, -0.670, 0.034, 
+;
+# Information for histogram 0: PWDR BAT1ug3_30mm_MonicaHamish_Ruoming_step size 0_BAT1ug3.xrdml Scan 1
+_pd_block_id
+;
+2021-08-04T17:21|QPABAT1ug3|McDougallHamish|PANalytical,Co-EmpyreanII_hist_0
+;
+# GSAS-II edited template follows Instrument_Template
+#==============================================================================
+# 9. INSTRUMENT CHARACTERIZATION
+
+_exptl_special_details
+; ?
+;
+
+# if regions of the data are excluded, the reason(s) are supplied here:
+_pd_proc_info_excluded_regions
+; ?
+;
+
+# The following item is used to identify the equipment used to record 
+# the powder pattern when the diffractogram was measured at a laboratory 
+# other than the authors' home institution, e.g. when neutron or synchrotron
+# radiation is used.
+
+_pd_instr_location
+; ?
+;
+_pd_calibration_special_details           # description of the method used
+                                          # to calibrate the instrument
+; ?
+;
+
+_diffrn_source                    Co-Ka       
+_diffrn_source_target             Co
+_diffrn_source_type               Graded_Flat
+_diffrn_measurement_device_type   Panalytical_Reflection_Transmission       
+_diffrn_detector                  PIXcel1D       
+_diffrn_detector_type             Empyrean_II       # make or model of detector
+
+_pd_meas_scan_method              ?       # options are 'step', 'cont',
+                                          # 'tof', 'fixed' or
+                                          # 'disp' (= dispersive)
+_pd_meas_special_details
+;  ?
+;
+
+# The following two items identify the program(s) used (if appropriate).
+_computing_data_collection        ?        
+_computing_data_reduction         ?                   
+
+# Describe any processing performed on the data, prior to refinement.
+# For example: a manual Lp correction or a precomputed absorption correction
+_pd_proc_info_data_reduction      ?
+
+# The following item is used for angular dispersive measurements only.
+
+_diffrn_radiation_monochromator   ?        
+
+# The following items are used to define the size of the instrument.
+# Not all distances are appropriate for all instrument types.
+
+_pd_instr_dist_src/mono           ?
+_pd_instr_dist_mono/spec          ?
+_pd_instr_dist_src/spec           ?
+_pd_instr_dist_spec/anal          ?
+_pd_instr_dist_anal/detc          ?
+_pd_instr_dist_spec/detc          ?
+
+# 10. Specimen size and mounting information
+
+# The next three fields give the specimen dimensions in mm.  The equatorial 
+# plane contains the incident and diffracted beam.
+
+_pd_spec_size_axial               ?       # perpendicular to 
+                                          # equatorial plane
+
+_pd_spec_size_equat               ?       # parallel to 
+                                          # scattering vector 
+                                          # in transmission
+
+_pd_spec_size_thick               ?       # parallel to 
+                                          # scattering vector 
+                                          # in reflection
+
+_pd_spec_mounting                         # This field should be
+                                          # used to give details of the 
+                                          # container.
+; ?
+;
+
+_pd_spec_mount_mode               ?       # options are 'reflection' 
+                                          # or 'transmission'
+    
+_pd_spec_shape                    ?       # options are 'cylinder' 
+                                          # 'flat_sheet' or 'irregular'
+
+
+loop_
+     _atom_type_symbol
+     _atom_type_scat_dispersion_real
+     _atom_type_scat_dispersion_imag
+     _atom_type_scat_dispersion_source
+  Al        0.255   0.328   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Fe       -3.332   0.490   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Na        0.167   0.167   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  O         0.063   0.044   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S         0.371   0.733   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si        0.298   0.438   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Ti       -0.063   2.321   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+_diffrn_radiation_type  K\a~1,2~
+loop_
+   _diffrn_radiation_wavelength
+   _diffrn_radiation_wavelength_wt
+   _diffrn_radiation_wavelength_id
+  1.78892         1.0             1     
+  1.79278         0.5000          2     
+
+# PHASE TABLE
+loop_
+   _pd_phase_id
+   _pd_phase_block_id
+   _pd_phase_mass_%
+  2  2021-08-04T17:21|QPABAT1ug3|phase_2|McDougallHamish  0.281(6)
+  0  2021-08-04T17:21|QPABAT1ug3|phase_0|McDougallHamish  0.579(7)
+  3  2021-08-04T17:21|QPABAT1ug3|phase_3|McDougallHamish  0.0297(28)
+  1  2021-08-04T17:21|QPABAT1ug3|phase_1|McDougallHamish  0.104(3)
+  4  2021-08-04T17:21|QPABAT1ug3|phase_4|McDougallHamish  0.0058(21)
+loop_
+   _gsas_proc_phase_R_F_factor
+   _gsas_proc_phase_R_Fsqd_factor
+   _gsas_proc_phase_id
+   _gsas_proc_phase_block_id
+    0.24965  0.69266  2  2021-08-04T17:21|QPABAT1ug3|phase_2|McDougallHamish
+    0.15002  0.34012  0  2021-08-04T17:21|QPABAT1ug3|phase_0|McDougallHamish
+    0.21889  0.48826  3  2021-08-04T17:21|QPABAT1ug3|phase_3|McDougallHamish
+    0.15685  0.44265  1  2021-08-04T17:21|QPABAT1ug3|phase_1|McDougallHamish
+    0.12670  0.33438  4  2021-08-04T17:21|QPABAT1ug3|phase_4|McDougallHamish
+_pd_proc_ls_prof_R_factor     0.23043
+_pd_proc_ls_prof_wR_factor    0.32290
+_gsas_proc_ls_prof_R_B_factor   0.31042
+_gsas_proc_ls_prof_wR_B_factor  0.38227
+_pd_proc_ls_prof_wR_expected  0.03887
+_diffrn_radiation_probe  x-ray
+_diffrn_radiation_polarisn_ratio  0.7000
+_pd_proc_ls_background_function
+;
+Background function: "chebyschev-1" function with 7 terms:
+    426(5), -521(8), 398(8), -193(7), 96(6), -25(5), 15(4), 
+;
+_diffrn_ambient_temperature  300
+_diffrn_ambient_pressure  100
+
+# STRUCTURE FACTOR TABLE
+loop_
+   _pd_refln_phase_id
+   _refln_index_h
+   _refln_index_k
+   _refln_index_l
+   _refln_F_squared_meas
+   _refln_F_squared_calc
+   _refln_phase_calc
+   _refln_d_spacing
+   _gsas_i100_meas
+  0  1    1    1    744.3560   652.8618   0.0     3.12892  13.80  
+  0  2    0    0    9722.6125  7206.1825  -0.0    2.70972  100.00 
+  0  2    1    0    3593.2893  3000.3630  0.0     2.42365  58.41  
+  0  2    1    1    1937.9535  1614.2461  -180.0  2.21248  51.95  
+  0  2    2    0    2504.2917  3412.9735  -0.0    1.91606  24.79  
+  0  2    2    1    37.4592    77.3355    -0.0    1.80648  0.66   
+  0  3    1    1    3539.6161  4748.1959  -0.0    1.63402  50.70  
+  0  2    2    2    2527.2539  2280.9669  0.0     1.56446  11.10  
+  0  3    0    2    2580.1269  3226.6030  -0.0    1.50308  15.80  
+  0  3    1    2    350.4550   367.8942   0.0     1.44841  4.02   
+  0  3    2    1    1744.0503  1830.8371  180.0   1.44841  20.02  
+  0  4    0    0    521.3699   268.6472   -180.0  1.35486  1.35   
+  0  3    2    2    96.9433    98.1154    -0.0    1.31441  0.96   
+  0  4    1    0    203.3363   205.7947   -0.0    1.31441  1.01   
+  0  4    1    1    148.7905   117.7887   180.0   1.27738  1.43   
+  0  3    3    1    674.8097   709.1302   -0.0    1.24331  6.32   
+  0  4    0    2    1093.2511  654.5316   0.0     1.21183  5.02   
+  0  4    2    0    1093.2511  654.5316   0.0     1.21183  5.02   
+  0  4    1    2    8.4222     6.4316     -0.0    1.18262  0.08   
+  0  4    2    1    1375.7245  1050.5598  -180.0  1.18262  12.49  
+  0  3    3    2    435.0464   513.1452   0.0     1.15543  3.93   
+  0  4    2    2    1193.5988  878.2403   0.0     1.10624  10.87  
+  0  4    3    0    154.9278   295.2910   -0.0    1.08389  0.72   
+  0  4    1    3    126.3332   170.1512   180.0   1.06284  1.20   
+  0  4    3    1    25.3858    34.1907    0.0     1.06284  0.24   
+  0  3    3    3    2402.5110  1174.1618  -0.0    1.04297  7.81   
+  0  5    1    1    6760.4466  3303.9839  -0.0    1.04297  65.93  
+  1  1    0    0    447.0354   242.5246   -180.0  4.25742  3.79   
+  1  1    0    1    633.2067   634.4931   120.0   3.34474  3.26   
+  1  1    0    -1   1506.3712  1509.4317  -120.0  3.34474  7.76   
+  1  1    1    0    292.4562   343.8792   -155.6  2.45803  0.79   
+  1  1    0    -2   114.8880   86.1851    -60.0   2.28195  0.26   
+  1  1    0    2    398.3798   298.8511   -120.0  2.28195  0.92   
+  1  1    1    1    165.1318   96.0634    82.9    2.23759  0.73   
+  1  2    0    0    1625.6738  308.9208   -0.0    2.12871  3.24   
+  1  2    0    -1   50.2840    77.2247    60.0    1.98069  0.09   
+  1  2    0    1    120.5019   185.0632   -60.0   1.98069  0.21   
+  1  1    1    2    747.9007   602.8751   9.8     1.81855  2.14   
+  1  0    0    3    30.3987    94.4562    0.0     1.80202  0.01   
+  1  2    0    2    92.1895    82.0908    60.0    1.67237  0.11   
+  1  2    0    -2   409.0663   364.2560   120.0   1.67237  0.49   
+  1  1    0    -3   305.9057   203.8509   180.0   1.65949  0.36   
+  1  1    0    3    3.8788     2.5848     0.0     1.65949  0.00   
+  1  2    1    0    27.8855    14.6460    -38.9   1.60916  0.06   
+  1  2    1    -1   325.4289   356.3967   95.9    1.54228  0.67   
+  1  2    1    1    280.0915   306.7449   -109.6  1.54228  0.58   
+  1  1    1    3    156.4796   142.5789   117.5   1.45331  0.29   
+  1  3    0    0    73.8849    76.3693    180.0   1.41914  0.07   
+  1  2    1    -2   628.9634   413.8371   -123.3  1.38269  1.08   
+  1  2    1    2    195.2834   128.4900   143.4   1.38269  0.34   
+  1  2    0    -3   296.7266   292.6684   -0.0    1.37538  0.25   
+  1  2    0    3    1044.7441  1030.4556  0.0     1.37538  0.89   
+  1  3    0    -1   863.7871   815.9639   -120.0  1.37263  0.73   
+  1  3    0    1    1.0758     1.0163     -60.0   1.37263  0.00   
+  1  1    0    -4   64.4319    120.2819   -120.0  1.28817  0.05   
+  1  1    0    4    212.3639   396.4426   120.0   1.28817  0.17   
+  1  3    0    -2   324.2459   208.3469   120.0   1.25650  0.25   
+  1  3    0    2    739.2011   474.9800   -120.0  1.25650  0.56   
+  1  2    2    0    236.0444   371.1166   -16.5   1.22901  0.18   
+  1  2    1    -3   71.6271    71.0140    179.1   1.20026  0.11   
+  1  2    1    3    304.0404   301.4378   -134.8  1.20026  0.45   
+  1  2    2    1    87.8663    105.6075   88.6    1.19843  0.13   
+  1  1    1    4    497.8841   334.1775   -14.4   1.18430  0.73   
+  1  3    1    0    392.5955   361.6235   121.4   1.18080  0.57   
+  1  3    1    -1   151.0170   189.9539   -18.5   1.15360  0.22   
+  1  3    1    1    50.4093    63.4064    16.4    1.15360  0.07   
+  1  2    0    -4   1.8597     1.4734     -120.0  1.14098  0.00   
+  1  2    0    4    89.2160    70.6815    120.0   1.14098  0.06   
+  1  2    2    2    3.0100     3.3518     -9.9    1.11880  0.00   
+  1  3    0    3    48.9703    62.7345    -180.0  1.11491  0.04   
+  1  3    0    -3   5.2209     6.6884     -0.0    1.11491  0.00   
+  1  3    1    -2   216.0480   304.4026   -8.9    1.08206  0.32   
+  1  3    1    2    88.2711    124.3703   59.1    1.08206  0.13   
+  1  4    0    0    191.8086   168.2132   0.0     1.06436  0.15   
+  1  1    0    -5   399.7216   346.2728   120.0   1.04795  0.31   
+  1  1    0    5    149.9654   129.9128   -120.0  1.04795  0.12   
+  1  4    0    -1   62.3606    31.4123    60.0    1.04431  0.05   
+  1  4    0    1    575.2382   289.7594   120.0   1.04431  0.45   
+  1  2    1    -4   3.6548     10.8628    51.2    1.03492  0.01   
+  1  2    1    4    81.0534    240.9044   -129.5  1.03492  0.13   
+  2  0    0    1    886.0848   685.7541   180.0   6.38786  3.07   
+  2  0    2    0    475.3796   396.3962   180.0   6.37466  0.01   
+  2  1    1    0    181.3815   238.2363   -0.0    6.33955  0.01   
+  2  1    -1   0    224.0326   287.4879   -0.0    6.29869  0.01   
+  2  1    1    -1   871.2945   406.2352   180.0   5.91009  0.03   
+  2  1    -1   -1   617.9879   415.6378   -180.0  5.58552  0.03   
+  2  0    2    -1   8.1163     16.5792    0.0     4.66174  0.00   
+  2  0    2    1    0.5350     1.8371     180.0   4.37623  0.00   
+  2  2    0    -1   67164.8635 21037.4763 -0.0    4.02732  0.77   
+  2  1    -1   1    10687.1948 3767.3897  -0.0    3.85265  0.38   
+  2  1    1    1    16805.0772 10390.3834 0.0     3.77565  1.35   
+  2  1    3    0    36297.4955 5886.9121  180.0   3.68167  0.44   
+  2  1    3    -1   22102.7079 4505.3267  0.0     3.66562  0.21   
+  2  1    -3   0    28045.2336 11675.3013 180.0   3.65766  0.26   
+  2  2    0    0    1.1064     2.5781     0.0     3.63776  0.00   
+  2  1    1    -2   5676.1315  4328.5159  0.0     3.50520  0.23   
+  2  2    2    -1   1361.8993  1650.0035  180.0   3.48122  0.01   
+  2  1    -3   -1   20.8676    12.1276    0.0     3.43616  0.00   
+  2  1    -1   -2   3319.2354  5251.4578  0.0     3.37264  0.28   
+  2  2    -2   -1   242.2970   364.8637   0.0     3.33313  0.00   
+  2  2    0    -2   20350.0836 26655.4799 -180.0  3.21484  0.28   
+  2  0    0    2    55868.4175 37071.8044 -180.0  3.19393  46.95  
+  2  0    4    0    39176.4480 25362.8195 180.0   3.18733  0.29   
+  2  2    2    0    16030.9736 13873.6743 180.0   3.16977  0.16   
+  2  2    -2   0    21530.3174 14946.6082 -180.0  3.14934  0.16   
+  2  1    -3   1    23465.9717 11175.2497 -180.0  2.96418  0.20   
+  2  2    2    -2   8310.6402  7187.5067  0.0     2.95504  0.07   
+  2  0    2    -2   10688.2088 5310.5610  0.0     2.93060  0.28   
+  2  0    4    -1   12308.8220 8585.7945  0.0     2.92677  0.08   
+  2  1    3    1    9250.7400  6897.0276  180.0   2.86133  0.18   
+  2  1    3    -2   2380.6073  1923.0466  -0.0    2.83885  0.02   
+  2  2    -2   -2   37.2063    183.4547   -0.0    2.79276  0.00   
+  2  0    2    2    63.8709    191.6414   0.0     2.78600  0.01   
+  2  0    4    1    160.1903   387.5360   -0.0    2.78271  0.00   
+  2  2    0    1    101.5379   109.5836   -0.0    2.68712  0.00   
+  2  3    1    -1   310.7446   431.0071   -180.0  2.66293  0.00   
+  2  1    -3   -2   17703.9935 6171.6319  -0.0    2.63839  0.36   
+  2  3    -1   -1   66.3248    33.5476    -180.0  2.62530  0.00   
+  2  2    4    -1   114995.1296 12550.4891 -180.0  2.55995  0.50   
+  2  3    1    -2   1486.3676  1812.0722  180.0   2.53704  0.01   
+  2  1    -1   2    394.7395   667.2869   180.0   2.51139  0.01   
+  2  2    -2   1    1987.9991  1686.7859  -180.0  2.49495  0.02   
+  2  3    -1   -2   411.1991   451.5613   180.0   2.48043  0.00   
+  2  1    1    2    107.4173   110.2849   180.0   2.46610  0.01   
+  2  2    2    1    1188.0084  1367.0046  -180.0  2.45771  0.02   
+  2  2    -4   -1   10903.3408 10453.7459 -180.0  2.44277  0.05   
+  2  1    5    -1   5929.4309  4093.1663  -0.0    2.42941  0.02   
+  2  1    5    0    50.7579    64.0884    180.0   2.41202  0.00   
+  2  2    4    0    3123.4317  3944.1458  -0.0    2.40628  0.02   
+  2  1    -5   0    1663.3282  2230.8323  180.0   2.40074  0.01   
+  2  2    -4   0    1694.1514  2079.3222  -0.0    2.38844  0.01   
+  2  3    1    0    1263.2412  1565.2946  -0.0    2.38575  0.01   
+  2  3    -1   0    1393.7250  2090.0863  -0.0    2.37918  0.01   
+  2  2    0    -3   6.4410     7.3701     180.0   2.35133  0.00   
+  2  2    4    -2   2.7144     2.9331     0.0     2.34729  0.00   
+  2  1    1    -3   111.8978   110.8373   -0.0    2.33656  0.00   
+  2  0    4    -2   1263.1060  884.3144   -180.0  2.33087  0.01   
+  2  3    3    -1   22955.8261 9809.7794  180.0   2.31766  0.08   
+  2  1    -5   -1   2590.3326  1044.9800  0.0     2.31526  0.01   
+  2  1    -1   -3   1984.3033  2291.2470  -0.0    2.27750  0.24   
+  2  2    2    -3   179.2390   155.6865   -0.0    2.26146  0.00   
+  2  3    3    -2   22.4759    15.9172    0.0     2.25070  0.00   
+  2  3    -3   -1   3747.1469  2703.2457  -180.0  2.24518  0.01   
+  2  1    -3   2    941.2983   824.7896   -0.0    2.22556  0.01   
+  2  0    4    2    2496.0559  2085.0250  0.0     2.18812  0.04   
+  2  2    -4   -2   1716.9830  1431.8638  0.0     2.18799  0.01   
+  2  1    -5   1    4910.0766  4194.8986  180.0   2.18493  0.02   
+  2  2    -2   -3   2148.5354  1851.4932  0.0     2.15451  0.03   
+  2  1    5    -2   395.8943   312.7232   -180.0  2.15169  0.00   
+  2  3    1    -3   449.7408   204.6119   0.0     2.13824  0.00   
+  2  3    -3   -2   1162.8548  512.1941   180.0   2.13724  0.00   
+  2  1    3    2    461.4282   174.4523   -180.0  2.13433  0.01   
+  2  0    0    3    2270.9231  454.6548   -0.0    2.12929  0.81   
+  2  0    6    0    83086.3137 11042.6256 -0.0    2.12489  0.26   
+  2  1    3    -3   4402.7858  674.2906   -180.0  2.11876  0.04   
+  2  1    5    1    25479.0221 4734.7647  180.0   2.11595  0.16   
+  2  3    3    0    7057.1730  1496.6439  -180.0  2.11318  0.03   
+  2  3    -3   0    298.5653   182.7827   -180.0  2.09956  0.00   
+  2  3    -1   -3   6385.4416  2416.5634  0.0     2.08973  0.04   
+  2  2    -4   1    7190.8064  8370.0925  180.0   2.07604  0.03   
+  2  0    2    -3   159.2922   286.8930   -180.0  2.05903  0.00   
+  2  0    6    -1   46.0371    83.9001    -0.0    2.05549  0.00   
+  2  2    4    1    2277.1828  2723.1302  180.0   2.03350  0.02   
+  2  4    0    -2   2416.2681  1673.8545  -0.0    2.01366  0.01   
+  2  1    -5   -2   2181.0187  976.2191   -0.0    2.00557  0.01   
+  2  4    0    -1   9328.0084  3207.5402  -0.0    2.00025  0.02   
+  2  2    0    2    2993.3028  914.6787   0.0     1.99827  0.05   
+  2  1    -3   -3   8015.6826  2006.9284  -0.0    1.99351  0.26   
+  2  0    2    3    879.0844   1320.4879  0.0     1.98235  0.31   
+  2  0    6    1    3706.6391  4760.1395  0.0     1.97919  0.01   
+  2  3    -1   1    3318.8844  1778.1424  0.0     1.97162  0.02   
+  2  3    3    -3   2056.2310  747.2487   -180.0  1.97003  0.01   
+  2  3    1    1    6797.0163  1049.8991  0.0     1.96352  0.04   
+  2  2    4    -3   1342.4058  210.6125   -180.0  1.96339  0.01   
+  2  4    2    -2   1902.3926  1505.1300  0.0     1.94723  0.00   
+  2  2    -2   2    4574.2931  4434.5615  -0.0    1.92633  0.04   
+  2  4    2    -1   179.6681   195.3738   0.0     1.92397  0.00   
+  2  2    6    -1   18.7342    25.7092    -0.0    1.91781  0.00   
+  2  4    -2   -2   16864.1615 14612.2943 -0.0    1.89414  0.04   
+  2  4    -2   -1   100.3208   83.9894    180.0   1.89341  0.00   
+  2  3    5    -1   4371.0449  3253.1319  -180.0  1.88804  0.01   
+  2  2    2    2    14605.4443 11147.4650 -0.0    1.88782  0.27   
+  2  3    -3   -3   477.5465   242.1347   -0.0    1.86184  0.00   
+  2  3    5    -2   321.3842   151.7748   -180.0  1.86122  0.00   
+  2  4    0    -3   41536.6581 17227.6438 -180.0  1.84958  0.12   
+  2  2    -6   -1   1327.6295  630.1904   -180.0  1.84310  0.00   
+  2  1    -5   2    69.1991    32.7906    -180.0  1.84286  0.00   
+  2  2    6    0    14661.5797 5973.8074  -0.0    1.84084  0.04   
+  2  2    6    -2   4343.6829  2234.4122  -180.0  1.83281  0.01   
+  2  1    -1   3    3155.0238  2403.8627  -180.0  1.82957  0.11   
+  2  2    -6   0    14376.3519 11170.3478 0.0     1.82883  0.03   
+  2  2    -4   -3   464.1226   351.5785   -0.0    1.82817  0.00   
+  2  0    4    -3   9265.4307  6600.1943  180.0   1.82454  0.06   
+  2  3    -5   -1   740.7064   547.0575   -180.0  1.82305  0.00   
+  2  0    6    -2   12716.4709 9376.7847  -180.0  1.82300  0.03   
+  2  4    0    0    20482.8327 16544.7345 -0.0    1.81888  0.06   
+  2  3    -3   1    1254.1837  1388.1619  -0.0    1.81269  0.00   
+  2  4    2    -3   860.6358   1698.2109  -0.0    1.80678  0.00   
+  2  1    1    3    4606.2705  13204.6231 -180.0  1.80269  0.59   
+  2  3    3    1    333.8546   659.8672   -0.0    1.79396  0.00   
+  2  1    5    -3   19.4227    36.9138    180.0   1.79152  0.00   
+  2  1    7    -1   135.2612   370.2527   -180.0  1.78554  0.00   
+  2  2    0    -4   10048.7549 29304.7955 0.0     1.78457  0.20   
+  2  1    7    0    2704.6523  1186.7943  -0.0    1.76994  0.01   
+  2  3    5    0    1040.4855  192.4714   -180.0  1.76391  0.00   
+  2  1    -7   0    10382.0986 1861.7091  0.0     1.76369  0.02   
+  2  1    5    2    12686.7333 1478.1411  -180.0  1.75728  0.11   
+  2  3    -5   -2   1954.8527  292.8600   -180.0  1.75539  0.00   
+  2  2    2    -4   18608.3762 5374.4235  180.0   1.75260  0.17   
+  2  4    2    0    11131.3069 3240.2714  180.0   1.75255  0.03   
+  2  3    -5   0    2.0111     0.6787     -180.0  1.75073  0.00   
+  2  4    -2   -3   4053.5028  1498.9920  -180.0  1.74735  0.01   
+  2  4    -2   0    4124.0380  1478.3757  -180.0  1.74562  0.01   
+  2  4    4    -2   25601.0344 11156.5991 -180.0  1.74061  0.05   
+  2  3    1    -4   30.0423    11.6942    0.0     1.73791  0.00   
+  2  1    1    -4   1990.4239  931.5858   180.0   1.73044  0.07   
+  2  0    4    3    4037.5417  1649.4123  180.0   1.72108  0.11   
+  2  1    -7   -1   1317.2209  544.5769   -0.0    1.72100  0.00   
+  2  2    -4   2    11831.4531 5111.9528  -180.0  1.72066  0.04   
+  2  0    6    2    8612.6369  4043.0244  180.0   1.71979  0.05   
+  2  2    -6   -2   9849.3979  5843.5104  180.0   1.71808  0.03   
+  2  1    -3   3    6070.6051  3889.7621  0.0     1.71755  0.05   
+  2  4    4    -1   4763.2798  3425.3612  -0.0    1.71605  0.01   
+  2  3    -1   -4   52.8235    26.3196    -0.0    1.70384  0.00   
+  2  3    5    -3   3097.7995  1781.5059  180.0   1.70048  0.01   
+  2  1    -1   -4   1550.0218  1087.2281  180.0   1.69839  0.20   
+  2  2    -2   -4   10397.2407 6607.2640  -0.0    1.68632  0.21   
+  2  2    -6   1    174.6989   111.8094   180.0   1.68403  0.00   
+  2  1    -7   1    1685.8827  1037.6002  0.0     1.67991  0.00   
+  2  1    7    -2   3799.0671  3014.1863  0.0     1.67337  0.01   
+  2  4    -4   -1   3875.9743  3113.5342  -0.0    1.67328  0.01   
+  2  1    -5   -3   360.1353   322.6770   -180.0  1.66739  0.00   
+  2  2    4    2    7840.6784  6980.1241  -180.0  1.66673  0.08   
+  2  4    -4   -2   3395.0296  2996.9232  -180.0  1.66656  0.01   
+  2  1    3    3    623.7452   605.4945   0.0     1.65314  0.03   
+  2  3    3    -4   467.2265   474.5918   180.0   1.65084  0.00   
+  2  2    6    1    14.3397    15.0623    180.0   1.64996  0.00   
+  2  4    4    -3   80.9873    81.5092    0.0     1.64497  0.00   
+  2  1    3    -4   1195.7745  1267.0308  -180.0  1.64299  0.01   
+  2  2    6    -3   345.1546   438.3802   0.0     1.63845  0.00   
+  2  1    7    1    787.0384   959.6711   0.0     1.63566  0.00   
+  2  5    1    -2   55.5010    62.3555    -180.0  1.62122  0.00   
+  2  2    4    -4   12.6508    6.6299     0.0     1.60885  0.00   
+  2  3    -1   2    467.8568   237.1891   -180.0  1.60779  0.00   
+  2  4    0    -4   50.3698    25.5451    0.0     1.60742  0.00   
+  2  5    -1   -2   197.8379   104.4782   -0.0    1.60481  0.00   
+  2  3    1    2    8.8358     3.3755     -180.0  1.59704  0.00   
+  2  0    0    4    4519.0899  1719.5025  -0.0    1.59697  0.90   
+  2  0    8    0    15298.3318 4104.7411  -0.0    1.59366  0.03   
+  2  3    -5   -3   13472.9364 7048.0684  -180.0  1.58673  0.04   
+  2  4    2    -4   10345.9603 5767.4424  -180.0  1.58523  0.03   
+  2  4    4    0    147.3923   80.5872    180.0   1.58489  0.00   
+  2  3    -5   1    8264.9479  3541.7994  0.0     1.57987  0.02   
+  2  1    -7   -2   229.6622   106.0592   180.0   1.57566  0.00   
+  2  4    -4   0    2110.4004  972.7791   180.0   1.57467  0.00   
+  2  4    0    1    2854.6751  1313.3627  0.0     1.57405  0.01   
+  2  0    2    -4   13776.1004 6835.8768  -180.0  1.57267  0.30   
+  2  5    1    -1   3459.9260  1838.8969  0.0     1.57223  0.01   
+  2  5    1    -3   7.5209     4.5305     0.0     1.57056  0.00   
+  2  0    8    -1   8265.3378  5105.5113  -180.0  1.56971  0.01   
+  2  3    -3   -4   280.3546   222.0271   -180.0  1.56739  0.00   
+  2  1    -3   -4   1309.7293  1168.3240  -180.0  1.56437  0.06   
+  2  5    -1   -1   3822.8457  3532.8589  -0.0    1.56314  0.01   
+  2  3    5    1    7482.0723  6630.5027  -0.0    1.55930  0.03   
+  2  2    0    3    2009.7424  1763.6711  -180.0  1.55911  0.04   
+  2  4    -4   -3   800.8634   668.2938   0.0     1.55805  0.00   
+  2  0    6    -3   65.6426    50.4752    180.0   1.55391  0.00   
+  2  5    -1   -3   3880.0220  3177.9812  180.0   1.54983  0.01   
+  2  5    3    -2   1976.9007  1684.3120  0.0     1.53962  0.00   
+  2  3    7    -1   406.1865   255.3064   -0.0    1.53554  0.00   
+  2  4    -2   -4   6483.4497  4566.3850  180.0   1.53333  0.02   
+  2  4    -2   1    462.5236   360.2122   -0.0    1.53138  0.00   
+  2  2    -2   3    3251.8178  3884.5431  0.0     1.52972  0.03   
+  2  1    -5   3    60.5199    114.2358   180.0   1.52775  0.00   
+  2  0    2    4    874.3195   1999.2534  180.0   1.52655  0.45   
+  2  3    7    -2   617.1995   1417.6951  180.0   1.52649  0.00   
+  2  4    2    1    27.9603    55.0425    -0.0    1.52494  0.00   
+  2  0    8    1    32.0526    53.4117    0.0     1.52385  0.00   
+  2  3    -3   2    449.3078   713.5252   0.0     1.52351  0.00   
+  2  2    -6   -3   1015.3160  972.3599   180.0   1.52111  0.00   
+  2  1    -7   2    3052.1756  2092.8268  180.0   1.51406  0.01   
+  2  2    -4   -4   4001.0750  3475.0688  -180.0  1.51008  0.04   
+  2  2    8    -1   9021.1839  8932.7653  0.0     1.50687  0.01   
+  2  5    3    -3   10164.6236 11216.4371 -0.0    1.50125  0.02   
+  2  2    2    3    228.3746   261.4234   0.0     1.49966  0.01   
+  2  5    -3   -2   1205.1655  1283.3165  0.0     1.49852  0.00   
+  2  4    6    -2   1617.2773  1643.4734  -180.0  1.49804  0.00   
+  2  3    3    2    3056.9839  2828.3266  0.0     1.49651  0.02   
+  2  5    3    -1   1834.3728  1375.8687  180.0   1.49230  0.00   
+  2  1    7    -3   1323.4074  963.7100   -0.0    1.49138  0.00   
+  2  3    5    -4   1699.4615  976.7543   0.0     1.48741  0.00   
+  2  3    -7   -1   8.5437     4.1505     -180.0  1.48641  0.00   
+  2  2    -6   2    7182.7503  2225.9899  -180.0  1.48209  0.01   
+  2  1    5    -4   2134.9910  569.2303   -0.0    1.48061  0.01   
+  2  4    4    -4   3617.4358  936.8644   -0.0    1.47752  0.01   
+  2  4    6    -1   9401.6065  2425.3077  -0.0    1.47727  0.01   
+  2  2    8    -2   6293.6091  2036.6290  -0.0    1.46947  0.01   
+  2  5    -3   -1   6857.8805  2250.7625  180.0   1.46932  0.01   
+  2  0    4    -4   4032.6965  1799.2981  0.0     1.46530  0.03   
+  2  2    8    0    32253.0467 17372.8918 180.0   1.46378  0.06   
+  2  0    8    -2   4756.4224  2670.5014  0.0     1.46338  0.01   
+  2  3    7    0    2349.1809  1344.4772  -0.0    1.46164  0.00   
+  2  0    6    3    13285.6565 9727.2084  -180.0  1.45874  0.10   
+  2  2    -8   -1   396.0352   277.6153   0.0     1.45806  0.00   
+  2  2    -8   0    19546.1969 14971.6548 -180.0  1.45572  0.03   
+  2  1    5    3    96.3576    84.4701    0.0     1.45352  0.00   
+  2  3    -7   0    1856.3467  1874.7884  -0.0    1.45113  0.00   
+  2  5    -3   -3   3918.0951  3973.0050  -0.0    1.44873  0.01   
+  2  1    7    2    339.2017   339.6716   180.0   1.44736  0.00   
+  2  5    1    0    481.6783   468.7582   0.0     1.44694  0.00   
+  2  5    -1   0    341.2179   282.6566   0.0     1.44450  0.00   
+  2  3    -7   -2   506.6538   407.5222   -180.0  1.44435  0.00   
+  2  5    1    -4   468.3216   376.0669   -0.0    1.44434  0.00   
+  2  4    6    -3   10073.3621 4799.2632  180.0   1.44037  0.01   
+  2  3    7    -3   4550.6714  2066.9126  0.0     1.43858  0.01   
+  2  4    -6   -1   30029.7933 13974.0377 -0.0    1.43651  0.04   
+  2  1    -1   4    2744.3435  1747.7612  -0.0    1.43156  0.09   
+  2  2    6    2    20735.6703 14127.5120 -180.0  1.43067  0.10   
+  2  4    -6   -2   17852.7356 11494.7453 -180.0  1.42772  0.03   
+  2  3    1    -5   100.6718   54.5453    0.0     1.42498  0.00   
+  2  2    -4   3    17319.0057 9304.7725  -0.0    1.42492  0.07   
+  2  5    -1   -4   10354.9634 6191.0063  0.0     1.42367  0.02   
+  2  2    0    -5   544.0634   530.6717   -0.0    1.41970  0.01   
+  2  2    6    -4   4087.2626  4109.1661  -0.0    1.41942  0.01   
+  2  4    -4   1    1331.3375  2328.2327  -180.0  1.41643  0.00   
+  2  1    1    4    3264.8518  9765.5200  -0.0    1.41417  0.41   
+  2  2    2    -5   107.5772   102.1798   180.0   1.40774  0.00   
+  2  4    4    1    6985.9297  4251.1055  -180.0  1.40628  0.02   
+  2  1    9    -1   558.9296   313.3806   180.0   1.40427  0.00   
+  2  3    -1   -5   1143.7837  559.2035   180.0   1.40173  0.01   
+  2  5    5    -2   202.6472   121.8591   180.0   1.39689  0.00   
+  2  4    -4   -4   478.3723   333.7965   -180.0  1.39638  0.00   
+  2  5    3    -4   14399.4945 10290.7248 -180.0  1.39407  0.02   
+  2  0    4    4    841.7208   603.2489   180.0   1.39300  0.04   
+  2  1    9    0    8563.1453  6061.3448  -180.0  1.39244  0.01   
+  2  0    8    2    1273.6108  841.8614   -0.0    1.39135  0.00   
+  2  1    -7   -3   12.8156    8.6161     0.0     1.39082  0.00   
+  2  2    -8   -2   586.7817   389.1003   0.0     1.38958  0.00   
+  2  1    -9   0    6507.9020  5032.6219  -180.0  1.38852  0.01   
+  2  3    -5   -4   888.1430   712.8918   180.0   1.38828  0.00   
+  2  1    -5   -4   14.7218    12.2841    -0.0    1.38705  0.00   
+  2  4    6    0    8316.6014  6881.9956  0.0     1.38694  0.02   
+  2  2    -8   1    3543.8670  2583.5813  -0.0    1.38353  0.00   
+  2  3    -5   2    179.1465   107.7060   180.0   1.38139  0.00   
+  2  1    -3   4    13209.0008 11498.8556 180.0   1.38001  0.12   
+  2  3    3    -5   691.3612   601.2645   -0.0    1.37984  0.00   
+  2  5    3    0    2375.3894  2064.1961  180.0   1.37983  0.00   
+  2  2    4    3    7344.3976  7682.9819  -0.0    1.37735  0.10   
+  2  4    -6   0    2753.1401  2929.6322  0.0     1.37669  0.00   
+  2  5    -3   0    2138.1532  1846.9850  -180.0  1.37349  0.00   
+  2  4    0    -5   11005.3893 9852.1453  -0.0    1.37263  0.04   
+  2  5    5    -3   1269.2102  1000.1841  -0.0    1.37203  0.00   
+  2  1    1    -5   101.9939   51.8333    180.0   1.36876  0.00   
+  2  2    8    -3   2159.3143  897.0709   0.0     1.36740  0.00   
+  2  2    -2   -5   2409.3275  890.9937   -180.0  1.36475  0.06   
+  2  1    -9   -1   6538.2740  2521.2414  180.0   1.36346  0.01   
+  2  4    2    -5   27023.5890 11335.5971 180.0   1.36264  0.08   
+  2  2    8    1    8937.6626  3611.9875  -180.0  1.35827  0.02   
+  2  5    5    -1   2100.9248  870.4892   -180.0  1.35737  0.00   
+  2  4    -6   -3   7110.1380  4126.3352  180.0   1.35385  0.01   
+  2  3    -7   1    888.9117   576.4772   0.0     1.35312  0.00   
+  2  1    9    -2   19250.4930 16147.0686 0.0     1.35152  0.02   
+  2  6    0    -2   19520.5210 16981.3924 180.0   1.35133  0.02   
+  2  1    -9   1    3813.2791  3741.5161  -0.0    1.35032  0.00   
+  2  1    -1   -5   7859.1665  10683.9602 -0.0    1.34891  1.04   
+  2  3    5    2    134.0565   209.3398   0.0     1.34817  0.00   
+  2  5    -5   -2   342.5248   568.7530   180.0   1.34647  0.00   
+  2  4    0    2    8957.1921  20266.7951 180.0   1.34356  0.03   
+  2  6    0    -3   243.9015   424.9852   0.0     1.34244  0.00   
+  2  3    -7   -3   624.9660   987.1236   180.0   1.34218  0.00   
+  2  5    -3   -4   19.2656    19.4544    -0.0    1.34037  0.00   
+  2  3    7    1    369.8184   545.2034   0.0     1.33504  0.00   
+  2  1    3    4    191.3681   303.9072   180.0   1.33473  0.01   
+  2  2    4    -5   1566.8619  2138.1647  -0.0    1.33359  0.01   
+  2  6    2    -2   4560.1920  7470.5514  0.0     1.33146  0.01   
+  2  3    -1   3    386.1438   551.6386   -0.0    1.32984  0.00   
+  2  5    -5   -1   2338.8802  3077.6343  -180.0  1.32879  0.00   
+  2  1    -7   3    589.3123   845.5145   -180.0  1.32789  0.00   
+  2  1    3    -5   9013.3152  12956.3684 180.0   1.32785  0.09   
+  2  4    6    -4   838.1174   1219.1637  0.0     1.32754  0.00   
+  2  6    2    -3   4.5833     6.0091     -0.0    1.32656  0.00   
+  2  4    -2   -5   3320.2425  3146.4347  0.0     1.32203  0.01   
+  2  1    9    1    1162.7104  1105.1306  -0.0    1.32057  0.00   
+  2  4    -2   2    2264.6988  2255.4357  0.0     1.32028  0.01   
+  2  3    1    3    3202.5527  3237.6008  0.0     1.32015  0.03   
+  2  2    -6   -4   121.7612   114.0134   0.0     1.31919  0.00   
+  2  3    -3   -5   2333.0808  2179.7868  180.0   1.31918  0.02   
+  2  0    6    -4   4068.1040  3685.3963  0.0     1.31717  0.01   
+  2  0    8    -3   5027.6754  4546.6333  -0.0    1.31636  0.01   
+  2  6    -2   -2   468.3156   330.6363   180.0   1.31265  0.00   
+  2  4    2    2    1226.5006  505.4413   0.0     1.30914  0.01   
+  2  5    -5   -3   14827.5725 6208.9517  0.0     1.30653  0.02   
+  2  3    7    -4   28.2252    11.5530    -180.0  1.30602  0.00   
+  2  6    0    -1   1701.4873  635.2341   -0.0    1.30261  0.00   
+  2  6    -2   -3   10587.5661 4797.6968  0.0     1.30107  0.01   
+  2  1    7    -4   1728.7636  816.7390   180.0   1.30069  0.00   
+  2  4    4    -5   1563.8869  839.8412   -180.0  1.29576  0.00   
+  2  5    -1   1    1054.6428  560.8179   -180.0  1.29287  0.00   
+  2  5    5    -4   180.2230   102.0732   -0.0    1.29210  0.00   
+  2  5    1    1    317.9211   213.0414   180.0   1.29128  0.00   
+  2  5    1    -5   867.4727   1297.0866  -180.0  1.28850  0.00   
+  2  1    -9   -2   8461.6171  7594.2794  0.0     1.28440  0.02   
+  2  3    -3   3    4531.4042  3821.2749  180.0   1.28422  0.02   
+  2  2    -6   3    143.6359   97.9036    -0.0    1.28363  0.00   
+  2  3    5    -5   4825.4055  3037.5557  -0.0    1.28334  0.01   
+  2  6    2    -1   4626.2717  2446.8719  180.0   1.28151  0.01   
+  2  4    8    -2   34669.5465 16043.2073 -0.0    1.27998  0.04   
+  2  6    0    -4   8327.4850  4642.8182  0.0     1.27913  0.01   
+  2  1    -5   4    0.4844     0.2762     -0.0    1.27885  0.00   
+  2  0    0    5    2071.0301  1504.7953  0.0     1.27757  0.29   
+  2  2    -8   -3   1645.8558  969.8153   0.0     1.27578  0.00   
+  2  1    -3   -5   2752.9071  1649.0848  -180.0  1.27554  0.21   
+  2  0    10   0    8682.6584  5612.4673  -0.0    1.27493  0.01   
+  2  3    9    -1   875.8684   567.6734   180.0   1.27318  0.00   
+  2  3    9    -2   261.5067   209.3409   0.0     1.27118  0.00   
+  2  6    -2   -1   737.4605   604.9530   -180.0  1.27102  0.00   
+  2  5    -1   -5   3631.5724  3287.3648  -0.0    1.27057  0.01   
+  2  4    -6   1    2259.2676  2157.0193  180.0   1.27033  0.00   
+  2  2    0    4    3795.6216  5970.9564  -0.0    1.26862  0.08   
+  2  6    2    -4   1670.6778  2642.8907  -180.0  1.26852  0.00   
+  2  0    2    -5   2689.2899  4140.6925  180.0   1.26818  0.06   
+  2  2    -8   2    10602.8570 15669.9235 0.0     1.26800  0.01   
+  2  5    5    0    1067.7913  1539.1640  -0.0    1.26791  0.00   
+  2  0    10   -1   834.3054   722.1628   -180.0  1.26570  0.00   
+  2  4    8    -1   296.9396   116.1733   180.0   1.26381  0.00   
+  2  2    -4   -5   103.8324   34.2839    180.0   1.26302  0.00   
+  2  1    -9   2    1309.8252  407.6104   0.0     1.26267  0.00   
+  2  6    4    -2   18228.3467 4060.9393  -0.0    1.26012  0.02   
+  2  1    7    3    6162.4785  1423.0605  -180.0  1.25993  0.03   
+  2  5    -5   0    5290.4076  1251.7915  -0.0    1.25974  0.01   
+  2  4    6    1    147.7796   35.4122    180.0   1.25938  0.00   
+  2  6    4    -3   24339.1283 5742.7030  -180.0  1.25904  0.03   
+  2  3    3    3    149.5740   34.1056    0.0     1.25855  0.00   
+  2  2    -2   4    4477.1610  2630.4316  180.0   1.25569  0.04   
+  2  5    3    -5   13509.2699 7849.9862  180.0   1.25548  0.02   
+  2  1    9    -3   530.7785   446.4585   -180.0  1.25310  0.00   
+  2  4    -4   2    2517.0294  2913.1494  0.0     1.24747  0.01   
+  2  4    8    -3   1310.9806  1591.0184  -180.0  1.24643  0.00   
+  2  5    -3   1    151.8859   154.1169   -180.0  1.24419  0.00   
+  2  4    -6   -4   4383.5885  4649.8078  0.0     1.24074  0.01   
+  2  1    5    -5   19.5272    20.8490    -0.0    1.24058  0.00   
+  2  6    -2   -4   108.8832   116.0421   -0.0    1.24022  0.00   
+  2  5    3    1    811.9006   865.0651   -180.0  1.23993  0.00   
+  2  0    6    4    4125.0202  4402.8269  -0.0    1.23960  0.05   
+  2  0    8    3    2354.4110  2523.8232  0.0     1.23892  0.01   
+  2  5    7    -2   43.7173    48.4702    -180.0  1.23815  0.00   
+  2  0    2    5    5.4730     6.1649     -0.0    1.23770  0.00   
+  2  3    -9   -1   1609.1090  1878.7146  -180.0  1.23697  0.00   
+  2  0    10   1    61.0672    69.0195    180.0   1.23540  0.00   
+  2  2    8    -4   0.5740     0.6712     -0.0    1.23509  0.00   
+  2  2    2    4    186.1737   202.3679   180.0   1.23305  0.01   
+  2  2    10   -1   558.7469   674.5837   -0.0    1.23266  0.00   
+  2  2    6    3    461.1024   591.5126   -0.0    1.23202  0.00   
+  2  4    -8   -1   1430.4666  1660.8265  180.0   1.22975  0.00   
+  2  4    4    2    5082.5936  7216.8110  -0.0    1.22886  0.02   
+  2  6    -4   -2   5346.2695  7429.0559  0.0     1.22874  0.01   
+  2  4    -4   -5   4866.1085  5935.8119  180.0   1.22833  0.02   
+  2  3    9    0    249.2299   207.1256   180.0   1.22722  0.00   
+  2  2    8    2    23487.2488 16367.8700 -0.0    1.22501  0.07   
+  2  3    -7   2    6.4079     4.4310     -180.0  1.22493  0.00   
+  2  5    7    -3   1501.4051  701.3947   180.0   1.22357  0.00   
+  2  5    -5   -4   897.6237   527.2945   -180.0  1.22255  0.00   
+  2  2    6    -5   151.8877   93.3157    -0.0    1.22244  0.00   
+  2  3    9    -3   5583.1130  3989.5508  -0.0    1.22187  0.01   
+  2  4    -8   -2   22107.8465 15576.6760 0.0     1.22139  0.03   
+  2  1    5    4    3453.9990  2923.6151  -180.0  1.22003  0.07   
+  2  3    -9   0    89.0455    63.1939    -0.0    1.21922  0.00   
+  2  6    -4   -3   3.0820     1.6171     -180.0  1.21643  0.00   
+  2  6    4    -1   24.9500    10.2523    180.0   1.21473  0.00   
+  2  2    10   -2   7735.1649  3195.8904  -180.0  1.21471  0.01   
+  2  3    -7   -4   16.6015    9.5153     0.0     1.21279  0.00   
+  2  6    0    0    22544.0134 13100.2263 0.0     1.21259  0.03   
+  2  1    9    2    3010.6094  1749.7864  0.0     1.21259  0.01   
+  2  0    4    -5   88.4277    51.4047    -180.0  1.21258  0.00   
+  2  1    -7   -4   1155.8596  673.8718   0.0     1.21254  0.01   
+  2  6    4    -4   337.2264   199.9465   0.0     1.21185  0.00   
+  2  0    10   -2   4279.2461  2393.1814  180.0   1.21068  0.00   
+  2  3    -9   -2   3.9541     2.4088     0.0     1.20966  0.00   
+  2  5    7    -1   1457.1030  919.5910   -0.0    1.20764  0.00   
+  2  5    -3   -5   2598.2398  1669.4106  -180.0  1.20756  0.01   
+  2  2    10   0    17.3316    11.8619    180.0   1.20601  0.00   
+  2  3    -5   -5   4998.6272  5223.5291  -0.0    1.20426  0.03   
+  2  4    8    0    2436.6367  2036.1638  -180.0  1.20314  0.00   
+  2  2    -10  0    1236.1406  1234.3417  180.0   1.20037  0.00   
+  2  2    -10  -1   1982.2459  1881.5821  0.0     1.19900  0.00   
+  2  2    -4   4    0.0037     0.0043     180.0   1.19841  0.00   
+  2  3    -5   3    4455.1898  5149.8089  -180.0  1.19827  0.01   
+  2  6    -4   -1   4512.7555  4013.4094  180.0   1.19705  0.01   
+  2  4    -8   0    2380.0795  1701.7086  -180.0  1.19422  0.00   
+  2  4    6    -5   7947.1313  5356.2972  -0.0    1.19366  0.01   
+  2  6    2    0    8536.8166  6359.8747  -180.0  1.19287  0.01   
+  2  3    1    -6   228.6804   172.0799   180.0   1.19278  0.00   
+  2  3    7    2    278.4225   210.6961   180.0   1.19262  0.00   
+  2  6    -2   0    3031.8895  1825.4606  -180.0  1.18959  0.00   
+  2  5    -7   -2   392.5494   235.2689   -180.0  1.18926  0.00   
+  2  5    5    -5   876.4281   652.0282   -0.0    1.18202  0.00   
+  2  6    0    -5   2332.6282  1859.8386  -0.0    1.18139  0.00   
+  2  5    -7   -1   1275.9390  1170.6276  -0.0    1.17956  0.00   
+  2  3    -1   -6   5251.9458  10651.6340 0.0     1.17652  0.06   
+  2  1    -9   -3   1478.9050  3479.3329  -0.0    1.17569  0.00   
+  2  4    0    -6   295.4168   694.8770   -180.0  1.17567  0.00   
+  2  6    2    -5   292.7567   690.4314   180.0   1.17553  0.00   
+  2  4    8    -4   1756.7089  5262.2410  180.0   1.17365  0.00   
+  2  1    -1   5    14.3368    44.3347    0.0     1.17349  0.00   
+  2  2    0    -6   905.3062   3262.2227  -180.0  1.17258  0.02   
+  2  4    2    -6   251.9423   785.7923   0.0     1.17185  0.00   
+  2  4    -8   -3   172.4371   512.5086   -0.0    1.17167  0.00   
+  2  1    -5   -5   1885.9626  5414.4867  -180.0  1.17131  0.04   
+  2  3    3    -6   2312.2246  3178.6335  180.0   1.16840  0.01   
+  2  5    7    -4   4366.1065  5932.4007  0.0     1.16833  0.01   
+  2  2    2    -6   330.0710   444.4424   0.0     1.16828  0.00   
+  2  0    8    -4   8056.5086  6734.2463  -180.0  1.16544  0.01   
+  2  3    5    3    10147.1733 9033.3981  -180.0  1.16397  0.07   
+  2  6    -4   -4   1448.2890  1331.0105  -180.0  1.16381  0.00   
+  2  3    7    -5   1274.2710  1180.8749  180.0   1.16377  0.00   
+  2  3    -9   1    14.7567    24.5109    -0.0    1.16177  0.00   
+  2  1    1    5    1065.1210  1984.2370  0.0     1.16142  0.14   
+  2  2    -10  1    214.8891   408.7012   -180.0  1.16134  0.00   
+  2  0    4    5    1822.8511  3674.6390  -180.0  1.16082  0.14   
+  2  6    6    -3   311.4835   572.9928   0.0     1.16041  0.00   
+  2  5    -5   1    4.8557     8.2052     180.0   1.16017  0.00   
+  2  7    1    -3   207.1467   326.8856   180.0   1.15995  0.00   
+  2  2    4    4    214.9633   334.7388   180.0   1.15990  0.00   
+  2  0    10   2    1328.3273  1953.1670  -180.0  1.15916  0.00   
+  2  5    -7   -3   9.4309     13.9221    0.0     1.15905  0.00   
+  2  6    6    -2   715.9810   1062.5954  180.0   1.15883  0.00   
+  2  2    -10  -2   750.9440   927.1428   -180.0  1.15763  0.00   
+  2  2    10   -3   381.5241   456.9863   180.0   1.15752  0.00   
+  2  1    -7   4    7151.8631  7894.1741  -0.0    1.15699  0.02   
+  2  1    11   -1   157.7538   172.4013   -0.0    1.15488  0.00   
+  2  5    5    1    13.7183    14.5872    180.0   1.15443  0.00   
+  2  4    0    3    418.3487   372.8509   -0.0    1.15214  0.00   
+  2  7    -1   -3   173.6771   190.7937   -0.0    1.15103  0.00   
+  2  1    -9   3    362.4378   390.2848   -180.0  1.15086  0.00   
+  2  7    1    -2   560.0602   417.6649   180.0   1.14957  0.00   
+  2  6    -2   -5   3.5149     3.3422     180.0   1.14818  0.00   
+  2  2    -8   -4   1336.6984  1241.1393  -0.0    1.14713  0.00   
+  2  3    9    1    920.0149   840.9132   -180.0  1.14703  0.00   
+  2  1    -3   5    148.6637   131.0137   -0.0    1.14691  0.00   
+  2  4    -6   2    1125.1035  884.2580   -180.0  1.14653  0.00   
+  2  1    11   0    714.1948   673.8595   0.0     1.14593  0.00   
+  2  3    -9   -3   6855.9120  6842.7549  -0.0    1.14539  0.01   
+  2  1    -11  0    49.2809    56.5171    180.0   1.14326  0.00   
+  2  7    -1   -2   222.7871   258.5173   180.0   1.14319  0.00   
+  2  2    10   1    1643.7386  2221.3310  -180.0  1.14260  0.00   
+  2  2    -6   -5   6090.2424  8280.7099  -0.0    1.14253  0.05   
+  2  5    -1   2    0.1870     0.2523     -180.0  1.14237  0.00   
+  2  4    -2   -6   201.0994   159.9954   -0.0    1.14109  0.00   
+  2  5    7    0    2010.8883  1584.2307  0.0     1.14103  0.00   
+  2  3    9    -4   5324.2613  3452.1120  -180.0  1.13977  0.01   
+  2  4    -2   3    1057.0222  675.3480   180.0   1.13965  0.00   
+  2  2    -8   3    1515.7640  940.5804   180.0   1.13923  0.00   
+  2  5    1    2    249.6719   151.0052   180.0   1.13897  0.00   
+  2  2    -2   -6   778.8128   457.5743   180.0   1.13875  0.03   
+  2  5    1    -6   292.3412   92.8501    180.0   1.13644  0.00   
+  2  6    4    0    30502.5289 9886.1889  -180.0  1.13618  0.05   
+  2  1    9    -4   20436.9787 6387.1239  180.0   1.13575  0.03   
+  2  7    1    -4   503.2125   104.3489   0.0     1.13318  0.00   
+  2  5    -7   0    3105.3316  561.3250   0.0     1.13270  0.00   
+  2  6    4    -5   24479.8309 3560.8356  -0.0    1.13225  0.03   
+  2  7    3    -3   14429.5144 1752.7599  180.0   1.13164  0.02   
+  2  1    7    -5   13525.9460 1876.4532  -0.0    1.13113  0.03   
+  2  4    4    -6   469.3792   74.0198    180.0   1.13073  0.00   
+  2  6    -4   0    55007.3659 8996.3605  -180.0  1.13052  0.07   
+  2  1    1    -6   77.4517    12.7255    180.0   1.13041  0.00   
+  2  4    2    3    165.3110   26.9687    0.0     1.12798  0.00   
+  2  1    11   -2   20105.8251 4054.5939  -180.0  1.12721  0.02   
+  2  2    4    -6   2895.9314  617.9103   -180.0  1.12706  0.02   
+  2  1    -11  -1   364.1645   80.5660    180.0   1.12692  0.00   
+  2  0    6    -5   3626.7873  825.3110   -0.0    1.12677  0.01   
+  2  0    10   -3   95.2159    25.1309    180.0   1.12560  0.00   
+  2  6    6    -4   3896.3322  1116.6065  -0.0    1.12535  0.00   
+  2  4    -8   1    4421.1156  1428.0735  -0.0    1.12500  0.01   
+  2  4    6    2    1507.5827  491.6513   180.0   1.12497  0.01   
+  2  3    -3   -6   6151.5388  2679.1058  0.0     1.12421  0.07   
+  2  1    -11  1    1200.1093  520.4388   180.0   1.12385  0.00   
+  2  3    -1   4    157.7605   62.3074    180.0   1.12290  0.00   
+  2  7    -1   -4   849.9935   340.7362   180.0   1.12266  0.00   
+  2  6    -6   -2   14.5432    5.8815     -0.0    1.12259  0.00   
+  2  5    -1   -6   7431.9093  3679.1020  -180.0  1.12188  0.02   
+  2  6    6    -1   30.8580    18.5196    -180.0  1.12105  0.00   
+  2  7    3    -2   633.0419   466.2613   -180.0  1.11981  0.00   
+  2  5    -5   -5   1554.9768  3254.1700  180.0   1.11710  0.00   
+  2  1    -1   -6   745.5450   1573.1101  -180.0  1.11699  0.11   
+  2  4    -6   -5   7.5047     12.1624    -180.0  1.11621  0.00   
+  2  5    3    -6   2762.9514  3572.8767  0.0     1.11574  0.01   
+  2  3    1    4    456.7216   557.2568   180.0   1.11489  0.01   
+  2  4    8    1    2501.0844  3030.2470  -0.0    1.11486  0.01   
+  2  1    3    5    200.7886   208.8946   -180.0  1.11404  0.02   
+  2  2    -6   4    2201.9378  1626.0861  -0.0    1.11278  0.01   
+  2  6    -6   -3   13037.3006 9170.8262  180.0   1.11104  0.02   
+  2  5    -3   2    34.9985    23.9804    -180.0  1.11049  0.00   
+  2  3    5    -6   112.1976   75.3696    -0.0    1.11017  0.00   
+  2  1    3    -6   4734.1599  3749.4968  0.0     1.10915  0.06   
+  2  7    3    -4   1065.1670  851.8273   -0.0    1.10885  0.00   
+  2  7    -3   -3   11.2177    8.0510     -0.0    1.10731  0.00   
+  2  7    1    -1   878.1416   540.2195   -180.0  1.10485  0.00   
+  2  6    0    1    4115.5119  2851.2916  180.0   1.10441  0.01   
+  2  1    11   1    518.9207   353.4958   0.0     1.10278  0.00   
+  2  7    -3   -2   10.5489    7.6618     -0.0    1.10240  0.00   
+  2  4    10   -2   354.0121   293.9448   -180.0  1.10139  0.00   
+  2  7    -1   -1   677.1784   560.8360   -180.0  1.10125  0.00   
+  2  5    3    2    111.9064   92.4856    -180.0  1.10119  0.00   
+  2  2    8    -5   4702.2383  3728.5603  180.0   1.10077  0.01   
+  2  6    -6   -1   7.9333     6.2337     0.0     1.10033  0.00   
+  2  5    -7   -4   133.3612   136.6182   0.0     1.09716  0.00   
+  2  3    -3   4    135.3516   143.6453   -0.0    1.09706  0.00   
+  2  1    7    4    45.4374    57.0295    -0.0    1.09661  0.00   
+  2  0    8    4    3247.0637  2959.2417  180.0   1.09406  0.02   
+  2  4    -8   -4   4034.1798  3685.4545  -180.0  1.09399  0.01   
+  2  4    -4   3    2409.8361  2186.7268  180.0   1.09385  0.01   
+  2  3    -7   3    2000.7352  1814.2931  0.0     1.09384  0.00   
+  2  1    9    3    340.3959   308.2223   180.0   1.09383  0.00   
+  2  2    -10  2    4.0432     3.3265     -0.0    1.09247  0.00   
+  2  2    8    3    538.0740   379.8198   0.0     1.09126  0.00   
+  2  5    9    -2   2353.6251  1582.6840  -0.0    1.09021  0.00   
+  2  4    10   -1   2.0893     1.7369     -180.0  1.08903  0.00   
+  2  6    -2   1    1.8354     1.5406     -180.0  1.08894  0.00   
+  2  1    -5   5    6711.4035  5646.2565  0.0     1.08884  0.03   
+  2  6    2    1    331.0733   245.3481   -0.0    1.08745  0.00   
+  2  2    -10  -3   814.6931   617.4947   180.0   1.08733  0.00   
+  2  5    7    -5   110.0790   91.0318    -180.0  1.08704  0.00   
+  2  6    -4   -5   282.0900   422.0173   180.0   1.08477  0.00   
+  2  3    -7   -5   2407.1157  3180.2930  0.0     1.08232  0.01   
+  2  5    9    -3   27.9534    37.0056    -180.0  1.08217  0.00   
+  2  4    10   -3   460.2472   496.5346   180.0   1.08176  0.00   
+  2  4    8    -5   578.0624   416.8216   0.0     1.08002  0.00   
+  2  7    -3   -4   659.3896   475.9937   -180.0  1.08002  0.00   
+  2  3    11   -2   1506.6411  1209.7235  180.0   1.07973  0.00   
+  2  3    -9   2    1488.8241  1162.0253  -0.0    1.07952  0.00   
+  2  1    -11  -2   830.9953   505.5742   -0.0    1.07909  0.00   
+  2  3    11   -1   4384.6154  2531.9784  -180.0  1.07901  0.01   
+  2  4    -4   -6   110.9356   79.4879    0.0     1.07725  0.00   
+  2  7    3    -1   583.2221   517.9063   0.0     1.07642  0.00   
+  2  7    1    -5   28.3207    25.2106    -0.0    1.07626  0.00   
+  2  5    -3   -6   1465.5158  1371.1187  180.0   1.07586  0.01   
+  2  2    10   -4   3024.6624  2842.5457  0.0     1.07584  0.00   
+  2  2    -4   -6   184.9744   186.5753   0.0     1.07568  0.00   
+  2  3    3    4    518.7193   560.4316   180.0   1.07511  0.01   
+  2  1    -11  2    537.5263   558.2780   -180.0  1.07370  0.00   
+  2  7    5    -3   820.0386   928.6481   180.0   1.07351  0.00   
+  2  4    4    3    715.8969   818.8776   180.0   1.07348  0.00   
+  2  1    -3   -6   120.0733   135.6225   180.0   1.07233  0.02   
+  2  6    0    -6   4.2807     4.1780     -180.0  1.07161  0.00   
+  2  1    11   -3   703.2067   540.3856   180.0   1.07008  0.00   
+  2  6    2    -6   117.2773   107.8329   0.0     1.06912  0.00   
+  2  6    -6   -4   650.3023   552.9788   0.0     1.06862  0.00   
+  2  5    9    -1   1163.7713  1026.4794  0.0     1.06732  0.00   
+  2  2    6    4    4544.0946  4143.5979  0.0     1.06716  0.06   
+  2  7    -3   -1   199.8706   173.9010   0.0     1.06652  0.00   
+  2  2    0    5    2088.1670  1937.9253  0.0     1.06580  0.06   
+  2  0    6    5    390.5001   358.8678   0.0     1.06561  0.01   
+  2  7    -1   -5   3671.9199  3288.8085  0.0     1.06535  0.01   
+  2  5    5    -6   506.1051   447.2840   -180.0  1.06509  0.00   
+  2  0    0    6    60.7252    53.4823    180.0   1.06464  0.01   
+  2  0    10   3    3719.6548  3276.3246  0.0     1.06463  0.01   
+  2  4    6    -6   24.9685    31.3322    -180.0  1.06282  0.00   
+  2  6    6    -5   354.3092   434.3157   -0.0    1.06260  0.00   
+  2  0    12   0    96.6266    112.6819   180.0   1.06244  0.00   
+  2  4    -10  -1   1173.0431  1132.6677  180.0   1.06171  0.00   
+  2  7    5    -2   4639.3641  4496.3914  -180.0  1.06153  0.01   
+  2  0    2    -6   695.7675   748.1993   0.0     1.06104  0.02   
+  2  5    -7   1    853.2768   969.1237   180.0   1.06052  0.00   
+  2  1    -9   -4   1638.6355  1706.8793  -180.0  1.06015  0.01   
+  2  2    -2   5    3448.0435  3313.4198  -180.0  1.05994  0.05   
+  2  3    -9   -4   14.3147    13.6703    -180.0  1.05993  0.00   
+  2  2    6    -6   342.2806   288.6216   -180.0  1.05938  0.00   
+  2  0    12   -1   1594.1060  1340.4500  -0.0    1.05892  0.00   
+  2  1    -7   -5   9.6972     7.5059     -180.0  1.05860  0.00   
+  2  1    5    -6   61.4937    47.4061    -180.0  1.05858  0.00   
+  2  2    10   2    1662.9276  1237.1699  -0.0    1.05797  0.00   
+  2  3    7    3    18.8615    12.9031    -180.0  1.05758  0.00   
+  2  7    3    -5   3340.5433  2239.1302  -180.0  1.05718  0.00   
+  2  6    6    0    702.7182   461.7745   -0.0    1.05659  0.00   
+  2  7    5    -4   3435.5304  2051.4003  0.0     1.05581  0.00   
+  2  4    -10  -2   4945.8815  3145.7849  0.0     1.05450  0.01   
+  2  5    7    1    58.3788    37.2884    180.0   1.05440  0.00   
+  2  6    8    -3   12407.6385 8866.7538  -0.0    1.05196  0.01   
+  2  3    -11  -1   363.6283   261.5320   -0.0    1.05193  0.00   
+  2  5    -5   2    6587.1216  5387.0808  -180.0  1.05131  0.01   
+  2  3    9    2    1040.9189  862.2832   -0.0    1.05108  0.00   
+  2  3    11   -3   832.8892   673.7850   180.0   1.05082  0.00   
+  2  6    -6   0    721.7067   488.9045   -0.0    1.04978  0.00   
+  2  6    8    -2   430.9977   331.3808   0.0     1.04899  0.00   
+  2  3    11   0    522.3071   407.0557   -0.0    1.04881  0.00   
+  2  3    -5   -6   1573.5568  1235.7557  -180.0  1.04872  0.02   
+  2  4    10   0    79.7625    61.4161    -0.0    1.04771  0.00   
+  2  5    -9   -2   3246.9340  2208.3085  -0.0    1.04729  0.00   
+  2  5    9    -4   370.8471   228.7958   -180.0  1.04516  0.00   
+  2  6    -2   -6   2326.1823  1293.5044  -0.0    1.04487  0.01   
+  2  6    -4   1    5706.4933  3160.5795  -0.0    1.04485  0.01   
+  2  3    -5   4    4486.5211  2301.6767  -0.0    1.04377  0.02   
+  2  3    9    -5   3484.2498  1817.7670  180.0   1.04328  0.01   
+  2  1    5    5    3435.5975  1623.2967  -0.0    1.04294  0.14   
+  2  3    -11  0    3346.0268  1387.3612  0.0     1.04270  0.00   
+  2  2    2    5    640.8148   264.3036   0.0     1.04269  0.03   
+  2  5    -9   -1   167.7808   62.5557    0.0     1.04240  0.00   
+  2  6    4    1    2716.9022  1021.8291  -0.0    1.04223  0.01   
+  2  4    -10  0    990.2629   554.7785   -0.0    1.04034  0.00   
+  2  2    12   -1   4645.4212  3828.0670  -180.0  1.03971  0.01   
+  2  0    2    6    1474.3313  1492.8101  0.0     1.03949  0.98   
+  2  7    -5   -3   3298.3667  3517.5593  180.0   1.03943  0.00   
+  2  5    5    2    3353.3069  4324.4718  -180.0  1.03825  0.01   
+  2  4    -8   2    212.4610   298.1823   -0.0    1.03802  0.00   
+  2  6    4    -6   873.4961   1251.2761  -180.0  1.03798  0.00   
+  2  0    12   1    161.7080   335.8693   -0.0    1.03750  0.00   
+  2  7    -5   -2   588.5834   1492.9651  -180.0  1.03709  0.00   
+  2  7    1    0    527.4777   1264.8986  -0.0    1.03656  0.00   
+  2  1    -9   4    1.3349     2.8086     180.0   1.03594  0.00   
+  2  1    11   2    797.0010   1702.3367  180.0   1.03580  0.00   
+  2  7    -1   0    688.0185   1823.6465  -0.0    1.03529  0.00   
+  2  4    10   -4   3.2669     9.1218     0.0     1.03486  0.00   
+  2  3    -11  -2   547.7124   1522.0493  -180.0  1.03326  0.00   
+  3  1    1    0    6463.6742  5231.0099  0.0     5.76594  0.00   
+  3  1    1    -1   1809.8283  1404.6004  0.0     5.75232  0.00   
+  3  0    0    2    14974.1237 6633.1011  0.0     5.69783  0.00   
+  3  2    0    0    1940.6645  777.5446   180.0   5.30293  0.00   
+  3  2    0    -2   19490.8279 11502.0778 0.0     5.26091  0.00   
+  3  1    1    1    6788.0010  5911.8003  -180.0  4.69648  0.00   
+  3  1    1    -2   393.3766   470.7803   -180.0  4.67448  0.00   
+  3  1    1    2    871.9095   1807.3929  -180.0  3.62746  0.00   
+  3  1    1    -3   3324.8214  6209.3234  180.0   3.61056  0.00   
+  3  0    2    0    2704.2782  1738.7564  180.0   3.43494  0.00   
+  3  3    1    -1   578.8303   1015.3222  -0.0    3.40549  0.00   
+  3  3    1    -2   1605.2691  3187.5991  180.0   3.39708  0.00   
+  3  0    2    1    2835.6679  5008.5811  -0.0    3.28878  0.00   
+  3  2    0    2    8523.8654  11583.9155 -0.0    3.21754  0.00   
+  3  2    0    -4   7560.7353  4992.9978  180.0   3.18941  0.00   
+  3  3    1    0    3013.2525  2137.5839  0.0     3.14348  0.00   
+  3  3    1    -3   2526.6591  2674.2929  180.0   3.12373  0.00   
+  3  4    0    -2   95800.3927 80889.4927 180.0   2.98036  0.01   
+  3  2    2    -1   112598.8395 75054.9545 -0.0    2.97614  0.01   
+  3  0    2    2    1376.9135  792.9854   0.0     2.94173  0.00   
+  3  2    2    0    632.8276   1810.0141  0.0     2.88297  0.00   
+  3  2    2    -2   434.7141   529.4444   -0.0    2.87616  0.00   
+  3  1    1    3    3329.0766  2483.8012  -0.0    2.86232  0.00   
+  3  1    1    -4   7241.3084  5795.0115  -0.0    2.85068  0.00   
+  3  0    0    4    13605.9883 10327.4229 -0.0    2.84891  0.00   
+  3  3    1    1    2402.3961  3752.9688  -180.0  2.75686  0.00   
+  3  3    1    -4   2332.7951  3260.3471  -0.0    2.73472  0.00   
+  3  4    0    0    71444.0777 71031.9739 0.0     2.65146  0.00   
+  3  2    2    1    267917.1400 133021.8059 0.0     2.64322  0.03   
+  3  2    2    -3   163687.1823 66256.8795 -180.0  2.63275  0.02   
+  3  4    0    -4   326961.0460 140408.5131 180.0   2.63045  0.02   
+  3  0    2    3    24559.3436 14178.9448 180.0   2.54775  0.00   
+  3  3    1    2    4721.8141  9770.8933  -180.0  2.37457  0.00   
+  3  3    1    -5   5401.8916  5853.7195  -0.0    2.35477  0.00   
+  3  2    2    2    128.7011   143.8080   -180.0  2.34824  0.00   
+  3  2    2    -4   903.2548   881.0292   180.0   2.33724  0.00   
+  3  1    1    4    3580.0291  2962.3958  -0.0    2.33431  0.00   
+  3  1    1    -5   502.7893   299.3623   -0.0    2.32619  0.00   
+  3  4    2    -2   1987.0608  1407.7759  -0.0    2.25112  0.00   
+  3  5    1    -2   3005.5764  2122.6657  180.0   2.24357  0.00   
+  3  5    1    -3   857.6279   538.9133   180.0   2.23956  0.00   
+  3  1    3    0    85.3474    52.5069    0.0     2.23838  0.00   
+  3  1    3    -1   6858.4461  4186.4607  -0.0    2.23758  0.00   
+  3  4    2    -1   1059.6264  918.4263   0.0     2.21152  0.00   
+  3  4    2    -3   11884.9861 13293.9488 -0.0    2.20537  0.00   
+  3  0    2    4    938.2615   966.6191   180.0   2.19284  0.00   
+  3  5    1    -1   14550.4745 11518.0733 -0.0    2.16497  0.00   
+  3  1    3    1    1282.8308  1032.4559  -0.0    2.15743  0.00   
+  3  1    3    -2   13244.5999 10975.2744 0.0     2.15528  0.00   
+  3  5    1    -4   863.1385   709.3160   -180.0  2.15419  0.00   
+  3  2    0    4    4101.5140  1630.1550  0.0     2.13573  0.00   
+  3  2    0    -6   52145.2230 7194.5336  0.0     2.12198  0.00   
+  3  4    2    0    1385.6482  728.4665   -180.0  2.09889  0.00   
+  3  4    2    -4   1299.7262  548.3517   -180.0  2.08843  0.00   
+  3  4    0    2    231472.7801 285697.3593 180.0   2.06942  0.01   
+  3  2    2    3    184672.3170 292739.5635 0.0     2.06298  0.01   
+  3  2    2    -5   170952.8957 296841.9566 0.0     2.05304  0.01   
+  3  4    0    -6   156200.5413 301707.2943 -180.0  2.04950  0.00   
+  3  3    1    3    559.0085   1080.9037  -180.0  2.04754  0.00   
+  3  3    1    -6   147.5344   154.5139   -0.0    2.03121  0.00   
+  3  5    1    0    848.7799   770.8901   180.0   2.02676  0.00   
+  3  1    3    2    18879.0076 14027.7008 -0.0    2.01822  0.00   
+  3  1    3    -3   1767.1511  1239.1409  -0.0    2.01530  0.00   
+  3  5    1    -5   21421.9890 14139.5360 -0.0    2.01208  0.00   
+  3  3    3    -1   6740.7990  7028.4172  -0.0    1.97745  0.00   
+  3  3    3    -2   214.6696   188.2663   0.0     1.97579  0.00   
+  3  6    0    -2   3942.6572  970.2995   180.0   1.96059  0.00   
+  3  1    1    5    17010.3617 4609.7618  180.0   1.95972  0.00   
+  3  6    0    -4   28297.4289 17245.6519 -180.0  1.95417  0.00   
+  3  1    1    -6   2519.7247  1559.2190  -0.0    1.95385  0.00   
+  3  4    2    1    25476.2941 20964.5733 -0.0    1.94283  0.00   
+  3  4    2    -5   77.7845    70.8548    180.0   1.93040  0.00   
+  3  3    3    0    8106.8489  9843.8331  180.0   1.92198  0.00   
+  3  3    3    -3   2069.7248  2770.5320  -0.0    1.91744  0.00   
+  3  0    0    6    1466.6974  1703.7779  -0.0    1.89928  0.00   
+  3  0    2    5    78.2095    90.1067    -180.0  1.89911  0.00   
+  3  5    1    1    5110.8483  2500.7434  -180.0  1.86038  0.00   
+  3  1    3    3    9045.1275  3425.0588  0.0     1.85196  0.00   
+  3  1    3    -4   1182.9744  508.9478   -180.0  1.84880  0.00   
+  3  5    1    -6   6280.4526  2893.5082  -180.0  1.84452  0.00   
+  3  3    3    1    4583.6321  3298.2389  -0.0    1.82246  0.00   
+  3  3    3    -4   17227.3178 15077.7022 -180.0  1.81602  0.00   
+  3  2    2    4    1974.2085  2004.2435  180.0   1.81373  0.00   
+  3  2    2    -6   52.2665    110.7433   -0.0    1.80528  0.00   
+  3  3    1    4    588.7349   1170.5401  -0.0    1.78145  0.00   
+  3  4    2    2    1009.7505  569.9378   -0.0    1.77259  0.00   
+  3  3    1    -7   1991.9256  719.8279   -180.0  1.76829  0.00   
+  3  6    0    0    99317.1895 33110.4566 180.0   1.76764  0.00   
+  3  4    2    -6   10021.5968 1197.0761  -0.0    1.76001  0.00   
+  3  6    0    -6   9.2571     2.0519     0.0     1.75364  0.00   
+  3  6    2    -3   807080.6047 369893.0340 -180.0  1.71990  0.03   
+  3  0    4    0    562903.1903 349239.0777 -180.0  1.71747  0.01   
+  3  6    2    -2   796.2563   389.5662   -0.0    1.70275  0.00   
+  3  6    2    -4   2370.4764  1559.0063  180.0   1.69854  0.00   
+  3  0    4    1    5007.7903  3261.4197  -0.0    1.69829  0.00   
+  3  3    3    2    5681.4088  3601.7539  -0.0    1.69795  0.00   
+  3  5    1    2    7589.9250  2566.7316  -180.0  1.69073  0.00   
+  3  3    3    -5   31131.2554 10531.2518 0.0     1.69066  0.00   
+  3  1    1    6    1169.2638  741.4035   -0.0    1.68395  0.00   
+  3  1    3    4    68.8495    44.9522    -0.0    1.68304  0.00   
+  3  1    3    -5   7628.6979  4679.6611  0.0     1.67999  0.00   
+  3  1    1    -7   19962.6347 12408.6046 -180.0  1.67955  0.00   
+  3  5    1    -7   377.3441   265.5075   -180.0  1.67544  0.00   
+  3  0    2    6    1357.7622  1002.9200  0.0     1.66212  0.00   
+  3  6    2    -1   849.5687   865.7198   -180.0  1.65035  0.00   
+  3  2    4    -1   2791.3636  2846.3024  180.0   1.65033  0.00   
+  3  7    1    -3   34.4495    35.4673    180.0   1.64981  0.00   
+  3  5    3    -2   333.5304   336.8527   -180.0  1.64806  0.00   
+  3  7    1    -4   552.9198   557.1489   -0.0    1.64758  0.00   
+  3  5    3    -3   1216.8456  1233.1133  -180.0  1.64647  0.00   
+  3  0    4    2    602.9911   612.1428   -180.0  1.64439  0.00   
+  3  6    2    -5   475.6523   504.8209   -180.0  1.64272  0.00   
+  3  2    4    0    581.3951   754.2136   -0.0    1.63391  0.00   
+  3  2    4    -2   3372.5323  4465.8946  180.0   1.63267  0.00   
+  3  7    1    -2   3856.2643  3569.9801  180.0   1.61839  0.00   
+  3  5    3    -1   1267.9219  967.0564   0.0     1.61614  0.00   
+  3  7    1    -5   1558.5974  916.1043   -0.0    1.61209  0.00   
+  3  5    3    -4   6625.1112  3834.9981  -180.0  1.61165  0.00   
+  3  4    0    4    122560.7306 64347.8084 180.0   1.60877  0.00   
+  3  4    2    3    53.3473    27.4467    180.0   1.60748  0.00   
+  3  2    2    5    70647.5878 37116.5064 -180.0  1.60456  0.00   
+  3  2    2    -7   170715.5509 66460.5555 0.0     1.59754  0.01   
+  3  4    2    -7   8048.8978  2577.6650  -0.0    1.59577  0.00   
+  3  4    0    -8   133913.4977 36891.4626 0.0     1.59471  0.00   
+  3  2    4    1    3705.3885  1926.6405  0.0     1.58631  0.00   
+  3  2    4    -3   3798.7714  1877.8866  0.0     1.58404  0.00   
+  3  2    0    6    61844.6801 28867.0796 -0.0    1.57431  0.00   
+  3  6    2    0    565.0721   317.3964   -0.0    1.57174  0.00   
+  3  3    1    5    2252.3404  1737.0799  180.0   1.56732  0.00   
+  3  2    0    -8   6357.2275  4964.5142  -180.0  1.56658  0.00   
+  3  3    3    3    610.0741   484.9151   0.0     1.56549  0.00   
+  3  0    4    3    3527.3409  2916.9964  -0.0    1.56494  0.00   
+  3  6    2    -6   1422.3264  1246.0869  -180.0  1.56187  0.00   
+  3  7    1    -1   2396.7990  2041.8362  -0.0    1.55870  0.00   
+  3  3    3    -6   1790.4775  1491.9744  -180.0  1.55816  0.00   
+  3  3    1    -8   2344.0942  1854.6907  0.0     1.55673  0.00   
+  3  5    3    0    4822.7355  3764.6000  180.0   1.55615  0.00   
+  3  5    3    -5   1731.4141  1406.8546  0.0     1.54947  0.00   
+  3  7    1    -6   4648.3599  3779.7017  -180.0  1.54933  0.00   
+  3  5    1    3    1004.0515  786.6440   0.0     1.53192  0.00   
+  3  1    3    5    3.9318     7.3949     -180.0  1.52518  0.00   
+  3  1    3    -6   943.5424   1154.8547  0.0     1.52240  0.00   
+  3  5    1    -8   8.3436     5.3938     0.0     1.51801  0.00   
+  3  2    4    2    6899.6954  4259.4685  180.0   1.51513  0.00   
+  3  2    4    -4   3472.5591  2488.9469  -0.0    1.51216  0.00   
+  3  6    0    2    8713.2316  8927.4646  180.0   1.50492  0.00   
+  3  6    0    -8   6176.4697  4374.4012  -180.0  1.49055  0.00   
+  3  8    0    -4   28572.3014 20075.3665 0.0     1.49018  0.00   
+  3  4    4    -2   34040.0671 20515.8401 -0.0    1.48807  0.00   
+  3  7    1    0    1950.0207  521.9936   0.0     1.47957  0.00   
+  3  6    2    1    1906.5675  505.0908   180.0   1.47788  0.00   
+  3  5    3    1    5569.8780  1470.6883  180.0   1.47692  0.00   
+  3  4    4    -1   674.3711   180.6211   180.0   1.47646  0.00   
+  3  4    4    -3   5333.1907  1669.9832  180.0   1.47463  0.00   
+  3  1    1    7    27762.8724 9066.3000  -0.0    1.47392  0.00   
+  3  0    2    7    7296.0117  2496.6943  180.0   1.47110  0.00   
+  3  0    4    4    1725.4507  584.6755   180.0   1.47086  0.00   
+  3  1    1    -8   22217.7080 7382.4328  0.0     1.47051  0.00   
+  3  5    3    -6   0.5264     0.1801     -180.0  1.46895  0.00   
+  3  7    1    -7   655.2331   231.4520   -180.0  1.46838  0.00   
+  3  6    2    -7   2895.3708  1074.5558  180.0   1.46696  0.00   
+  3  4    2    4    461.6036   308.9633   -180.0  1.45690  0.00   
+  3  4    2    -8   324.1415   302.0532   -180.0  1.44643  0.00   
+  3  8    0    -2   59767.4292 52285.4717 0.0     1.44512  0.00   
+  3  4    4    0    70723.0441 40432.7863 -180.0  1.44149  0.00   
+  3  8    0    -6   83937.0077 39471.3565 -180.0  1.43828  0.00   
+  3  4    4    -4   113946.3158 54140.5267 0.0     1.43808  0.00   
+  3  3    3    4    9736.1898  4619.7202  -180.0  1.43649  0.00   
+  3  2    2    6    1.2319     0.8037     -180.0  1.43116  0.00   
+  3  2    4    3    4229.4958  2700.6054  180.0   1.42969  0.00   
+  3  3    3    -7   2279.4806  1447.2851  0.0     1.42957  0.00   
+  3  2    4    -5   2619.7848  1672.6772  180.0   1.42637  0.00   
+  3  2    2    -8   3121.0898  1818.1746  -0.0    1.42534  0.00   
+  3  0    0    8    483452.4970 266275.2162 -0.0    1.42446  0.01   
+  3  3    1    6    1317.4013  937.0051   180.0   1.39419  0.00   
+  3  7    1    1    75.6856    50.2076    -180.0  1.39022  0.00   
+  3  5    1    4    1142.6759  766.2784   0.0     1.38968  0.00   
+  3  4    4    1    4437.6679  3625.7812  -0.0    1.38783  0.00   
+  3  5    3    2    537.6728   442.9270   -180.0  1.38764  0.00   
+  3  3    1    -9   987.4124   705.3414   -0.0    1.38558  0.00   
+  3  1    3    6    4412.3642  3147.0402  0.0     1.38389  0.00   
+  3  4    4    -5   1734.2874  1224.4467  0.0     1.38328  0.00   
+  3  1    3    -7   779.5916   485.6081   -180.0  1.38144  0.00   
+  3  5    3    -7   1304.8002  1074.4975  180.0   1.37915  0.00   
+  3  6    2    2    295.7596   255.5080   -180.0  1.37843  0.00   
+  3  7    1    -8   262.6616   231.0290   0.0     1.37830  0.00   
+  3  5    1    -9   3177.8271  3153.2469  -0.0    1.37741  0.00   
+  3  0    4    5    512.5683   361.2535   -180.0  1.37163  0.00   
+  3  6    2    -8   6.8137     2.8764     0.0     1.36736  0.00   
+  3  8    2    -4   1787.3445  738.3691   180.0   1.36707  0.00   
+  3  7    3    -3   8488.0413  3197.7857  -180.0  1.36475  0.00   
+  3  7    3    -4   1189.0635  462.3547   -180.0  1.36348  0.00   
+  3  1    5    0    10714.1147 4378.3377  -180.0  1.36259  0.00   
+  3  1    5    -1   142.2132   57.4971    -0.0    1.36241  0.00   
+  3  8    2    -3   4689.8054  1921.4590  180.0   1.35877  0.00   
+  3  8    2    -5   28681.2197 14138.1993 180.0   1.35592  0.00   
+  3  7    3    -2   4509.7794  6972.0574  0.0     1.34680  0.00   
+  3  1    5    1    3631.8053  7448.7932  0.0     1.34369  0.00   
+  3  7    3    -5   1226.9794  2389.4463  180.0   1.34316  0.00   
+  3  1    5    -2   1438.7931  2806.0453  180.0   1.34317  0.00   
+  3  2    4    4    252.7519   204.8237   -180.0  1.33840  0.00   
+  3  2    4    -6   3157.8468  4275.4207  180.0   1.33499  0.00   
+  3  8    2    -2   129.7463   192.1770   0.0     1.33203  0.00   
+  3  8    2    -6   88.9939    116.5596   0.0     1.32667  0.00   
+  3  8    0    0    105732.1280 126627.2507 0.0     1.32573  0.00   
+  3  4    2    5    12531.3269 12803.0480 0.0     1.32376  0.00   
+  3  4    4    2    125379.4868 113941.2603 0.0     1.32161  0.00   
+  3  3    3    5    1381.4776  1245.0587  -0.0    1.31694  0.00   
+  3  4    4    -6   134375.3847 120657.4919 0.0     1.31637  0.00   
+  3  0    2    8    406.5007   367.8173   180.0   1.31580  0.00   
+  3  8    0    -8   149090.7294 138911.0933 -0.0    1.31523  0.00   
+  3  4    2    -9   5895.3809  5515.4935  180.0   1.31459  0.00   
+  3  7    3    -1   1667.7788  1032.3073  180.0   1.31181  0.00   
+  3  3    3    -8   13751.5289 7089.9054  180.0   1.31063  0.00   
+  3  1    1    8    368.4748   156.9928   180.0   1.30926  0.00   
+  3  1    5    2    4663.6740  1741.3190  180.0   1.30797  0.00   
+  3  1    5    -3   18951.5048 7332.4016  -0.0    1.30718  0.00   
+  3  1    1    -9   1737.4849  714.2405   180.0   1.30655  0.00   
+  3  7    3    -6   18376.6396 7534.6306  -0.0    1.30621  0.00   
+  3  6    4    -3   4178.5145  2358.6087  -0.0    1.29933  0.00   
+  3  9    1    -4   1438.5559  840.1413   0.0     1.29924  0.00   
+  3  7    1    2    5369.6547  3970.4242  -180.0  1.29813  0.00   
+  3  9    1    -5   362.6330   256.4854   0.0     1.29783  0.00   
+  3  3    5    -1   1241.2766  624.0157   0.0     1.29668  0.00   
+  3  3    5    -2   4218.0766  2195.2865  -0.0    1.29621  0.00   
+  3  5    3    3    639.5484   335.5224   180.0   1.29573  0.00   
+  3  6    4    -2   42.3547    25.6370    0.0     1.29189  0.00   
+  3  6    4    -4   7728.2693  7144.7715  -0.0    1.29005  0.00   
+  3  4    0    6    20052.2610 18430.0994 180.0   1.29008  0.00   
+  3  8    2    -1   9480.1066  8916.0617  180.0   1.28996  0.00   
+  3  5    3    -8   2511.8903  3481.2865  180.0   1.28728  0.00   
+  3  2    2    7    11587.5757 16103.7102 -0.0    1.28730  0.00   
+  3  7    1    -9   115.3345   133.1321   180.0   1.28629  0.00   
+  3  9    1    -3   7127.9148  5502.1713  180.0   1.28403  0.00   
+  3  8    2    -7   738.7385   428.7763   -180.0  1.28268  0.00   
+  3  2    2    -9   34299.1655 19711.1402 0.0     1.28246  0.00   
+  3  3    5    0    1574.4121  723.1256   -0.0    1.28066  0.00   
+  3  4    0    -10  44837.2322 20573.2507 -180.0  1.28039  0.00   
+  3  6    2    3    0.8174     0.3798     180.0   1.28021  0.00   
+  3  9    1    -6   388.0478   186.1560   -0.0    1.27997  0.00   
+  3  3    5    -3   11192.3982 6056.7903  -0.0    1.27931  0.00   
+  3  0    4    6    180.4869   118.7129   180.0   1.27387  0.00   
+  3  6    2    -9   401.2190   464.2431   180.0   1.26958  0.00   
+  3  6    4    -1   346.7061   482.2612   -180.0  1.26855  0.00   
+  3  6    0    4    10236.4934 7253.9356  180.0   1.26527  0.00   
+  3  6    4    -5   880.3684   581.7941   -180.0  1.26508  0.00   
+  3  5    1    5    7151.6707  4606.9251  180.0   1.26501  0.00   
+  3  7    3    0    2151.1570  802.8327   180.0   1.26358  0.00   
+  3  1    3    7    36616.7543 8416.8791  -0.0    1.26006  0.00   
+  3  1    5    3    145.6294   35.3569    180.0   1.25930  0.00   
+  3  1    5    -4   12675.1053 3108.7211  180.0   1.25830  0.00   
+  3  1    3    -8   11592.3325 3093.4250  180.0   1.25793  0.00   
+  3  7    3    -7   4701.3472  2419.4252  180.0   1.25659  0.00   
+  3  5    1    -10  10392.9902 7028.2195  -180.0  1.25432  0.00   
+  3  9    1    -2   483.1919   361.5721   0.0     1.25388  0.00   
+  3  6    0    -10  146.4529   117.8452   -180.0  1.25331  0.00   
+  3  3    1    7    2010.6620  1611.2755  -0.0    1.25270  0.00   
+  3  3    5    1    9774.4179  8365.6876  0.0     1.24990  0.00   
+  3  4    4    3    18.0187    16.4616    0.0     1.24877  0.00   
+  3  3    5    -4   1032.8028  1094.7115  -0.0    1.24782  0.00   
+  3  9    1    -7   7956.0153  8715.4401  -180.0  1.24760  0.00   
+  3  2    4    5    1026.2744  1152.2483  0.0     1.24740  0.00   
+  3  3    1    -10  2673.6264  2982.8745  180.0   1.24561  0.00   
+  3  2    4    -7   780.2464   791.0948   0.0     1.24409  0.00   
+  3  4    4    -7   6440.3862  6542.7513  -0.0    1.24325  0.00   
+  3  2    0    8    26.9640    27.5719    -0.0    1.24099  0.00   
+  3  8    2    0    659.6597   732.3491   180.0   1.23681  0.00   
+  3  2    0    -10  1921.9021  2002.5013  180.0   1.23612  0.00   
+  3  6    4    0    11850.4527 14163.9232 -0.0    1.23179  0.00   
+  3  8    2    -8   555.4441   626.3480   180.0   1.22827  0.00   
+  3  6    4    -6   158.3338   129.6800   -180.0  1.22702  0.00   
+  3  9    1    -1   4666.0080  2736.0544  -0.0    1.21182  0.00   
+  3  3    3    6    1408.6059  848.8094   0.0     1.20915  0.00   
+  3  7    1    3    123.5619   73.3088    180.0   1.20840  0.00   
+  3  4    2    6    654.1537   411.4914   -0.0    1.20771  0.00   
+  3  3    5    2    5732.8478  3752.4577  0.0     1.20747  0.00   
+  3  7    3    1    3898.5609  2737.7149  180.0   1.20655  0.00   
+  3  5    3    4    10826.2851 7533.1217  -180.0  1.20620  0.00   
+  3  3    5    -5   58.3952    48.9010    180.0   1.20485  0.00   
+  3  9    1    -8   2396.1236  2317.0795  0.0     1.20390  0.00   
+  3  3    3    -9   1048.3222  943.1430   -0.0    1.20352  0.00   
+  3  1    5    4    4078.0104  3946.3181  180.0   1.20208  0.00   
+  3  1    5    -5   630.0092   657.9301   0.0     1.20097  0.00   
+  3  4    2    -10  189.7085   165.1119   -0.0    1.19975  0.00   
+  3  7    3    -8   5.3573     5.4244     0.0     1.19874  0.00   
+  3  5    3    -9   276.9309   300.8008   180.0   1.19815  0.00   
+  3  7    1    -10  9064.2556  8276.9170  -180.0  1.19711  0.00   
+  3  5    5    -2   5048.1602  3032.9471  -0.0    1.18914  0.00   
+  3  5    5    -3   0.1701     0.1012     -0.0    1.18854  0.00   
+  3  0    2    9    467.6257   269.3572   -0.0    1.18804  0.00   
+  3  6    2    4    413.5128   267.8685   180.0   1.18728  0.00   
+  3  10   0    -4   9718.9792  6786.3001  0.0     1.18686  0.00   
+  3  6    4    1    1846.4090  1321.4870  0.0     1.18502  0.00   
+  3  10   0    -6   15954.2468 11069.8912 0.0     1.18449  0.00   
+  3  0    4    7    362.1930   286.2966   180.0   1.18151  0.00   
+  3  6    4    -7   1853.0363  1786.0275  0.0     1.17937  0.00   
+  3  8    0    2    24018.5024 31203.7473 180.0   1.17794  0.00   
+  3  6    2    -10  1.6412     2.2500     -0.0    1.17739  0.00   
+  3  5    5    -1   4687.7807  7333.3701  -180.0  1.17698  0.00   
+  3  1    1    9    79.2651    122.6202   -0.0    1.17700  0.00   
+  3  8    2    1    3715.1821  5828.2210  -180.0  1.17697  0.00   
+  3  5    5    -4   2418.6272  5569.9415  -0.0    1.17524  0.00   
+  3  1    1    -10  318.1432   762.3801   180.0   1.17480  0.00   
+  3  4    4    4    13127.7546 33797.9536 0.0     1.17412  0.00   
+  3  4    4    -8   20296.9176 28595.8783 -180.0  1.16862  0.00   
+  3  8    2    -9   7136.8924  8397.1111  180.0   1.16778  0.00   
+  3  2    2    8    98.8753    100.3672   0.0     1.16716  0.00   
+  3  8    0    -10  39822.8500 38189.7985 0.0     1.16691  0.00   
+  3  2    2    -10  519.5371   558.5305   -0.0    1.16310  0.00   
+  3  9    1    0    102.4800   175.9707   180.0   1.16146  0.00   
+  3  2    4    6    7753.3486  13788.4423 180.0   1.16052  0.00   
+  3  2    4    -8   2056.7544  2415.9757  0.0     1.15742  0.00   
+  3  3    5    3    2817.4035  3138.9340  0.0     1.15698  0.00   
+  3  5    1    6    45.8664    50.4532    0.0     1.15671  0.00   
+  3  3    5    -6   46.2596    51.9103    -0.0    1.15401  0.00   
+  3  5    5    0    5986.6090  6678.1581  -0.0    1.15319  0.00   
+  3  9    1    -9   581.4914   564.6421   180.0   1.15252  0.00   
+  3  1    3    8    2864.4817  2759.9706  0.0     1.15249  0.00   
+  3  1    3    -9   1.3632     1.3234     -0.0    1.15063  0.00   
+  3  5    5    -5   9188.8826  8520.9404  -180.0  1.15046  0.00   
+  3  5    1    -11  1644.3172  1510.3893  0.0     1.14744  0.00   
+  3  9    3    -4   442.5488   426.5956   0.0     1.14563  0.00   
+  3  0    6    0    2781.7836  2617.6245  -0.0    1.14498  0.00   
+  3  7    3    2    5202.8059  4899.1825  -0.0    1.14488  0.00   
+  3  9    3    -5   68.0895    64.8278    -0.0    1.14467  0.00   
+  3  10   0    -2   22185.4605 15968.0855 0.0     1.14060  0.00   
+  3  1    5    5    7204.0992  5051.5907  -0.0    1.14041  0.00   
+  3  0    0    10   681.1207   423.2012   -0.0    1.13957  0.00   
+  3  1    5    -6   8837.4255  5314.9524  180.0   1.13925  0.00   
+  3  0    6    1    2751.5321  1653.0194  180.0   1.13924  0.00   
+  3  7    3    -9   14596.0482 4655.8618  180.0   1.13673  0.00   
+  3  3    1    8    237.6740   68.5169    180.0   1.13561  0.00   
+  3  9    3    -3   5898.0527  1425.0085  -180.0  1.13516  0.00   
+  3  10   0    -8   7736.2282  1444.5643  0.0     1.13431  0.00   
+  3  9    3    -6   11868.6586 1853.0409  -0.0    1.13236  0.00   
+  3  6    4    2    21241.6061 2828.5025  0.0     1.13187  0.00   
+  3  3    1    -11  215.1134   30.9235    0.0     1.12971  0.00   
+  3  10   2    -5   25906.7896 6250.7551  0.0     1.12624  0.00   
+  3  6    4    -8   8045.8555  2095.8324  -0.0    1.12572  0.00   
+  3  8    4    -4   15363.5446 4159.5086  -180.0  1.12556  0.00   
+  3  2    6    -1   9057.2389  3577.3431  180.0   1.12442  0.00   
+  3  7    1    4    11770.1015 4922.1591  -0.0    1.12392  0.00   
+  3  0    6    2    3322.2317  1380.3426  -180.0  1.12254  0.00   
+  3  5    3    5    4113.3249  1969.2775  -180.0  1.12196  0.00   
+  3  10   2    -4   17.9845    9.0514     180.0   1.12179  0.00   
+  3  8    4    -3   5649.5270  3321.2004  -180.0  1.12091  0.00   
+  3  5    5    1    987.1608   712.3818   0.0     1.11981  0.00   
+  3  10   2    -6   236.8093   172.3994   180.0   1.11978  0.00   
+  3  8    4    -5   1241.9722  1031.1584  180.0   1.11931  0.00   
+  3  2    6    0    6139.3598  5324.5816  180.0   1.11919  0.00   
+  3  2    6    -2   991.8490   994.7961   180.0   1.11879  0.00   
+  3  5    5    -6   1589.9520  2506.0954  0.0     1.11633  0.00   
+  3  5    3    -10  1483.6392  1592.9982  -0.0    1.11448  0.00   
+  3  8    2    2    116.6558   120.6121   0.0     1.11424  0.00   
+  3  9    3    -2   1972.5147  2018.2403  0.0     1.11417  0.00   
+  3  7    1    -11  2415.2407  2076.1894  180.0   1.11344  0.00   
+  3  3    3    7    8551.7751  7158.7424  0.0     1.11335  0.00   
+  3  9    3    -7   2516.0777  1747.8303  -180.0  1.10976  0.00   
+  3  3    3    -10  348.3663   264.2542   -0.0    1.10836  0.00   
+  3  4    2    7    12737.8916 9257.1392  0.0     1.10705  0.00   
+  3  10   2    -3   47895.1369 35122.0418 -180.0  1.10679  0.00   
+  3  9    1    1    5326.0427  3803.3771  -180.0  1.10633  0.00   
+  3  8    4    -2   47168.1546 29363.1790 -180.0  1.10576  0.00   
+  3  8    2    -10  58.5858    36.3896    0.0     1.10489  0.00   
+  3  2    6    1    39264.9496 27660.2202 -180.0  1.10353  0.00   
+  3  10   2    -7   51106.2482 34918.8172 0.0     1.10295  0.00   
+  3  2    6    -3   43149.2585 29933.5896 0.0     1.10277  0.00   
+  3  8    4    -6   43036.8719 30130.4862 0.0     1.10269  0.00   
+  3  3    5    4    89.7405    70.5207    0.0     1.10188  0.00   
+  3  6    2    5    163368.3648 132075.9030 -180.0  1.10160  0.00   
+  3  4    4    5    3331.7610  2697.8124  180.0   1.10101  0.00   
+  3  4    2    -11  2668.0692  2168.2631  -0.0    1.10016  0.00   
+  3  3    5    -7   3086.9569  2938.6164  0.0     1.09874  0.00   
+  3  9    1    -10  254.2978   278.9248   0.0     1.09690  0.00   
+  3  0    4    8    111427.1720 133852.3770 -180.0  1.09642  0.00   
+  3  0    6    3    2845.4128  3406.0054  -0.0    1.09626  0.00   
+  3  4    4    -9   121.5670   133.8105   0.0     1.09572  0.00   
+  3  6    2    -11  181062.8071 149427.3819 -180.0  1.09256  0.00   
+  3  9    3    -1   687.5529   1114.0707  0.0     1.08435  0.00   
+  3  10   2    -2   725.3740   878.7302   -0.0    1.08248  0.00   
+  3  7    3    3    5466.8278  5993.9369  180.0   1.08190  0.00   
+  3  0    2    10   145.5261   133.4720   0.0     1.08160  0.00   
+  3  8    4    -1   8.4316     6.5251     0.0     1.08134  0.00   
+  3  2    4    7    191.2630   143.5155   180.0   1.07976  0.00   
+  3  5    5    2    7629.0201  5313.8332  0.0     1.07936  0.00   
+  3  2    6    2    923.3011   479.5892   0.0     1.07871  0.00   
+  3  9    3    -8   33.2506    16.9995    180.0   1.07867  0.00   
+  3  2    6    -4   5302.6358  3161.4599  -0.0    1.07764  0.00   
+  3  1    5    6    12293.8891 7500.0737  180.0   1.07759  0.00   
+  3  10   2    -8   409.9839   301.0108   0.0     1.07710  0.00   
+  3  8    4    -7   1186.5162  885.4324   -0.0    1.07703  0.00   
+  3  2    4    -9   1686.5851  1302.0632  -180.0  1.07690  0.00   
+  3  1    5    -7   13001.5960 11193.5196 0.0     1.07644  0.00   
+  3  6    4    3    1498.6082  1519.4304  -180.0  1.07557  0.00   
+  3  5    5    -7   15.6329    16.4899    0.0     1.07535  0.00   
+  3  7    3    -10  12242.6780 12239.7749 0.0     1.07377  0.00   
+  3  6    0    6    785.0599   878.1551   180.0   1.07251  0.00   
+  3  11   1    -5   187.5234   156.7234   180.0   1.06983  0.00   
+  3  6    4    -9   895.3551   816.5987   -180.0  1.06924  0.00   
+  3  11   1    -6   6.4336     5.6606     -180.0  1.06887  0.00   
+  3  4    6    -2   2851.3269  2494.4283  -180.0  1.06882  0.00   
+  3  1    1    10   3030.9673  2596.6805  -180.0  1.06861  0.00   
+  3  7    5    -3   1564.2687  1331.7364  -180.0  1.06848  0.00   
+  3  7    5    -4   206.0271   168.6670   180.0   1.06788  0.00   
+  3  4    0    8    28733.1763 23517.9783 -0.0    1.06787  0.00   
+  3  1    1    -11  47.2896    42.3756    0.0     1.06679  0.00   
+  3  2    2    9    26888.4422 24364.2928 -0.0    1.06594  0.00   
+  3  4    6    -1   2.3271     2.0449     -0.0    1.06449  0.00   
+  3  4    6    -3   3256.6672  2831.4348  180.0   1.06381  0.00   
+  3  6    0    -12  2682.5846  2923.4798  -180.0  1.06314  0.00   
+  3  5    1    7    2788.3445  3261.6628  0.0     1.06281  0.00   
+  3  2    2    -11  18441.5597 20983.9567 -180.0  1.06250  0.00   
+  3  0    6    4    1510.0901  1675.3120  0.0     1.06239  0.00   
+  3  11   1    -4   5167.0767  5105.4905  0.0     1.06146  0.00   
+  3  4    0    -12  26683.1011 28218.7960 -180.0  1.06099  0.00   
+  3  10   0    0    754.1449   818.1245   0.0     1.06059  0.00   
+  3  7    5    -2   1.7944     1.6435     -0.0    1.05981  0.00   
+  3  1    3    9    1907.5654  1609.5467  0.0     1.05919  0.00   
+  3  11   1    -7   83.4918    65.8892    -180.0  1.05866  0.00   
+  3  7    5    -5   5234.9597  3885.4940  -180.0  1.05803  0.00   
+  3  1    3    -10  3394.8634  2354.8872  0.0     1.05759  0.00   
+  3  5    1    -12  3440.2175  2089.2343  -180.0  1.05477  0.00   
+  3  10   0    -10  6964.1588  4636.8736  0.0     1.05218  0.00   
+  3  8    2    3    29088.3918 22544.6331 180.0   1.05151  0.00   
+  3  4    6    0    1995.5551  1594.4768  0.0     1.05116  0.00   
+  3  10   2    -1   76510.6000 57904.1973 0.0     1.05066  0.00   
+  3  4    6    -4   1714.5691  1172.4235  0.0     1.04984  0.00   
+  3  8    4    0    86312.1223 62151.2478 -180.0  1.04945  0.00   
+  3  9    1    2    181.6740   132.4263   -0.0    1.04936  0.00   
+  3  9    3    0    3010.1873  2356.0217  0.0     1.04783  0.00   
+  3  2    6    3    78757.7609 55957.0122 -180.0  1.04656  0.00   
+  3  7    1    5    1447.4255  1023.2699  0.0     1.04608  0.00   
+  3  2    6    -5   89266.8226 56250.7200 -180.0  1.04525  0.00   
+  3  3    5    5    6110.3104  3648.7025  -0.0    1.04507  0.00   
+  3  11   1    -3   52.2561    27.3279    180.0   1.04440  0.00   
+  3  5    3    6    2687.4524  1399.6862  -180.0  1.04433  0.00   
+  3  8    4    -8   130148.3082 67472.6956 -180.0  1.04421  0.00   
+  3  10   2    -9   129772.9934 67104.2744 0.0     1.04411  0.00   
+  3  7    5    -1   11499.6058 4657.8874  -180.0  1.04250  0.00   
+  3  8    2    -11  12.1538    4.8409     0.0     1.04235  0.00   
+  3  3    5    -8   873.4685   382.1113   -0.0    1.04191  0.00   
+  3  9    3    -9   884.7453   492.4025   -180.0  1.04124  0.00   
+  3  11   1    -8   7931.2411  5319.7562  0.0     1.03996  0.00   
+  3  9    1    -11  6827.4401  4922.1695  180.0   1.03985  0.00   
+  3  7    5    -6   25.0514    20.5769    180.0   1.03968  0.00   
+  3  3    1    9    517.6176   982.6857   -180.0  1.03750  0.00   
+  3  5    3    -11  87.1969    166.6629   -0.0    1.03749  0.00   
+  3  7    1    -12  251.6838   562.7466   -180.0  1.03650  0.00   
+  3  8    0    4    1092.1747  2816.3580  -0.0    1.03471  0.00   
+  3  5    5    3    549.7797   1394.6166  -180.0  1.03437  0.00   
+  4  1    1    0    1350.3621  1291.4299  -0.0    3.35586  0.03   
+  4  1    0    1    438.7463   491.2958   -0.0    2.46956  0.01   
+  4  2    0    0    67.5773    146.2787   -0.0    2.37295  0.00   
+  4  1    1    1    409.1202   375.6372   180.0   2.19071  0.01   
+  4  2    1    0    1104.1884  162.4468   0.0     2.12243  0.02   
+  4  2    1    1    1056.6429  896.5147   -0.0    1.71106  0.02   
+  4  2    2    0    1869.4315  1202.3175  -0.0    1.67793  0.01   
+  4  3    1    0    349.4557   370.6401   -0.0    1.50078  0.00   
+  4  2    2    1    31.7328    29.7263    180.0   1.45133  0.00   
+  4  0    0    2    1542.2002  1358.6905  -0.0    1.44596  0.00   
+  4  3    0    1    1400.4855  1096.5893  -0.0    1.38788  0.01   
+  4  3    1    1    24.5078    34.6309    0.0     1.33209  0.00   
+  4  1    1    2    397.3015   529.7813   -0.0    1.32794  0.00   
+  4  3    2    0    18.4506    16.3092    180.0   1.31628  0.00   
+  4  2    0    2    126.8966   144.5590   -0.0    1.23478  0.00   
+  4  3    2    1    156.9231   159.1322   -0.0    1.19802  0.00   
+  4  2    1    2    47.0243    41.5883    0.0     1.19499  0.00   
+  4  4    0    0    629.0228   448.4383   -0.0    1.18647  0.00   
+  4  4    1    0    87.5925    85.8115    180.0   1.15105  0.00   
+  4  3    3    0    647.0837   633.8388   -0.0    1.11862  0.00   
+  4  2    2    2    569.0101   564.8012   -0.0    1.09536  0.00   
+  4  4    1    1    323.9428   285.0225   -0.0    1.06945  0.00   
+  4  4    2    0    260.8393   262.4087   -0.0    1.06122  0.00   
+  4  3    3    1    8.3627     4.2490     180.0   1.04329  0.00   
+  4  3    1    2    407.7514   222.7816   -0.0    1.04129  0.01   
+_reflns_number_total  1188
+_reflns_d_resolution_low    6.388
+_reflns_d_resolution_high   1.033
+
+# POWDER DATA TABLE
+_pd_meas_2theta_range_min  10.01313
+_pd_meas_2theta_range_max  119.99238
+_pd_meas_2theta_range_inc  0.02626
+_pd_proc_2theta_range_min  9.99428
+_pd_proc_2theta_range_max  119.97353
+_pd_proc_2theta_range_inc  0.02626
+_pd_proc_number_of_points  4189
+
+loop_
+   _pd_meas_intensity_total
+   _pd_calc_intensity_total
+   _pd_proc_intensity_bkg_calc
+   _pd_proc_ls_weight
+  2898         0            0           0         
+  2829         0            0           0         
+  2767         0            0           0         
+  2788         0            0           0         
+  2720         0            0           0         
+  2904         0            0           0         
+  2958         0            0           0         
+  3043         0            0           0         
+  3060         0            0           0         
+  3096         0            0           0         
+  3035         0            0           0         
+  3056         0            0           0         
+  2904         0            0           0         
+  2865         0            0           0         
+  2822         0            0           0         
+  2770         0            0           0         
+  2755         0            0           0         
+  2695         0            0           0         
+  2639         0            0           0         
+  2706         0            0           0         
+  2690         0            0           0         
+  2651         0            0           0         
+  2684         0            0           0         
+  2673         0            0           0         
+  2504         0            0           0         
+  2619         0            0           0         
+  2607         0            0           0         
+  2670         0            0           0         
+  2650         0            0           0         
+  2609         0            0           0         
+  2591         0            0           0         
+  2637         0            0           0         
+  2558         0            0           0         
+  2638         0            0           0         
+  2497         0            0           0         
+  2513         0            0           0         
+  2606         0            0           0         
+  2553         0            0           0         
+  2553         0            0           0         
+  2642         0            0           0         
+  2530         0            0           0         
+  2562         0            0           0         
+  2590         0            0           0         
+  2586         0            0           0         
+  2484         0            0           0         
+  2526         0            0           0         
+  2518         0            0           0         
+  2417         0            0           0         
+  2547         0            0           0         
+  2400         0            0           0         
+  2429         0            0           0         
+  2388         0            0           0         
+  2473         0            0           0         
+  2407         0            0           0         
+  2461         0            0           0         
+  2457         0            0           0         
+  2372         0            0           0         
+  2404         0            0           0         
+  2386         0            0           0         
+  2351         0            0           0         
+  2339         0            0           0         
+  2400         0            0           0         
+  2330         0            0           0         
+  2414         0            0           0         
+  2457         0            0           0         
+  2377         0            0           0         
+  2396         0            0           0         
+  2377         0            0           0         
+  2272         0            0           0         
+  2401         0            0           0         
+  2393         0            0           0         
+  2361         0            0           0         
+  2351         0            0           0         
+  2303         0            0           0         
+  2310         0            0           0         
+  2290         0            0           0         
+  2376         0            0           0         
+  2266         0            0           0         
+  2367         0            0           0         
+  2265         0            0           0         
+  2272         0            0           0         
+  2245         0            0           0         
+  2256         0            0           0         
+  2242         0            0           0         
+  2295         0            0           0         
+  2279         0            0           0         
+  2215         0            0           0         
+  2252         0            0           0         
+  2301         0            0           0         
+  2274         0            0           0         
+  2244         0            0           0         
+  2272         0            0           0         
+  2145         0            0           0         
+  2244         0            0           0         
+  2205         0            0           0         
+  2205         0            0           0         
+  2269         0            0           0         
+  2213         0            0           0         
+  2124         0            0           0         
+  2222         0            0           0         
+  2292         0            0           0         
+  2171         0            0           0         
+  2249         0            0           0         
+  2216         0            0           0         
+  2217         0            0           0         
+  2195         0            0           0         
+  2110         0            0           0         
+  2119         0            0           0         
+  2128         0            0           0         
+  2223         0            0           0         
+  2086         0            0           0         
+  2165         0            0           0         
+  2184         0            0           0         
+  1992         0            0           0         
+  2076         0            0           0         
+  2146         0            0           0         
+  2146         0            0           0         
+  2123         0            0           0         
+  2132         0            0           0         
+  2131         0            0           0         
+  2106         0            0           0         
+  2101         0            0           0         
+  2104         0            0           0         
+  2052         0            0           0         
+  2061         0            0           0         
+  1990         0            0           0         
+  2021         0            0           0         
+  2023         0            0           0         
+  2075         0            0           0         
+  2124         0            0           0         
+  2039         0            0           0         
+  1972         0            0           0         
+  1967         0            0           0         
+  2056         0            0           0         
+  1985         0            0           0         
+  1984         0            0           0         
+  1986         0            0           0         
+  1971         0            0           0         
+  1968         0            0           0         
+  2022         0            0           0         
+  1971         0            0           0         
+  2017         0            0           0         
+  2005         0            0           0         
+  1925         0            0           0         
+  1960         0            0           0         
+  1937         0            0           0         
+  2062         0            0           0         
+  1995         0            0           0         
+  1917         0            0           0         
+  1902         0            0           0         
+  1955         0            0           0         
+  1921         0            0           0         
+  1939         0            0           0         
+  1902         0            0           0         
+  1837         0            0           0         
+  1861         0            0           0         
+  1882         0            0           0         
+  1882         0            0           0         
+  1936         0            0           0         
+  1891         0            0           0         
+  1874         0            0           0         
+  1882         0            0           0         
+  1891         0            0           0         
+  1853         0            0           0         
+  1854         0            0           0         
+  1895         0            0           0         
+  1810         0            0           0         
+  1909         0            0           0         
+  1848         0            0           0         
+  1923         0            0           0         
+  1888         0            0           0         
+  1897         0            0           0         
+  1987         0            0           0         
+  1844         0            0           0         
+  1929         0            0           0         
+  1907         0            0           0         
+  1831         0            0           0         
+  1839         0            0           0         
+  1810         0            0           0         
+  1824         0            0           0         
+  1785         0            0           0         
+  1772         0            0           0         
+  1722         0            0           0         
+  1748         0            0           0         
+  1797         0            0           0         
+  1714         0            0           0         
+  1738         0            0           0         
+  1715         1677.6184    1674.10714  0.00058309 
+  1834         1674.4979    1670.83553  0.00054526 
+  1771         1671.39371   1667.57018  0.00056465 
+  1718         1668.30674   1664.3111   0.00058207 
+  1728         1665.23798   1661.05826  0.0005787 
+  1729         1662.18855   1657.81167  0.00057837 
+  1779         1659.15975   1654.5713   0.00056211 
+  1715         1656.15298   1651.33715  0.00058309 
+  1748         1653.16985   1648.10921  0.00057208 
+  1704         1650.21221   1644.88747  0.00058685 
+  1732         1647.28212   1641.67191  0.00057737 
+  1720         1644.38192   1638.46253  0.0005814 
+  1633         1641.51433   1635.25932  0.00061237 
+  1674         1638.68244   1632.06227  0.00059737 
+  1677         1635.88983   1628.87136  0.0005963 
+  1654         1633.14064   1625.68659  0.00060459 
+  1634         1630.43965   1622.50794  0.000612  
+  1699         1627.79247   1619.33541  0.00058858 
+  1728         1625.20569   1616.16898  0.0005787 
+  1707         1622.68703   1613.00865  0.00058582 
+  1683         1620.24568   1609.8544   0.00059418 
+  1686         1617.89264   1606.70623  0.00059312 
+  1632         1615.64104   1603.56412  0.00061275 
+  1683         1613.50677   1600.42806  0.00059418 
+  1609         1611.50927   1597.29805  0.0006215 
+  1655         1609.6723    1594.17407  0.00060423 
+  1602         1608.02533   1591.05612  0.00062422 
+  1586         1606.60535   1587.94418  0.00063052 
+  1639         1605.45888   1584.83824  0.00061013 
+  1590         1604.64579   1581.7383   0.00062893 
+  1630         1604.24335   1578.64434  0.0006135 
+  1601         1604.35312   1575.55635  0.00062461 
+  1641         1605.11127   1572.47433  0.00060938 
+  1569         1606.70258   1569.39826  0.00063735 
+  1614         1609.38355   1566.32813  0.00061958 
+  1605         1613.51997   1563.26394  0.00062305 
+  1609         1619.64553   1560.20567  0.0006215 
+  1584         1628.56562   1557.15331  0.00063131 
+  1533         1641.54646   1554.10686  0.00065232 
+  1697         1660.68297   1551.06629  0.00058928 
+  1719         1689.80486   1548.03162  0.00058173 
+  1702         1737.14666   1545.00281  0.00058754 
+  1765         1822.14502   1541.97987  0.00056657 
+  2144         1986.86506   1538.96278  0.00046642 
+  2248         2300.34818   1535.95154  0.00044484 
+  2782         2814.09411   1532.94613  0.00035945 
+  3753         3575.67231   1529.94654  0.00026645 
+  5611         4320.62986   1526.95277  0.00017822 
+  6413         4440.37867   1523.9648   0.00015593 
+  4696         3751.47746   1520.98262  0.00021295 
+  2679         2864.99898   1518.00623  0.00037327 
+  1790         2246.97555   1515.03562  0.00055866 
+  1686         1935.29028   1512.07077  0.00059312 
+  1675         1785.77199   1509.11167  0.00059701 
+  1545         1704.78171   1506.15832  0.00064725 
+  1567         1654.98304   1503.21071  0.00063816 
+  1559         1621.54632   1500.26882  0.00064144 
+  1585         1595.57398   1497.33265  0.00063091 
+  1514         1573.53406   1494.40218  0.0006605 
+  1591         1555.43829   1491.47742  0.00062854 
+  1527         1541.34446   1488.55833  0.00065488 
+  1559         1530.2597    1485.64493  0.00064144 
+  1504         1521.13451   1482.73719  0.00066489 
+  1533         1513.31284   1479.83512  0.00065232 
+  1451         1506.42119   1476.93869  0.00068918 
+  1483         1500.23068   1474.0479   0.00067431 
+  1455         1494.58526   1471.16274  0.00068729 
+  1487         1489.37186   1468.28319  0.00067249 
+  1442         1484.50662   1465.40926  0.00069348 
+  1508         1479.92573   1462.54093  0.00066313 
+  1509         1475.57969   1459.67819  0.00066269 
+  1462         1471.42988   1456.82103  0.00068399 
+  1447         1467.44565   1453.96945  0.00069109 
+  1467         1463.60227   1451.12342  0.00068166 
+  1504         1459.8799    1448.28295  0.00066489 
+  1470         1456.26231   1445.44802  0.00068027 
+  1490         1452.73616   1442.61863  0.00067114 
+  1484         1449.29053   1439.79476  0.00067385 
+  1467         1445.91636   1436.97641  0.00068166 
+  1451         1442.60617   1434.16356  0.00068918 
+  1466         1439.35386   1431.35621  0.00068213 
+  1426         1436.15446   1428.55434  0.00070126 
+  1435         1433.00406   1425.75795  0.00069686 
+  1458         1429.8998    1422.96703  0.00068587 
+  1351         1426.83981   1420.18157  0.00074019 
+  1448         1423.82341   1417.40156  0.00069061 
+  1453         1420.85143   1414.62699  0.00068823 
+  1414         1417.92671   1411.85785  0.00070721 
+  1442         1415.05521   1409.09412  0.00069348 
+  1386         1412.24816   1406.33582  0.0007215 
+  1466         1409.52695   1403.58291  0.00068213 
+  1442         1406.93806   1400.8354   0.00069348 
+  1451         1404.59857   1398.09327  0.00068918 
+  1411         1402.78659   1395.35652  0.00070872 
+  1392         1402.00177   1392.62513  0.00071839 
+  1424         1402.58211   1389.8991   0.00070225 
+  1404         1404.02737   1387.17841  0.00071225 
+  1422         1405.66672   1384.46306  0.00070323 
+  1401         1402.85188   1381.75305  0.00071378 
+  1446         1396.09958   1379.04835  0.00069156 
+  1383         1388.43926   1376.34896  0.00072307 
+  1364         1382.54927   1373.65487  0.00073314 
+  1422         1378.44425   1370.96608  0.00070323 
+  1415         1375.31569   1368.28257  0.00070671 
+  1389         1372.68957   1365.60433  0.00071994 
+  1412         1370.41217   1362.93135  0.00070822 
+  1292         1368.49604   1360.26364  0.00077399 
+  1345         1367.07154   1357.60117  0.00074349 
+  1374         1366.45236   1354.94393  0.0007278 
+  1358         1367.30579   1352.29193  0.00073638 
+  1392         1370.87468   1349.64514  0.00071839 
+  1383         1378.83935   1347.00356  0.00072307 
+  1394         1391.51384   1344.36719  0.00071736 
+  1378         1406.99574   1341.73601  0.00072569 
+  1348         1418.87697   1339.11001  0.00074184 
+  1410         1416.17733   1336.48918  0.00070922 
+  1464         1401.37533   1333.87352  0.00068306 
+  1394         1381.9189    1331.26302  0.00071736 
+  1351         1366.8383    1328.65766  0.00074019 
+  1311         1359.23621   1326.05745  0.00076278 
+  1309         1358.54061   1323.46236  0.00076394 
+  1384         1361.75052   1320.87239  0.00072254 
+  1432         1364.7503    1318.28754  0.00069832 
+  1421         1359.95061   1315.70778  0.00070373 
+  1447         1348.34547   1313.13312  0.00069109 
+  1420         1335.02642   1310.56355  0.00070423 
+  1348         1324.39248   1307.99905  0.00074184 
+  1314         1317.07779   1305.43962  0.00076104 
+  1363         1311.92302   1302.88525  0.00073368 
+  1313         1307.97633   1300.33593  0.00076161 
+  1274         1304.75835   1297.79165  0.00078493 
+  1325         1302.17261   1295.2524   0.00075472 
+  1309         1300.48414   1292.71818  0.00076394 
+  1367         1300.34215   1290.18897  0.00073153 
+  1375         1302.22872   1287.66476  0.00072727 
+  1289         1305.39479   1285.14555  0.0007758 
+  1265         1308.27195   1282.63133  0.00079051 
+  1266         1304.45275   1280.1221   0.00078989 
+  1267         1296.11787   1277.61783  0.00078927 
+  1181         1286.83197   1275.11852  0.00084674 
+  1237         1279.87436   1272.62417  0.00080841 
+  1217         1275.14183   1270.13476  0.00082169 
+  1213         1271.55142   1267.65029  0.0008244 
+  1201         1268.45087   1265.17075  0.00083264 
+  1216         1265.57355   1262.69612  0.00082237 
+  1237         1262.81957   1260.22641  0.00080841 
+  1219         1260.15151   1257.7616   0.00082034 
+  1288         1257.5304    1255.30168  0.0007764 
+  1232         1254.95272   1252.84664  0.00081169 
+  1310         1252.40206   1250.39648  0.00076336 
+  1286         1249.87615   1247.95119  0.0007776 
+  1231         1247.37103   1245.51076  0.00081235 
+  1295         1244.88401   1243.07518  0.0007722 
+  1271         1242.41329   1240.64444  0.00078678 
+  1231         1239.95767   1238.21853  0.00081235 
+  1256         1237.51646   1235.79745  0.00079618 
+  1209         1235.08934   1233.38119  0.00082713 
+  1227         1232.67635   1230.96973  0.000815  
+  1197         1230.27789   1228.56307  0.00083542 
+  1226         1227.89474   1226.16121  0.00081566 
+  1244         1225.52811   1223.76412  0.00080386 
+  1235         1223.17975   1221.37181  0.00080972 
+  1147         1220.85217   1218.98427  0.00087184 
+  1164         1218.54887   1216.60148  0.00085911 
+  1207         1216.27478   1214.22344  0.0008285 
+  1219         1214.03706   1211.85014  0.00082034 
+  1188         1211.8464    1209.48158  0.00084175 
+  1236         1209.72002   1207.11774  0.00080906 
+  1169         1207.68801   1204.75861  0.00085543 
+  1242         1205.80584   1202.40419  0.00080515 
+  1179         1204.17157   1200.05447  0.00084818 
+  1187         1202.92567   1197.70944  0.00084246 
+  1252         1202.15563   1195.36909  0.00079872 
+  1230         1201.82746   1193.03342  0.00081301 
+  1201         1201.76553   1190.70241  0.00083264 
+  1165         1201.92975   1188.37606  0.00085837 
+  1224         1203.7589    1186.05436  0.00081699 
+  1176         1209.15476   1183.7373   0.00085034 
+  1168         1218.71516   1181.42487  0.00085616 
+  1220         1229.97956   1179.11706  0.00081967 
+  1235         1236.10894   1176.81388  0.00080972 
+  1333         1228.59727   1174.5153   0.00075019 
+  1219         1213.29275   1172.22132  0.00082034 
+  1183         1196.70163   1169.93193  0.00084531 
+  1198         1184.27099   1167.64712  0.00083472 
+  1176         1176.14357   1165.36689  0.00085034 
+  1145         1170.63907   1163.09123  0.00087336 
+  1223         1166.49792   1160.82013  0.00081766 
+  1151         1163.0489    1158.55357  0.00086881 
+  1123         1159.97933   1156.29156  0.00089047 
+  1142         1157.14119   1154.03409  0.00087566 
+  1129         1154.45983   1151.78114  0.00088574 
+  1084         1151.88036   1149.53271  0.00092251 
+  1062         1149.37927   1147.28879  0.00094162 
+  1099         1146.93291   1145.04938  0.00090992 
+  1109         1144.53002   1142.81445  0.00090171 
+  1104         1142.16125   1140.58402  0.0009058 
+  1154         1139.81992   1138.35806  0.00086655 
+  1105         1137.50113   1136.13657  0.00090498 
+  1108         1135.20124   1133.91955  0.00090253 
+  1080         1132.91748   1131.70698  0.00092593 
+  1079         1130.64772   1129.49886  0.00092678 
+  1116         1128.3903    1127.29517  0.00089606 
+  1173         1126.14392   1125.09592  0.00085251 
+  1127         1123.90753   1122.90109  0.00088731 
+  1084         1121.68028   1120.71067  0.00092251 
+  1143         1119.46149   1118.52466  0.00087489 
+  1094         1117.25061   1116.34305  0.00091408 
+  1070         1115.04717   1114.16583  0.00093458 
+  1095         1112.85078   1111.99299  0.00091324 
+  1100         1110.66112   1109.82453  0.00090909 
+  1091         1108.47792   1107.66044  0.00091659 
+  1084         1106.30119   1105.5007   0.00092251 
+  1103         1104.15599   1103.34532  0.00090662 
+  1118         1101.99123   1101.19428  0.00089445 
+  1060         1099.84491   1099.04758  0.0009434 
+  1033         1097.69144   1096.90521  0.00096805 
+  1063         1095.54429   1094.76715  0.00094073 
+  1098         1093.40173   1092.63341  0.00091075 
+  1159         1091.26448   1090.50398  0.00086281 
+  1046         1089.13291   1088.37884  0.00095602 
+  1137         1087.00612   1086.25799  0.00087951 
+  1110         1084.88449   1084.14143  0.0009009 
+  1110         1082.76796   1082.02913  0.0009009 
+  1146         1080.65652   1079.92111  0.0008726 
+  1104         1078.55013   1077.81734  0.0009058 
+  1111         1076.44878   1075.71782  0.00090009 
+  1057         1074.35245   1073.62255  0.00094607 
+  1155         1072.26114   1071.53151  0.0008658 
+  1001         1070.17484   1069.4447   0.000999  
+  1017         1068.09358   1067.36212  0.00098328 
+  1067         1066.01735   1065.28374  0.00093721 
+  1060         1063.95248   1063.20957  0.0009434 
+  1034         1061.88645   1061.1396   0.00096712 
+  1037         1059.82869   1059.07381  0.00096432 
+  1084         1057.77299   1057.01221  0.00092251 
+  1044         1055.72254   1054.95479  0.00095785 
+  1027         1053.67741   1052.90153  0.00097371 
+  1064         1051.6377    1050.85243  0.00093985 
+  952          1049.60351   1048.80748  0.00105042 
+  1040         1047.5772    1046.76668  0.00096154 
+  999          1045.5545    1044.73002  0.001001  
+  929          1043.53891   1042.69748  0.00107643 
+  1044         1041.52844   1040.66907  0.00095785 
+  987          1039.52449   1038.64477  0.00101317 
+  946          1037.52868   1036.62458  0.00105708 
+  1033         1035.5388    1034.60849  0.00096805 
+  947          1033.56059   1032.59649  0.00105597 
+  1003         1031.58679   1030.58857  0.00099701 
+  1052         1029.62207   1028.58473  0.00095057 
+  1013         1027.66902   1026.58497  0.00098717 
+  969          1025.72553   1024.58926  0.00103199 
+  1026         1023.79474   1022.59761  0.00097466 
+  982          1021.87863   1020.61001  0.00101833 
+  991          1019.97972   1018.62645  0.00100908 
+  969          1018.10141   1016.64692  0.00103199 
+  980          1016.24828   1014.67142  0.00102041 
+  1037         1014.42662   1012.69993  0.00096432 
+  991          1012.64529   1010.73246  0.00100908 
+  1008         1010.91702   1008.76899  0.00099206 
+  1022         1009.26062   1006.80951  0.00097847 
+  989          1007.70489   1004.85403  0.00101112 
+  984          1006.29566   1002.90253  0.00101626 
+  942          1005.11068   1000.955    0.00106157 
+  1041         1004.29868   999.01144   0.00096061 
+  971          1004.18491   997.07183   0.00102987 
+  1033         1005.49225   995.13619   0.00096805 
+  1001         1009.57557   993.20448   0.000999  
+  997          1018.15143   991.27672   0.00100301 
+  1004         1030.70445   989.35288   0.00099602 
+  1089         1037.82527   987.43297   0.00091827 
+  1041         1032.7533    985.51698   0.00096061 
+  966          1021.62961   983.60489   0.0010352 
+  966          1008.66534   981.69671   0.0010352 
+  940          998.50621    979.79243   0.00106383 
+  1014         991.19756    977.89203   0.00098619 
+  969          985.78494    975.99551   0.00103199 
+  946          981.39958    974.10286   0.00105708 
+  902          977.72954    972.21408   0.00110865 
+  847          974.63338    970.32917   0.00118064 
+  919          971.90616    968.4481    0.00108814 
+  910          969.45245    966.57088   0.0010989 
+  963          967.18633    964.69749   0.00103842 
+  902          965.03738    962.82794   0.00110865 
+  922          962.96374    960.96221   0.0010846 
+  944          960.94237    959.1003    0.00105932 
+  897          958.95948    957.2422    0.00111483 
+  922          957.00646    955.3879    0.0010846 
+  881          955.07771    953.5374    0.00113507 
+  887          953.16806    951.69069   0.0011274 
+  950          951.27482    949.84776   0.00105263 
+  892          949.39584    948.0086    0.00112108 
+  917          947.52897    946.17321   0.00109051 
+  859          945.67304    944.34158   0.00116414 
+  893          943.82699    942.51371   0.00111982 
+  936          941.99001    940.68958   0.00106838 
+  912          940.16685    938.8692    0.00109649 
+  849          938.34622    937.05254   0.00117786 
+  918          936.53578    935.23962   0.00108932 
+  896          934.72984    933.43041   0.00111607 
+  930          932.93085    931.62491   0.00107527 
+  951          931.13859    929.82313   0.00105152 
+  854          929.35294    928.02503   0.00117096 
+  855          927.5738     926.23064   0.00116959 
+  873          925.80153    924.43992   0.00114548 
+  895          924.03525    922.65289   0.00111732 
+  895          922.27561    920.86952   0.00111732 
+  920          920.52222    919.08982   0.00108696 
+  883          918.77533    917.31378   0.0011325 
+  962          917.03504    915.54139   0.0010395 
+  914          915.30146    913.77264   0.00109409 
+  934          913.57473    912.00753   0.00107066 
+  884          911.85502    910.24606   0.00113122 
+  846          910.14253    908.4882    0.00118203 
+  862          908.43749    906.73396   0.00116009 
+  890          906.74019    904.98334   0.0011236 
+  881          905.05093    903.23631   0.00113507 
+  890          903.37007    901.49289   0.0011236 
+  865          901.69805    899.75305   0.00115607 
+  895          900.03532    898.0168    0.00111732 
+  893          898.38245    896.28412   0.00111982 
+  868          896.74007    894.55501   0.00115207 
+  874          895.10891    892.82947   0.00114416 
+  858          893.48984    891.10748   0.0011655 
+  827          891.88387    889.38905   0.00120919 
+  835          890.2922     887.67416   0.0011976 
+  813          888.71633    885.9628    0.00123001 
+  868          887.15825    884.25498   0.00115207 
+  823          885.62154    882.55068   0.00121507 
+  837          884.11042    880.84989   0.00119474 
+  851          882.6345     879.15262   0.00117509 
+  802          881.20042    877.45885   0.00124688 
+  837          879.8013     875.76858   0.00119474 
+  841          878.40929    874.0818    0.00118906 
+  874          877.00886    872.3985    0.00114416 
+  846          875.64077    870.71868   0.00118203 
+  863          874.31888    869.04233   0.00115875 
+  849          873.07064    867.36945   0.00117786 
+  804          871.90664    865.70002   0.00124378 
+  918          870.83472    864.03405   0.00108932 
+  782          869.86899    862.37152   0.00127877 
+  800          869.04514    860.71243   0.00125   
+  817          868.3659     859.05677   0.00122399 
+  877          867.88585    857.40454   0.00114025 
+  840          867.66779    855.75573   0.00119048 
+  872          867.77567    854.11033   0.00114679 
+  854          868.32648    852.46834   0.00117096 
+  843          869.48113    850.82974   0.00118624 
+  878          871.48221    849.19454   0.00113895 
+  902          874.70775    847.56273   0.00110865 
+  960          879.77585    845.9343    0.00104167 
+  907          887.75455    844.30924   0.00110254 
+  1014         900.65488    842.68755   0.00098619 
+  1084         923.16628    841.06923   0.00092251 
+  1121         969.84799    839.45426   0.00089206 
+  1530         1083.53133   837.84263   0.00065359 
+  2262         1343.61901   836.23435   0.00044209 
+  3073         1752.23812   834.62941   0.00032541 
+  3715         2126.74278   833.0278    0.00026918 
+  2750         2020.1866    831.42951   0.00036364 
+  2258         1737.61315   829.83454   0.00044287 
+  1394         1395.01558   828.24288   0.00071736 
+  977          1107.27817   826.65452   0.00102354 
+  873          967.99121    825.06946   0.00114548 
+  817          910.35348    823.4877    0.00122399 
+  893          882.41241    821.90922   0.00111982 
+  873          865.40637    820.33402   0.00114548 
+  831          853.75652    818.7621    0.00120337 
+  865          845.22298    817.19344   0.00115607 
+  838          838.64361    815.62804   0.00119332 
+  805          833.35344    814.0659    0.00124224 
+  854          828.94999    812.50701   0.00117096 
+  854          825.17654    810.95136   0.00117096 
+  881          821.86376    809.39895   0.00113507 
+  820          818.89661    807.84977   0.00121951 
+  822          816.19409    806.30381   0.00121655 
+  867          813.69812    804.76107   0.0011534 
+  825          811.36644    803.22155   0.00121212 
+  796          809.16738    801.68522   0.00125628 
+  756          807.07701    800.1521    0.00132275 
+  784          805.07719    798.62217   0.00127551 
+  802          803.1538     797.09543   0.00124688 
+  799          801.29589    795.57188   0.00125156 
+  749          799.65344    794.05149   0.00133511 
+  785          797.90429    792.53428   0.00127389 
+  765          796.20067    791.02023   0.00130719 
+  772          794.6179     789.50933   0.00129534 
+  769          792.99514    788.00159   0.00130039 
+  779          791.40959    786.497     0.0012837 
+  775          789.86023    784.99554   0.00129032 
+  764          788.34729    783.49721   0.0013089 
+  714          786.87183    782.00202   0.00140056 
+  801          785.43601    780.50994   0.00124844 
+  723          784.04356    779.02098   0.00138313 
+  764          782.699      777.53513   0.0013089 
+  748          781.40973    776.05238   0.0013369 
+  761          780.1857     774.57273   0.00131406 
+  749          779.04035    773.09617   0.00133511 
+  788          777.99287    771.6227    0.00126904 
+  750          777.07009    770.1523    0.00133333 
+  756          776.31073    768.68498   0.00132275 
+  757          775.78337    767.22073   0.001321  
+  771          775.55138    765.75954   0.00129702 
+  803          775.76233    764.30141   0.00124533 
+  795          776.64599    762.84632   0.00125786 
+  899          778.58523    761.39428   0.00111235 
+  1054         782.38623    759.94528   0.00094877 
+  1221         790.03021    758.49931   0.000819  
+  1624         806.69285    757.05637   0.00061576 
+  2027         844.2779     755.61645   0.00049334 
+  1841         912.29615    754.17954   0.00054318 
+  1546         996.6973     752.74564   0.00064683 
+  1281         1042.1314    751.31475   0.00078064 
+  1011         1003.25231   749.88686   0.00098912 
+  810          946.04069    748.46195   0.00123457 
+  707          874.30121    747.04003   0.00141443 
+  690          817.93708    745.6211    0.00144928 
+  669          787.23039    744.20513   0.00149477 
+  662          771.70827    742.79214   0.00151057 
+  704          763.00554    741.38211   0.00142045 
+  659          757.2386     739.97504   0.00151745 
+  751          752.95568    738.57091   0.00133156 
+  752          749.55131    737.16974   0.00132979 
+  675          746.70695    735.7715    0.00148148 
+  733          744.24173    734.3762    0.00136426 
+  716          742.04274    732.98383   0.00139665 
+  704          740.03723    731.59438   0.00142045 
+  687          738.17664    730.20785   0.0014556 
+  709          736.43127    728.82423   0.00141044 
+  677          734.77089    727.44352   0.0014771 
+  681          733.18415    726.0657    0.00146843 
+  676          731.65567    724.69079   0.00147929 
+  642          730.17864    723.31876   0.00155763 
+  704          728.74696    721.94961   0.00142045 
+  698          727.35643    720.58335   0.00143266 
+  706          726.00443    719.21995   0.00141643 
+  753          724.68962    717.85943   0.00132802 
+  715          723.4119     716.50176   0.0013986 
+  646          722.17236    715.14695   0.00154799 
+  721          720.97343    713.79499   0.00138696 
+  676          719.81903    712.44588   0.00147929 
+  651          718.71502    711.0996    0.0015361 
+  671          717.66976    709.75616   0.00149031 
+  716          716.69502    708.41555   0.00139665 
+  669          715.80755    707.07776   0.00149477 
+  688          715.03147    705.74279   0.00145349 
+  713          714.40212    704.41062   0.00140252 
+  790          713.97308    703.08127   0.00126582 
+  691          713.82847    701.75471   0.00144718 
+  732          714.10547    700.43095   0.00136612 
+  724          715.04494    699.10998   0.00138122 
+  683          717.11881    697.7918    0.00146413 
+  753          721.50556    696.47639   0.00132802 
+  854          731.59923    695.16376   0.00117096 
+  1043         755.16728    693.85389   0.00095877 
+  1288         801.22221    692.54679   0.0007764 
+  1372         854.61896    691.24244   0.00072886 
+  1214         854.82676    689.94085   0.00082372 
+  1055         828.82344    688.642     0.00094787 
+  891          796.19479    687.34589   0.00112233 
+  696          755.6269     686.05252   0.00143678 
+  641          729.35775    684.76188   0.00156006 
+  623          716.28955    683.47397   0.00160514 
+  679          710.16229    682.18877   0.00147275 
+  643          707.18099    680.90629   0.00155521 
+  658          705.86733    679.62651   0.00151976 
+  642          705.76605    678.34944   0.00155763 
+  660          706.80336    677.07507   0.00151515 
+  693          709.12294    675.8034    0.001443  
+  697          713.17344    674.5344    0.00143472 
+  672          719.4666     673.2681    0.0014881 
+  704          729.30815    672.00447   0.00142045 
+  747          745.09476    670.74351   0.00133869 
+  802          772.27135    669.48521   0.00124688 
+  943          826.74323    668.22958   0.00106045 
+  1183         948.72245    666.97661   0.00084531 
+  1646         1198.80979   665.72628   0.00060753 
+  2540         1554.27564   664.4786    0.0003937 
+  2771         1667.29153   663.23357   0.00036088 
+  2231         1512.92517   661.99116   0.00044823 
+  1776         1347.66793   660.75139   0.00056306 
+  1189         1096.8599    659.51424   0.00084104 
+  781          902.26154    658.27971   0.00128041 
+  722          798.94835    657.0478    0.00138504 
+  652          748.96611    655.81849   0.00153374 
+  661          722.51966    654.59179   0.00151286 
+  610          706.15838    653.36769   0.00163934 
+  612          694.92248    652.14618   0.00163399 
+  658          686.72767    650.92727   0.00151976 
+  683          680.48993    649.71093   0.00146413 
+  632          675.58007    648.49717   0.00158228 
+  628          671.61129    647.28599   0.00159236 
+  640          668.3379     646.07737   0.0015625 
+  629          665.60641    644.87132   0.00158983 
+  565          663.31663    643.66783   0.00176991 
+  588          661.41558    642.46689   0.00170068 
+  673          659.88562    641.26849   0.00148588 
+  661          658.74921    640.07264   0.00151286 
+  692          658.08332    638.87933   0.00144509 
+  713          658.05976    637.68855   0.00140252 
+  693          659.07925    636.5003    0.001443  
+  762          662.26266    635.31457   0.00131234 
+  880          670.60041    634.13136   0.00113636 
+  1030         689.29882    632.95066   0.00097087 
+  1127         719.68196    631.77247   0.00088731 
+  1209         737.73188    630.59678   0.00082713 
+  1336         729.33993    629.42359   0.0007485 
+  1508         724.77019    628.2529    0.00066313 
+  1649         722.07263    627.08469   0.00060643 
+  1512         731.87204    625.91896   0.00066138 
+  1455         750.55475    624.75571   0.00068729 
+  1226         778.8956     623.59494   0.00081566 
+  940          800.28605    622.43663   0.00106383 
+  822          772.11518    621.28078   0.00121655 
+  683          741.52359    620.1274    0.00146413 
+  655          708.12724    618.97646   0.00152672 
+  629          674.88804    617.82798   0.00158983 
+  578          654.92564    616.68194   0.0017301 
+  603          645.11035    615.53834   0.00165837 
+  586          640.83412    614.39717   0.00170648 
+  562          639.5764     613.25843   0.00177936 
+  600          639.30618    612.12211   0.00166667 
+  584          638.08519    610.98822   0.00171233 
+  638          637.43955    609.85673   0.0015674 
+  574          638.70118    608.72766   0.00174216 
+  608          642.54084    607.60099   0.00164474 
+  609          647.20792    606.47672   0.00164204 
+  626          645.9974     605.35485   0.00159744 
+  630          640.78368    604.23537   0.0015873 
+  623          634.67635    603.11827   0.00160514 
+  568          627.1169     602.00356   0.00176056 
+  620          620.83437    600.89121   0.0016129 
+  581          616.58099    599.78124   0.00172117 
+  596          613.71516    598.67364   0.00167785 
+  574          611.62592    597.5684    0.00174216 
+  593          609.95005    596.46552   0.00168634 
+  593          608.50914    595.36498   0.00168634 
+  590          607.2193     594.2668    0.00169492 
+  554          606.03752    593.17095   0.00180505 
+  548          604.93948    592.07745   0.00182482 
+  574          603.91096    590.98628   0.00174216 
+  628          602.94396    589.89744   0.00159236 
+  602          602.03486    588.81092   0.00166113 
+  618          601.18357    587.72672   0.00161812 
+  588          600.39309    586.64483   0.00170068 
+  618          599.66981    585.56526   0.00161812 
+  633          599.02404    584.48799   0.00157978 
+  645          598.47141    583.41302   0.00155039 
+  695          598.03489    582.34034   0.00143885 
+  661          597.74839    581.26996   0.00151286 
+  662          597.66301    580.20186   0.00151057 
+  669          597.85768    579.13605   0.00149477 
+  711          598.45864    578.07251   0.00140647 
+  759          599.67799    577.01125   0.00131752 
+  817          601.89926    575.95225   0.00122399 
+  789          605.93754    574.89552   0.00126743 
+  764          614.01129    573.84105   0.0013089 
+  739          632.26494    572.78883   0.00135318 
+  857          672.40089    571.73886   0.00116686 
+  777          740.92794    570.69114   0.001287  
+  744          791.13843    569.64566   0.00134409 
+  672          766.46114    568.60241   0.0014881 
+  620          737.45277    567.5614    0.0016129 
+  660          698.97525    566.52261   0.00151515 
+  551          651.38432    565.48604   0.00181488 
+  595          622.11703    564.4517    0.00168067 
+  584          609.81561    563.41956   0.00171233 
+  604          607.41222    562.38964   0.00165563 
+  621          606.43259    561.36192   0.00161031 
+  597          601.24478    560.3364    0.00167504 
+  562          596.83076    559.31308   0.00177936 
+  574          592.08858    558.29195   0.00174216 
+  563          587.0693     557.273     0.0017762 
+  559          583.69522    556.25624   0.00178891 
+  586          581.68237    555.24166   0.00170648 
+  555          580.4186     554.22924   0.0018018 
+  541          579.54776    553.219     0.00184843 
+  574          578.92878    552.21092   0.00174216 
+  604          578.51684    551.20501   0.00165563 
+  605          578.31621    550.20125   0.00165289 
+  622          578.38236    549.19964   0.00160772 
+  656          578.82785    548.20017   0.00152439 
+  645          579.76389    547.20285   0.00155039 
+  631          580.97757    546.20767   0.00158479 
+  622          581.58177    545.21462   0.00160772 
+  572          581.64549    544.2237    0.00174825 
+  577          581.81767    543.23491   0.0017331 
+  589          581.96769    542.24824   0.00169779 
+  565          582.42165    541.26368   0.00176991 
+  543          583.47582    540.28124   0.00184162 
+  537          585.20614    539.3009    0.0018622 
+  552          587.74077    538.32267   0.00181159 
+  554          591.32156    537.34653   0.00180505 
+  539          596.11522    536.3725    0.00185529 
+  618          601.73179    535.40055   0.00161812 
+  576          608.40495    534.43069   0.00173611 
+  575          616.75629    533.46291   0.00173913 
+  543          624.24059    532.49721   0.00184162 
+  587          630.8555     531.53358   0.00170358 
+  518          640.35232    530.57202   0.0019305 
+  576          654.0658     529.61253   0.00173611 
+  645          676.6456     528.6551    0.00155039 
+  613          720.51222    527.69972   0.00163132 
+  635          811.3577     526.7464    0.0015748 
+  752          978.45427    525.79512   0.00132979 
+  825          1172.18125   524.84589   0.00121212 
+  857          1193.97423   523.8987    0.00116686 
+  826          1147.91257   522.95354   0.00121065 
+  906          1139.29148   522.01042   0.00110375 
+  1021         1104.18729   521.06932   0.00097943 
+  1286         1125.69608   520.13025   0.0007776 
+  1549         1241.04159   519.19319   0.00064558 
+  1873         1494.33388   518.25815   0.0005339 
+  2564         2140.94483   517.32512   0.00039002 
+  4289         3700.54841   516.3941    0.00023315 
+  7269         6092.91786   515.46508   0.00013757 
+  8389         7312.92917   514.53805   0.0001192 
+  5759         6020.22726   513.61302   0.00017364 
+  4763         5056.50353   512.68998   0.00020995 
+  3574         3926.54702   511.76893   0.0002798 
+  1587         2361.14009   510.84986   0.00063012 
+  848          1452.69058   509.93277   0.00117925 
+  704          1072.28725   509.01765   0.00142045 
+  640          905.8589     508.10449   0.0015625 
+  672          813.62433    507.19331   0.0014881 
+  661          754.79577    506.28408   0.00151286 
+  646          714.8844     505.37682   0.00154799 
+  665          686.69765    504.4715    0.00150376 
+  591          666.25928    503.56814   0.00169205 
+  551          651.19708    502.66672   0.00181488 
+  593          640.06365    501.76724   0.00168634 
+  559          631.99932    500.8697    0.00178891 
+  568          626.5946     499.97409   0.00176056 
+  562          623.8668     499.08041   0.00177936 
+  568          624.12061    498.18866   0.00176056 
+  593          627.09171    497.29882   0.00168634 
+  560          629.49088    496.41091   0.00178571 
+  528          628.0723     495.52491   0.00189394 
+  566          626.39034    494.64081   0.00176678 
+  568          624.99091    493.75862   0.00176056 
+  583          623.3747     492.87834   0.00171527 
+  545          623.36604    491.99995   0.00183486 
+  582          625.35583    491.12345   0.00171821 
+  563          628.99118    490.24884   0.0017762 
+  604          633.98504    489.37612   0.00165563 
+  613          640.21067    488.50528   0.00163132 
+  617          647.67209    487.63632   0.00162075 
+  627          656.46287    486.76923   0.0015949 
+  605          666.72981    485.90401   0.00165289 
+  610          678.674      485.04066   0.00163934 
+  631          692.55579    484.17917   0.00158479 
+  616          708.7068     483.31953   0.00162338 
+  669          727.54857    482.46175   0.00149477 
+  628          749.626      481.60583   0.00159236 
+  686          775.63914    480.75175   0.00145773 
+  689          806.51426    479.89951   0.00145138 
+  684          843.49898    479.04911   0.00146199 
+  707          888.30739    478.20054   0.00141443 
+  758          943.40974    477.35381   0.00131926 
+  824          1012.61419   476.5089    0.00121359 
+  838          1102.60771   475.66582   0.00119332 
+  927          1227.24525   474.82456   0.00107875 
+  1007         1413.60017   473.98511   0.00099305 
+  1176         1694.01573   473.14747   0.00085034 
+  1377         2045.73213   472.31165   0.00072622 
+  1557         2330.88922   471.47763   0.00064226 
+  2090         2660.15692   470.6454    0.00047847 
+  2893         3223.93291   469.81498   0.00034566 
+  4074         4137.80677   468.98635   0.00024546 
+  6116         5981.26469   468.15951   0.00016351 
+  10498        10170.40174  467.33445   0.00009526 
+  20357        18852.46069  466.51118   0.00004912 
+  44300        31590.30517  465.68968   0.00002257 
+  68184        36228.90377  464.86996   0.00001467 
+  52647        29933.06639  464.05201   0.00001899 
+  47193        26115.17958  463.23583   0.00002119 
+  39383        20246.59493  462.42141   0.00002539 
+  20615        12244.76794  461.60875   0.00004851 
+  11195        7089.87013   460.79785   0.00008933 
+  5113         4484.39913   459.9887    0.00019558 
+  2625         3212.27108   459.18129   0.00038095 
+  2172         2539.00519   458.37564   0.00046041 
+  2545         2140.9533    457.57172   0.00039293 
+  1966         1833.47108   456.76954   0.00050865 
+  1685         1585.70929   455.9691    0.00059347 
+  1686         1410.03597   455.17038   0.00059312 
+  1363         1259.39957   454.37339   0.00073368 
+  1163         1138.84822   453.57813   0.00085985 
+  1280         1061.53464   452.78458   0.00078125 
+  1564         1026.73081   451.99275   0.00063939 
+  1421         1026.02638   451.20264   0.00070373 
+  1254         1013.97837   450.41423   0.00079745 
+  1225         975.03445    449.62753   0.00081633 
+  1127         959.64465    448.84252   0.00088731 
+  1080         958.58605    448.05922   0.00092593 
+  1331         983.49964    447.27761   0.00075131 
+  1648         1107.78929   446.49769   0.0006068 
+  2119         1500.86939   445.71946   0.00047192 
+  3639         2442.59582   444.94291   0.0002748 
+  5361         3716.79524   444.16804   0.00018653 
+  4400         3969.77065   443.39485   0.00022727 
+  2929         3165.50823   442.62333   0.00034141 
+  2862         2809.27222   441.85348   0.00034941 
+  1873         2270.23823   441.08529   0.0005339 
+  913          1464.98035   440.31877   0.00109529 
+  736          997.30476    439.5539    0.0013587 
+  579          799.24844    438.7907    0.00172712 
+  559          709.37924    438.02914   0.00178891 
+  583          657.10565    437.26923   0.00171527 
+  536          621.87441    436.51097   0.00186567 
+  568          596.35644    435.75435   0.00176056 
+  560          576.93462    434.99936   0.00178571 
+  623          561.57706    434.24601   0.00160514 
+  619          549.0596     433.49429   0.00161551 
+  560          538.60357    432.7442    0.00178571 
+  567          529.69357    431.99573   0.00176367 
+  608          521.97452    431.24888   0.00164474 
+  532          515.19353    430.50365   0.0018797 
+  535          509.16693    429.76004   0.00186916 
+  509          503.75748    429.01803   0.00196464 
+  521          498.86       428.27763   0.00191939 
+  537          494.39348    427.53883   0.0018622 
+  503          490.29392    426.80164   0.00198807 
+  478          486.50973    426.06604   0.00209205 
+  447          482.99957    425.33203   0.00223714 
+  440          479.72948    424.59961   0.00227273 
+  480          476.66584    423.86878   0.00208333 
+  458          473.79584    423.13953   0.00218341 
+  448          471.09187    422.41187   0.00223214 
+  403          468.54231    421.68577   0.00248139 
+  404          466.13047    420.96126   0.00247525 
+  406          463.84418    420.23831   0.00246305 
+  428          461.67479    419.51692   0.00233645 
+  430          459.60997    418.7971    0.00232558 
+  432          457.6439     418.07884   0.00231481 
+  453          455.77098    417.36214   0.00220751 
+  441          453.98414    416.64699   0.00226757 
+  462          452.27978    415.93339   0.0021645 
+  505          450.65429    415.22133   0.0019802 
+  472          449.10505    414.51082   0.00211864 
+  402          447.63022    413.80185   0.00248756 
+  407          446.22881    413.09441   0.002457  
+  417          444.9013     412.38851   0.00239808 
+  408          443.64801    411.68413   0.00245098 
+  410          442.47166    410.98129   0.00243902 
+  406          441.37615    410.27996   0.00246305 
+  398          440.36732    409.58016   0.00251256 
+  423          439.45301    408.88187   0.00236407 
+  398          438.64389    408.1851    0.00251256 
+  394          437.95513    407.48984   0.00253807 
+  405          437.40715    406.79608   0.00246914 
+  382          437.02757    406.10383   0.0026178 
+  417          436.85489    405.41308   0.00239808 
+  387          436.94307    404.72383   0.00258398 
+  410          437.36954    404.03607   0.00243902 
+  420          438.24804    403.3498    0.00238095 
+  389          439.75052    402.66502   0.00257069 
+  427          442.14983    401.98172   0.00234192 
+  442          445.91231    401.29991   0.00226244 
+  443          451.93004    400.61957   0.00225734 
+  496          462.07096    399.94071   0.00201613 
+  450          480.10507    399.26332   0.00222222 
+  484          512.42127    398.5874    0.00206612 
+  507          565.84704    397.91295   0.00197239 
+  614          633.62405    397.23996   0.00162866 
+  745          691.19175    396.56842   0.00134228 
+  726          727.33397    395.89835   0.00137741 
+  696          711.17549    395.22972   0.00143678 
+  879          668.45611    394.56255   0.00113766 
+  973          636.70286    393.89682   0.00102775 
+  1040         610.02664    393.23254   0.00096154 
+  1139         600.08728    392.5697    0.00087796 
+  860          585.83425    391.90829   0.00116279 
+  787          551.60208    391.24832   0.00127065 
+  746          541.04056    390.58978   0.00134048 
+  627          545.34947    389.93267   0.0015949 
+  497          533.88523    389.27699   0.00201207 
+  471          502.80514    388.62272   0.00212314 
+  449          480.81328    387.96988   0.00222717 
+  433          470.08298    387.31845   0.00230947 
+  438          454.14716    386.66843   0.00228311 
+  434          440.76597    386.01983   0.00230415 
+  422          434.68457    385.37263   0.00236967 
+  447          434.31798    384.72683   0.00223714 
+  545          440.56473    384.08244   0.00183486 
+  638          459.55649    383.43944   0.0015674 
+  838          501.0833     382.79784   0.00119332 
+  965          562.54943    382.15763   0.00103627 
+  865          589.81263    381.51881   0.00115607 
+  802          577.63994    380.88137   0.00124688 
+  722          562.23844    380.24532   0.00138504 
+  574          531.55183    379.61065   0.00174216 
+  457          492.32895    378.97735   0.00218818 
+  370          458.57615    378.34543   0.0027027 
+  366          431.92578    377.71488   0.00273224 
+  377          416.21335    377.08569   0.00265252 
+  353          407.67439    376.45787   0.00283286 
+  382          402.67026    375.83141   0.0026178 
+  327          399.3178     375.20632   0.0030581 
+  379          396.83339    374.58257   0.00263852 
+  359          394.88338    373.96018   0.00278552 
+  357          393.29572    373.33915   0.00280112 
+  369          391.97328    372.71945   0.00271003 
+  386          390.85899    372.10111   0.00259067 
+  346          389.92307    371.4841    0.00289017 
+  360          389.15817    370.86843   0.00277778 
+  345          388.58898    370.2541    0.00289855 
+  342          388.29163    369.6411    0.00292398 
+  384          388.40987    369.02943   0.00260417 
+  357          389.1081     368.41909   0.00280112 
+  346          390.25733    367.81007   0.00289017 
+  348          390.8297     367.20237   0.00287356 
+  352          390.58869    366.59599   0.00284091 
+  333          390.81548    365.99093   0.003003  
+  343          391.37578    365.38718   0.00291545 
+  371          391.84318    364.78474   0.00269542 
+  409          393.41962    364.1836    0.00244499 
+  465          397.52954    363.58377   0.00215054 
+  415          406.91478    362.98524   0.00240964 
+  454          428.50703    362.38801   0.00220264 
+  582          471.26578    361.79208   0.00171821 
+  639          525.60483    361.19743   0.00156495 
+  629          530.81205    360.60408   0.00158983 
+  585          499.31341    360.01202   0.0017094 
+  466          488.92014    359.42124   0.00214592 
+  489          476.30689    358.83174   0.00204499 
+  406          449.44777    358.24351   0.00246305 
+  425          430.79323    357.65657   0.00235294 
+  432          418.12659    357.0709    0.00231481 
+  485          408.97681    356.4865    0.00206186 
+  436          404.21185    355.90336   0.00229358 
+  416          401.92181    355.32149   0.00240385 
+  455          401.87067    354.74089   0.0021978 
+  427          400.45348    354.16154   0.00234192 
+  406          393.20313    353.58345   0.00246305 
+  375          388.04711    353.00661   0.00266667 
+  405          385.27228    352.43102   0.00246914 
+  362          380.24604    351.85669   0.00276243 
+  373          375.46848    351.2836    0.00268097 
+  345          372.48817    350.71175   0.00289855 
+  357          370.7518     350.14114   0.00280112 
+  339          369.63544    349.57177   0.00294985 
+  319          368.81987    349.00363   0.0031348 
+  328          368.18242    348.43673   0.00304878 
+  368          367.67119    347.87105   0.00271739 
+  322          367.26009    347.3066    0.00310559 
+  316          366.93424    346.74338   0.00316456 
+  387          366.68708    346.18138   0.00258398 
+  363          366.51715    345.62059   0.00275482 
+  321          366.42794    345.06102   0.00311526 
+  342          366.42841    344.50267   0.00292398 
+  365          366.53576    343.94553   0.00273973 
+  339          366.78061    343.38959   0.00294985 
+  348          367.22714    342.83486   0.00287356 
+  326          368.01188    342.28133   0.00306748 
+  297          369.38159    341.72901   0.003367  
+  306          371.63822    341.17788   0.00326797 
+  322          374.91306    340.62794   0.00310559 
+  357          380.96213    340.0792    0.00280112 
+  346          392.29556    339.53165   0.00289017 
+  346          406.39516    338.98528   0.00289017 
+  332          407.55964    338.4401    0.00301205 
+  371          401.17501    337.8961    0.00269542 
+  380          398.52939    337.35328   0.00263158 
+  365          394.62143    336.81164   0.00273973 
+  370          387.17856    336.27117   0.0027027 
+  355          381.59174    335.73187   0.0028169 
+  306          378.70107    335.19374   0.00326797 
+  328          377.93561    334.65678   0.00304878 
+  342          378.38698    334.12098   0.00292398 
+  362          379.55766    333.58634   0.00276243 
+  357          381.28824    333.05287   0.00280112 
+  355          383.62411    332.52054   0.0028169 
+  362          386.77128    331.98937   0.00276243 
+  355          391.03602    331.45936   0.0028169 
+  352          396.45877    330.93049   0.00284091 
+  386          401.62649    330.40277   0.00259067 
+  403          404.81847    329.87619   0.00248139 
+  380          408.01405    329.35075   0.00263158 
+  386          412.37893    328.82645   0.00259067 
+  388          416.92034    328.30329   0.00257732 
+  383          422.04067    327.78126   0.00261097 
+  371          428.74177    327.26036   0.00269542 
+  379          437.19132    326.74059   0.00263852 
+  430          447.82207    326.22194   0.00232558 
+  439          460.90326    325.70442   0.0022779 
+  403          477.01347    325.18802   0.00248139 
+  398          496.93865    324.67274   0.00251256 
+  438          520.40007    324.15858   0.00228311 
+  471          546.79758    323.64553   0.00212314 
+  493          579.07086    323.13359   0.0020284 
+  486          620.78604    322.62275   0.00205761 
+  620          674.53291    322.11303   0.0016129 
+  675          745.57518    321.60441   0.00148148 
+  876          843.16556    321.09689   0.00114155 
+  1047         981.6715     320.59047   0.00095511 
+  1470         1186.38115   320.08515   0.00068027 
+  1905         1506.97806   319.58092   0.00052493 
+  2974         2069.44368   319.07778   0.00033625 
+  4604         3334.63412   318.57573   0.0002172 
+  8861         6764.09419   318.07477   0.00011285 
+  17339        14304.54196  317.5749    0.00005767 
+  31571        21789.02016  317.0761    0.00003167 
+  31561        17566.66158  316.57839   0.00003168 
+  16176        12621.40207  316.08175   0.00006182 
+  14974        12967.14411  315.58619   0.00006678 
+  16489        10754.5315   315.0917    0.00006065 
+  7982         5856.75481   314.59828   0.00012528 
+  2540         2997.37496   314.10593   0.0003937 
+  1442         1837.23373   313.61465   0.00069348 
+  1163         1343.10193   313.12443   0.00085985 
+  953          1071.23735   312.63527   0.00104932 
+  820          897.40381    312.14717   0.00121951 
+  697          778.56403    311.66012   0.00143472 
+  640          693.72684    311.17413   0.0015625 
+  658          630.70862    310.68919   0.00151976 
+  573          581.95847    310.2053    0.0017452 
+  503          543.81247    309.72245   0.00198807 
+  488          513.63768    309.24065   0.00204918 
+  450          489.03768    308.7599    0.00222222 
+  450          468.73312    308.28018   0.00222222 
+  460          452.00418    307.8015    0.00217391 
+  414          438.16477    307.32386   0.00241546 
+  416          426.63499    306.84724   0.00240385 
+  386          417.02572    306.37166   0.00259067 
+  387          409.07798    305.89711   0.00258398 
+  369          402.67432    305.42359   0.00271003 
+  368          397.83887    304.95109   0.00271739 
+  329          394.61986    304.47961   0.00303951 
+  384          392.57155    304.00915   0.00260417 
+  345          391.27708    303.5397    0.00289855 
+  349          392.34537    303.07128   0.00286533 
+  354          397.57419    302.60386   0.00282486 
+  417          408.93431    302.13746   0.00239808 
+  378          429.39067    301.67206   0.0026455 
+  376          457.65203    301.20767   0.00265957 
+  431          478.52064    300.74428   0.00232019 
+  447          492.05544    300.2819    0.00223714 
+  472          527.7329     299.82051   0.00211864 
+  533          596.33146    299.36012   0.00187617 
+  694          675.15169    298.90073   0.00144092 
+  798          705.67889    298.44233   0.00125313 
+  978          699.08089    297.98492   0.00102249 
+  2149         723.90464    297.5285    0.00046533 
+  2582         726.06111    297.07306   0.0003873 
+  1395         690.16185    296.61861   0.00071685 
+  1243         694.70342    296.16514   0.00080451 
+  1684         715.12351    295.71265   0.00059382 
+  1311         685.80609    295.26113   0.00076278 
+  1145         625.11173    294.8106    0.00087336 
+  1079         571.55327    294.36103   0.00092678 
+  719          527.96695    293.91244   0.00139082 
+  602          479.10428    293.46481   0.00166113 
+  650          427.70213    293.01815   0.00153846 
+  485          389.3068     292.57246   0.00206186 
+  393          365.12566    292.12773   0.00254453 
+  379          350.20121    291.68396   0.00263852 
+  375          340.49885    291.24114   0.00266667 
+  345          333.66502    290.79928   0.00289855 
+  352          328.50786    290.35838   0.00284091 
+  324          324.42736    289.91843   0.00308642 
+  310          321.08954    289.47942   0.00322581 
+  292          318.28837    289.04137   0.00342466 
+  295          315.8882     288.60426   0.00338983 
+  321          313.79572    288.16809   0.00311526 
+  280          311.94526    287.73287   0.00357143 
+  288          310.22515    287.29858   0.00347222 
+  284          308.74096    286.86523   0.00352113 
+  305          307.37432    286.43282   0.00327869 
+  305          306.08717    286.00133   0.00327869 
+  310          304.92658    285.57078   0.00322581 
+  294          303.85564    285.14116   0.00340136 
+  295          302.85072    284.71247   0.00338983 
+  322          301.91134    284.2847    0.00310559 
+  289          301.03195    283.85785   0.00346021 
+  315          300.20855    283.43192   0.0031746 
+  274          299.43865    283.00691   0.00364964 
+  279          298.7216     282.58282   0.00358423 
+  295          298.05818    282.15964   0.00338983 
+  303          297.45121    281.73737   0.00330033 
+  317          296.8991     281.31601   0.00315457 
+  300          296.42761    280.89557   0.00333333 
+  282          296.04488    280.47602   0.0035461 
+  298          295.77255    280.05739   0.0033557 
+  328          295.66133    279.63965   0.00304878 
+  334          295.7801     279.22281   0.00299401 
+  325          296.2641     278.80688   0.00307692 
+  350          297.41694    278.39184   0.00285714 
+  436          300.08685    277.97769   0.00229358 
+  517          305.78559    277.56444   0.00193424 
+  947          319.42337    277.15207   0.00105597 
+  1433         339.92139    276.74059   0.00069784 
+  1057         348.59125    276.33      0.00094607 
+  795          335.28256    275.9203    0.00125786 
+  845          327.1005     275.51148   0.00118343 
+  831          327.63159    275.10353   0.00120337 
+  513          321.70076    274.69647   0.00194932 
+  409          313.53219    274.29028   0.00244499 
+  327          312.29901    273.88497   0.0030581 
+  292          315.86907    273.48053   0.00342466 
+  298          315.3912     273.07696   0.0033557 
+  299          309.79256    272.67425   0.00334448 
+  267          306.10873    272.27242   0.00374532 
+  313          304.22491    271.87145   0.00319489 
+  293          300.67492    271.47134   0.00341297 
+  289          297.78865    271.0721    0.00346021 
+  279          297.10928    270.67371   0.00358423 
+  279          294.73056    270.27618   0.00358423 
+  257          290.86531    269.8795    0.00389105 
+  302          288.9474     269.48368   0.00331126 
+  284          288.04197    269.08871   0.00352113 
+  276          285.81301    268.69459   0.00362319 
+  277          283.53643    268.30132   0.00361011 
+  268          282.09264    267.90889   0.00373134 
+  275          281.27152    267.51731   0.00363636 
+  311          280.79779    267.12657   0.00321543 
+  273          280.53953    266.73667   0.003663  
+  306          280.48071    266.3476    0.00326797 
+  257          280.68208    265.95938   0.00389105 
+  257          281.34663    265.57199   0.00389105 
+  293          283.07899    265.18543   0.00341297 
+  269          287.20265    264.7997    0.00371747 
+  285          295.05961    264.4148    0.00350877 
+  265          303.35866    264.03073   0.00377358 
+  273          301.25391    263.64748   0.003663  
+  311          295.05095    263.26506   0.00321543 
+  267          293.58297    262.88345   0.00374532 
+  241          293.38994    262.50267   0.00414938 
+  270          288.67031    262.12271   0.0037037 
+  294          284.32304    261.74356   0.00340136 
+  270          282.29376    261.36522   0.0037037 
+  280          282.23009    260.9877    0.00357143 
+  313          284.29253    260.61099   0.00319489 
+  289          288.49739    260.23509   0.00346021 
+  297          292.96159    259.86      0.003367  
+  285          291.8581     259.48571   0.00350877 
+  309          288.87918    259.11222   0.00323625 
+  324          288.59473    258.73954   0.00308642 
+  266          288.89282    258.36765   0.0037594 
+  290          287.04329    257.99656   0.00344828 
+  288          285.54757    257.62627   0.00347222 
+  320          285.49261    257.25678   0.003125  
+  292          286.70036    256.88808   0.00342466 
+  289          288.95851    256.52016   0.00346021 
+  271          291.7223     256.15304   0.00369004 
+  287          294.3081     255.78671   0.00348432 
+  313          298.02572    255.42116   0.00319489 
+  305          304.10576    255.05639   0.00327869 
+  294          313.02758    254.69241   0.00340136 
+  277          325.57877    254.32921   0.00361011 
+  317          342.38183    253.96679   0.00315457 
+  306          359.72594    253.60514   0.00326797 
+  312          370.415      253.24427   0.00320513 
+  388          375.9848     252.88417   0.00257732 
+  425          381.65423    252.52485   0.00235294 
+  402          387.40287    252.16629   0.00248756 
+  393          403.94846    251.8085    0.00254453 
+  460          462.70689    251.45148   0.00217391 
+  553          617.44353    251.09523   0.00180832 
+  723          845.58867    250.73974   0.00138313 
+  672          832.65034    250.38501   0.0014881 
+  539          647.53627    250.03104   0.00185529 
+  590          603.86018    249.67782   0.00169492 
+  560          647.33627    249.32537   0.00178571 
+  459          564.18192    248.97367   0.00217865 
+  463          453.07101    248.62272   0.00215983 
+  438          401.03596    248.27253   0.00228311 
+  428          389.16386    247.92308   0.00233645 
+  442          397.31395    247.57438   0.00226244 
+  437          419.238      247.22643   0.00228833 
+  444          443.90486    246.87922   0.00225225 
+  408          453.00727    246.53276   0.00245098 
+  465          464.35894    246.18704   0.00215054 
+  438          492.24221    245.84206   0.00228311 
+  534          530.57736    245.49782   0.00187266 
+  605          575.06804    245.15431   0.00165289 
+  730          641.69097    244.81154   0.00136986 
+  1020         746.061      244.4695    0.00098039 
+  1411         909.93598    244.12819   0.00070872 
+  2263         1178.58531   243.78761   0.00044189 
+  2771         1689.57827   243.44777   0.00036088 
+  3922         2980.49868   243.10865   0.00025497 
+  7279         6326.25848   242.77025   0.00013738 
+  13854        12072.7241   242.43258   0.00007218 
+  19767        13649.22901  242.09563   0.00005059 
+  11424        8965.0948    241.7594    0.00008754 
+  6671         6910.91023   241.42389   0.0001499 
+  8296         8018.19627   241.08909   0.00012054 
+  8936         6881.10908   240.75501   0.00011191 
+  3941         3786.10235   240.42165   0.00025374 
+  1514         1955.2636    240.089     0.0006605 
+  984          1212.08842   239.75706   0.00101626 
+  658          898.33111    239.42582   0.00151976 
+  542          727.83787    239.0953    0.00184502 
+  507          621.62728    238.76548   0.00197239 
+  495          553.32016    238.43637   0.0020202 
+  451          506.01427    238.10796   0.00221729 
+  415          463.46944    237.78025   0.00240964 
+  425          428.66577    237.45324   0.00235294 
+  363          406.09459    237.12693   0.00275482 
+  327          389.46709    236.80132   0.0030581 
+  319          368.87051    236.4764    0.0031348 
+  328          349.60342    236.15217   0.00304878 
+  322          335.95802    235.82864   0.00310559 
+  305          325.89566    235.5058    0.00327869 
+  262          316.37984    235.18365   0.00381679 
+  297          308.43746    234.86218   0.003367  
+  309          303.14096    234.5414    0.00323625 
+  276          300.74692    234.22131   0.00362319 
+  293          300.16874    233.90189   0.00341297 
+  279          298.1494     233.58316   0.00358423 
+  285          295.50057    233.26511   0.00350877 
+  264          291.42875    232.94774   0.00378788 
+  270          287.66486    232.63105   0.0037037 
+  323          285.70173    232.31503   0.00309598 
+  279          286.25774    231.99968   0.00358423 
+  269          286.44027    231.68501   0.00371747 
+  262          283.97175    231.37101   0.00381679 
+  276          283.69403    231.05767   0.00362319 
+  276          287.14075    230.74501   0.00362319 
+  237          287.88167    230.43301   0.00421941 
+  234          282.45637    230.12168   0.0042735 
+  214          276.61476    229.81101   0.0046729 
+  247          272.72835    229.501     0.00404858 
+  247          268.55387    229.19166   0.00404858 
+  247          263.39068    228.88297   0.00404858 
+  226          258.63741    228.57494   0.00442478 
+  215          254.96581    228.26757   0.00465116 
+  223          252.34529    227.96085   0.0044843 
+  227          250.51977    227.65478   0.00440529 
+  243          249.32883    227.34937   0.00411523 
+  221          248.80203    227.04461   0.00452489 
+  216          249.13941    226.74049   0.00462963 
+  267          250.50788    226.43703   0.00374532 
+  265          252.14477    226.13421   0.00377358 
+  256          251.59783    225.83203   0.00390625 
+  215          249.22273    225.5305    0.00465116 
+  243          247.54978    225.22961   0.00411523 
+  270          246.64525    224.92937   0.0037037 
+  222          245.04019    224.62976   0.0045045 
+  260          242.83326    224.33078   0.00384615 
+  232          241.01157    224.03245   0.00431034 
+  227          239.75726    223.73475   0.00440529 
+  206          238.96635    223.43768   0.00485437 
+  220          238.52842    223.14124   0.00454545 
+  282          238.50988    222.84544   0.0035461 
+  240          239.21213    222.55026   0.00416667 
+  215          240.98749    222.25572   0.00465116 
+  225          243.39205    221.9618    0.00444444 
+  245          244.34845    221.6685    0.00408163 
+  244          244.16064    221.37583   0.00409836 
+  252          244.21818    221.08378   0.00396825 
+  252          245.18804    220.79235   0.00396825 
+  258          245.05469    220.50154   0.00387597 
+  244          242.36045    220.21135   0.00409836 
+  260          239.8458     219.92178   0.00384615 
+  234          238.78907    219.63282   0.0042735 
+  264          238.20253    219.34448   0.00378788 
+  253          237.18028    219.05675   0.00395257 
+  229          237.13995    218.76963   0.00436681 
+  251          239.32271    218.48312   0.00398406 
+  301          245.47702    218.19722   0.00332226 
+  318          257.34601    217.91192   0.00314465 
+  332          269.51511    217.62724   0.00301205 
+  315          266.60142    217.34316   0.0031746 
+  311          258.15913    217.05968   0.00321543 
+  362          254.7343     216.7768    0.00276243 
+  299          254.56539    216.49453   0.00334448 
+  322          249.09119    216.21285   0.00310559 
+  296          241.79037    215.93177   0.00337838 
+  275          236.36952    215.65129   0.00363636 
+  275          232.73505    215.37141   0.00363636 
+  240          231.07201    215.09212   0.00416667 
+  232          230.24855    214.81342   0.00431034 
+  224          229.67081    214.53532   0.00446429 
+  212          229.5549     214.2578    0.00471698 
+  256          229.64558    213.98088   0.00390625 
+  213          229.92609    213.70454   0.00469484 
+  221          230.40323    213.42879   0.00452489 
+  237          231.10532    213.15362   0.00421941 
+  242          232.07922    212.87904   0.00413223 
+  247          233.3991     212.60504   0.00404858 
+  264          235.18013    212.33162   0.00378788 
+  252          237.59976    212.05878   0.00396825 
+  230          240.94308    211.78652   0.00434783 
+  260          245.68723    211.51484   0.00384615 
+  245          252.68406    211.24373   0.00408163 
+  283          263.65415    210.9732    0.00353357 
+  327          283.35043    210.70325   0.0030581 
+  467          328.89977    210.43386   0.00214133 
+  674          444.42732    210.16505   0.00148368 
+  952          660.66329    209.89681   0.00105042 
+  1177         788.46391    209.62914   0.00084962 
+  935          661.56669    209.36203   0.00106952 
+  665          625.60654    209.09549   0.00150376 
+  654          751.26101    208.82952   0.00152905 
+  649          777.96703    208.56411   0.00154083 
+  573          595.1643     208.29926   0.0017452 
+  311          467.87299    208.03497   0.00321543 
+  298          436.96619    207.77125   0.0033557 
+  282          401.8089     207.50808   0.0035461 
+  288          336.95012    207.24547   0.00347222 
+  226          290.11197    206.98342   0.00442478 
+  207          265.10629    206.72192   0.00483092 
+  262          252.43588    206.46098   0.00381679 
+  258          245.34785    206.20059   0.00387597 
+  238          240.96044    205.94075   0.00420168 
+  241          238.22856    205.68146   0.00414938 
+  241          236.61167    205.42272   0.00414938 
+  208          235.31089    205.16453   0.00480769 
+  235          233.97743    204.90689   0.00425532 
+  247          233.17239    204.64979   0.00404858 
+  283          232.98944    204.39324   0.00353357 
+  233          233.09392    204.13723   0.00429185 
+  246          233.30427    203.88176   0.00406504 
+  243          233.96943    203.62684   0.00411523 
+  262          235.22705    203.37245   0.00381679 
+  235          236.87051    203.1186    0.00425532 
+  260          238.43719    202.86529   0.00384615 
+  267          240.40833    202.61252   0.00374532 
+  267          243.91303    202.36028   0.00374532 
+  275          249.66182    202.10858   0.00363636 
+  272          256.64181    201.85741   0.00367647 
+  272          261.17458    201.60677   0.00367647 
+  253          265.37658    201.35666   0.00395257 
+  293          275.14218    201.10708   0.00341297 
+  363          299.89515    200.85803   0.00275482 
+  431          358.82805    200.6095    0.00232019 
+  682          462.00363    200.36151   0.00146628 
+  858          507.05608    200.11403   0.0011655 
+  679          424.90839    199.86708   0.00147275 
+  528          375.18504    199.62066   0.00189394 
+  509          394.46947    199.37475   0.00196464 
+  551          416.33055    199.12937   0.00181488 
+  471          375.02092    198.8845    0.00212314 
+  391          339.2518     198.64016   0.00255754 
+  345          330.31814    198.39633   0.00289855 
+  322          337.69555    198.15301   0.00310559 
+  382          354.09453    197.91022   0.0026178 
+  363          376.36761    197.66793   0.00275482 
+  408          402.71038    197.42616   0.00245098 
+  506          438.27307    197.1849    0.00197628 
+  561          489.15601    196.94415   0.00178253 
+  578          561.54182    196.70391   0.0017301 
+  677          665.77976    196.46417   0.0014771 
+  946          826.19599    196.22495   0.00105708 
+  1413         1098.5023    195.98623   0.00070771 
+  2223         1668.25212   195.74801   0.00044984 
+  4219         3176.41687   195.5103    0.00023702 
+  8313         6786.88915   195.27309   0.00012029 
+  14596        11712.96236  195.03639   0.00006851 
+  15115        10864.03349  194.80018   0.00006616 
+  7874         6559.36543   194.56448   0.000127  
+  5514         5224.80667   194.32927   0.00018136 
+  7094         6583.24308   194.09456   0.00014096 
+  7686         6316.77673   193.86035   0.00013011 
+  3959         3649.13217   193.62663   0.00025259 
+  1492         1864.92444   193.3934    0.00067024 
+  797          1112.08823   193.16067   0.00125471 
+  586          803.51887    192.92843   0.00170648 
+  466          642.99873    192.69669   0.00214592 
+  395          542.10573    192.46543   0.00253165 
+  372          471.72676    192.23466   0.00268817 
+  365          421.34317    192.00438   0.00273973 
+  318          385.30571    191.77459   0.00314465 
+  299          359.77514    191.54528   0.00334448 
+  294          342.50725    191.31646   0.00340136 
+  242          332.29899    191.08812   0.00413223 
+  292          328.14008    190.86026   0.00342466 
+  330          328.28568    190.63289   0.0030303 
+  335          330.4694     190.406     0.00298507 
+  395          335.28877    190.17958   0.00253165 
+  382          335.55109    189.95365   0.0026178 
+  370          320.59929    189.72819   0.0027027 
+  351          307.44191    189.50321   0.002849  
+  317          298.78229    189.27871   0.00315457 
+  287          287.79436    189.05468   0.00348432 
+  287          271.26283    188.83112   0.00348432 
+  263          256.76923    188.60804   0.00380228 
+  245          247.18377    188.38543   0.00408163 
+  245          238.32723    188.16329   0.00408163 
+  240          231.11765    187.94162   0.00416667 
+  234          226.08683    187.72041   0.0042735 
+  214          222.52454    187.49968   0.0046729 
+  247          219.81936    187.27941   0.00404858 
+  219          217.65542    187.05961   0.00456621 
+  186          215.90793    186.84027   0.00537634 
+  238          214.55332    186.6214    0.00420168 
+  196          213.65724    186.40299   0.00510204 
+  209          213.43387    186.18504   0.00478469 
+  204          214.28085    185.96755   0.00490196 
+  241          216.63994    185.75052   0.00414938 
+  212          220.10047    185.53395   0.00471698 
+  251          221.35491    185.31784   0.00398406 
+  211          218.50738    185.10219   0.00473934 
+  231          215.70567    184.88699   0.004329  
+  242          215.13783    184.67225   0.00413223 
+  200          215.6785     184.45796   0.005     
+  227          215.60762    184.24412   0.00440529 
+  225          216.94442    184.03074   0.00444444 
+  245          222.46795    183.81781   0.00408163 
+  224          233.12233    183.60532   0.00446429 
+  238          243.38979    183.39329   0.00420168 
+  255          239.91749    183.18171   0.00392157 
+  231          229.07027    182.97057   0.004329  
+  213          224.1698     182.75988   0.00469484 
+  232          224.40102    182.54964   0.00431034 
+  208          221.70985    182.33984   0.00480769 
+  205          213.65057    182.13048   0.00487805 
+  216          207.03426    181.92157   0.00462963 
+  226          203.20822    181.7131    0.00442478 
+  200          201.20736    181.50507   0.005     
+  241          200.31025    181.29748   0.00414938 
+  224          200.09985    181.09033   0.00446429 
+  228          200.43628    180.88361   0.00438596 
+  221          201.37817    180.67734   0.00452489 
+  227          203.15176    180.4715    0.00440529 
+  238          206.02161    180.2661    0.00420168 
+  232          209.83668    180.06113   0.00431034 
+  265          214.38535    179.85659   0.00377358 
+  255          220.91708    179.65249   0.00392157 
+  255          230.7871     179.44882   0.00392157 
+  280          244.89849    179.24558   0.00357143 
+  371          273.20424    179.04278   0.00269542 
+  523          341.9371     178.8404    0.00191205 
+  953          489.60224    178.63845   0.00104932 
+  1479         681.10583    178.43692   0.00067613 
+  1987         676.27782    178.23583   0.00050327 
+  2749         508.84512    178.03516   0.00036377 
+  3495         443.26881    177.83491   0.00028612 
+  2807         493.17948    177.63509   0.00035625 
+  1809         514.27528    177.43569   0.00055279 
+  1665         412.80775    177.23671   0.0006006 
+  1787         320.98239    177.03816   0.0005596 
+  1546         278.59984    176.84002   0.00064683 
+  909          260.42955    176.64231   0.00110011 
+  641          248.3539     176.44501   0.00156006 
+  652          242.29975    176.24813   0.00153374 
+  564          242.69737    176.05167   0.00177305 
+  505          240.83512    175.85563   0.0019802 
+  461          230.24643    175.66      0.0021692 
+  436          221.82209    175.46478   0.00229358 
+  470          217.42386    175.26998   0.00212766 
+  378          214.5439     175.07559   0.0026455 
+  318          207.99193    174.88162   0.00314465 
+  288          200.95984    174.68805   0.00347222 
+  228          196.25592    174.49489   0.00438596 
+  221          192.3558     174.30215   0.00452489 
+  218          189.53615    174.10981   0.00458716 
+  205          187.74533    173.91788   0.00487805 
+  202          186.59605    173.72636   0.0049505 
+  190          185.82738    173.53524   0.00526316 
+  220          185.34092    173.34453   0.00454545 
+  184          184.88312    173.15423   0.00543478 
+  174          184.93762    172.96432   0.00574713 
+  175          184.93178    172.77482   0.00571429 
+  185          184.54934    172.58573   0.00540541 
+  209          184.02359    172.39703   0.00478469 
+  200          183.93671    172.20873   0.005     
+  175          184.1515     172.02084   0.00571429 
+  189          184.51142    171.83334   0.00529101 
+  233          185.33569    171.64624   0.00429185 
+  238          187.51715    171.45953   0.00420168 
+  283          191.89466    171.27323   0.00353357 
+  257          197.0111     171.08732   0.00389105 
+  211          196.59714    170.9018    0.00473934 
+  212          192.62108    170.71668   0.00471698 
+  244          190.88638    170.53195   0.00409836 
+  229          191.98929    170.34761   0.00436681 
+  203          192.94149    170.16367   0.00492611 
+  213          191.25634    169.98011   0.00469484 
+  203          189.73575    169.79695   0.00492611 
+  222          189.61503    169.61417   0.0045045 
+  203          190.78887    169.43179   0.00492611 
+  207          193.29471    169.24979   0.00483092 
+  218          197.98247    169.06818   0.00458716 
+  200          206.67796    168.88695   0.005     
+  226          220.49777    168.70611   0.00442478 
+  201          232.52279    168.52565   0.00497512 
+  211          232.37853    168.34558   0.00473934 
+  189          233.77718    168.16589   0.00529101 
+  211          248.00494    167.98659   0.00473934 
+  237          278.26637    167.80766   0.00421941 
+  273          321.15825    167.62912   0.003663  
+  267          368.24461    167.45095   0.00374532 
+  313          385.92817    167.27317   0.00319489 
+  389          365.95716    167.09576   0.00257069 
+  399          358.90814    166.91873   0.00250627 
+  349          390.72907    166.74208   0.00286533 
+  345          457.4811     166.5658    0.00289855 
+  385          535.71049    166.3899    0.0025974 
+  390          587.50937    166.21438   0.0025641 
+  365          546.97802    166.03923   0.00273973 
+  280          469.69572    165.86445   0.00357143 
+  301          434.63425    165.69004   0.00332226 
+  288          442.5018     165.51601   0.00347222 
+  297          440.55369    165.34234   0.003367  
+  270          406.01272    165.16905   0.0037037 
+  265          387.77475    164.99613   0.00377358 
+  290          415.19179    164.82357   0.00344828 
+  322          490.56756    164.65139   0.00310559 
+  429          575.32814    164.47957   0.002331  
+  456          582.25825    164.30812   0.00219298 
+  333          541.55544    164.13703   0.003003  
+  296          542.27995    163.96631   0.00337838 
+  321          569.54831    163.79595   0.00311526 
+  369          544.8467     163.62596   0.00271003 
+  315          463.43688    163.45633   0.0031746 
+  223          392.47658    163.28706   0.0044843 
+  212          354.75266    163.11816   0.00471698 
+  204          322.35511    162.94961   0.00490196 
+  242          280.94619    162.78143   0.00413223 
+  174          246.55162    162.61361   0.00574713 
+  181          223.81565    162.44614   0.00552486 
+  188          209.67612    162.27903   0.00531915 
+  193          200.76783    162.11228   0.00518135 
+  227          194.88794    161.94589   0.00440529 
+  175          190.9326     161.77985   0.00571429 
+  175          188.59217    161.61417   0.00571429 
+  164          188.29294    161.44884   0.00609756 
+  188          190.97679    161.28387   0.00531915 
+  182          196.22332    161.11925   0.00549451 
+  195          197.01035    160.95498   0.00512821 
+  167          190.30671    160.79107   0.00598802 
+  184          185.03476    160.6275    0.00543478 
+  177          183.91704    160.46429   0.00564972 
+  184          184.87878    160.30143   0.00543478 
+  190          182.758      160.13891   0.00526316 
+  176          178.64002    159.97675   0.00568182 
+  188          175.67042    159.81493   0.00531915 
+  172          173.84085    159.65346   0.00581395 
+  184          172.83007    159.49233   0.00543478 
+  167          172.42929    159.33156   0.00598802 
+  168          172.54582    159.17112   0.00595238 
+  165          173.21824    159.01104   0.00606061 
+  171          174.83208    158.85129   0.00584795 
+  186          177.96033    158.69189   0.00537634 
+  200          182.36469    158.53283   0.005     
+  189          184.95489    158.37411   0.00529101 
+  194          183.40093    158.21574   0.00515464 
+  177          181.90859    158.0577    0.00564972 
+  213          183.41944    157.90001   0.00469484 
+  194          187.57254    157.74265   0.00515464 
+  203          191.05002    157.58564   0.00492611 
+  190          191.36976    157.42896   0.00526316 
+  204          188.39961    157.27262   0.00490196 
+  182          183.70801    157.11661   0.00549451 
+  197          180.98756    156.96094   0.00507614 
+  202          180.31211    156.80561   0.0049505 
+  172          180.23367    156.65061   0.00581395 
+  206          179.60418    156.49595   0.00485437 
+  194          179.05327    156.34162   0.00515464 
+  218          177.47058    156.18762   0.00458716 
+  200          175.04586    156.03395   0.005     
+  207          174.40266    155.88062   0.00483092 
+  207          176.42691    155.72762   0.00483092 
+  235          180.94946    155.57495   0.00425532 
+  204          186.04079    155.4226    0.00490196 
+  226          189.58624    155.27059   0.00442478 
+  235          193.22177    155.11891   0.00425532 
+  231          193.87124    154.96755   0.004329  
+  298          193.56864    154.81652   0.0033557 
+  391          200.06558    154.66582   0.00255754 
+  506          216.35093    154.51544   0.00197628 
+  607          240.41804    154.36539   0.00164745 
+  628          245.92049    154.21566   0.00159236 
+  523          225.65332    154.06626   0.00191205 
+  403          211.46484    153.91718   0.00248139 
+  407          212.33678    153.76843   0.002457  
+  448          222.10371    153.62      0.00223214 
+  342          224.02415    153.47189   0.00292398 
+  322          220.06348    153.3241    0.00310559 
+  237          224.53563    153.17663   0.00421941 
+  218          244.18571    153.02948   0.00458716 
+  222          291.86427    152.88265   0.0045045 
+  231          394.07974    152.73614   0.004329  
+  214          571.99967    152.58995   0.0046729 
+  300          740.99013    152.44407   0.00333333 
+  328          749.77472    152.29852   0.00304878 
+  407          686.51064    152.15327   0.002457  
+  359          570.65857    152.00835   0.00278552 
+  295          534.36404    151.86374   0.00338983 
+  267          533.63609    151.71945   0.00374532 
+  255          486.87845    151.57547   0.00392157 
+  322          412.26596    151.4318    0.00310559 
+  273          314.55113    151.28845   0.003663  
+  240          251.66739    151.1454    0.00416667 
+  213          221.27154    151.00267   0.00469484 
+  201          207.6476     150.86026   0.00497512 
+  214          200.01242    150.71815   0.0046729 
+  203          192.18748    150.57635   0.00492611 
+  192          185.34236    150.43487   0.00520833 
+  190          180.52434    150.29369   0.00526316 
+  184          178.2303     150.15282   0.00543478 
+  196          176.8636     150.01226   0.00510204 
+  221          174.79577    149.872     0.00452489 
+  241          173.47658    149.73205   0.00414938 
+  480          173.70892    149.59241   0.00208333 
+  513          174.7389     149.45308   0.00194932 
+  321          173.3566     149.31405   0.00311526 
+  235          171.30338    149.17532   0.00425532 
+  269          171.18035    149.0369    0.00371747 
+  305          172.63176    148.89878   0.00327869 
+  302          173.21041    148.76096   0.00331126 
+  227          171.37807    148.62345   0.00440529 
+  193          169.7954     148.48624   0.00518135 
+  173          170.05056    148.34933   0.00578035 
+  190          171.93609    148.21272   0.00526316 
+  167          174.31694    148.07641   0.00598802 
+  186          175.19769    147.9404    0.00537634 
+  208          173.26423    147.80469   0.00480769 
+  168          170.99319    147.66928   0.00595238 
+  198          170.24333    147.53417   0.00505051 
+  169          170.89501    147.39935   0.00591716 
+  160          171.58123    147.26483   0.00625   
+  157          171.57909    147.13061   0.00636943 
+  190          172.13002    146.99668   0.00526316 
+  180          173.03387    146.86305   0.00555556 
+  174          173.4457     146.72971   0.00574713 
+  192          175.25388    146.59667   0.00520833 
+  197          179.76915    146.46392   0.00507614 
+  165          186.64673    146.33147   0.00606061 
+  215          191.12879    146.19931   0.00465116 
+  174          188.84849    146.06744   0.00574713 
+  217          184.84372    145.93586   0.00460829 
+  170          183.6428     145.80457   0.00588235 
+  218          185.09469    145.67358   0.00458716 
+  187          186.59061    145.54287   0.00534759 
+  179          185.60386    145.41246   0.00558659 
+  191          184.28206    145.28233   0.0052356 
+  193          184.23842    145.15249   0.00518135 
+  177          185.48571    145.02294   0.00564972 
+  186          187.74272    144.89368   0.00537634 
+  183          190.82873    144.7647    0.00546448 
+  211          194.71396    144.63601   0.00473934 
+  183          199.49375    144.50761   0.00546448 
+  196          205.37896    144.3795    0.00510204 
+  214          212.79004    144.25166   0.0046729 
+  243          222.71124    144.12412   0.00411523 
+  284          237.14652    143.99685   0.00352113 
+  324          258.49642    143.86988   0.00308642 
+  296          284.54137    143.74318   0.00337838 
+  295          300.96917    143.61677   0.00338983 
+  318          311.75342    143.49064   0.00314465 
+  358          334.14373    143.36479   0.0027933 
+  362          373.55903    143.23922   0.00276243 
+  361          430.44573    143.11393   0.00277008 
+  355          501.30635    142.98892   0.0028169 
+  477          601.79815    142.8642    0.00209644 
+  613          772.88735    142.73975   0.00163132 
+  877          1111.72904   142.61558   0.00114025 
+  1299         1961.85101   142.49169   0.00076982 
+  2539         4123.68671   142.36807   0.00039386 
+  5363         7880.21203   142.24474   0.00018646 
+  7624         9143.57878   142.12168   0.00013116 
+  4397         5748.60924   141.9989    0.00022743 
+  2111         3333.11994   141.87639   0.00047371 
+  2057         3192.02605   141.75416   0.00048614 
+  3153         4594.90025   141.6322    0.00031716 
+  3701         4917.69244   141.51052   0.0002702 
+  2122         3001.94986   141.38911   0.00047125 
+  975          1524.39434   141.26798   0.00102564 
+  527          872.54337    141.14712   0.00189753 
+  393          611.72872    141.02653   0.00254453 
+  335          481.48928    140.90621   0.00298507 
+  263          401.64481    140.78617   0.00380228 
+  256          347.99292    140.66639   0.00390625 
+  233          310.01864    140.54689   0.00429185 
+  209          282.09643    140.42766   0.00478469 
+  210          260.96062    140.3087    0.0047619 
+  207          244.60724    140.19      0.00483092 
+  209          231.76705    140.07158   0.00478469 
+  174          221.6168     139.95342   0.00574713 
+  196          213.59336    139.83554   0.00510204 
+  194          207.18743    139.71792   0.00515464 
+  191          202.01582    139.60056   0.0052356 
+  201          198.31044    139.48348   0.00497512 
+  203          196.88497    139.36666   0.00492611 
+  183          199.31815    139.2501    0.00546448 
+  189          207.32864    139.13381   0.00529101 
+  193          217.70312    139.01779   0.00518135 
+  190          215.82091    138.90203   0.00526316 
+  194          205.50988    138.78653   0.00515464 
+  202          201.79162    138.6713    0.0049505 
+  255          208.9219     138.55633   0.00392157 
+  333          229.03963    138.44163   0.003003  
+  451          264.18798    138.32718   0.00221729 
+  473          323.79039    138.213     0.00211416 
+  433          382.73597    138.09908   0.00230947 
+  389          352.81662    137.98542   0.00257069 
+  303          284.3748     137.87202   0.00330033 
+  321          250.66895    137.75888   0.00311526 
+  322          256.95768    137.646     0.00310559 
+  276          277.79095    137.53338   0.00362319 
+  225          259.73644    137.42102   0.00444444 
+  188          218.01791    137.30892   0.00531915 
+  190          188.87378    137.19707   0.00526316 
+  172          173.51655    137.08549   0.00581395 
+  164          165.66036    136.97416   0.00609756 
+  186          161.07237    136.86308   0.00537634 
+  153          157.96631    136.75226   0.00653595 
+  143          155.68398    136.6417    0.00699301 
+  148          153.91504    136.5314    0.00675676 
+  156          152.49351    136.42135   0.00641026 
+  175          151.32048    136.31155   0.00571429 
+  147          150.32711    136.20201   0.00680272 
+  157          149.47255    136.09272   0.00636943 
+  145          148.72702    135.98368   0.00689655 
+  157          148.06959    135.8749    0.00636943 
+  178          147.48524    135.76637   0.00561798 
+  175          146.96568    135.65809   0.00571429 
+  150          146.4976     135.55006   0.00666667 
+  142          146.07825    135.44229   0.00704225 
+  130          145.70426    135.33477   0.00769231 
+  166          145.37456    135.22749   0.0060241 
+  152          145.0912     135.12047   0.00657895 
+  171          144.86125    135.01369   0.00584795 
+  162          144.70498    134.90717   0.00617284 
+  137          144.67453    134.80089   0.00729927 
+  131          144.87393    134.69487   0.00763359 
+  168          145.41538    134.58909   0.00595238 
+  137          146.14041    134.48356   0.00729927 
+  190          146.50314    134.37827   0.00526316 
+  171          146.35724    134.27323   0.00584795 
+  140          145.74822    134.16844   0.00714286 
+  141          145.286      134.0639    0.0070922 
+  160          145.25068    133.9596    0.00625   
+  170          145.35316    133.85555   0.00588235 
+  137          145.41695    133.75174   0.00729927 
+  171          145.41657    133.64817   0.00584795 
+  158          145.65543    133.54485   0.00632911 
+  149          146.50858    133.44178   0.00671141 
+  183          148.28609    133.33894   0.00546448 
+  171          151.48342    133.23635   0.00584795 
+  250          157.01032    133.134     0.004     
+  244          167.14134    133.0319    0.00409836 
+  283          183.5016     132.93003   0.00353357 
+  265          193.70044    132.82841   0.00377358 
+  233          182.49975    132.72703   0.00429185 
+  223          169.00437    132.62589   0.0044843 
+  215          164.11623    132.52499   0.00465116 
+  227          167.59767    132.42433   0.00440529 
+  215          172.84413    132.32391   0.00465116 
+  190          168.56274    132.22373   0.00526316 
+  204          160.61225    132.12378   0.00490196 
+  181          156.00754    132.02408   0.00552486 
+  162          155.28126    131.92461   0.00617284 
+  185          158.25431    131.82538   0.00540541 
+  212          163.05616    131.72639   0.00471698 
+  220          162.06581    131.62764   0.00454545 
+  175          156.61893    131.52912   0.00571429 
+  171          153.26505    131.43084   0.00584795 
+  174          153.06144    131.33279   0.00574713 
+  222          155.14893    131.23498   0.0045045 
+  205          155.81718    131.1374    0.00487805 
+  218          153.91711    131.04006   0.00458716 
+  212          153.07794    130.94296   0.00471698 
+  190          154.47852    130.84608   0.00526316 
+  198          158.13119    130.74945   0.00505051 
+  225          163.31404    130.65304   0.00444444 
+  223          170.18551    130.55687   0.0044843 
+  225          184.87156    130.46093   0.00444444 
+  199          213.79595    130.36522   0.00502513 
+  218          249.57843    130.26974   0.00458716 
+  219          255.24908    130.1745    0.00456621 
+  218          231.21205    130.07948   0.00458716 
+  248          211.86446    129.9847    0.00403226 
+  276          213.10954    129.89015   0.00362319 
+  289          233.76169    129.79583   0.00346021 
+  332          256.11119    129.70173   0.00301205 
+  295          262.93773    129.60787   0.00338983 
+  293          255.33992    129.51424   0.00341297 
+  270          251.41006    129.42083   0.0037037 
+  301          253.90881    129.32765   0.00332226 
+  418          273.89727    129.2347    0.00239234 
+  451          336.84919    129.14198   0.00221729 
+  596          497.62381    129.04949   0.00167785 
+  776          836.92393    128.95722   0.00128866 
+  1278         1184.76452   128.86518   0.00078247 
+  1491         979.08264    128.77336   0.00067069 
+  953          611.46782    128.68178   0.00104932 
+  608          461.99129    128.59041   0.00164474 
+  497          519.50584    128.49927   0.00201207 
+  652          686.20205    128.40836   0.00153374 
+  760          665.52459    128.31767   0.00131579 
+  598          455.67624    128.22721   0.00167224 
+  343          318.20573    128.13697   0.00291545 
+  249          261.37338    128.04695   0.00401606 
+  212          240.27962    127.95716   0.00471698 
+  197          234.66212    127.86758   0.00507614 
+  195          240.06953    127.77824   0.00512821 
+  185          258.53175    127.68911   0.00540541 
+  223          303.70786    127.60021   0.0044843 
+  271          409.08015    127.51152   0.00369004 
+  388          585.36084    127.42306   0.00257732 
+  455          669.88328    127.33482   0.0021978 
+  349          616.31349    127.2468    0.00286533 
+  337          698.98962    127.159     0.00296736 
+  357          1053.2635    127.07142   0.00280112 
+  438          1682.95839   126.98406   0.00228311 
+  595          2068.66287   126.89692   0.00168067 
+  465          1610.88957   126.80999   0.00215054 
+  391          1060.37917   126.72329   0.00255754 
+  361          840.81378    126.6368    0.00277008 
+  342          924.84795    126.55054   0.00292398 
+  334          1105.89822   126.46449   0.00299401 
+  303          978.04042    126.37865   0.00330033 
+  259          660.64797    126.29304   0.003861  
+  205          436.53306    126.20764   0.00487805 
+  185          320.33567    126.12245   0.00540541 
+  183          263.97319    126.03749   0.00546448 
+  171          234.06853    125.95274   0.00584795 
+  155          215.66002    125.8682    0.00645161 
+  158          202.22664    125.78388   0.00632911 
+  156          192.67802    125.69977   0.00641026 
+  164          186.76552    125.61588   0.00609756 
+  148          183.8856     125.5322    0.00675676 
+  164          183.57111    125.44874   0.00609756 
+  168          185.28666    125.36549   0.00595238 
+  166          189.83563    125.28245   0.0060241 
+  155          199.76049    125.19963   0.00645161 
+  146          220.21368    125.11702   0.00684932 
+  197          264.84787    125.03462   0.00507614 
+  199          361.06964    124.95243   0.00502513 
+  190          533.08984    124.87045   0.00526316 
+  199          704.58947    124.78869   0.00502513 
+  205          643.62031    124.70714   0.00487805 
+  185          465.43655    124.62579   0.00540541 
+  184          365.97402    124.54466   0.00543478 
+  188          366.41356    124.46374   0.00531915 
+  199          431.31       124.38303   0.00502513 
+  164          444.55272    124.30252   0.00609756 
+  148          348.35302    124.22223   0.00675676 
+  147          257.22469    124.14214   0.00680272 
+  164          205.51474    124.06227   0.00609756 
+  142          179.9196     123.9826    0.00704225 
+  153          166.41348    123.90314   0.00653595 
+  137          158.12612    123.82389   0.00729927 
+  139          152.51809    123.74484   0.00719424 
+  124          148.54231    123.66601   0.00806452 
+  162          145.66523    123.58737   0.00617284 
+  152          143.58517    123.50895   0.00657895 
+  150          142.09613    123.43073   0.00666667 
+  154          141.05659    123.35272   0.00649351 
+  150          140.61842    123.27491   0.00666667 
+  149          141.0903     123.19731   0.00671141 
+  170          142.28575    123.11992   0.00588235 
+  147          143.46236    123.04272   0.00680272 
+  163          145.46919    122.96574   0.00613497 
+  180          147.91693    122.88895   0.00555556 
+  158          148.1833     122.81237   0.00632911 
+  179          145.20052    122.736     0.00558659 
+  188          142.71608    122.65983   0.00531915 
+  189          141.91661    122.58386   0.00529101 
+  194          143.13796    122.50809   0.00515464 
+  197          144.27408    122.43253   0.00507614 
+  198          142.32411    122.35717   0.00505051 
+  195          138.8317     122.28201   0.00512821 
+  214          136.6689     122.20705   0.0046729 
+  245          136.0738     122.13229   0.00408163 
+  240          136.61438    122.05773   0.00416667 
+  265          137.28045    121.98338   0.00377358 
+  291          138.00286    121.90922   0.00343643 
+  377          140.5453     121.83527   0.00265252 
+  409          144.88264    121.76151   0.00244499 
+  434          146.2747     121.68796   0.00230415 
+  422          143.55127    121.6146    0.00236967 
+  321          142.36747    121.54145   0.00311526 
+  320          145.13964    121.46849   0.003125  
+  338          154.1406     121.39573   0.00295858 
+  335          171.10604    121.32317   0.00298507 
+  315          189.77997    121.2508    0.0031746 
+  286          188.60077    121.17864   0.0034965 
+  261          168.85725    121.10667   0.00383142 
+  215          154.67132    121.0349    0.00465116 
+  222          151.29725    120.96333   0.0045045 
+  191          156.67553    120.89195   0.0052356 
+  181          162.94309    120.82077   0.00552486 
+  205          157.80332    120.74978   0.00487805 
+  184          148.80687    120.67899   0.00543478 
+  166          142.35713    120.6084    0.0060241 
+  161          138.8495     120.538     0.00621118 
+  192          137.14628    120.46779   0.00520833 
+  166          135.52704    120.39778   0.0060241 
+  143          134.83058    120.32797   0.00699301 
+  181          135.07801    120.25835   0.00552486 
+  182          135.9799     120.18892   0.00549451 
+  174          138.90889    120.11969   0.00574713 
+  158          144.43998    120.05065   0.00632911 
+  155          150.37553    119.9818    0.00645161 
+  166          148.63047    119.91314   0.0060241 
+  170          141.69933    119.84468   0.00588235 
+  169          137.40175    119.77641   0.00591716 
+  162          136.88056    119.70833   0.00617284 
+  164          139.20751    119.64045   0.00609756 
+  190          141.20218    119.57275   0.00526316 
+  166          138.8681     119.50525   0.0060241 
+  152          135.6549     119.43794   0.00657895 
+  172          134.01738    119.37082   0.00581395 
+  159          133.799      119.30389   0.00628931 
+  160          134.61326    119.23714   0.00625   
+  163          136.67149    119.17059   0.00613497 
+  162          141.09258    119.10423   0.00617284 
+  183          149.66734    119.03806   0.00546448 
+  158          162.0225     118.97208   0.00632911 
+  186          167.22883    118.90628   0.00537634 
+  177          158.84965    118.84068   0.00564972 
+  143          151.10986    118.77526   0.00699301 
+  195          149.43518    118.71003   0.00512821 
+  216          153.34997    118.64499   0.00462963 
+  193          160.03216    118.58013   0.00518135 
+  212          162.01235    118.51547   0.00471698 
+  250          160.06035    118.45099   0.004     
+  343          161.00451    118.38669   0.00291545 
+  530          166.46743    118.32259   0.00188679 
+  680          177.28076    118.25867   0.00147059 
+  580          196.63198    118.19493   0.00172414 
+  469          231.88335    118.13138   0.0021322 
+  622          293.31284    118.06802   0.00160772 
+  697          381.28241    118.00484   0.00143472 
+  942          469.02993    117.94185   0.00106157 
+  1106         511.82088    117.87904   0.00090416 
+  943          482.53376    117.81642   0.00106045 
+  755          458.74163    117.75398   0.0013245 
+  629          478.93701    117.69173   0.00158983 
+  592          492.63398    117.62966   0.00168919 
+  611          469.38028    117.56777   0.00163666 
+  604          423.17604    117.50606   0.00165563 
+  532          363.02243    117.44454   0.0018797 
+  402          326.34294    117.3832    0.00248756 
+  310          313.20739    117.32205   0.00322581 
+  288          294.3386     117.26108   0.00347222 
+  242          271.5087     117.20028   0.00413223 
+  236          261.01325    117.13967   0.00423729 
+  192          258.80092    117.07925   0.00520833 
+  183          251.38196    117.019     0.00546448 
+  180          233.7629     116.95893   0.00555556 
+  184          215.52493    116.89905   0.00543478 
+  200          204.10137    116.83934   0.005     
+  181          199.83333    116.77982   0.00552486 
+  196          197.78967    116.72048   0.00510204 
+  208          190.96269    116.66131   0.00480769 
+  199          178.96265    116.60233   0.00502513 
+  189          166.99776    116.54352   0.00529101 
+  195          157.89819    116.48489   0.00512821 
+  177          151.80316    116.42645   0.00564972 
+  201          148.08326    116.36818   0.00497512 
+  171          146.15996    116.31009   0.00584795 
+  230          145.84725    116.25218   0.00434783 
+  222          147.41829    116.19444   0.0045045 
+  206          151.85597    116.13689   0.00485437 
+  209          161.12776    116.07951   0.00478469 
+  208          179.16771    116.0223    0.00480769 
+  212          213.94229    115.96528   0.00471698 
+  230          262.40516    115.90843   0.00434783 
+  225          274.06906    115.85176   0.00444444 
+  239          232.00039    115.79526   0.0041841 
+  223          195.3105     115.73895   0.0044843 
+  209          181.88762    115.6828    0.00478469 
+  229          189.50973    115.62683   0.00436681 
+  220          207.43987    115.57104   0.00454545 
+  222          204.29659    115.51542   0.0045045 
+  247          179.03541    115.45998   0.00404858 
+  221          159.12655    115.40471   0.00452489 
+  232          149.29678    115.34962   0.00431034 
+  245          146.22253    115.2947    0.00408163 
+  213          146.74802    115.23995   0.00469484 
+  231          147.82872    115.18538   0.004329  
+  255          147.41553    115.13098   0.00392157 
+  304          147.78561    115.07676   0.00328947 
+  332          152.12056    115.0227    0.00301205 
+  277          164.39681    114.96882   0.00361011 
+  276          190.75919    114.91512   0.00362319 
+  253          233.01152    114.86158   0.00395257 
+  237          262.21298    114.80822   0.00421941 
+  230          235.39746    114.75503   0.00434783 
+  233          196.22023    114.70201   0.00429185 
+  233          176.92827    114.64916   0.00429185 
+  175          178.13856    114.59648   0.00571429 
+  212          194.00967    114.54398   0.00471698 
+  196          204.25201    114.49164   0.00510204 
+  210          188.61507    114.43948   0.0047619 
+  216          170.59877    114.38748   0.00462963 
+  234          163.22812    114.33566   0.0042735 
+  207          164.17415    114.284     0.00483092 
+  179          167.41001    114.23252   0.00558659 
+  208          169.83335    114.1812    0.00480769 
+  204          172.21742    114.13005   0.00490196 
+  231          172.92048    114.07908   0.004329  
+  207          171.25741    114.02827   0.00483092 
+  174          170.24326    113.97763   0.00574713 
+  199          171.31013    113.92715   0.00502513 
+  213          175.38529    113.87685   0.00469484 
+  245          186.05723    113.82671   0.00408163 
+  301          212.23754    113.77674   0.00332226 
+  275          275.16703    113.72694   0.00363636 
+  366          385.76751    113.6773    0.00273224 
+  441          440.96356    113.62783   0.00226757 
+  361          336.89619    113.57853   0.00277008 
+  270          242.20957    113.5294    0.0037037 
+  249          209.93062    113.48043   0.00401606 
+  252          226.83046    113.43163   0.00396825 
+  254          278.79108    113.38299   0.00393701 
+  306          306.64088    113.33452   0.00326797 
+  265          263.80166    113.28621   0.00377358 
+  221          235.85247    113.23807   0.00452489 
+  219          231.93984    113.19009   0.00456621 
+  211          212.28816    113.14228   0.00473934 
+  210          185.05434    113.09463   0.0047619 
+  183          169.67485    113.04715   0.00546448 
+  193          167.25357    112.99983   0.00518135 
+  196          174.68771    112.95267   0.00510204 
+  168          183.24122    112.90568   0.00595238 
+  190          178.34886    112.85885   0.00526316 
+  173          168.69526    112.81218   0.00578035 
+  187          167.25309    112.76568   0.00534759 
+  222          181.80669    112.71934   0.0045045 
+  288          222.01663    112.67316   0.00347222 
+  357          272.78637    112.62715   0.00280112 
+  346          256.64       112.58129   0.00289017 
+  283          205.08821    112.5356    0.00353357 
+  211          177.47272    112.49007   0.00473934 
+  199          174.53979    112.4447    0.00502513 
+  233          191.03514    112.39949   0.00429185 
+  266          215.9199     112.35445   0.0037594 
+  253          209.83268    112.30956   0.00395257 
+  225          186.09535    112.26484   0.00444444 
+  201          176.45025    112.22027   0.00497512 
+  190          180.54403    112.17587   0.00526316 
+  174          186.45989    112.13162   0.00574713 
+  167          181.45004    112.08753   0.00598802 
+  174          174.35743    112.04361   0.00574713 
+  186          172.50356    111.99984   0.00537634 
+  166          175.52582    111.95623   0.0060241 
+  167          181.27       111.91278   0.00598802 
+  181          186.36255    111.86949   0.00552486 
+  163          186.02699    111.82636   0.00613497 
+  202          184.75553    111.78338   0.0049505 
+  163          186.37216    111.74057   0.00613497 
+  206          190.37549    111.69791   0.00485437 
+  186          195.46937    111.65541   0.00537634 
+  184          201.29767    111.61306   0.00543478 
+  202          208.45887    111.57088   0.0049505 
+  231          217.67504    111.52885   0.004329  
+  231          229.54737    111.48697   0.004329  
+  244          244.76263    111.44526   0.00409836 
+  271          262.69116    111.40369   0.00369004 
+  270          279.22943    111.36229   0.0037037 
+  312          296.16842    111.32104   0.00320513 
+  329          319.02824    111.27995   0.00303951 
+  325          350.0694     111.23901   0.00307692 
+  374          391.21314    111.19823   0.0026738 
+  371          445.05806    111.1576    0.00269542 
+  390          514.37741    111.11712   0.0025641 
+  415          607.23775    111.07681   0.00240964 
+  523          739.6411     111.03664   0.00191205 
+  756          937.78711    110.99663   0.00132275 
+  1036         1254.1861    110.95677   0.00096525 
+  1715         1833.66148   110.91707   0.00058309 
+  2906         3184.66121   110.87752   0.00034412 
+  5424         6623.67649   110.83813   0.00018437 
+  9806         13299.25725  110.79888   0.00010198 
+  12859        18155.77002  110.75979   0.00007777 
+  9073         12843.61636  110.72086   0.00011022 
+  4936         6720.07319   110.68207   0.00020259 
+  3237         4139.50088   110.64344   0.00030893 
+  3540         4387.99935   110.60496   0.00028249 
+  4840         6929.19641   110.56663   0.00020661 
+  6214         9624.3789    110.52845   0.00016093 
+  5000         7410.69638   110.49043   0.0002    
+  2528         3884.31904   110.45255   0.00039557 
+  1304         1981.59393   110.41483   0.00076687 
+  751          1206.96518   110.37726   0.00133156 
+  597          865.67574    110.33983   0.00167504 
+  489          674.31947    110.30256   0.00204499 
+  368          550.6773     110.26544   0.00271739 
+  295          465.18191    110.22847   0.00338983 
+  296          403.33131    110.19165   0.00337838 
+  255          356.97677    110.15497   0.00392157 
+  204          321.24523    110.11845   0.00490196 
+  230          293.06169    110.08208   0.00434783 
+  209          270.40883    110.04585   0.00478469 
+  215          251.91644    110.00977   0.00465116 
+  199          236.63134    109.97385   0.00502513 
+  196          223.86163    109.93807   0.00510204 
+  204          213.08363    109.90243   0.00490196 
+  175          203.95324    109.86695   0.00571429 
+  180          196.28133    109.83162   0.00555556 
+  184          189.89724    109.79643   0.00543478 
+  168          184.4717     109.76139   0.00595238 
+  177          179.31617    109.72649   0.00564972 
+  153          174.25194    109.69174   0.00653595 
+  194          169.78132    109.65714   0.00515464 
+  169          166.06679    109.62269   0.00591716 
+  185          162.91259    109.58838   0.00540541 
+  150          160.15374    109.55422   0.00666667 
+  168          157.64059    109.5202    0.00595238 
+  169          155.27101    109.48633   0.00591716 
+  176          153.34514    109.45261   0.00568182 
+  184          152.08983    109.41903   0.00543478 
+  187          151.51406    109.38559   0.00534759 
+  167          151.40058    109.3523    0.00598802 
+  161          151.39921    109.31916   0.00621118 
+  177          152.14619    109.28616   0.00564972 
+  219          155.94683    109.2533    0.00456621 
+  236          165.12472    109.22059   0.00423729 
+  245          176.67563    109.18802   0.00408163 
+  228          176.73539    109.15559   0.00438596 
+  230          167.07208    109.12331   0.00434783 
+  228          158.6723     109.09117   0.00438596 
+  207          155.12967    109.05918   0.00483092 
+  189          157.45112    109.02733   0.00529101 
+  203          165.12156    108.99562   0.00492611 
+  205          171.90925    108.96405   0.00487805 
+  239          173.23236    108.93262   0.0041841 
+  227          168.79343    108.90134   0.00440529 
+  213          160.33224    108.8702    0.00469484 
+  219          153.74506    108.8392    0.00456621 
+  162          151.15034    108.80834   0.00617284 
+  186          152.28424    108.77762   0.00537634 
+  210          156.18441    108.74704   0.0047619 
+  212          160.31969    108.71661   0.00471698 
+  204          163.20036    108.68631   0.00490196 
+  202          168.63292    108.65616   0.0049505 
+  219          181.68399    108.62614   0.00456621 
+  269          209.92993    108.59627   0.00371747 
+  374          267.10142    108.56653   0.0026738 
+  647          365.112      108.53694   0.0015456 
+  840          474.23569    108.50748   0.00119048 
+  827          472.1668     108.47816   0.00120919 
+  675          364.52923    108.44898   0.00148148 
+  609          283.43525    108.41994   0.00164204 
+  772          257.02712    108.39104   0.00129534 
+  909          274.56162    108.36228   0.00110011 
+  881          317.43649    108.33366   0.00113507 
+  732          333.15293    108.30517   0.00136612 
+  608          278.56555    108.27682   0.00164474 
+  413          217.89606    108.24861   0.00242131 
+  427          181.88496    108.22054   0.00234192 
+  464          164.0073     108.1926    0.00215517 
+  393          154.2461     108.1648    0.00254453 
+  332          147.69597    108.13714   0.00301205 
+  251          142.23868    108.10961   0.00398406 
+  256          138.38425    108.08222   0.00390625 
+  196          136.79203    108.05497   0.00510204 
+  168          137.90892    108.02785   0.00595238 
+  178          142.48233    108.00086   0.00561798 
+  172          149.64537    107.97402   0.00581395 
+  172          152.40806    107.94731   0.00581395 
+  165          149.89557    107.92073   0.00606061 
+  141          148.9342     107.89429   0.0070922 
+  151          146.03377    107.86798   0.00662252 
+  141          141.81948    107.84181   0.0070922 
+  167          140.85851    107.81577   0.00598802 
+  183          141.33071    107.78987   0.00546448 
+  171          139.48632    107.7641    0.00584795 
+  176          138.03476    107.73846   0.00568182 
+  175          137.20676    107.71296   0.00571429 
+  183          135.15321    107.68759   0.00546448 
+  189          134.29844    107.66235   0.00529101 
+  183          135.08097    107.63725   0.00546448 
+  167          134.66897    107.61228   0.00598802 
+  172          132.64163    107.58744   0.00581395 
+  185          131.51049    107.56274   0.00540541 
+  152          131.82209    107.53816   0.00657895 
+  156          133.4855     107.51372   0.00641026 
+  147          136.44466    107.48941   0.00680272 
+  172          140.13685    107.46523   0.00581395 
+  187          143.97979    107.44119   0.00534759 
+  214          149.98737    107.41727   0.0046729 
+  245          160.33501    107.39349   0.00408163 
+  275          176.50951    107.36983   0.00363636 
+  326          201.92905    107.34631   0.00306748 
+  520          243.72127    107.32291   0.00192308 
+  578          286.35418    107.29965   0.0017301 
+  418          274.26164    107.27652   0.00239234 
+  329          232.23367    107.25351   0.00303951 
+  251          207.32274    107.23064   0.00398406 
+  300          204.13888    107.2079    0.00333333 
+  321          218.81696    107.18528   0.00311526 
+  393          245.74149    107.16279   0.00254453 
+  361          260.19262    107.14043   0.00277008 
+  292          249.73391    107.11821   0.00342466 
+  270          244.96497    107.0961    0.0037037 
+  292          260.13965    107.07413   0.00342466 
+  328          298.88038    107.05229   0.00304878 
+  447          375.50671    107.03057   0.00223714 
+  772          550.28952    107.00898   0.00129534 
+  1440         995.92808    106.98752   0.00069444 
+  2286         1912.05043   106.96618   0.00043745 
+  2962         2790.21666   106.94497   0.00033761 
+  2014         2204.55386   106.92389   0.00049652 
+  994          1229.54237   106.90293   0.00100604 
+  743          739.44539    106.88211   0.0013459 
+  793          650.82448    106.8614    0.00126103 
+  1109         874.88248    106.84083   0.00090171 
+  1398         1352.33072   106.82037   0.00071531 
+  1382         1486.46893   106.80005   0.00072359 
+  779          978.52848    106.77985   0.0012837 
+  539          571.03102    106.75977   0.00185529 
+  385          391.65658    106.73982   0.0025974 
+  351          309.46242    106.72      0.002849  
+  257          253.26901    106.7003    0.00389105 
+  229          216.57581    106.68072   0.00436681 
+  224          195.48239    106.66127   0.00446429 
+  197          186.19869    106.64194   0.00507614 
+  210          185.00023    106.62273   0.0047619 
+  186          183.37667    106.60365   0.00537634 
+  186          171.96551    106.58469   0.00537634 
+  176          158.56994    106.56586   0.00568182 
+  164          149.12679    106.54714   0.00609756 
+  147          143.31346    106.52855   0.00680272 
+  153          139.72645    106.51009   0.00653595 
+  164          137.17143    106.49174   0.00609756 
+  143          135.10898    106.47352   0.00699301 
+  144          133.67814    106.45542   0.00694444 
+  156          133.17168    106.43744   0.00641026 
+  129          133.85465    106.41958   0.00775194 
+  145          135.71536    106.40185   0.00689655 
+  136          137.20888    106.38423   0.00735294 
+  149          136.30815    106.36674   0.00671141 
+  134          134.59977    106.34936   0.00746269 
+  147          133.82426    106.33211   0.00680272 
+  177          134.46869    106.31498   0.00564972 
+  144          136.58176    106.29796   0.00694444 
+  148          140.02362    106.28107   0.00675676 
+  139          143.92084    106.2643    0.00719424 
+  141          148.32949    106.24764   0.0070922 
+  160          155.31427    106.23111   0.00625   
+  161          167.61154    106.21469   0.00621118 
+  196          191.22046    106.1984    0.00510204 
+  256          246.77286    106.18222   0.00390625 
+  320          385.46025    106.16616   0.003125  
+  452          653.81602    106.15022   0.00221239 
+  583          861.94948    106.1344    0.00171527 
+  596          658.4919     106.11869   0.00167785 
+  483          400.68901    106.1031    0.00207039 
+  386          279.36058    106.08763   0.00259067 
+  287          261.87897    106.07228   0.00348432 
+  298          326.27364    106.05705   0.0033557 
+  346          458.41336    106.04193   0.00289017 
+  366          498.20377    106.02693   0.00273224 
+  349          356.72191    106.01204   0.00286533 
+  272          238.40816    105.99727   0.00367647 
+  216          183.49387    105.98262   0.00462963 
+  192          161.81451    105.96808   0.00520833 
+  166          152.0338     105.95366   0.0060241 
+  175          146.48187    105.93935   0.00571429 
+  189          143.31722    105.92516   0.00529101 
+  171          142.30849    105.91108   0.00584795 
+  158          143.8339     105.89712   0.00632911 
+  180          148.09137    105.88328   0.00555556 
+  181          152.62445    105.86954   0.00552486 
+  188          152.37466    105.85593   0.00531915 
+  152          150.92157    105.84242   0.00657895 
+  185          152.46834    105.82903   0.00540541 
+  232          157.89616    105.81576   0.00431034 
+  226          168.35903    105.80259   0.00442478 
+  238          185.91057    105.78954   0.00420168 
+  200          208.22181    105.77661   0.005     
+  203          223.60536    105.76378   0.00492611 
+  183          237.46015    105.75107   0.00546448 
+  201          274.61974    105.73847   0.00497512 
+  223          364.73002    105.72598   0.0044843 
+  288          552.43978    105.71361   0.00347222 
+  381          860.90085    105.70135   0.00262467 
+  307          1104.33642   105.68919   0.00325733 
+  270          937.96505    105.67715   0.0037037 
+  238          631.70571    105.66522   0.00420168 
+  226          445.79923    105.65341   0.00442478 
+  193          390.94836    105.6417    0.00518135 
+  234          442.85662    105.6301    0.0042735 
+  229          572.91556    105.61862   0.00436681 
+  198          643.59844    105.60724   0.00505051 
+  192          515.79949    105.59597   0.00520833 
+  182          357.06539    105.58482   0.00549451 
+  181          259.24632    105.57377   0.00552486 
+  172          209.83294    105.56283   0.00581395 
+  170          184.22969    105.552     0.00588235 
+  164          168.7728     105.54128   0.00609756 
+  169          158.46278    105.53067   0.00591716 
+  159          151.38836    105.52017   0.00628931 
+  188          146.66468    105.50978   0.00531915 
+  149          143.65119    105.49949   0.00671141 
+  179          141.65127    105.48931   0.00558659 
+  168          139.78693    105.47924   0.00595238 
+  146          138.25135    105.46928   0.00684932 
+  149          137.52178    105.45942   0.00671141 
+  172          137.64509    105.44967   0.00581395 
+  168          138.52489    105.44003   0.00595238 
+  189          139.81116    105.4305    0.00529101 
+  181          141.22244    105.42107   0.00552486 
+  145          142.66963    105.41175   0.00689655 
+  160          143.28875    105.40253   0.00625   
+  158          144.08617    105.39342   0.00632911 
+  176          146.1939     105.38441   0.00568182 
+  179          149.67566    105.37551   0.00558659 
+  194          154.54575    105.36672   0.00515464 
+  178          162.11176    105.35803   0.00561798 
+  185          174.19484    105.34945   0.00540541 
+  193          189.05654    105.34097   0.00518135 
+  184          195.69052    105.33259   0.00543478 
+  227          192.17549    105.32432   0.00440529 
+  206          191.80212    105.31615   0.00485437 
+  246          198.63847    105.30809   0.00406504 
+  241          213.3158     105.30013   0.00414938 
+  262          236.99563    105.29227   0.00381679 
+  266          268.77135    105.28452   0.0037594 
+  275          300.4828     105.27687   0.00363636 
+  337          337.46188    105.26932   0.00296736 
+  377          400.5402     105.26187   0.00265252 
+  556          514.31728    105.25453   0.00179856 
+  806          748.95848    105.24729   0.00124069 
+  1282         1332.04647   105.24015   0.00078003 
+  2423         2683.35871   105.23311   0.00041271 
+  3449         4703.53432   105.22618   0.00028994 
+  3046         4887.07058   105.21934   0.0003283 
+  1823         2943.14848   105.21261   0.00054855 
+  1217         1572.55602   105.20597   0.00082169 
+  1051         1065.57746   105.19944   0.00095147 
+  1105         1110.18213   105.19301   0.00090498 
+  1484         1664.73319   105.18668   0.00067385 
+  1799         2592.50226   105.18045   0.00055586 
+  1624         2598.20239   105.17432   0.00061576 
+  1077         1572.69026   105.16828   0.00092851 
+  634          843.17645    105.16235   0.00157729 
+  456          519.61944    105.15652   0.00219298 
+  381          385.78276    105.15078   0.00262467 
+  307          317.61598    105.14515   0.00325733 
+  271          278.03915    105.13961   0.00369004 
+  225          249.43344    105.13417   0.00444444 
+  215          222.01024    105.12883   0.00465116 
+  211          200.28477    105.12359   0.00473934 
+  179          185.15527    105.11844   0.00558659 
+  197          174.68576    105.11339   0.00507614 
+  155          167.94519    105.10844   0.00645161 
+  183          164.30919    105.10359   0.00546448 
+  184          160.72053    105.09883   0.00543478 
+  159          154.97248    105.09417   0.00628931 
+  167          149.80132    105.08961   0.00598802 
+  174          145.95663    105.08514   0.00574713 
+  142          143.51937    105.08077   0.00704225 
+  163          141.99454    105.0765    0.00613497 
+  150          141.10901    105.07232   0.00666667 
+  161          139.48886    105.06823   0.00621118 
+  125          138.00293    105.06424   0.008     
+  157          137.70896    105.06035   0.00636943 
+  136          138.86095    105.05655   0.00735294 
+  157          140.23608    105.05284   0.00636943 
+  161          139.17518    105.04923   0.00621118 
+  130          135.82827    105.04571   0.00769231 
+  145          132.02494    105.04229   0.00689655 
+  123          128.83707    105.03896   0.00813008 
+  159          127.06788    105.03573   0.00628931 
+  144          126.70366    105.03258   0.00694444 
+  149          126.8613     105.02954   0.00671141 
+  133          126.04816    105.02658   0.0075188 
+  143          124.23075    105.02371   0.00699301 
+  169          122.42741    105.02094   0.00591716 
+  163          121.47776    105.01826   0.00613497 
+  163          121.61625    105.01568   0.00613497 
+  163          122.40007    105.01318   0.00613497 
+  144          122.16876    105.01078   0.00694444 
+  152          120.94611    105.00846   0.00657895 
+  151          120.27609    105.00624   0.00662252 
+  185          119.90828    105.00411   0.00540541 
+  155          119.33044    105.00207   0.00645161 
+  161          119.20177    105.00012   0.00621118 
+  142          119.67863    104.99826   0.00704225 
+  163          120.16942    104.99649   0.00613497 
+  180          120.70701    104.99482   0.00555556 
+  177          122.13013    104.99323   0.00564972 
+  189          123.35105    104.99172   0.00529101 
+  175          122.3055     104.99031   0.00571429 
+  210          120.35181    104.98899   0.0047619 
+  161          119.16098    104.98776   0.00621118 
+  169          119.05042    104.98661   0.00591716 
+  159          120.01667    104.98556   0.00628931 
+  161          121.90203    104.98459   0.00621118 
+  161          123.83874    104.98371   0.00621118 
+  177          124.01293    104.98292   0.00564972 
+  149          122.31923    104.98221   0.00671141 
+  141          120.68392    104.98159   0.0070922 
+  137          120.04286    104.98106   0.00729927 
+  139          120.48363    104.98062   0.00719424 
+  160          121.91587    104.98026   0.00625   
+  153          123.96972    104.97999   0.00653595 
+  160          125.70809    104.9798    0.00625   
+  176          126.25929    104.9797    0.00568182 
+  185          126.40811    104.97969   0.00540541 
+  186          126.53366    104.97976   0.00537634 
+  158          125.22395    104.97992   0.00632911 
+  179          123.7971     104.98016   0.00558659 
+  159          123.5472     104.98049   0.00628931 
+  150          124.23626    104.9809    0.00666667 
+  181          125.35272    104.9814    0.00552486 
+  209          126.89094    104.98198   0.00478469 
+  184          129.40203    104.98264   0.00543478 
+  154          132.76613    104.98339   0.00649351 
+  187          136.92492    104.98422   0.00534759 
+  185          139.78071    104.98514   0.00540541 
+  190          143.1118     104.98614   0.00526316 
+  184          151.00375    104.98722   0.00543478 
+  206          157.42077    104.98838   0.00485437 
+  177          152.83064    104.98963   0.00564972 
+  168          145.47005    104.99096   0.00595238 
+  188          142.54945    104.99237   0.00531915 
+  175          142.97124    104.99386   0.00571429 
+  205          144.60816    104.99544   0.00487805 
+  192          148.55734    104.99709   0.00520833 
+  167          154.45935    104.99883   0.00598802 
+  199          158.14831    105.00065   0.00502513 
+  173          163.83244    105.00254   0.00578035 
+  184          179.09394    105.00452   0.00543478 
+  216          201.38336    105.00658   0.00462963 
+  205          206.27915    105.00872   0.00487805 
+  199          188.1096     105.01094   0.00502513 
+  201          172.67454    105.01324   0.00497512 
+  274          167.53488    105.01562   0.00364964 
+  223          171.96413    105.01808   0.0044843 
+  222          185.68062    105.02061   0.0045045 
+  248          206.79785    105.02323   0.00403226 
+  256          220.24593    105.02592   0.00390625 
+  245          215.7001     105.02869   0.00408163 
+  246          214.84147    105.03154   0.00406504 
+  303          234.62855    105.03447   0.00330033 
+  359          285.0378     105.03747   0.00278552 
+  357          348.00856    105.04056   0.00280112 
+  337          347.25043    105.04372   0.00296736 
+  278          315.75002    105.04695   0.00359712 
+  305          309.78192    105.05027   0.00327869 
+  330          334.1846     105.05366   0.0030303 
+  376          388.505      105.05712   0.00265957 
+  405          482.49298    105.06067   0.00246914 
+  595          637.20016    105.06429   0.00168067 
+  909          888.78865    105.06798   0.00110011 
+  1518         1446.84525   105.07175   0.00065876 
+  2627         2831.43612   105.07559   0.00038066 
+  4971         5276.63786   105.07951   0.00020117 
+  5749         6498.83041   105.08351   0.00017394 
+  3609         4356.61537   105.08758   0.00027709 
+  1950         2294.36211   105.09172   0.00051282 
+  1205         1358.59929   105.09594   0.00082988 
+  1157         1149.59937   105.10023   0.0008643 
+  1409         1466.70633   105.10459   0.00070972 
+  2248         2404.1389    105.10903   0.00044484 
+  2914         3457.17022   105.11354   0.00034317 
+  2309         2872.38429   105.11813   0.00043309 
+  1308         1608.65925   105.12278   0.00076453 
+  914          866.56801    105.12751   0.00109409 
+  633          550.13897    105.13232   0.00157978 
+  450          414.1335     105.13719   0.00222222 
+  340          342.79298    105.14214   0.00294118 
+  290          300.19344    105.14715   0.00344828 
+  284          273.32708    105.15224   0.00352113 
+  277          253.5193     105.1574    0.00361011 
+  324          234.5107     105.16263   0.00308642 
+  308          217.20529    105.16793   0.00324675 
+  311          203.99808    105.17331   0.00321543 
+  346          193.9709     105.17875   0.00289017 
+  423          189.14189    105.18426   0.00236407 
+  367          190.97654    105.18984   0.0027248 
+  308          198.07602    105.1955    0.00324675 
+  299          202.91646    105.20122   0.00334448 
+  253          197.50862    105.20701   0.00395257 
+  273          187.23686    105.21287   0.003663  
+  277          180.56867    105.2188    0.00361011 
+  282          177.51689    105.22479   0.0035461 
+  265          171.86537    105.23086   0.00377358 
+  245          165.99626    105.23699   0.00408163 
+  232          163.66668    105.24319   0.00431034 
+  194          161.31719    105.24946   0.00515464 
+  252          156.63869    105.25579   0.00396825 
+  212          153.06459    105.2622    0.00471698 
+  218          152.74055    105.26867   0.00458716 
+  212          153.55392    105.2752    0.00471698 
+  200          154.64097    105.28181   0.005     
+  205          161.68321    105.28848   0.00487805 
+  247          178.80892    105.29521   0.00404858 
+  257          201.44474    105.30201   0.00389105 
+  228          212.80509    105.30888   0.00438596 
+  255          215.83681    105.31581   0.00392157 
+  239          203.81312    105.32281   0.0041841 
+  232          180.04986    105.32987   0.00431034 
+  207          165.07426    105.33699   0.00483092 
+  223          162.52084    105.34418   0.0044843 
+  221          170.48886    105.35144   0.00452489 
+  202          181.54617    105.35876   0.0049505 
+  189          188.82184    105.36614   0.00529101 
+  204          189.36061    105.37358   0.00490196 
+  183          175.7173     105.38109   0.00546448 
+  175          162.56447    105.38867   0.00571429 
+  177          158.56418    105.3963    0.00564972 
+  203          164.64015    105.404     0.00492611 
+  218          182.13175    105.41176   0.00458716 
+  283          209.3486     105.41958   0.00353357 
+  467          229.67101    105.42746   0.00214133 
+  407          225.37342    105.43541   0.002457  
+  313          204.90438    105.44342   0.00319489 
+  201          184.29583    105.45149   0.00497512 
+  221          169.69824    105.45961   0.00452489 
+  194          164.86784    105.4678    0.00515464 
+  210          169.81354    105.47605   0.0047619 
+  241          179.8759     105.48437   0.00414938 
+  294          184.31039    105.49274   0.00340136 
+  264          179.70949    105.50117   0.00378788 
+  220          172.9696     105.50966   0.00454545 
+  162          170.94313    105.51821   0.00617284 
+  184          177.68436    105.52682   0.00543478 
+  159          190.52248    105.53548   0.00628931 
+  220          194.80712    105.54421   0.00454545 
+  198          180.74305    105.553     0.00505051 
+  199          169.22468    105.56184   0.00502513 
+  192          168.0655     105.57074   0.00520833 
+  177          175.53668    105.5797    0.00564972 
+  171          191.2145     105.58872   0.00584795 
+  169          216.39566    105.59779   0.00591716 
+  189          250.36684    105.60692   0.00529101 
+  199          294.49495    105.61611   0.00502513 
+  227          376.7732     105.62535   0.00440529 
+  251          554.1116     105.63465   0.00398406 
+  254          869.13508    105.64401   0.00393701 
+  268          1208.33448   105.65342   0.00373134 
+  238          1157.36725   105.66289   0.00420168 
+  216          806.22956    105.67242   0.00462963 
+  174          535.65654    105.682     0.00574713 
+  190          405.41906    105.69163   0.00526316 
+  173          383.14239    105.70132   0.00578035 
+  179          452.25974    105.71106   0.00558659 
+  205          602.36772    105.72086   0.00487805 
+  201          717.78734    105.73071   0.00497512 
+  193          608.48953    105.74062   0.00518135 
+  143          420.27914    105.75058   0.00699301 
+  159          292.55268    105.76059   0.00628931 
+  145          224.20801    105.77066   0.00689655 
+  130          189.2196     105.78078   0.00769231 
+  140          169.72514    105.79095   0.00714286 
+  119          157.60613    105.80117   0.00840336 
+  131          149.63938    105.81145   0.00763359 
+  120          144.28207    105.82178   0.00833333 
+  158          141.06819    105.83216   0.00632911 
+  132          140.28385    105.84259   0.00757576 
+  153          140.66967    105.85307   0.00653595 
+  176          137.8787     105.86361   0.00568182 
+  163          132.50608    105.87419   0.00613497 
+  148          128.33626    105.88483   0.00675676 
+  118          125.91237    105.89552   0.00847458 
+  136          124.65905    105.90625   0.00735294 
+  131          124.26039    105.91704   0.00763359 
+  160          124.78265    105.92788   0.00625   
+  151          125.42588    105.93876   0.00662252 
+  144          124.28261    105.9497    0.00694444 
+  151          122.69036    105.96068   0.00662252 
+  127          122.27663    105.97171   0.00787402 
+  138          122.25923    105.98279   0.00724638 
+  135          120.86255    105.99392   0.00740741 
+  123          118.95929    106.0051    0.00813008 
+  147          117.61682    106.01633   0.00680272 
+  114          116.89553    106.0276    0.00877193 
+  154          116.65316    106.03892   0.00649351 
+  123          116.83291    106.05029   0.00813008 
+  138          117.36178    106.0617    0.00724638 
+  133          117.66103    106.07316   0.0075188 
+  132          117.14073    106.08467   0.00757576 
+  136          116.54774    106.09623   0.00735294 
+  129          116.34819    106.10783   0.00775194 
+  139          116.54866    106.11947   0.00719424 
+  117          117.03746    106.13116   0.00854701 
+  131          117.60471    106.1429    0.00763359 
+  112          118.15085    106.15468   0.00892857 
+  106          119.17583    106.16651   0.00943396 
+  128          121.36753    106.17838   0.0078125 
+  136          125.55775    106.19029   0.00735294 
+  139          132.28253    106.20225   0.00719424 
+  152          139.16334    106.21426   0.00657895 
+  137          142.95215    106.2263    0.00729927 
+  155          148.01662    106.23839   0.00645161 
+  155          151.25568    106.25053   0.00645161 
+  146          146.81145    106.2627    0.00684932 
+  136          140.00595    106.27492   0.00735294 
+  166          135.96123    106.28719   0.0060241 
+  177          136.22777    106.29949   0.00564972 
+  149          137.86067    106.31184   0.00671141 
+  156          139.20155    106.32422   0.00641026 
+  177          142.78152    106.33665   0.00564972 
+  202          146.50765    106.34913   0.0049505 
+  176          148.04413    106.36164   0.00568182 
+  187          150.61248    106.37419   0.00534759 
+  162          156.74068    106.38678   0.00617284 
+  167          164.09411    106.39942   0.00598802 
+  172          167.94883    106.41209   0.00581395 
+  151          167.65365    106.42481   0.00662252 
+  173          165.42068    106.43756   0.00578035 
+  177          161.8816     106.45035   0.00564972 
+  154          156.72157    106.46319   0.00649351 
+  161          154.53819    106.47606   0.00621118 
+  185          157.06523    106.48897   0.00540541 
+  181          162.39185    106.50192   0.00552486 
+  185          168.59574    106.51491   0.00540541 
+  159          176.58531    106.52793   0.00628931 
+  193          190.98028    106.54099   0.00518135 
+  253          223.45291    106.5541    0.00395257 
+  350          302.34414    106.56723   0.00285714 
+  565          460.62647    106.58041   0.00176991 
+  792          612.80204    106.59362   0.00126263 
+  928          515.62447    106.60687   0.00107759 
+  761          341.20439    106.62016   0.00131406 
+  508          247.65735    106.63348   0.0019685 
+  357          221.37212    106.64684   0.00280112 
+  296          237.83944    106.66023   0.00337838 
+  303          298.92015    106.67366   0.00330033 
+  391          404.27599    106.68712   0.00255754 
+  466          473.6388     106.70062   0.00214592 
+  533          394.28462    106.71416   0.00187617 
+  425          285.00649    106.72773   0.00235294 
+  315          230.8732     106.74133   0.0031746 
+  240          223.97575    106.75497   0.00416667 
+  222          249.89435    106.76864   0.0045045 
+  205          294.94821    106.78234   0.00487805 
+  219          319.5745     106.79608   0.00456621 
+  212          309.94947    106.80985   0.00471698 
+  302          321.97674    106.82366   0.00331126 
+  366          421.4091     106.8375    0.00273224 
+  581          628.29907    106.85137   0.00172117 
+  630          744.71155    106.86527   0.0015873 
+  615          571.26428    106.8792    0.00162602 
+  470          400.93579    106.89317   0.00212766 
+  369          320.91393    106.90716   0.00271003 
+  328          301.3497     106.92119   0.00304878 
+  335          352.74861    106.93525   0.00298507 
+  446          511.94707    106.94934   0.00224215 
+  547          745.82944    106.96347   0.00182815 
+  714          766.51076    106.97762   0.00140056 
+  561          528.77863    106.9918    0.00178253 
+  450          333.17587    107.00601   0.00222222 
+  312          241.30155    107.02025   0.00320513 
+  270          211.03418    107.03453   0.0037037 
+  281          217.65601    107.04883   0.00355872 
+  264          261.71501    107.06316   0.00378788 
+  264          325.84433    107.07751   0.00378788 
+  254          311.76398    107.0919    0.00393701 
+  246          234.44765    107.10632   0.00406504 
+  220          180.80274    107.12076   0.00454545 
+  176          154.92008    107.13523   0.00568182 
+  188          143.11908    107.14973   0.00531915 
+  174          137.09782    107.16426   0.00574713 
+  174          133.41572    107.17881   0.00574713 
+  182          130.81232    107.19339   0.00549451 
+  163          129.32268    107.208     0.00613497 
+  176          129.19662    107.22263   0.00568182 
+  179          130.7779     107.23729   0.00558659 
+  202          134.65959    107.25198   0.0049505 
+  217          141.25003    107.26669   0.00460829 
+  214          146.28231    107.28143   0.0046729 
+  208          143.40101    107.29619   0.00480769 
+  178          139.07731    107.31098   0.00561798 
+  192          139.29451    107.32579   0.00520833 
+  174          144.46845    107.34063   0.00574713 
+  169          153.48907    107.35549   0.00591716 
+  184          159.24512    107.37037   0.00543478 
+  225          154.2305     107.38528   0.00444444 
+  203          146.99237    107.40022   0.00492611 
+  210          139.70135    107.41518   0.0047619 
+  221          134.07065    107.43016   0.00452489 
+  219          132.19396    107.44516   0.00456621 
+  223          133.61692    107.46019   0.0044843 
+  199          137.41747    107.47523   0.00502513 
+  193          140.74733    107.4903    0.00518135 
+  177          138.66361    107.5054    0.00564972 
+  175          135.25062    107.52051   0.00571429 
+  163          134.42967    107.53565   0.00613497 
+  199          135.0395     107.55081   0.00502513 
+  187          134.35685    107.56599   0.00534759 
+  181          133.71398    107.58119   0.00552486 
+  187          134.60124    107.59641   0.00534759 
+  171          137.33995    107.61165   0.00584795 
+  195          142.86851    107.62691   0.00512821 
+  205          153.02206    107.64219   0.00487805 
+  242          173.05882    107.6575    0.00413223 
+  335          214.68963    107.67282   0.00298507 
+  442          280.52953    107.68816   0.00226244 
+  549          305.08238    107.70352   0.00182149 
+  476          248.21149    107.7189    0.00210084 
+  311          199.46259    107.73429   0.00321543 
+  240          178.59231    107.74971   0.00416667 
+  220          173.93548    107.76514   0.00454545 
+  201          180.16382    107.78059   0.00497512 
+  307          200.31537    107.79606   0.00325733 
+  329          240.29911    107.81155   0.00303951 
+  377          281.46283    107.82706   0.00265252 
+  367          282.60461    107.84258   0.0027248 
+  329          271.47197    107.85812   0.00303951 
+  271          273.6927     107.87367   0.00369004 
+  332          304.8915     107.88924   0.00301205 
+  435          384.59674    107.90483   0.00229885 
+  673          553.61232    107.92044   0.00148588 
+  804          863.94028    107.93606   0.00124378 
+  904          1267.46839   107.95169   0.00110619 
+  732          1372.12419   107.96734   0.00136612 
+  527          1028.44983   107.98301   0.00189753 
+  400          678.03979    107.99869   0.0025    
+  324          477.09445    108.01438   0.00308642 
+  295          398.33599    108.03009   0.00338983 
+  372          408.23481    108.04581   0.00268817 
+  454          503.50238    108.06155   0.00220264 
+  495          676.92083    108.0773    0.0020202 
+  444          793.08671    108.09307   0.00225225 
+  350          663.80097    108.10884   0.00285714 
+  255          461.55662    108.12464   0.00392157 
+  196          327.46546    108.14044   0.00510204 
+  166          260.49173    108.15626   0.0060241 
+  173          236.30811    108.17208   0.00578035 
+  122          236.69499    108.18792   0.00819672 
+  151          239.17493    108.20378   0.00662252 
+  129          218.01467    108.21964   0.00775194 
+  130          188.93656    108.23552   0.00769231 
+  116          168.73573    108.2514    0.00862069 
+  144          157.38766    108.2673    0.00694444 
+  127          151.85005    108.28321   0.00787402 
+  140          151.57778    108.29913   0.00714286 
+  118          157.04042    108.31506   0.00847458 
+  103          164.99247    108.331     0.00970874 
+  139          163.0275     108.34695   0.00719424 
+  136          150.65155    108.36291   0.00735294 
+  116          139.77043    108.37888   0.00862069 
+  123          133.09009    108.39486   0.00813008 
+  136          129.03835    108.41084   0.00735294 
+  118          126.31997    108.42684   0.00847458 
+  120          124.47978    108.44284   0.00833333 
+  153          123.09514    108.45886   0.00653595 
+  139          122.27551    108.47488   0.00719424 
+  148          121.73797    108.49091   0.00675676 
+  132          121.48522    108.50694   0.00757576 
+  114          121.55941    108.52299   0.00877193 
+  150          122.10537    108.53904   0.00666667 
+  131          123.48431    108.5551    0.00763359 
+  135          126.34577    108.57116   0.00740741 
+  114          131.68708    108.58723   0.00877193 
+  113          138.97576    108.60331   0.00884956 
+  122          142.90863    108.6194    0.00819672 
+  113          139.38002    108.63549   0.00884956 
+  141          135.5153     108.65158   0.0070922 
+  134          134.19662    108.66768   0.00746269 
+  119          132.21055    108.68379   0.00840336 
+  145          130.1988     108.6999    0.00689655 
+  111          130.76967    108.71602   0.00900901 
+  130          134.40384    108.73214   0.00769231 
+  112          139.53858    108.74827   0.00892857 
+  122          141.92777    108.7644    0.00819672 
+  119          140.07063    108.78053   0.00840336 
+  131          137.15637    108.79667   0.00763359 
+  116          135.64742    108.81281   0.00862069 
+  110          135.34261    108.82895   0.00909091 
+  137          137.13733    108.8451    0.00729927 
+  132          140.8551     108.86125   0.00757576 
+  161          147.78335    108.87741   0.00621118 
+  156          161.26523    108.89356   0.00641026 
+  161          184.17817    108.90972   0.00621118 
+  177          218.12434    108.92588   0.00564972 
+  194          251.26129    108.94204   0.00515464 
+  191          244.04424    108.9582    0.0052356 
+  143          207.89965    108.97437   0.00699301 
+  140          180.40065    108.99054   0.00714286 
+  148          168.19308    109.0067    0.00675676 
+  151          168.5221     109.02287   0.00662252 
+  154          177.57656    109.03904   0.00649351 
+  158          189.80834    109.05521   0.00632911 
+  177          202.17045    109.07138   0.00564972 
+  175          205.91684    109.08755   0.00571429 
+  174          188.8832     109.10371   0.00574713 
+  157          168.87939    109.11988   0.00636943 
+  143          157.47224    109.13605   0.00699301 
+  154          153.30666    109.15222   0.00649351 
+  175          153.74981    109.16838   0.00571429 
+  143          157.49896    109.18455   0.00699301 
+  180          163.00577    109.20071   0.00555556 
+  169          171.56342    109.21687   0.00591716 
+  179          182.42404    109.23303   0.00558659 
+  201          187.77295    109.24918   0.00497512 
+  212          182.90006    109.26534   0.00471698 
+  202          175.31916    109.28149   0.0049505 
+  167          174.05017    109.29764   0.00598802 
+  148          178.56238    109.31378   0.00675676 
+  156          179.17871    109.32993   0.00641026 
+  147          175.8182     109.34607   0.00680272 
+  177          177.76542    109.3622    0.00564972 
+  182          179.69594    109.37833   0.00549451 
+  187          175.44337    109.39446   0.00534759 
+  207          168.98492    109.41058   0.00483092 
+  170          167.11954    109.4267    0.00588235 
+  208          173.56392    109.44282   0.00480769 
+  210          186.30666    109.45893   0.0047619 
+  199          198.45733    109.47503   0.00502513 
+  202          211.10924    109.49113   0.0049505 
+  244          224.02823    109.50722   0.00409836 
+  278          227.03563    109.52331   0.00359712 
+  245          230.73298    109.53939   0.00408163 
+  246          257.03997    109.55547   0.00406504 
+  266          331.00064    109.57154   0.0037594 
+  453          481.06629    109.5876    0.00220751 
+  554          637.81398    109.60366   0.00180505 
+  475          557.13581    109.61971   0.00210526 
+  362          379.15478    109.63575   0.00276243 
+  265          272.85039    109.65178   0.00377358 
+  215          224.91464    109.66781   0.00465116 
+  210          208.03097    109.68383   0.0047619 
+  233          214.43324    109.69984   0.00429185 
+  254          251.69975    109.71585   0.00393701 
+  311          328.40537    109.73184   0.00321543 
+  323          380.98621    109.74783   0.00309598 
+  255          308.54296    109.76381   0.00392157 
+  222          220.62908    109.77978   0.0045045 
+  217          172.57766    109.79574   0.00460829 
+  184          150.99921    109.81169   0.00543478 
+  164          140.63468    109.82763   0.00609756 
+  171          134.92268    109.84356   0.00584795 
+  161          131.54864    109.85948   0.00621118 
+  158          129.06647    109.87539   0.00632911 
+  174          127.01423    109.8913    0.00574713 
+  169          125.87278    109.90719   0.00591716 
+  156          125.62984    109.92307   0.00641026 
+  150          125.92527    109.93894   0.00666667 
+  177          126.74283    109.9548    0.00564972 
+  146          128.22686    109.97064   0.00684932 
+  140          130.12989    109.98648   0.00714286 
+  159          130.44565    110.0023    0.00628931 
+  147          127.56354    110.01812   0.00680272 
+  147          123.95429    110.03392   0.00680272 
+  134          121.4222     110.0497    0.00746269 
+  151          120.11279    110.06548   0.00662252 
+  125          119.70408    110.08124   0.008     
+  153          119.98577    110.09699   0.00653595 
+  152          120.71758    110.11273   0.00657895 
+  131          121.58292    110.12846   0.00763359 
+  134          121.48972    110.14417   0.00746269 
+  125          120.11911    110.15986   0.008     
+  137          118.73659    110.17555   0.00729927 
+  122          117.85031    110.19122   0.00819672 
+  146          117.31639    110.20687   0.00684932 
+  145          117.31499    110.22251   0.00689655 
+  127          118.13494    110.23814   0.00787402 
+  150          119.76316    110.25375   0.00666667 
+  136          121.00026    110.26935   0.00735294 
+  136          120.29804    110.28493   0.00735294 
+  144          118.74328    110.3005    0.00694444 
+  124          117.6213     110.31605   0.00806452 
+  132          117.2367     110.33159   0.00757576 
+  130          117.26085    110.34711   0.00769231 
+  111          117.46399    110.36261   0.00900901 
+  120          117.94935    110.3781    0.00833333 
+  113          118.9118     110.39357   0.00884956 
+  113          119.62432    110.40903   0.00884956 
+  111          119.06961    110.42447   0.00900901 
+  112          117.91428    110.43989   0.00892857 
+  106          117.11078    110.45529   0.00943396 
+  127          116.94156    110.47068   0.00787402 
+  133          117.22338    110.48605   0.0075188 
+  124          117.67852    110.50141   0.00806452 
+  108          118.09183    110.51674   0.00925926 
+  128          118.18124    110.53206   0.0078125 
+  120          117.67659    110.54736   0.00833333 
+  119          116.99712    110.56264   0.00840336 
+  125          116.49576    110.5779    0.008     
+  129          116.2956     110.59314   0.00775194 
+  132          116.38885    110.60837   0.00757576 
+  147          116.74348    110.62357   0.00680272 
+  114          117.33572    110.63876   0.00877193 
+  125          118.09426    110.65393   0.008     
+  134          118.69169    110.66907   0.00746269 
+  113          118.72629    110.6842    0.00884956 
+  153          118.69821    110.69931   0.00653595 
+  125          119.05193    110.7144    0.008     
+  113          119.8745     110.72947   0.00884956 
+  144          121.23553    110.74451   0.00694444 
+  145          123.1957     110.75954   0.00689655 
+  131          126.04651    110.77455   0.00763359 
+  127          130.11098    110.78953   0.00787402 
+  147          134.61012    110.8045    0.00680272 
+  139          137.97579    110.81944   0.00719424 
+  130          141.73064    110.83436   0.00769231 
+  165          151.49858    110.84926   0.00606061 
+  155          177.55431    110.86414   0.00645161 
+  144          233.75788    110.879     0.00694444 
+  158          309.60484    110.89383   0.00632911 
+  140          311.50474    110.90864   0.00714286 
+  144          239.95773    110.92343   0.00694444 
+  141          188.00012    110.9382    0.0070922 
+  141          163.13191    110.95294   0.0070922 
+  133          152.15292    110.96767   0.0075188 
+  153          149.71224    110.98236   0.00653595 
+  154          157.69035    110.99704   0.00649351 
+  155          182.00075    111.01169   0.00645161 
+  146          219.72645    111.02632   0.00684932 
+  156          227.49399    111.04092   0.00641026 
+  156          196.30821    111.05551   0.00641026 
+  155          175.38383    111.07006   0.00645161 
+  122          167.85085    111.0846    0.00819672 
+  155          159.87019    111.0991    0.00645161 
+  139          151.0567     111.11359   0.00719424 
+  130          145.74723    111.12805   0.00769231 
+  134          142.3824     111.14248   0.00746269 
+  154          140.53411    111.15689   0.00649351 
+  163          140.7155     111.17128   0.00613497 
+  157          141.90781    111.18563   0.00636943 
+  159          144.64513    111.19997   0.00628931 
+  167          148.3925     111.21428   0.00598802 
+  181          149.04885    111.22856   0.00552486 
+  227          148.097      111.24282   0.00440529 
+  252          150.21299    111.25705   0.00396825 
+  275          155.46017    111.27125   0.00363636 
+  292          161.81357    111.28543   0.00342466 
+  292          165.34894    111.29958   0.00342466 
+  205          166.43683    111.3137    0.00487805 
+  215          170.39792    111.3278    0.00465116 
+  209          179.43401    111.34187   0.00478469 
+  269          199.49187    111.35592   0.00371747 
+  363          244.7973     111.36994   0.00275482 
+  484          337.56124    111.38393   0.00206612 
+  544          481.91157    111.39789   0.00183824 
+  482          577.6782     111.41182   0.00207469 
+  388          485.52748    111.42573   0.00257732 
+  397          343.18861    111.43961   0.00251889 
+  307          265.1659     111.45346   0.00325733 
+  369          245.93245    111.46728   0.00271003 
+  474          265.45873    111.48107   0.0021097 
+  485          303.73806    111.49484   0.00206186 
+  465          330.21164    111.50858   0.00215054 
+  462          360.18345    111.52228   0.0021645 
+  419          390.57263    111.53596   0.00238663 
+  333          345.95999    111.54961   0.003003  
+  296          260.28688    111.56323   0.00337838 
+  239          205.58323    111.57683   0.0041841 
+  249          184.32757    111.59039   0.00401606 
+  259          184.28664    111.60392   0.003861  
+  243          193.47752    111.61742   0.00411523 
+  252          191.86558    111.6309    0.00396825 
+  218          174.41445    111.64434   0.00458716 
+  222          157.8217     111.65775   0.0045045 
+  177          147.22327    111.67113   0.00564972 
+  153          142.12329    111.68449   0.00653595 
+  169          141.07656    111.69781   0.00591716 
+  174          142.80712    111.7111    0.00574713 
+  139          145.76251    111.72436   0.00719424 
+  169          147.63235    111.73759   0.00591716 
+  152          149.87057    111.75078   0.00657895 
+  142          157.09414    111.76395   0.00704225 
+  131          174.40448    111.77709   0.00763359 
+  168          208.06582    111.79019   0.00595238 
+  156          259.42946    111.80326   0.00641026 
+  169          302.14309    111.8163    0.00591716 
+  168          304.16406    111.82931   0.00595238 
+  182          270.75728    111.84229   0.00549451 
+  164          222.51701    111.85524   0.00609756 
+  173          186.24727    111.86815   0.00578035 
+  139          167.32559    111.88103   0.00719424 
+  155          162.353      111.89388   0.00645161 
+  141          169.47133    111.90669   0.0070922 
+  165          188.57659    111.91947   0.00606061 
+  137          211.8634     111.93222   0.00729927 
+  145          218.98341    111.94494   0.00689655 
+  145          206.64146    111.95763   0.00689655 
+  139          181.55894    111.97028   0.00719424 
+  139          158.41323    111.9829    0.00719424 
+  145          143.56929    111.99548   0.00689655 
+  137          135.26469    112.00803   0.00729927 
+  129          130.74578    112.02055   0.00775194 
+  143          128.21572    112.03303   0.00699301 
+  127          126.80425    112.04548   0.00787402 
+  146          126.0813     112.0579    0.00684932 
+  134          125.60675    112.07028   0.00746269 
+  146          125.0469     112.08263   0.00684932 
+  150          124.38411    112.09494   0.00666667 
+  135          123.8301     112.10722   0.00740741 
+  156          123.68751    112.11947   0.00641026 
+  159          124.14441    112.13168   0.00628931 
+  208          125.42784    112.14385   0.00480769 
+  221          127.93325    112.15599   0.00452489 
+  229          132.03354    112.1681    0.00436681 
+  221          136.80843    112.18017   0.00452489 
+  246          138.8032     112.1922    0.00406504 
+  246          137.33537    112.20421   0.00406504 
+  258          136.18984    112.21617   0.00387597 
+  260          136.22589    112.2281    0.00384615 
+  255          136.17694    112.24      0.00392157 
+  317          137.27396    112.25185   0.00315457 
+  324          140.63643    112.26368   0.00308642 
+  317          147.23952    112.27547   0.00315457 
+  347          159.88793    112.28722   0.00288184 
+  350          186.09044    112.29893   0.00285714 
+  308          241.0487     112.31061   0.00324675 
+  312          333.68338    112.32226   0.00320513 
+  324          390.86161    112.33386   0.00308642 
+  349          323.70637    112.34544   0.00286533 
+  363          247.95231    112.35697   0.00275482 
+  294          207.59412    112.36847   0.00340136 
+  254          183.30446    112.37993   0.00393701 
+  252          168.05329    112.39135   0.00396825 
+  227          164.02483    112.40274   0.00440529 
+  233          175.32566    112.41409   0.00429185 
+  219          207.99098    112.42541   0.00456621 
+  216          252.59469    112.43669   0.00462963 
+  210          249.58337    112.44793   0.0047619 
+  218          205.37859    112.45913   0.00458716 
+  179          174.98727    112.4703    0.00558659 
+  191          158.24458    112.48142   0.0052356 
+  130          146.25888    112.49252   0.00769231 
+  142          138.03835    112.50357   0.00704225 
+  122          133.2065     112.51459   0.00819672 
+  130          130.50421    112.52556   0.00769231 
+  141          128.81677    112.5365    0.0070922 
+  136          127.76009    112.54741   0.00735294 
+  125          127.34216    112.55827   0.008     
+  121          127.54104    112.5691    0.00826446 
+  119          128.16234    112.57989   0.00840336 
+  134          128.74521    112.59064   0.00746269 
+  144          128.75204    112.60135   0.00694444 
+  155          128.4464     112.61203   0.00645161 
+  137          128.45702    112.62266   0.00729927 
+  129          129.04987    112.63326   0.00775194 
+  133          130.35055    112.64382   0.0075188 
+  131          132.55752    112.65434   0.00763359 
+  142          135.87901    112.66482   0.00704225 
+  130          140.02448    112.67527   0.00769231 
+  132          143.24811    112.68567   0.00757576 
+  128          144.05215    112.69604   0.0078125 
+  136          144.44069    112.70637   0.00735294 
+  141          146.22813    112.71666   0.0070922 
+  137          149.52418    112.72691   0.00729927 
+  125          154.27243    112.73712   0.008     
+  141          161.25721    112.74729   0.0070922 
+  165          171.3178     112.75742   0.00606061 
+  176          185.7795     112.76752   0.00568182 
+  198          206.99206    112.77757   0.00505051 
+  229          239.37845    112.78759   0.00436681 
+  260          297.40145    112.79756   0.00384615 
+  412          425.83068    112.8075    0.00242718 
+  697          718.80594    112.8174    0.00143472 
+  1130         1250.06478   112.82725   0.00088496 
+  1421         1684.49301   112.83707   0.00070373 
+  1240         1335.86623   112.84685   0.00080645 
+  831          788.14577    112.85659   0.00120337 
+  527          473.64138    112.86629   0.00189753 
+  379          341.56102    112.87595   0.00263852 
+  364          296.39953    112.88557   0.00274725 
+  332          298.21049    112.89515   0.00301205 
+  403          357.6995     112.90469   0.00248139 
+  507          520.36342    112.91419   0.00197239 
+  728          798.37248    112.92365   0.00137363 
+  803          934.65659    112.93307   0.00124533 
+  640          693.27346    112.94245   0.0015625 
+  433          445.03458    112.95179   0.00230947 
+  310          319.46703    112.96109   0.00322581 
+  249          260.89782    112.97035   0.00401606 
+  220          222.06639    112.97957   0.00454545 
+  180          195.68445    112.98875   0.00555556 
+  170          177.58657    112.9979    0.00588235 
+  166          166.0506     113.007     0.0060241 
+  140          159.79064    113.01606   0.00714286 
+  148          156.3257     113.02507   0.00675676 
+  158          155.06021    113.03405   0.00632911 
+  152          156.85749    113.04299   0.00657895 
+  145          160.04068    113.05189   0.00689655 
+  163          157.3545     113.06075   0.00613497 
+  137          149.65529    113.06957   0.00729927 
+  145          142.99336    113.07835   0.00689655 
+  141          137.81106    113.08708   0.0070922 
+  142          134.40113    113.09578   0.00704225 
+  122          132.77412    113.10444   0.00819672 
+  139          132.20376    113.11305   0.00719424 
+  132          131.66697    113.12163   0.00757576 
+  99           130.78418    113.13016   0.01010101 
+  118          129.8238     113.13866   0.00847458 
+  106          128.93461    113.14711   0.00943396 
+  149          128.63199    113.15553   0.00671141 
+  137          129.32775    113.1639    0.00729927 
+  128          130.95968    113.17223   0.0078125 
+  121          132.22404    113.18052   0.00826446 
+  119          132.24927    113.18878   0.00840336 
+  132          132.59502    113.19699   0.00757576 
+  132          133.9236     113.20516   0.00757576 
+  122          134.8345     113.21329   0.00819672 
+  126          133.95581    113.22138   0.00793651 
+  128          132.43589    113.22943   0.0078125 
+  147          131.83449    113.23743   0.00680272 
+  149          132.81677    113.2454    0.00671141 
+  141          135.54652    113.25333   0.0070922 
+  149          139.85196    113.26121   0.00671141 
+  139          147.04887    113.26906   0.00719424 
+  146          162.51044    113.27687   0.00684932 
+  164          195.45827    113.28463   0.00609756 
+  170          251.18487    113.29236   0.00588235 
+  146          292.95335    113.30004   0.00684932 
+  177          262.78062    113.30768   0.00564972 
+  165          214.06019    113.31529   0.00606061 
+  147          180.53224    113.32285   0.00680272 
+  150          159.87424    113.33037   0.00666667 
+  165          149.24265    113.33785   0.00606061 
+  172          146.00917    113.34529   0.00581395 
+  148          149.88439    113.3527    0.00675676 
+  144          163.89948    113.36006   0.00694444 
+  150          190.5328     113.36738   0.00666667 
+  165          211.84648    113.37466   0.00606061 
+  157          198.74163    113.3819    0.00636943 
+  176          178.31074    113.38909   0.00568182 
+  162          168.85694    113.39625   0.00617284 
+  150          169.38499    113.40337   0.00666667 
+  160          171.40205    113.41045   0.00625   
+  180          162.04298    113.41749   0.00555556 
+  169          148.20448    113.42449   0.00591716 
+  153          138.49487    113.43145   0.00653595 
+  171          133.28252    113.43836   0.00584795 
+  173          131.06588    113.44524   0.00578035 
+  161          130.68971    113.45208   0.00621118 
+  182          132.01243    113.45888   0.00549451 
+  189          135.77973    113.46564   0.00529101 
+  182          142.32444    113.47236   0.00549451 
+  178          148.61822    113.47903   0.00561798 
+  153          149.16075    113.48567   0.00653595 
+  149          147.56119    113.49227   0.00671141 
+  159          147.91014    113.49883   0.00628931 
+  147          148.42467    113.50535   0.00680272 
+  172          146.15756    113.51183   0.00581395 
+  185          145.73852    113.51827   0.00540541 
+  163          151.57012    113.52467   0.00613497 
+  152          164.23206    113.53103   0.00657895 
+  167          175.59296    113.53736   0.00598802 
+  137          170.22004    113.54364   0.00729927 
+  148          156.23759    113.54988   0.00675676 
+  150          146.61949    113.55609   0.00666667 
+  148          142.30942    113.56225   0.00675676 
+  163          140.55822    113.56838   0.00613497 
+  142          138.40536    113.57447   0.00704225 
+  153          137.22247    113.58051   0.00653595 
+  146          139.25916    113.58652   0.00684932 
+  145          144.98198    113.59249   0.00689655 
+  140          151.25313    113.59842   0.00714286 
+  153          149.94764    113.60432   0.00653595 
+  161          142.82813    113.61017   0.00621118 
+  165          137.13024    113.61599   0.00606061 
+  150          134.20247    113.62176   0.00666667 
+  138          133.26256    113.6275    0.00724638 
+  170          133.54991    113.6332    0.00588235 
+  150          134.68546    113.63887   0.00666667 
+  180          136.60796    113.64449   0.00555556 
+  232          139.42621    113.65007   0.00431034 
+  223          143.18278    113.65562   0.0044843 
+  242          147.37765    113.66113   0.00413223 
+  212          151.79185    113.6666    0.00471698 
+  209          157.75682    113.67204   0.00478469 
+  205          166.61569    113.67743   0.00487805 
+  218          179.88054    113.68279   0.00458716 
+  277          200.26119    113.68811   0.00361011 
+  304          233.12634    113.6934    0.00328947 
+  413          290.97464    113.69864   0.00242131 
+  619          406.16901    113.70385   0.00161551 
+  989          649.82238    113.70903   0.00101112 
+  1601         1095.15446   113.71416   0.00062461 
+  2264         1507.31288   113.71926   0.0004417 
+  1963         1258.3705    113.72432   0.00050942 
+  1322         764.5618     113.72934   0.00075643 
+  800          462.80219    113.73433   0.00125   
+  537          330.14829    113.73928   0.0018622 
+  410          280.60805    113.7442    0.00243902 
+  412          270.38389    113.74908   0.00242718 
+  432          294.79484    113.75392   0.00231481 
+  567          376.73304    113.75873   0.00176367 
+  774          557.07947    113.7635    0.00129199 
+  1123         795.02493    113.76823   0.00089047 
+  1200         778.04038    113.77293   0.00083333 
+  851          523.34439    113.77759   0.00117509 
+  569          333.26834    113.78222   0.00175747 
+  359          240.00503    113.78681   0.00278552 
+  275          199.12644    113.79137   0.00363636 
+  235          179.18054    113.79589   0.00425532 
+  207          167.14076    113.80037   0.00483092 
+  182          157.89973    113.80483   0.00549451 
+  161          150.81478    113.80924   0.00621118 
+  157          146.01604    113.81362   0.00636943 
+  173          142.91382    113.81797   0.00578035 
+  164          140.66284    113.82228   0.00609756 
+  145          138.63678    113.82656   0.00689655 
+  153          136.9228     113.83081   0.00653595 
+  150          136.09574    113.83502   0.00666667 
+  165          136.6138     113.83919   0.00606061 
+  150          138.72159    113.84334   0.00666667 
+  144          142.45194    113.84745   0.00694444 
+  143          148.2263     113.85152   0.00699301 
+  150          153.52937    113.85556   0.00666667 
+  128          151.48167    113.85957   0.0078125 
+  135          144.98947    113.86355   0.00740741 
+  145          140.01939    113.86749   0.00689655 
+  152          137.38234    113.8714    0.00657895 
+  149          136.04588    113.87528   0.00671141 
+  155          135.33115    113.87913   0.00645161 
+  135          135.91027    113.88294   0.00740741 
+  139          138.36476    113.88672   0.00719424 
+  128          142.9425     113.89047   0.0078125 
+  137          149.19855    113.89419   0.00729927 
+  122          154.74046    113.89787   0.00819672 
+  144          160.16689    113.90153   0.00694444 
+  172          174.29466    113.90515   0.00581395 
+  228          211.08168    113.90874   0.00438596 
+  261          285.59982    113.91231   0.00383142 
+  324          376.1342     113.91584   0.00308642 
+  356          365.07957    113.91934   0.00280899 
+  331          273.06494    113.92281   0.00302115 
+  287          208.16549    113.92624   0.00348432 
+  225          180.57477    113.92965   0.00444444 
+  196          177.01108    113.93303   0.00510204 
+  170          191.35856    113.93638   0.00588235 
+  204          222.17272    113.9397    0.00490196 
+  187          249.31467    113.94299   0.00534759 
+  212          254.2468     113.94625   0.00471698 
+  232          271.97084    113.94948   0.00431034 
+  253          284.71186    113.95269   0.00395257 
+  233          243.2456     113.95586   0.00429185 
+  219          196.31022    113.95901   0.00456621 
+  200          169.27029    113.96213   0.005     
+  163          157.16075    113.96522   0.00613497 
+  158          155.3541     113.96828   0.00632911 
+  153          162.4577     113.97131   0.00653595 
+  141          174.27435    113.97432   0.0070922 
+  153          172.74265    113.9773    0.00653595 
+  142          158.18803    113.98025   0.00704225 
+  123          146.51651    113.98318   0.00813008 
+  155          140.36504    113.98608   0.00645161 
+  130          137.7551     113.98895   0.00769231 
+  138          136.77699    113.9918    0.00724638 
+  153          136.19132    113.99462   0.00653595 
+  142          136.11979    113.99741   0.00704225 
+  153          136.80952    114.00018   0.00653595 
+  147          136.70356    114.00292   0.00680272 
+  133          136.09935    114.00564   0.0075188 
+  144          136.65949    114.00834   0.00694444 
+  127          136.47312    114.01101   0.00787402 
+  124          133.81914    114.01365   0.00806452 
+  137          130.9066     114.01627   0.00729927 
+  127          129.11736    114.01887   0.00787402 
+  125          128.49434    114.02144   0.008     
+  151          128.70673    114.02399   0.00662252 
+  162          129.46357    114.02651   0.00617284 
+  140          130.34836    114.02902   0.00714286 
+  149          130.57559    114.0315    0.00671141 
+  141          130.90818    114.03395   0.0070922 
+  163          131.80214    114.03639   0.00613497 
+  142          132.02217    114.0388    0.00704225 
+  135          131.522      114.04119   0.00740741 
+  150          131.26373    114.04356   0.00666667 
+  139          131.14073    114.04591   0.00719424 
+  156          130.90465    114.04823   0.00641026 
+  148          130.7754     114.05054   0.00675676 
+  137          130.91038    114.05283   0.00729927 
+  152          131.43206    114.05509   0.00657895 
+  143          132.35494    114.05733   0.00699301 
+  174          133.6718     114.05956   0.00574713 
+  187          135.42948    114.06176   0.00534759 
+  152          137.74429    114.06395   0.00657895 
+  141          140.67463    114.06612   0.0070922 
+  149          144.13588    114.06827   0.00671141 
+  158          147.59682    114.07039   0.00632911 
+  146          150.8552     114.07251   0.00684932 
+  166          154.06529    114.0746    0.0060241 
+  168          157.76494    114.07667   0.00595238 
+  173          162.83398    114.07873   0.00578035 
+  161          170.29803    114.08077   0.00621118 
+  215          181.75205    114.0828    0.00465116 
+  220          201.0843     114.0848    0.00454545 
+  312          237.7555     114.0868    0.00320513 
+  423          306.41429    114.08877   0.00236407 
+  594          405.15624    114.09073   0.0016835 
+  659          451.67238    114.09267   0.00151745 
+  584          411.15366    114.0946    0.00171233 
+  549          397.29851    114.09652   0.00182149 
+  679          465.6206     114.09842   0.00147275 
+  887          679.82972    114.1003    0.0011274 
+  1519         1159.70783   114.10217   0.00065833 
+  2556         1927.95388   114.10403   0.00039124 
+  2839         2312.24114   114.10587   0.00035224 
+  2279         1697.12142   114.1077    0.00043879 
+  1449         1039.91157   114.10952   0.00069013 
+  1025         709.18798    114.11133   0.00097561 
+  793          562.6916     114.11312   0.00126103 
+  692          488.99338    114.1149    0.00144509 
+  581          501.84353    114.11667   0.00172117 
+  612          599.55535    114.11843   0.00163399 
+  750          713.44915    114.12018   0.00133333 
+  1035         871.24803    114.12192   0.00096618 
+  1374         1175.01882   114.12365   0.0007278 
+  1591         1265.76707   114.12536   0.00062854 
+  1087         899.88267    114.12707   0.00091996 
+  759          555.31548    114.12877   0.00131752 
+  497          371.47014    114.13046   0.00201207 
+  399          292.38136    114.13214   0.00250627 
+  271          266.53662    114.13382   0.00369004 
+  265          275.06232    114.13548   0.00377358 
+  250          304.23414    114.13714   0.004     
+  264          300.21021    114.13879   0.00378788 
+  208          252.50131    114.14043   0.00480769 
+  206          214.63923    114.14207   0.00485437 
+  230          197.90384    114.1437    0.00434783 
+  196          198.0243     114.14533   0.00510204 
+  183          211.80658    114.14695   0.00546448 
+  171          235.93087    114.14856   0.00584795 
+  162          252.4497     114.15017   0.00617284 
+  140          236.27397    114.15178   0.00714286 
+  146          207.50802    114.15338   0.00684932 
+  136          187.85918    114.15498   0.00735294 
+  151          176.4767     114.15657   0.00662252 
+  131          168.41831    114.15816   0.00763359 
+  146          163.52017    114.15975   0.00684932 
+  128          162.77523    114.16134   0.0078125 
+  143          167.42304    114.16292   0.00699301 
+  141          178.59254    114.16451   0.0070922 
+  146          195.17249    114.16609   0.00684932 
+  147          207.31649    114.16767   0.00680272 
+  146          202.06767    114.16925   0.00684932 
+  129          189.88607    114.17083   0.00775194 
+  126          184.11936    114.17242   0.00793651 
+  141          188.65658    114.174     0.0070922 
+  137          202.77845    114.17558   0.00729927 
+  121          217.52083    114.17717   0.00826446 
+  130          213.63405    114.17876   0.00769231 
+  118          200.14727    114.18035   0.00847458 
+  138          197.18478    114.18194   0.00724638 
+  133          209.50763    114.18354   0.0075188 
+  153          231.80721    114.18514   0.00653595 
+  148          240.95564    114.18674   0.00675676 
+  129          219.73097    114.18835   0.00775194 
+  129          193.13721    114.18996   0.00775194 
+  143          178.3628     114.19158   0.00699301 
+  123          176.10108    114.19321   0.00813008 
+  140          179.71524    114.19484   0.00714286 
+  115          177.01198    114.19647   0.00869565 
+  118          169.22871    114.19812   0.00847458 
+  132          166.80209    114.19977   0.00757576 
+  148          173.35532    114.20143   0.00675676 
+  145          187.99392    114.2031    0.00689655 
+  139          200.97156    114.20477   0.00719424 
+  142          198.8728     114.20646   0.00704225 
+  146          186.39698    114.20815   0.00684932 
+  127          170.19733    114.20986   0.00787402 
+  147          156.86232    114.21157   0.00680272 
+  134          148.58543    114.2133    0.00746269 
+  143          144.18107    114.21504   0.00699301 
+  113          142.51262    114.21679   0.00884956 
+  145          142.31674    114.21855   0.00689655 
+  114          142.35704    114.22032   0.00877193 
+  164          142.9501     114.22211   0.00609756 
+  174          145.29947    114.22391   0.00574713 
+  145          149.37571    114.22573   0.00689655 
+  174          153.10469    114.22756   0.00574713 
+  161          154.12065    114.2294    0.00621118 
+  166          152.90589    114.23126   0.0060241 
+  134          150.0229     114.23314   0.00746269 
+  186          148.47525    114.23503   0.00537634 
+  182          150.91775    114.23694   0.00549451 
+  196          158.58815    114.23886   0.00510204 
+  211          171.77063    114.24081   0.00473934 
+  227          186.32369    114.24277   0.00440529 
+  227          188.48225    114.24475   0.00440529 
+  205          177.02465    114.24675   0.00487805 
+  188          166.49773    114.24877   0.00531915 
+  184          162.36998    114.25081   0.00543478 
+  167          163.49655    114.25287   0.00598802 
+  186          167.70851    114.25495   0.00537634 
+  165          176.27624    114.25706   0.00606061 
+  154          193.57074    114.25918   0.00649351 
+  201          226.32921    114.26133   0.00497512 
+  186          283.62942    114.26351   0.00537634 
+  246          368.21148    114.2657    0.00406504 
+  238          444.94236    114.26792   0.00420168 
+  240          465.15249    114.27017   0.00416667 
+  222          466.14864    114.27244   0.0045045 
+  199          441.30432    114.27473   0.00502513 
+  179          363.68719    114.27705   0.00558659 
+  172          287.96477    114.2794    0.00581395 
+  179          241.08995    114.28178   0.00558659 
+  161          218.49982    114.28418   0.00621118 
+  187          212.76153    114.28662   0.00534759 
+  167          223.03717    114.28908   0.00598802 
+  205          250.51768    114.29157   0.00487805 
+  186          286.55872    114.29409   0.00537634 
+  189          304.80639    114.29664   0.00529101 
+  162          307.31613    114.29922   0.00617284 
+  201          305.48505    114.30184   0.00497512 
+  190          277.25997    114.30448   0.00526316 
+  188          238.26106    114.30716   0.00531915 
+  183          212.17352    114.30987   0.00546448 
+  198          200.65959    114.31262   0.00505051 
+  199          199.20567    114.3154    0.00502513 
+  188          203.60081    114.31822   0.00531915 
+  204          210.03717    114.32107   0.00490196 
+  210          221.84533    114.32395   0.0047619 
+  252          248.9776     114.32688   0.00396825 
+  329          311.95561    114.32984   0.00303951 
+  507          456.01244    114.33284   0.00197239 
+  750          737.72612    114.33587   0.00133333 
+  814          1090.41514   114.33895   0.0012285 
+  795          1083.6434    114.34206   0.00125786 
+  593          733.24849    114.34522   0.00168634 
+  457          462.60219    114.34842   0.00218818 
+  352          329.69918    114.35165   0.00284091 
+  291          277.89028    114.35493   0.00343643 
+  278          267.97214    114.35826   0.00359712 
+  244          294.2154     114.36162   0.00409836 
+  293          360.29476    114.36503   0.00341297 
+  339          436.06064    114.36848   0.00294985 
+  400          490.84771    114.37198   0.0025    
+  527          602.33516    114.37552   0.00189753 
+  509          688.29229    114.37911   0.00196464 
+  415          553.07273    114.38275   0.00240964 
+  322          372.06143    114.38643   0.00310559 
+  255          263.95763    114.39016   0.00392157 
+  218          213.42411    114.39394   0.00458716 
+  193          192.70334    114.39777   0.00518135 
+  190          189.76978    114.40165   0.00526316 
+  182          203.37246    114.40558   0.00549451 
+  167          226.67382    114.40955   0.00598802 
+  164          224.20226    114.41359   0.00609756 
+  158          192.68566    114.41767   0.00632911 
+  169          166.74591    114.42181   0.00591716 
+  153          151.93351    114.426     0.00653595 
+  151          143.79142    114.43024   0.00662252 
+  156          138.87686    114.43454   0.00641026 
+  168          135.58761    114.4389    0.00595238 
+  153          133.04216    114.44331   0.00653595 
+  133          130.95587    114.44777   0.0075188 
+  136          129.43391    114.4523    0.00735294 
+  133          128.43933    114.45688   0.0075188 
+  128          127.83315    114.46153   0.0078125 
+  120          127.45664    114.46623   0.00833333 
+  124          127.18434    114.47099   0.00806452 
+  135          126.98982    114.47581   0.00740741 
+  121          126.88669    114.4807    0.00826446 
+  123          127.13536    114.48564   0.00813008 
+  128          127.97365    114.49065   0.0078125 
+  125          129.00552    114.49572   0.008     
+  101          128.97743    114.50086   0.00990099 
+  138          127.82776    114.50606   0.00724638 
+  136          126.69822    114.51133   0.00735294 
+  140          126.00819    114.51666   0.00714286 
+  136          126.05437    114.52206   0.00735294 
+  125          127.08209    114.52753   0.008     
+  118          129.10239    114.53307   0.00847458 
+  135          131.60608    114.53868   0.00740741 
+  130          132.39302    114.54435   0.00769231 
+  144          131.09456    114.5501    0.00694444 
+  145          129.82382    114.55591   0.00689655 
+  133          128.94281    114.5618    0.0075188 
+  114          127.98401    114.56777   0.00877193 
+  143          127.19621    114.5738    0.00699301 
+  137          127.05097    114.57991   0.00729927 
+  113          127.73907    114.58609   0.00884956 
+  124          129.68309    114.59235   0.00806452 
+  115          133.60791    114.59869   0.00869565 
+  147          140.67938    114.6051    0.00680272 
+  128          152.066      114.61159   0.0078125 
+  127          166.97465    114.61816   0.00787402 
+  132          178.1224     114.62481   0.00757576 
+  133          172.42517    114.63154   0.0075188 
+  128          156.95209    114.63835   0.0078125 
+  123          144.86129    114.64524   0.00813008 
+  113          138.80438    114.65221   0.00884956 
+  159          138.31304    114.65927   0.00628931 
+  151          143.31596    114.66641   0.00662252 
+  171          152.4684     114.67363   0.00584795 
+  164          156.87505    114.68094   0.00609756 
+  160          152.67133    114.68834   0.00625   
+  152          150.83617    114.69582   0.00657895 
+  161          154.38201    114.70339   0.00621118 
+  122          158.16273    114.71105   0.00819672 
+  148          154.90199    114.7188    0.00675676 
+  141          148.00758    114.72664   0.0070922 
+  140          142.70207    114.73457   0.00714286 
+  136          140.84529    114.74259   0.00735294 
+  148          142.52148    114.7507    0.00675676 
+  153          146.85155    114.75891   0.00653595 
+  150          149.73039    114.76721   0.00666667 
+  132          146.15877    114.7756    0.00757576 
+  148          138.32169    114.78409   0.00675676 
+  173          132.346      114.79268   0.00578035 
+  125          129.12238    114.80136   0.008     
+  150          127.93439    114.81015   0.00666667 
+  167          128.09532    114.81903   0.00598802 
+  152          128.82215    114.82801   0.00657895 
+  162          129.96902    114.83709   0.00617284 
+  145          132.21585    114.84627   0.00689655 
+  170          135.91861    114.85555   0.00588235 
+  165          140.67719    114.86494   0.00606061 
+  161          143.15903    114.87443   0.00621118 
+  170          140.90725    114.88403   0.00588235 
+  171          136.8379     114.89373   0.00584795 
+  160          132.06438    114.90354   0.00625   
+  130          127.76991    114.91346   0.00769231 
+  165          124.97259    114.92348   0.00606061 
+  149          123.39836    114.93361   0.00671141 
+  155          122.68074    114.94385   0.00645161 
+  141          122.63969    114.95421   0.0070922 
+  156          123.19574    114.96467   0.00641026 
+  169          124.24791    114.97525   0.00591716 
+  190          126.00319    114.98594   0.00526316 
+  159          127.56113    114.99674   0.00628931 
+  158          127.63058    115.00766   0.00632911 
+  150          126.79591    115.0187    0.00666667 
+  139          125.4197     115.02985   0.00719424 
+  151          124.22109    115.04112   0.00662252 
+  168          123.91158    115.05251   0.00595238 
+  181          124.39545    115.06401   0.00552486 
+  160          125.19474    115.07564   0.00625   
+  206          125.31518    115.08739   0.00485437 
+  201          124.81222    115.09926   0.00497512 
+  221          124.60759    115.11126   0.00452489 
+  221          124.74483    115.12338   0.00452489 
+  216          125.38965    115.13562   0.00462963 
+  178          126.43801    115.14799   0.00561798 
+  194          127.40834    115.16048   0.00515464 
+  181          128.82819    115.17311   0.00552486 
+  172          129.76593    115.18586   0.00581395 
+  161          128.34577    115.19874   0.00621118 
+  152          126.1011     115.21176   0.00657895 
+  181          124.6211     115.2249    0.00552486 
+  192          123.63018    115.23818   0.00520833 
+  186          122.79666    115.25159   0.00537634 
+  208          122.3457     115.26513   0.00480769 
+  201          122.23263    115.27881   0.00497512 
+  173          122.44177    115.29262   0.00578035 
+  178          122.96006    115.30658   0.00561798 
+  189          123.49955    115.32067   0.00529101 
+  171          124.28627    115.3349    0.00584795 
+  188          125.12639    115.34927   0.00531915 
+  189          125.00231    115.36378   0.00529101 
+  196          124.51344    115.37843   0.00510204 
+  176          124.89929    115.39322   0.00568182 
+  205          126.28886    115.40816   0.00487805 
+  172          127.56328    115.42325   0.00581395 
+  166          127.56591    115.43848   0.0060241 
+  191          126.7107     115.45385   0.0052356 
+  167          125.68998    115.46938   0.00598802 
+  155          125.08118    115.48505   0.00645161 
+  177          124.89605    115.50088   0.00564972 
+  160          125.0305     115.51685   0.00625   
+  163          125.59926    115.53298   0.00613497 
+  177          126.57452    115.54925   0.00564972 
+  144          127.88458    115.56569   0.00694444 
+  170          129.765      115.58228   0.00588235 
+  188          132.50163    115.59902   0.00531915 
+  151          136.14284    115.61592   0.00662252 
+  146          141.20444    115.63298   0.00684932 
+  170          147.34154    115.6502    0.00588235 
+  176          149.79597    115.66758   0.00568182 
+  166          144.85733    115.68511   0.0060241 
+  161          137.88294    115.70282   0.00621118 
+  159          132.66474    115.72068   0.00628931 
+  160          129.67137    115.73871   0.00625   
+  164          128.39582    115.7569    0.00609756 
+  141          128.21177    115.77526   0.0070922 
+  152          128.72227    115.79379   0.00657895 
+  171          129.87632    115.81249   0.00584795 
+  154          131.9329     115.83135   0.00649351 
+  172          135.66171    115.85039   0.00581395 
+  181          141.05511    115.8696    0.00552486 
+  149          144.46699    115.88898   0.00671141 
+  168          141.64541    115.90853   0.00595238 
+  166          135.99254    115.92826   0.0060241 
+  119          131.56226    115.94817   0.00840336 
+  145          128.97175    115.96825   0.00689655 
+  138          127.65973    115.98851   0.00724638 
+  151          127.0793     116.00895   0.00662252 
+  135          127.03693    116.02957   0.00740741 
+  133          127.49448    116.05038   0.0075188 
+  158          128.51197    116.07136   0.00632911 
+  124          130.21046    116.09253   0.00806452 
+  151          132.57175    116.11388   0.00662252 
+  155          135.06212    116.13542   0.00645161 
+  155          136.68358    116.15715   0.00645161 
+  136          137.88346    116.17906   0.00735294 
+  150          139.58974    116.20117   0.00666667 
+  131          141.27905    116.22346   0.00763359 
+  137          142.32051    116.24595   0.00729927 
+  132          143.69287    116.26863   0.00757576 
+  161          146.57005    116.2915    0.00621118 
+  143          152.46644    116.31457   0.00699301 
+  126          163.89869    116.33783   0.00793651 
+  127          184.99178    116.36129   0.00787402 
+  114          220.64366    116.38495   0.00877193 
+  148          269.79116    116.40881   0.00675676 
+  189          304.4351     116.43288   0.00529101 
+  147          284.55128    116.45714   0.00680272 
+  112          237.33989    116.4816    0.00892857 
+  148          200.10011    116.50628   0.00675676 
+  147          177.91353    116.53115   0.00680272 
+  133          166.61278    116.55623   0.0075188 
+  150          162.23919    116.58152   0.00666667 
+  149          161.57562    116.60702   0.00671141 
+  152          164.39274    116.63274   0.00657895 
+  145          174.59565    116.65866   0.00689655 
+  162          195.52096    116.68479   0.00617284 
+  132          222.75646    116.71114   0.00757576 
+  153          241.9709     116.7377    0.00653595 
+  132          241.43388    116.76448   0.00757576 
+  148          219.74263    116.79148   0.00675676 
+  138          197.47668    116.8187    0.00724638 
+  121          180.20689    116.84614   0.00826446 
+  149          165.75956    116.87379   0.00671141 
+  154          156.18923    116.90167   0.00649351 
+  157          150.98815    116.92978   0.00636943 
+  153          148.01871    116.95811   0.00653595 
+  150          147.10808    116.98666   0.00666667 
+  135          148.97678    117.01545   0.00740741 
+  175          152.34623    117.04446   0.00571429 
+  141          152.5442     117.0737    0.0070922 
+  189          147.92325    117.10317   0.00529101 
+  181          144.42409    117.13288   0.00552486 
+  193          144.1602     117.16282   0.00518135 
+  152          145.5534     117.19299   0.00657895 
+  174          145.70738    117.22341   0.00574713 
+  159          145.18181    117.25405   0.00628931 
+  143          145.42132    117.28494   0.00699301 
+  156          144.75164    117.31607   0.00641026 
+  168          142.84783    117.34744   0.00595238 
+  160          141.61358    117.37905   0.00625   
+  149          141.4936     117.41091   0.00671141 
+  166          142.11681    117.44301   0.0060241 
+  170          143.85636    117.47536   0.00588235 
+  183          147.48682    117.50796   0.00546448 
+  172          153.88331    117.5408    0.00581395 
+  191          163.75076    117.5739    0.0052356 
+  153          175.04361    117.60725   0.00653595 
+  190          179.74132    117.64085   0.00526316 
+  180          175.77175    117.67471   0.00555556 
+  177          171.22985    117.70882   0.00564972 
+  188          169.18609    117.74319   0.00531915 
+  183          170.12488    117.77782   0.00546448 
+  173          174.53975    117.81271   0.00578035 
+  161          182.66665    117.84786   0.00621118 
+  208          195.19782    117.88327   0.00480769 
+  219          213.79147    117.91895   0.00456621 
+  263          241.70227    117.95489   0.00380228 
+  336          285.33207    117.9911    0.00297619 
+  407          359.61074    118.02758   0.002457  
+  586          501.24386    118.06433   0.00170648 
+  838          781.35839    118.10135   0.00119332 
+  1434         1270.6307    118.13864   0.00069735 
+  1980         1779.19249   118.1762    0.00050505 
+  1954         1634.55235   118.21404   0.00051177 
+  1549         1068.00838   118.25216   0.00064558 
+  1160         654.34902    118.29055   0.00086207 
+  860          439.69815    118.32923   0.00116279 
+  623          340.29519    118.36818   0.00160514 
+  516          294.3924     118.40742   0.00193798 
+  452          275.33808    118.44694   0.00221239 
+  368          275.4642     118.48674   0.00271739 
+  399          297.72764    118.52683   0.00250627 
+  489          359.17091    118.56721   0.00204499 
+  603          496.07009    118.60788   0.00165837 
+  900          741.6589     118.64884   0.00111111 
+  1047         987.58816    118.69009   0.00095511 
+  1092         898.00299    118.73164   0.00091575 
+  867          614.84319    118.77348   0.0011534 
+  673          413.05388    118.81562   0.00148588 
+  482          309.52514    118.85805   0.00207469 
+  393          261.47232    118.90079   0.00254453 
+  282          236.10563    118.94382   0.0035461 
+  283          218.28496    118.98716   0.00353357 
+  253          204.25783    119.0308    0.00395257 
+  237          195.38961    119.07475   0.00421941 
+  218          192.2622     119.119     0.00458716 
+  193          193.69292    119.16357   0.00518135 
+  219          196.64255    119.20844   0.00456621 
+  177          195.73031    119.25362   0.00564972 
+  196          189.12865    119.29912   0.00510204 
+  197          181.07422    119.34493   0.00507614 
+  177          174.88551    119.39106   0.00564972 
+  184          171.00707    119.4375    0.00543478 
+  193          167.89568    119.48426   0.00518135 
+  203          164.43959    119.53135   0.00492611 
+  171          160.3263     119.57875   0.00584795 
+  144          156.13511    119.62648   0.00694444 
+  160          153.27056    119.67453   0.00625   
+  167          152.68786    119.72291   0.00598802 
+  157          154.18078    119.77162   0.00636943 
+  161          156.51841    119.82066   0.00621118 
+  180          156.87744    119.87003   0.00555556 
+  154          153.91497    119.91973   0.00649351 
+  160          149.7031     119.96976   0.00625   
+  150          146.17005    120.02014   0.00666667 
+  136          143.61511    120.07085   0.00735294 
+  148          141.44481    120.12189   0.00675676 
+  156          139.64316    120.17328   0.00641026 
+  142          138.66578    120.22501   0.00704225 
+  139          138.58501    120.27709   0.00719424 
+  162          139.40729    120.32951   0.00617284 
+  145          141.32408    120.38228   0.00689655 
+  130          144.66847    120.43539   0.00769231 
+  142          149.79855    120.48886   0.00704225 
+  134          157.08508    120.54267   0.00746269 
+  133          166.17348    120.59684   0.0075188 
+  147          173.7639     120.65137   0.00680272 
+  142          174.52227    120.70625   0.00704225 
+  148          168.59825    120.76149   0.00675676 
+  157          161.44386    120.81709   0.00636943 
+  149          156.36097    120.87306   0.00671141 
+  139          153.60811    120.92938   0.00719424 
+  147          152.2268     120.98607   0.00680272 
+  144          151.25315    121.04313   0.00694444 
+  161          150.52959    121.10055   0.00621118 
+  150          150.74084    121.15835   0.00666667 
+  180          152.82838    121.21651   0.00555556 
+  177          157.71697    121.27505   0.00564972 
+  172          166.04201    121.33396   0.00581395 
+  160          176.29073    121.39325   0.00625   
+  167          182.15565    121.45292   0.00598802 
+  163          178.59419    121.51297   0.00613497 
+  153          170.23347    121.5734    0.00653595 
+  154          163.77402    121.63421   0.00649351 
+  179          161.75369    121.69541   0.00558659 
+  148          164.05099    121.75699   0.00675676 
+  159          169.87711    121.81896   0.00628931 
+  196          177.53218    121.88133   0.00510204 
+  162          182.56429    121.94408   0.00617284 
+  170          179.87495    122.00723   0.00588235 
+  201          171.48088    122.07077   0.00497512 
+  179          163.53303    122.13471   0.00558659 
+  169          158.9373     122.19905   0.00591716 
+  169          156.78339    122.26379   0.00591716 
+  160          154.12117    122.32893   0.00625   
+  168          150.20611    122.39447   0.00595238 
+  182          146.5986     122.46042   0.00549451 
+  156          144.53899    122.52678   0.00641026 
+  152          144.55471    122.59354   0.00657895 
+  187          146.68937    122.66072   0.00534759 
+  148          150.60032    122.72831   0.00675676 
+  163          154.67566    122.79632   0.00613497 
+  171          155.62404    122.86474   0.00584795 
+  169          152.28585    122.93358   0.00591716 
+  154          147.62001    123.00283   0.00649351 
+  156          144.22892    123.07252   0.00641026 
+  148          143.01857    123.14262   0.00675676 
+  137          144.30631    123.21315   0.00729927 
+  153          148.11334    123.2841    0.00653595 
+  136          152.69696    123.35549   0.00735294 
+  142          152.90557    123.4273    0.00704225 
+  151          147.64391    123.49955   0.00662252 
+  152          141.97753    123.57224   0.00657895 
+  163          138.18897    123.64535   0.00613497 
+  163          136.12915    123.71891   0.00613497 
+  130          135.18227    123.79291   0.00769231 
+  144          134.80395    123.86735   0.00694444 
+  146          134.81248    123.94223   0.00684932 
+  147          135.12153    124.01755   0.00680272 
+  140          135.61391    124.09333   0.00714286 
+  151          136.58219    124.16955   0.00662252 
+  129          138.48496    124.24623   0.00775194 
+  172          141.34267    124.32335   0.00581395 
+  144          143.68214    124.40094   0.00694444 
+  153          143.15813    124.47898   0.00653595 
+  122          140.98536    124.55747   0.00819672 
+  130          139.40754    124.63643   0.00769231 
+  125          138.92711    124.71585   0.008     
+  172          139.40514    124.79574   0.00581395 
+  138          140.71008    124.87609   0.00724638 
+  124          142.85931    124.9569    0.00806452 
+  135          146.01615    125.03819   0.00740741 
+  165          150.50304    125.11995   0.00606061 
+  142          157.1275     125.20219   0.00704225 
+  144          168.19311    125.2849    0.00694444 
+  138          189.66026    125.36809   0.00724638 
+  157          233.05192    125.45175   0.00636943 
+  190          310.1978     125.5359    0.00526316 
+  165          399.33283    125.62054   0.00606061 
+  167          396.53866    125.70566   0.00598802 
+  166          308.85785    125.79126   0.0060241 
+  178          237.68112    125.87736   0.00561798 
+  177          200.76092    125.96394   0.00564972 
+  145          186.4836     126.05102   0.00689655 
+  182          185.17607    126.1386    0.00549451 
+  172          194.45857    126.22667   0.00581395 
+  207          219.19204    126.31525   0.00483092 
+  177          270.20652    126.40432   0.00564972 
+  198          355.30782    126.4939    0.00505051 
+  258          441.67352    126.58398   0.00387597 
+  278          436.67283    126.67457   0.00359712 
+  275          387.64214    126.76567   0.00363636 
+  280          359.55555    126.85728   0.00357143 
+  234          307.19779    126.94941   0.0042735 
+  232          243.68938    127.04205   0.00431034 
+  230          202.0704     127.13521   0.00434783 
+  205          180.43935    127.22888   0.00487805 
+  195          170.68324    127.32308   0.00512821 
+  187          167.83925    127.41781   0.00534759 
+  182          170.96954    127.51305   0.00549451 
+  194          182.75947    127.60883   0.00515464 
+  188          208.38186    127.70514   0.00531915 
+  179          249.44281    127.80198   0.00558659 
+  176          281.44367    127.89935   0.00568182 
+  195          258.08354    127.99726   0.00512821 
+  203          212.738      128.09571   0.00492611 
+  194          181.39083    128.19469   0.00515464 
+  208          164.49778    128.29422   0.00480769 
+  213          155.37405    128.3943    0.00469484 
+  185          149.74788    128.49492   0.00540541 
+  183          146.12337    128.59609   0.00546448 
+  198          143.85648    128.69781   0.00505051 
+  178          142.57676    128.80009   0.00561798 
+  177          142.07713    128.90292   0.00564972 
+  161          142.21386    129.0063    0.00621118 
+  172          142.72322    129.11025   0.00581395 
+  158          143.12129    129.21476   0.00632911 
+  144          143.17163    129.31983   0.00694444 
+  139          143.07567    129.42547   0.00719424 
+  153          143.03822    129.53167   0.00653595 
+  144          143.2281     129.63845   0.00694444 
+  128          143.71522    129.7458    0.0078125 
+  148          144.28406    129.85372   0.00675676 
+  134          144.75492    129.96222   0.00746269 
+  157          145.28436    130.0713    0.00636943 
+  141          146.45989    130.18096   0.0070922 
+  166          148.26004    130.29121   0.0060241 
+  150          149.21245    130.40203   0.00666667 
+  151          148.5952     130.51345   0.00662252 
+  136          147.70967    130.62546   0.00735294 
+  139          147.51069    130.73806   0.00719424 
+  149          147.16435    130.85125   0.00671141 
+  152          145.64254    130.96504   0.00657895 
+  142          143.89168    131.07943   0.00704225 
+  158          142.89956    131.19442   0.00632911 
+  168          142.82314    131.31002   0.00595238 
+  148          143.57121    131.42622   0.00675676 
+  129          144.95164    131.54303   0.00775194 
+  154          146.77708    131.66044   0.00649351 
+  146          148.92333    131.77848   0.00684932 
+  164          150.85596    131.89712   0.00609756 
+  129          151.3296     132.01638   0.00775194 
+  152          149.84794    132.13627   0.00657895 
+  130          148.1434     132.25677   0.00769231 
+  103          147.7123     132.3779    0.00970874 
+  130          148.59315    132.49965   0.00769231 
+  134          150.24804    132.62203   0.00746269 
+  145          152.48539    132.74505   0.00689655 
+  142          153.49135    132.86869   0.00704225 
+  142          151.31463    132.99298   0.00704225 
+  146          148.13381    133.1179    0.00684932 
+  155          146.01136    133.24346   0.00645161 
+  143          145.15569    133.36966   0.00699301 
+  154          145.13511    133.49651   0.00649351 
+  132          145.39256    133.624     0.00757576 
+  142          145.46932    133.75215   0.00704225 
+  130          145.16131    133.88094   0.00769231 
+  143          144.91618    134.01039   0.00699301 
+  171          145.23907    134.1405    0.00584795 
+  168          146.34468    134.27127   0.00595238 
+  157          148.36132    134.40269   0.00636943 
+  155          151.2171     134.53479   0.00645161 
+  152          153.97743    134.66754   0.00657895 
+  162          155.22143    134.80097   0.00617284 
+  173          155.49961    134.93507   0.00578035 
+  143          155.75105    135.06984   0.00699301 
+  146          155.75819    135.20529   0.00684932 
+  160          155.21847    135.34141   0.00625   
+  160          154.34387    135.47822   0.00625   
+  153          153.57672    135.61571   0.00653595 
+  148          153.17031    135.75388   0.00675676 
+  164          153.07998    135.89275   0.00609756 
+  165          153.26151    136.0323    0.00606061 
+  156          153.98132    136.17255   0.00641026 
+  147          155.55903    136.31349   0.00680272 
+  180          158.11742    136.45513   0.00555556 
+  195          161.7093     136.59747   0.00512821 
+  157          166.90149    136.74051   0.00636943 
+  192          174.78719    136.88426   0.00520833 
+  183          184.93616    137.02872   0.00546448 
+  159          191.70998    137.17388   0.00628931 
+  175          188.49042    137.31976   0.00571429 
+  176          180.38473    137.46636   0.00568182 
+  177          174.50458    137.61367   0.00564972 
+  176          172.7565     137.76171   0.00568182 
+  205          175.26954    137.91046   0.00487805 
+  179          182.23852    138.05994   0.00558659 
+  168          193.60824    138.21015   0.00595238 
+  198          206.21967    138.3611    0.00505051 
+  185          211.03282    138.51277   0.00540541 
+  222          204.81924    138.66518   0.0045045 
+  209          196.27853    138.81833   0.00478469 
+  222          191.57197    138.97221   0.0045045 
+  223          192.4276     139.12685   0.0044843 
+  212          198.3093     139.28222   0.00471698 
+  241          206.30937    139.43835   0.00414938 
+  239          215.92469    139.59523   0.0041841 
+  239          228.25691    139.75286   0.0041841 
+  227          232.8771     139.91125   0.00440529 
+  249          220.32273    140.07039   0.00401606 
+  232          208.99622    140.2303    0.00431034 
+  280          208.32273    140.39097   0.00357143 
+  262          217.74321    140.55241   0.00381679 
+  235          235.05695    140.71462   0.00425532 
+  273          262.27858    140.8776    0.003663  
+  304          315.13966    141.04135   0.00328947 
+  286          412.56045    141.20589   0.0034965 
+  358          529.20592    141.3712    0.0027933 
+  331          532.41801    141.53729   0.00302115 
+  302          418.14816    141.70417   0.00331126 
+  289          320.45722    141.87184   0.00346021 
+  260          268.31408    142.0403    0.00384615 
+  237          245.42163    142.20955   0.00421941 
+  241          229.81936    142.3796    0.00414938 
+  208          215.08132    142.55045   0.00480769 
+  236          206.94888    142.7221    0.00423729 
+  191          205.35914    142.89455   0.0052356 
+  242          208.98772    143.06781   0.00413223 
+  202          218.83422    143.24188   0.0049505 
+  205          237.26998    143.41677   0.00487805 
+  244          269.49065    143.59246   0.00409836 
+  248          322.48647    143.76898   0.00403226 
+  225          370.35252    143.94631   0.00444444 
+  252          347.6782     144.12447   0.00396825 
+  229          291.23535    144.30346   0.00436681 
+  225          253.34283    144.48327   0.00444444 
+  210          232.31457    144.66392   0.0047619 
+  219          215.08999    144.8454    0.00456621 
+  198          199.85332    145.02771   0.00505051 
+  205          189.48261    145.21087   0.00487805 
+  189          183.5792     145.39487   0.00529101 
+  193          180.46559    145.57972   0.00518135 
+  160          179.10882    145.76541   0.00625   
+  195          178.79307    145.95195   0.00512821 
+  174          177.85895    146.13935   0.00574713 
+  162          175.40707    146.32761   0.00617284 
+  190          173.1016     146.51672   0.00526316 
+  180          172.44515    146.7067    0.00555556 
+  167          173.74469    146.89755   0.00598802 
+  167          176.52434    147.08926   0.00598802 
+  197          179.43611    147.28184   0.00507614 
+  195          180.01061    147.4753    0.00512821 
+  187          176.59388    147.66963   0.00534759 
+  176          171.97346    147.86484   0.00568182 
+  197          168.43462    148.06094   0.00507614 
+  165          165.83169    148.25792   0.00606061 
+  164          163.9592     148.45579   0.00609756 
+  177          162.82568    148.65455   0.00564972 
+  153          162.13805    148.8542    0.00653595 
+  157          161.64771    149.05475   0.00636943 
+  192          161.44963    149.25621   0.00520833 
+  185          161.65956    149.45856   0.00540541 
+  174          162.26175    149.66182   0.00574713 
+  144          162.9273     149.86599   0.00694444 
+  171          163.08368    150.07107   0.00584795 
+  185          162.769      150.27706   0.00540541 
+  176          162.52389    150.48398   0.00568182 
+  168          162.61284    150.69181   0.00595238 
+  166          163.06146    150.90057   0.0060241 
+  180          163.74076    151.11025   0.00555556 
+  171          164.42549    151.32086   0.00584795 
+  173          165.05422    151.53241   0.00578035 
+  157          165.32333    151.74489   0.00636943 
+  197          164.97695    151.95831   0.00507614 
+  165          164.48292    152.17267   0.00606061 
+  176          164.25743    152.38798   0.00568182 
+  153          164.38048    152.60423   0.00653595 
+  182          164.78319    152.82143   0.00549451 
+  186          165.29496    153.03959   0.00537634 
+  169          165.72697    153.2587    0.00591716 
+  178          166.15442    153.47878   0.00561798 
+  165          166.74683    153.69981   0.00606061 
+  185          167.58313    153.92181   0.00540541 
+  187          168.72587    154.14478   0.00534759 
+  187          170.27333    154.36873   0.00534759 
+  214          172.36243    154.59364   0.0046729 
+  184          175.11466    154.81954   0.00543478 
+  164          178.44692    155.04642   0.00609756 
+  179          181.91945    155.27428   0.00558659 
+  212          184.63658    155.50313   0.00471698 
+  204          186.43553    155.73296   0.00490196 
+  181          188.59828    155.9638    0.00552486 
+  191          191.29593    156.19563   0.0052356 
+  206          193.44716    156.42845   0.00485437 
+  189          194.37325    156.66229   0.00529101 
+  192          195.18665    156.89712   0.00520833 
+  192          196.81031    157.13297   0.00520833 
+  191          198.43716    157.36983   0.0052356 
+  204          198.39114    157.60771   0.00490196 
+  237          196.78637    157.8466    0.00421941 
+  238          195.45924    158.08652   0.00420168 
+  264          195.75617    158.32746   0.00378788 
+  225          198.12722    158.56943   0.00444444 
+  228          202.43922    158.81243   0.00438596 
+  226          207.75172    159.05646   0.00442478 
+  217          212.48495    159.30154   0.00460829 
+  224          215.39429    159.54765   0.00446429 
+  222          216.53804    159.79481   0.0045045 
+  228          217.49256    160.04302   0.00438596 
+  230          219.48444    160.29228   0.00434783 
+  239          223.0261     160.54259   0.0041841 
+  257          227.99712    160.79396   0.00389105 
+  254          236.28552    161.04639   0.00393701 
+  231          253.16353    161.29988   0.004329  
+  309          284.92457    161.55444   0.00323625 
+  307          330.4088     161.81007   0.00325733 
+  311          352.89928    162.06677   0.00321543 
+  299          320.28994    162.32456   0.00334448 
+  337          278.73138    162.58342   0.00296736 
+  327          253.97354    162.84336   0.0030581 
+  328          243.44102    163.1044    0.00304878 
+  299          240.14916    163.36652   0.00334448 
+  285          239.84155    163.62973   0.00350877 
+  299          241.81112    163.89405   0.00334448 
+  242          246.11613    164.15946   0.00413223 
+  298          251.47223    164.42598   0.0033557 
+  264          255.83294    164.6936    0.00378788 
+  308          259.69318    164.96233   0.00324675 
+  280          267.16615    165.23218   0.00357143 
+  289          282.8938     165.50314   0.00346021 
+  308          309.3533     165.77523   0.00324675 
+  349          337.66751    166.04844   0.00286533 
+  362          342.93538    166.32277   0.00276243 
+  351          333.62696    166.59824   0.002849  
+  375          331.12749    166.87484   0.00266667 
+  409          337.67038    167.15257   0.00244499 
+  429          351.84108    167.43145   0.002331  
+  432          374.57819    167.71147   0.00231481 
+  489          409.51758    167.99264   0.00204499 
+  558          462.9603     168.27496   0.00179211 
+  632          535.86302    168.55844   0.00158228 
+  736          604.05803    168.84307   0.0013587 
+  854          646.7592     169.12887   0.00117096 
+  1053         702.01928    169.41583   0.00094967 
+  1281         806.74698    169.70395   0.00078064 
+  1693         997.9423     169.99325   0.00059067 
+  2324         1357.70718   170.28373   0.00043029 
+  3402         2065.25908   170.57538   0.00029394 
+  5433         3394.16639   170.86822   0.00018406 
+  8527         5458.76254   171.16224   0.00011727 
+  11779        7125.94593   171.45745   0.0000849 
+  12522        6199.26077   171.75386   0.00007986 
+  10422        4047.03439   172.05146   0.00009595 
+  7934         2473.97119   172.35026   0.00012604 
+  5815         1607.41544   172.65026   0.00017197 
+  4232         1178.63333   172.95148   0.00023629 
+  3089         967.14045    173.2539    0.00032373 
+  2454         845.72147    173.55753   0.0004075 
+  1981         767.6221     173.86239   0.0005048 
+  1745         733.42384    174.16846   0.00057307 
+  1649         747.7046     174.47576   0.00060643 
+  1736         825.79595    174.78429   0.00057604 
+  1962         1015.79636   175.09405   0.00050968 
+  2513         1421.07255   175.40505   0.00039793 
+  3510         2178.02858   175.71729   0.0002849 
+  4910         3249.69732   176.03077   0.00020367 
+  6085         3785.46096   176.34549   0.00016434 
+  6192         3006.29488   176.66147   0.0001615 
+  5056         1969.94128   176.9787    0.00019778 
+  3799         1301.93765   177.29718   0.00026323 
+  2834         967.3465     177.61693   0.00035286 
+  2124         838.78978    177.93795   0.00047081 
+  1548         835.7626     178.26023   0.00064599 
+  1126         918.48759    178.58378   0.0008881 
+  894          1022.52517   178.90861   0.00111857 
+  795          1012.6       179.23472   0.00125786 
+  646          855.95824    179.56212   0.00154799 
+  547          676.46662    179.8908    0.00182815 
+  460          542.32088    180.22077   0.00217391 
+  434          454.88111    180.55204   0.00230415 
+  397          400.58386    180.8846    0.00251889 
+  327          367.63856    181.21846   0.0030581 
+  364          348.39207    181.55364   0.00274725 
+  330          337.94217    181.89012   0.0030303 
+  307          332.87091    182.22791   0.00325733 
+  319          333.64349    182.56702   0.0031348 
+  295          344.48063    182.90746   0.00338983 
+  279          371.23392    183.24921   0.00358423 
+  262          420.44834    183.5923    0.00381679 
+  263          493.19753    183.93671   0.00380228 
+  251          562.78359    184.28247   0.00398406 
+  288          564.19835    184.62956   0.00347222 
+  260          491.03602    184.978     0.00384615 
+  240          408.10832    185.32778   0.00416667 
+  199          347.27969    185.67892   0.00502513 
+  249          308.52947    186.03141   0.00401606 
+  211          284.91863    186.38525   0.00473934 
+  230          270.67394    186.74047   0.00434783 
+  242          262.38911    187.09705   0.00413223 
+  218          257.78745    187.45499   0.00458716 
+  238          254.90256    187.81432   0.00420168 
+  230          253.06365    188.17502   0.00434783 
+  238          253.05869    188.5371    0.00420168 
+  236          257.05879    188.90058   0.00423729 
+  223          268.86573    189.26544   0.0044843 
+  211          293.84812    189.63169   0.00473934 
+  236          336.18777    189.99934   0.00423729 
+  234          380.59579    190.3684    0.0042735 
+  228          374.95499    190.73886   0.00438596 
+  232          326.37557    191.11073   0.00431034 
+  221          284.8121     191.48401   0.00452489 
+  224          260.64602    191.85871   0.00446429 
+  208          248.52629    192.23483   0.00480769 
+  199          242.98835    192.61238   0.00502513 
+  191          241.223      192.99136   0.0052356 
+  213          242.25197    193.37177   0.00469484 
+  215          245.98057    193.75362   0.00465116 
+  200          252.83072    194.13691   0.005     
+  198          264.17231    194.52164   0.00505051 
+  176          283.92261    194.90783   0.00568182 
+  201          320.90533    195.29547   0.00497512 
+#--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--#
+
+
+# start Validation Reply Form
+_vrf_PLAT741_QPABAT1ug3_phase_1 # for all atoms in 1_quartz
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT741_QPABAT1ug3_phase_3 # for all atoms in 3_pyrrhotite
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT741_QPABAT1ug3_phase_4 # for all atoms in 4_rutile
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT741_QPABAT1ug3_phase_2 # for all atoms in 2_albite
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT155_QPABAT1ug3_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT141_QPABAT1ug3_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT142_QPABAT1ug3_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT143_QPABAT1ug3_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT144_QPABAT1ug3_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT145_QPABAT1ug3_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT146_QPABAT1ug3_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT148_QPABAT1ug3_phase_3 # 3_pyrrhotite
+;
+PROBLEM: s.u. on the a-Axis and b-Axis is (Too) Large 
+RESPONSE: untreated sample, s.u. expected to be high
+;
+_vrf_PLAT151_QPABAT1ug3_phase_2
+;
+PROBLEM: No s.u. (esd) Given on Volume ..................     Please Do !  
+RESPONSE: unit cell not refined
+;
+# end Validation Reply Form

--- a/data/hamish/vb5042sup5.cif
+++ b/data/hamish/vb5042sup5.cif
@@ -1,0 +1,6675 @@
+
+data_NEW1minmill_publ
+_audit_creation_method  "created in GSAS-II"
+_audit_creation_date  2021-08-04T18:19
+_audit_author_name  "McDougall, Hamish"
+_audit_update_record
+   "2021-08-04T18:19  Initial software-generated CIF"
+_pd_block_id  2021-08-04T18:19|NEW1minmill|McDougallHamish|Overall
+# GSAS-II edited template follows Publication_Template
+#=============================================================================
+# this information describes the project, paper etc. for the CIF             #
+# Acta Cryst. Section C papers and editorial correspondence is generated     #
+# from the information in this section                                       #
+#                                                                            #
+#   (from)   CIF submission form for Rietveld refinements (Acta Cryst. C)    #
+#                                                 Version 14 December 1998   #
+#=============================================================================
+# 1. SUBMISSION DETAILS
+
+_publ_contact_author_name            "Suzanne Neville, Vanessa Peterson, Christophe Didier"   # Name of author for correspondence
+_publ_contact_author_address             # Address of author for correspondence
+; ?
+;
+_publ_contact_author_email           "s.neville@unsw.edu.au; vanessa.peterson@ansto.gov.au; drchristophedidier@gmail.com"
+_publ_contact_author_fax             ?
+_publ_contact_author_phone           ?
+
+_publ_contact_letter
+; ?
+;
+   
+_publ_requested_journal              ?
+_publ_requested_coeditor_name        ?
+_publ_requested_category             ?   # Acta C: one of CI/CM/CO/FI/FM/FO
+
+#==============================================================================
+
+# 2. PROCESSING SUMMARY (IUCr Office Use Only)
+
+_journal_data_validation_number      ?
+
+_journal_date_recd_electronic        ?
+_journal_date_to_coeditor            ?
+_journal_date_from_coeditor          ?
+_journal_date_accepted               ?
+_journal_date_printers_first         ?
+_journal_date_printers_final         ?
+_journal_date_proofs_out             ?
+_journal_date_proofs_in              ?
+_journal_coeditor_name               ?
+_journal_coeditor_code               ?
+_journal_coeditor_notes
+; ?
+;
+_journal_techeditor_code             ?
+_journal_techeditor_notes
+; ?
+;
+_journal_coden_ASTM                  ?
+_journal_name_full                   ?
+_journal_year                        ?
+_journal_volume                      ?
+_journal_issue                       ?
+_journal_page_first                  ?
+_journal_page_last                   ?
+_journal_paper_category              ?
+_journal_suppl_publ_number           ?
+_journal_suppl_publ_pages            ?
+
+#==============================================================================
+
+# 3. TITLE AND AUTHOR LIST
+
+_publ_section_title
+; ?
+;
+_publ_section_title_footnote
+; ?
+;         
+ 
+# The loop structure below should contain the names and addresses of all 
+# authors, in the required order of publication. Repeat as necessary.
+
+loop_
+	_publ_author_name
+        _publ_author_footnote
+	_publ_author_address
+ ?                                   #<--'Last name, first name' 
+; ?
+;
+; ?
+;
+
+#==============================================================================
+
+# 4. TEXT
+
+_publ_section_synopsis
+;  ?
+;
+_publ_section_abstract                         
+; ?
+;          
+_publ_section_comment                          
+; ?
+;
+_publ_section_exptl_prep      # Details of the preparation of the sample(s)
+                              # should be given here. 
+; ?
+;
+_publ_section_exptl_refinement                  
+; ?
+;
+_publ_section_references
+; ?
+;
+_publ_section_figure_captions
+; ?
+;
+_publ_section_acknowledgements
+; ?
+;
+
+#=============================================================================
+# 5. OVERALL REFINEMENT & COMPUTING DETAILS
+
+_refine_special_details
+; ?
+;
+_pd_proc_ls_special_details
+; ?
+;
+
+# The following items are used to identify the programs used.
+_computing_molecular_graphics     ?
+_computing_publication_material   ?
+
+_refine_ls_weighting_scheme       ?        
+_refine_ls_weighting_details      ?
+_refine_ls_hydrogen_treatment     ?        
+_refine_ls_extinction_method      ?        
+_refine_ls_extinction_coef        ?         
+_refine_ls_number_constraints     ?        
+
+_refine_ls_restrained_S_all       ?        
+_refine_ls_restrained_S_obs       ?
+
+#==============================================================================
+# 6. SAMPLE PREPARATION DATA
+
+# (In the unusual case where multiple samples are used in a single
+#  Rietveld study, this information should be moved into the phase
+#  blocks)
+
+# The following three fields describe the preparation of the material.
+# The cooling rate is in K/min.  The pressure at which the sample was  
+# prepared is in kPa.  The temperature of preparation is in K.
+               
+_pd_prep_cool_rate                N/A        
+_pd_prep_pressure                 101.3        
+_pd_prep_temperature              298          
+
+_pd_char_colour                   ?       # use ICDD colour descriptions
+
+data_NEW1minmill_overall
+_pd_proc_info_datetime  2021-08-04T18:19
+_pd_calc_method  "Rietveld Refinement"
+_computing_structure_refinement
+   "GSAS-II (Toby & Von Dreele, J. Appl. Cryst. 46, 544-549, 2013)"
+_refine_ls_number_parameters  27
+_refine_ls_goodness_of_fit_all  3.078
+_refine_ls_shift/su_max  4.0766
+
+# OVERALL WEIGHTED R-FACTOR
+_refine_ls_wR_factor_obs  0.13200
+_refine_ls_matrix_type  full
+# POINTERS TO PHASE AND HISTOGRAM BLOCKS
+loop_   _pd_phase_block_id
+  2021-08-04T18:19|NEW1minmill|phase_0|McDougallHamish
+  2021-08-04T18:19|NEW1minmill|phase_2|McDougallHamish
+  2021-08-04T18:19|NEW1minmill|phase_4|McDougallHamish
+  2021-08-04T18:19|NEW1minmill|phase_1|McDougallHamish
+  2021-08-04T18:19|NEW1minmill|phase_3|McDougallHamish
+_pd_block_diffractogram_id
+;
+2021-08-04T18:19|NEW1minmill|McDougallHamish|PANalytical,Co-EmpyreanII_hist_0
+;
+
+data_NEW1minmill_phase_0
+# Information for phase 0
+_pd_block_id  2021-08-04T18:19|NEW1minmill|phase_0|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for FeS2 follows
+_pd_phase_name  FeS2
+_cell_length_a  5.41977(4)
+_cell_length_b  5.41977(4)
+_cell_length_c  5.41977(4)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  90
+_cell_volume  159.200(4)
+_exptl_crystal_density_diffrn  5.0053
+_symmetry_cell_setting  cubic
+_symmetry_space_group_name_H-M  "P a -3"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  z,x,y
+     3  y,z,x
+     4  1/2+x,y,1/2-z
+     5  1/2-z,1/2+x,y
+     6  y,1/2-z,1/2+x
+     7  -z,1/2+x,1/2-y
+     8  1/2-y,-z,1/2+x
+     9  1/2+y,1/2-z,-x
+    10  -x,1/2+y,1/2-z
+    11  1/2-z,-x,1/2+y
+    12  1/2+x,1/2-y,-z
+    13  -x,-y,-z
+    14  -z,-x,-y
+    15  -y,-z,-x
+    16  1/2-x,-y,1/2+z
+    17  1/2+z,1/2-x,-y
+    18  -y,1/2+z,1/2-x
+    19  z,1/2-x,1/2+y
+    20  1/2+y,z,1/2-x
+    21  1/2-y,1/2+z,x
+    22  x,1/2-y,1/2+z
+    23  1/2+z,x,1/2-y
+    24  1/2-x,1/2+y,z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Fe1    Fe   0.00000     0.00000     0.00000     1.000      Uiso 0.010      4   
+S2     S    0.38589     0.38589     0.38589     1.000      Uiso 0.010      8   
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Fe   4      11.7695    7.3573     3.5222     2.3045     4.7611     0.3072     15.3535    76.8805    1.0369     0.945
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S    8      6.9053     5.2034     1.4379     1.5863     1.4679     22.2151    0.2536     56.172     0.8669     0.2847
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Fe S2"
+_chemical_formula_weight  119.97
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Fe1    S2     2.26694      1_555    4_455 yes
+  Fe1    S2     2.26694      1_555    5_545 yes
+  Fe1    S2     2.26694      1_555    6_554 yes
+  Fe1    S2     2.26694      1_555    7_545 yes
+  Fe1    S2     2.26694      1_555    8_554 yes
+  Fe1    S2     2.26694      1_555    9_455 yes
+  S2     Fe1    2.26694      1_555    4_555 yes
+  S2     Fe1    2.26694      1_555    5_555 yes
+  S2     Fe1    2.26694      1_555    6_555 yes
+  S2     S2     2.14245      1_555   13_666 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.2413(26), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW1minmill_phase_2
+# Information for phase 2
+_pd_block_id  2021-08-04T18:19|NEW1minmill|phase_2|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for NaAlSi3O8 follows
+_pd_phase_name  NaAlSi3O8
+_cell_length_a  8.137
+_cell_length_b  12.785
+_cell_length_c  7.1583
+_cell_angle_alpha  94.26
+_cell_angle_beta   116.6
+_cell_angle_gamma  87.71
+_cell_volume  664.008
+_exptl_crystal_density_diffrn  2.6230
+_symmetry_cell_setting  triclinic
+_symmetry_space_group_name_H-M  "C -1"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -x,-y,-z
+     3  1/2+x,1/2+y,z
+     4  1/2-x,1/2-y,-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Al1    Al3+ 0.00887     0.16846     0.20805     1.000      Uani 0.007      4   
+Si1    Si4+ 0.00375     0.82051     0.23737     1.000      Uani 0.006      4   
+Si2    Si4+ 0.69162     0.11021     0.31466     1.000      Uani 0.006      4   
+Si3    Si4+ 0.68129     0.88190     0.36076     1.000      Uani 0.006      4   
+Na1    Na1+ 0.26799     0.98865     0.14650     1.000      Uani 0.031      4   
+O1     O2-  0.00490     0.13103     0.96660     1.000      Uani 0.012      4   
+O2     O2-  0.59176     0.99756     0.28040     1.000      Uani 0.008      4   
+O3     O2-  0.81230     0.10966     0.19010     1.000      Uani 0.014      4   
+O4     O2-  0.82000     0.85101     0.25870     1.000      Uani 0.018      4   
+O5     O2-  0.01288     0.30238     0.27060     1.000      Uani 0.011      4   
+O6     O2-  0.02329     0.69368     0.22910     1.000      Uani 0.011      4   
+O7     O2-  0.20780     0.10896     0.38900     1.000      Uani 0.011      4   
+O8     O2-  0.18400     0.86817     0.43620     1.000      Uani 0.012      4   
+
+loop_
+   _atom_site_aniso_label
+   _atom_site_aniso_U_11
+   _atom_site_aniso_U_22
+   _atom_site_aniso_U_33
+   _atom_site_aniso_U_12
+   _atom_site_aniso_U_13
+   _atom_site_aniso_U_23
+Al1    0.0074      0.0068      0.0061      -0.0009     0.0031      0.0004      
+Si1    0.0068      0.0065      0.0055      0.0011      0.0030      0.0008      
+Si2    0.0061      0.0055      0.0073      -0.0002     0.0025      0.0004      
+Si3    0.0060      0.0055      0.0074      0.0006      0.0028      0.0009      
+Na1    0.0136      0.0471      0.0315      -0.0050     0.0084      -0.0219     
+O1     0.0164      0.0122      0.0074      -0.0002     0.0067      0.0014      
+O2     0.0074      0.0056      0.0119      0.0003      0.0033      0.0020      
+O3     0.0117      0.0130      0.0162      -0.0040     0.0093      -0.0017     
+O4     0.0134      0.0179      0.0216      0.0046      0.0129      0.0020      
+O5     0.0103      0.0076      0.0150      -0.0020     0.0052      -0.0009     
+O6     0.0101      0.0071      0.0145      0.0022      0.0034      0.0012      
+O7     0.0120      0.0129      0.0080      0.0024      0.0013      0.0015      
+O8     0.0140      0.0140      0.0084      -0.0026     -0.0002     -0.0006     
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Al   4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Na   4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  O    32     ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si   12     ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Al Na O8 Si3"
+_chemical_formula_weight  262.22
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Al1    O1     1.74519      1_555    1_554 yes
+  Al1    O3     1.7429       1_555    1_455 yes
+  Al1    O5     1.73509      1_555    1_555 yes
+  Al1    O7     1.74556      1_555    1_555 yes
+  Si1    O1     1.59985      1_555    2_566 yes
+  Si1    O4     1.59997      1_555    1_455 yes
+  Si1    O6     1.62225      1_555    1_555 yes
+  Si1    O8     1.61907      1_555    1_555 yes
+  Si2    O2     1.63011      1_555    1_545 yes
+  Si2    O3     1.59435      1_555    1_555 yes
+  Si2    O6     1.61836      1_555    3_545 yes
+  Si2    O8     1.6168       1_555    2_666 yes
+  Si3    O2     1.64718      1_555    1_555 yes
+  Si3    O4     1.61975      1_555    1_555 yes
+  Si3    O5     1.59682      1_555    3_555 yes
+  Si3    O7     1.60203      1_555    2_666 yes
+  Na1    O1     2.66887      1_555    1_564 yes
+  Na1    O1     2.53079      1_555    2_566 yes
+  Na1    O2     2.3704       1_555    1_555 yes
+  Na1    O3     2.45321      1_555    2_665 yes
+  Na1    O7     2.43384      1_555    1_565 yes
+  O1     Al1    1.74519      1_555    1_556 yes
+  O1     Si1    1.59985      1_555    2_566 yes
+  O1     Na1    2.66887      1_555    1_546 yes
+  O1     Na1    2.53079      1_555    2_566 yes
+  O2     Si2    1.63011      1_555    1_565 yes
+  O2     Si3    1.64718      1_555    1_555 yes
+  O2     Na1    2.3704       1_555    1_555 yes
+  O3     Al1    1.7429       1_555    1_655 yes
+  O3     Si2    1.59435      1_555    1_555 yes
+  O3     Na1    2.45321      1_555    2_665 yes
+  O4     Si1    1.59997      1_555    1_655 yes
+  O4     Si3    1.61975      1_555    1_555 yes
+  O5     Al1    1.73509      1_555    1_555 yes
+  O5     Si3    1.59682      1_555    3_445 yes
+  O6     Si1    1.62225      1_555    1_555 yes
+  O6     Si2    1.61836      1_555    3_455 yes
+  O7     Al1    1.74556      1_555    1_555 yes
+  O7     Si3    1.60203      1_555    2_666 yes
+  O7     Na1    2.43384      1_555    1_545 yes
+  O8     Si1    1.61907      1_555    1_555 yes
+  O8     Si2    1.6168       1_555    2_666 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Al1    O3     102.836       1_554  1_555    1_455 yes
+  O1     Al1    O5     116.047       1_554  1_555    1_555 yes
+  O3     Al1    O5     112.215       1_455  1_555    1_555 yes
+  O1     Al1    O7     104.004       1_554  1_555    1_555 yes
+  O3     Al1    O7     111.151       1_455  1_555    1_555 yes
+  O5     Al1    O7     110.14        1_555  1_555    1_555 yes
+  O1     Si1    O4     109.433       2_566  1_555    1_455 yes
+  O1     Si1    O6     112.47        2_566  1_555    1_555 yes
+  O4     Si1    O6     108.187       1_455  1_555    1_555 yes
+  O1     Si1    O8     107.176       2_566  1_555    1_555 yes
+  O4     Si1    O8     111.446       1_455  1_555    1_555 yes
+  O6     Si1    O8     108.16        1_555  1_555    1_555 yes
+  O2     Si2    O3     111.144       1_545  1_555    1_555 yes
+  O2     Si2    O6     104.24        1_545  1_555    3_545 yes
+  O3     Si2    O6     112.114       1_555  1_555    3_545 yes
+  O2     Si2    O8     106.97        1_545  1_555    2_666 yes
+  O3     Si2    O8     111.591       1_555  1_555    2_666 yes
+  O6     Si2    O8     110.422       3_545  1_555    2_666 yes
+  O2     Si3    O4     107.269       1_555  1_555    1_555 yes
+  O2     Si3    O5     105.914       1_555  1_555    3_555 yes
+  O4     Si3    O5     110.224       1_555  1_555    3_555 yes
+  O2     Si3    O7     108.565       1_555  1_555    2_666 yes
+  O4     Si3    O7     110.208       1_555  1_555    2_666 yes
+  O5     Si3    O7     114.328       3_555  1_555    2_666 yes
+  Al1    O1     Si1    141.397       1_556  1_555    2_566 yes
+  Si2    O2     Si3    130.019       1_565  1_555    1_555 yes
+  Si2    O2     Na1    120.351       1_565  1_555    1_555 yes
+  Si3    O2     Na1    108.811       1_555  1_555    1_555 yes
+  Al1    O3     Si2    139.461       1_655  1_555    1_555 yes
+  Si1    O4     Si3    161.151       1_655  1_555    1_555 yes
+  Al1    O5     Si3    129.689       1_555  1_555    3_445 yes
+  Si1    O6     Si2    135.676       1_555  1_555    3_455 yes
+  Al1    O7     Si3    133.943       1_555  1_555    2_666 yes
+  Si1    O8     Si2    151.747       1_555  1_555    2_666 yes
+_pd_proc_ls_pref_orient_corr  none
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.177(14), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW1minmill_phase_4
+# Information for phase 4
+_pd_block_id  2021-08-04T18:19|NEW1minmill|phase_4|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Pyrrhotite 4M follows
+_pd_phase_name  "Pyrrhotite 4M"
+_cell_length_a  11.904(12)
+_cell_length_b  6.8784(21)
+_cell_length_c  12.814(15)
+_cell_angle_alpha  90
+_cell_angle_beta   117.119(25)
+_cell_angle_gamma  90
+_cell_volume  933.92(25)
+_exptl_crystal_density_diffrn  4.6045
+_symmetry_cell_setting  monoclinic
+_symmetry_space_group_name_H-M  "C 2/c"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -x,y,1/2-z
+     3  -x,-y,-z
+     4  x,-y,1/2+z
+     5  1/2+x,1/2+y,z
+     6  1/2-x,1/2+y,1/2-z
+     7  1/2-x,1/2-y,-z
+     8  1/2+x,1/2-y,1/2+z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+S1     S    0.01800     0.38330     0.11960     1.000      Uiso 0.010      8   
+S2     S    0.02910     0.11420     0.63900     1.000      Uiso 0.010      8   
+Fe3    Fe   0.10860     0.10250     0.49980     1.000      Uiso 0.010      8   
+S4     S    0.23410     0.13550     0.38260     1.000      Uiso 0.010      8   
+Fe5    Fe   0.24180     0.36600     0.24680     1.000      Uiso 0.010      8   
+S6     S    0.26790     0.13400     0.12360     1.000      Uiso 0.010      8   
+Fe7    Fe   0.38720     0.15000     0.01260     1.000      Uiso 0.010      8   
+Fe8    Fe   0.00000     0.14720     0.25000     1.000      Uiso 0.010      4   
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Fe   28     11.7695    7.3573     3.5222     2.3045     4.7611     0.3072     15.3535    76.8805    1.0369     0.945
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S    32     6.9053     5.2034     1.4379     1.5863     1.4679     22.2151    0.2536     56.172     0.8669     0.2847
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Fe7 S8"
+_chemical_formula_weight  647.41
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  S1     Fe3    2.49812      1_555    2_555 yes
+  S1     Fe5    2.41036      1_555    1_555 yes
+  S1     Fe7    2.39236      1_555    5_455 yes
+  S1     Fe7    2.43697      1_555    7_555 yes
+  S1     Fe8    2.40872      1_555    1_555 yes
+  S2     Fe3    2.37128      1_555    1_555 yes
+  S2     Fe3    2.32686      1_555    3_556 yes
+  S2     Fe5    2.44121      1_555    7_556 yes
+  S2     Fe7    2.36923      1_555    8_456 yes
+  S2     Fe8    2.41356      1_555    3_556 yes
+  Fe3    S1     2.49812      1_555    2_555 yes
+  Fe3    S2     2.37128      1_555    1_555 yes
+  Fe3    S2     2.32686      1_555    3_556 yes
+  Fe3    S6     2.45285      1_555    4_556 yes
+  S4     Fe5    2.38659      1_555    1_555 yes
+  Fe5    S1     2.41036      1_555    1_555 yes
+  Fe5    S2     2.44121      1_555    7_556 yes
+  Fe5    S4     2.38659      1_555    1_555 yes
+  Fe5    S6     2.36277      1_555    1_555 yes
+  S6     Fe3    2.45285      1_555    4_555 yes
+  S6     Fe5    2.36277      1_555    1_555 yes
+  S6     Fe7    2.42773      1_555    1_555 yes
+  S6     Fe7    2.39264      1_555    7_555 yes
+  Fe7    S1     2.39236      1_555    5_545 yes
+  Fe7    S1     2.43697      1_555    7_555 yes
+  Fe7    S2     2.36923      1_555    8_555 yes
+  Fe7    S6     2.42773      1_555    1_555 yes
+  Fe7    S6     2.39264      1_555    7_555 yes
+  Fe8    S1     2.40872      1_555    1_555 yes
+  Fe8    S1     2.40872      1_555    2_555 yes
+  Fe8    S2     2.41356      1_555    3_556 yes
+  Fe8    S2     2.41356      1_555    4_555 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.071(6), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW1minmill_phase_1
+# Information for phase 1
+_pd_block_id  2021-08-04T18:19|NEW1minmill|phase_1|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for SiO2 follows
+_pd_phase_name  SiO2
+_cell_length_a  4.9162(4)
+_cell_length_b  4.9162(4)
+_cell_length_c  5.4061(4)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  120
+_cell_volume  113.154(10)
+_exptl_crystal_density_diffrn  2.6452
+_symmetry_cell_setting  trigonal
+_symmetry_space_group_name_H-M  "P 32 2 1"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -y,x-y,2/3+z
+     3  y-x,-x,1/3+z
+     4  y,x,-z
+     5  -x,y-x,2/3-z
+     6  x-y,-y,1/3-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Si1    Si4+ 0.47000     0.00000     0.66670     1.000      Uani 0.006      3   
+O1     O2-  0.41460     0.26780     0.78543     1.000      Uani 0.011      6   
+
+loop_
+   _atom_site_aniso_label
+   _atom_site_aniso_U_11
+   _atom_site_aniso_U_22
+   _atom_site_aniso_U_33
+   _atom_site_aniso_U_12
+   _atom_site_aniso_U_13
+   _atom_site_aniso_U_23
+Si1    0.0073      0.0059      0.0053      0.0029      0.0003      0.0006      
+O1     0.0120      0.0105      0.0118      0.0065      -0.0029     -0.0040     
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  O    6      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si   3      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  3
+_chemical_formula_sum  "O2 Si"
+_chemical_formula_weight  60.08
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Si1    O1     1.60563      1_555    1_555 yes
+  Si1    O1     1.61187      1_555    2_654 yes
+  Si1    O1     1.61161      1_555    5_656 yes
+  Si1    O1     1.60577      1_555    6_556 yes
+  O1     Si1    1.60563      1_555    1_555 yes
+  O1     Si1    1.61187      1_555    3_665 yes
+  O1     Si1    1.61161      1_555    5_666 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Si1    O1     110.252       1_555  1_555    2_654 yes
+  O1     Si1    O1     108.754       1_555  1_555    5_656 yes
+  O1     Si1    O1     109.677       2_654  1_555    5_656 yes
+  O1     Si1    O1     109.158       1_555  1_555    6_556 yes
+  O1     Si1    O1     108.734       2_654  1_555    6_556 yes
+  O1     Si1    O1     110.258       5_656  1_555    6_556 yes
+  Si1    O1     Si1    143.831       1_555  1_555    3_665 yes
+  Si1    O1     Si1    143.835       1_555  1_555    5_666 yes
+  Si1    O1     Si1    0.009         3_665  1_555    5_666 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.220(14), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW1minmill_phase_3
+# Information for phase 3
+_pd_block_id  2021-08-04T18:19|NEW1minmill|phase_3|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for TiO2 follows
+_pd_phase_name  TiO2
+_cell_length_a  4.5994(25)
+_cell_length_b  4.5994(25)
+_cell_length_c  2.9601(22)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  90
+_cell_volume  62.62(5)
+_exptl_crystal_density_diffrn  4.2373
+_symmetry_cell_setting  tetragonal
+_symmetry_space_group_name_H-M  "P 42/m n m"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  1/2-y,1/2+x,1/2+z
+     3  -x,-y,z
+     4  1/2+y,1/2-x,1/2+z
+     5  1/2-x,1/2+y,1/2+z
+     6  -y,-x,z
+     7  1/2+x,1/2-y,1/2+z
+     8  y,x,z
+     9  -x,-y,-z
+    10  1/2+y,1/2-x,1/2-z
+    11  x,y,-z
+    12  1/2-y,1/2+x,1/2-z
+    13  1/2+x,1/2-y,1/2-z
+    14  y,x,-z
+    15  1/2-x,1/2+y,1/2-z
+    16  -y,-x,-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Ti1    Ti4+ 0.00000     0.00000     0.00000     1.000      Uani 0.006      2   
+O1     O2-  0.30493     0.30493     0.00000     1.000      Uani 0.006      4   
+
+loop_
+   _atom_site_aniso_label
+   _atom_site_aniso_U_11
+   _atom_site_aniso_U_22
+   _atom_site_aniso_U_33
+   _atom_site_aniso_U_12
+   _atom_site_aniso_U_13
+   _atom_site_aniso_U_23
+Ti1    0.0070      0.0070      0.0047      -0.0002     0.0000      0.0000      
+O1     0.0060      0.0060      0.0045      -0.0019     0.0000      0.0000      
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  O    4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Ti   2      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  2
+_chemical_formula_sum  "O2 Ti"
+_chemical_formula_weight  79.9
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Ti1    O1     1.98345      1_555    1_555 yes
+  Ti1    O1     1.94951      1_555    2_544 yes
+  Ti1    O1     1.94951      1_555    2_545 yes
+  Ti1    O1     1.98345      1_555    3_555 yes
+  Ti1    O1     1.94951      1_555    4_454 yes
+  Ti1    O1     1.94951      1_555    4_455 yes
+  O1     Ti1    1.98345      1_555    1_555 yes
+  O1     Ti1    1.94951      1_555    2_554 yes
+  O1     Ti1    1.94951      1_555    2_555 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Ti1    O1     90            1_555  1_555    2_544 yes
+  O1     Ti1    O1     90            1_555  1_555    2_545 yes
+  O1     Ti1    O1     98.787        2_544  1_555    2_545 yes
+  O1     Ti1    O1     180           1_555  1_555    3_555 yes
+  O1     Ti1    O1     90            2_544  1_555    3_555 yes
+  O1     Ti1    O1     90            2_545  1_555    3_555 yes
+  O1     Ti1    O1     90            1_555  1_555    4_454 yes
+  O1     Ti1    O1     81.213        2_544  1_555    4_454 yes
+  O1     Ti1    O1     180           2_545  1_555    4_454 yes
+  O1     Ti1    O1     90            3_555  1_555    4_454 yes
+  O1     Ti1    O1     90            1_555  1_555    4_455 yes
+  O1     Ti1    O1     180           2_544  1_555    4_455 yes
+  O1     Ti1    O1     81.213        2_545  1_555    4_455 yes
+  O1     Ti1    O1     90            3_555  1_555    4_455 yes
+  O1     Ti1    O1     98.787        4_454  1_555    4_455 yes
+  Ti1    O1     Ti1    130.606       1_555  1_555    2_554 yes
+  Ti1    O1     Ti1    130.606       1_555  1_555    2_555 yes
+  Ti1    O1     Ti1    98.787        2_554  1_555    2_555 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.100, 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW1minmill_pwd_0
+_pd_proc_ls_profile_function
+;
+Finger-Cox-Jephcoat function parameters U, V, W, X, Y, SH/L:
+  peak variance(Gauss) = Utan(Th)^2^+Vtan(Th)+W:
+  peak HW(Lorentz) = X/cos(Th)+Ytan(Th); SH/L = S/L+H/L
+  U, V, W in (centideg)^2^, X & Y in centideg
+    0.000, 0.000, 1.089, 0.882, 1.689, 0.058, 
+;
+# Information for histogram 0: PWDR BAT3_1min_milla_30mm_MonicaHamish_Ruoming_step size 0_1_min_mill_a.xrdml Scan 1
+_pd_block_id
+;
+2021-08-04T18:19|NEW1minmill|McDougallHamish|PANalytical,Co-EmpyreanII_hist_0
+;
+# GSAS-II edited template follows Instrument_Template
+#==============================================================================
+# 9. INSTRUMENT CHARACTERIZATION
+
+_exptl_special_details
+; ?
+;
+
+# if regions of the data are excluded, the reason(s) are supplied here:
+_pd_proc_info_excluded_regions
+; ?
+;
+
+# The following item is used to identify the equipment used to record 
+# the powder pattern when the diffractogram was measured at a laboratory 
+# other than the authors' home institution, e.g. when neutron or synchrotron
+# radiation is used.
+
+_pd_instr_location
+; ?
+;
+_pd_calibration_special_details           # description of the method used
+                                          # to calibrate the instrument
+; ?
+;
+
+_diffrn_source                    Co-Ka       
+_diffrn_source_target             Co
+_diffrn_source_type               Graded_Flat
+_diffrn_measurement_device_type   Panalytical_Reflection_Transmission       
+_diffrn_detector                  PIXcel1D       
+_diffrn_detector_type             Empyrean_II       # make or model of detector
+
+_pd_meas_scan_method              ?       # options are 'step', 'cont',
+                                          # 'tof', 'fixed' or
+                                          # 'disp' (= dispersive)
+_pd_meas_special_details
+;  ?
+;
+
+# The following two items identify the program(s) used (if appropriate).
+_computing_data_collection        ?        
+_computing_data_reduction         ?                   
+
+# Describe any processing performed on the data, prior to refinement.
+# For example: a manual Lp correction or a precomputed absorption correction
+_pd_proc_info_data_reduction      ?
+
+# The following item is used for angular dispersive measurements only.
+
+_diffrn_radiation_monochromator   ?        
+
+# The following items are used to define the size of the instrument.
+# Not all distances are appropriate for all instrument types.
+
+_pd_instr_dist_src/mono           ?
+_pd_instr_dist_mono/spec          ?
+_pd_instr_dist_src/spec           ?
+_pd_instr_dist_spec/anal          ?
+_pd_instr_dist_anal/detc          ?
+_pd_instr_dist_spec/detc          ?
+
+# 10. Specimen size and mounting information
+
+# The next three fields give the specimen dimensions in mm.  The equatorial 
+# plane contains the incident and diffracted beam.
+
+_pd_spec_size_axial               ?       # perpendicular to 
+                                          # equatorial plane
+
+_pd_spec_size_equat               ?       # parallel to 
+                                          # scattering vector 
+                                          # in transmission
+
+_pd_spec_size_thick               ?       # parallel to 
+                                          # scattering vector 
+                                          # in reflection
+
+_pd_spec_mounting                         # This field should be
+                                          # used to give details of the 
+                                          # container.
+; ?
+;
+
+_pd_spec_mount_mode               ?       # options are 'reflection' 
+                                          # or 'transmission'
+    
+_pd_spec_shape                    ?       # options are 'cylinder' 
+                                          # 'flat_sheet' or 'irregular'
+
+
+loop_
+     _atom_type_symbol
+     _atom_type_scat_dispersion_real
+     _atom_type_scat_dispersion_imag
+     _atom_type_scat_dispersion_source
+  Al        0.255   0.328   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Fe       -3.332   0.490   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Na        0.167   0.167   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  O         0.063   0.044   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S         0.371   0.733   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si        0.298   0.438   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Ti       -0.063   2.321   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+_diffrn_radiation_type  K\a~1,2~
+loop_
+   _diffrn_radiation_wavelength
+   _diffrn_radiation_wavelength_wt
+   _diffrn_radiation_wavelength_id
+  1.78892         1.0             1     
+  1.79278         0.5000          2     
+
+# PHASE TABLE
+loop_
+   _pd_phase_id
+   _pd_phase_block_id
+   _pd_phase_mass_%
+  0  2021-08-04T18:19|NEW1minmill|phase_0|McDougallHamish  0.731(4)
+  2  2021-08-04T18:19|NEW1minmill|phase_2|McDougallHamish  0.133(3)
+  4  2021-08-04T18:19|NEW1minmill|phase_4|McDougallHamish  0.0539(16)
+  1  2021-08-04T18:19|NEW1minmill|phase_1|McDougallHamish  0.0754(13)
+  3  2021-08-04T18:19|NEW1minmill|phase_3|McDougallHamish  0.0072(8)
+loop_
+   _gsas_proc_phase_R_F_factor
+   _gsas_proc_phase_R_Fsqd_factor
+   _gsas_proc_phase_id
+   _gsas_proc_phase_block_id
+    0.06473  0.11770  0  2021-08-04T18:19|NEW1minmill|phase_0|McDougallHamish
+    0.13114  0.28099  2  2021-08-04T18:19|NEW1minmill|phase_2|McDougallHamish
+    0.11500  0.24264  4  2021-08-04T18:19|NEW1minmill|phase_4|McDougallHamish
+    0.08345  0.16213  1  2021-08-04T18:19|NEW1minmill|phase_1|McDougallHamish
+    0.11629  0.33088  3  2021-08-04T18:19|NEW1minmill|phase_3|McDougallHamish
+_pd_proc_ls_prof_R_factor     0.09508
+_pd_proc_ls_prof_wR_factor    0.13200
+_gsas_proc_ls_prof_R_B_factor   0.12376
+_gsas_proc_ls_prof_wR_B_factor  0.16147
+_pd_proc_ls_prof_wR_expected  0.04302
+_diffrn_radiation_probe  x-ray
+_diffrn_radiation_polarisn_ratio  0.7000
+_pd_proc_ls_background_function
+;
+Background function: "chebyschev-1" function with 7 terms:
+    416.1(17), -490.8(28), 375.8(27), -195.5(24), 98.2(22), -36.4(17), 
+    8.9(15), 
+;
+_diffrn_ambient_temperature  300
+_diffrn_ambient_pressure  100
+
+# STRUCTURE FACTOR TABLE
+loop_
+   _pd_refln_phase_id
+   _refln_index_h
+   _refln_index_k
+   _refln_index_l
+   _refln_F_squared_meas
+   _refln_F_squared_calc
+   _refln_phase_calc
+   _refln_d_spacing
+   _gsas_i100_meas
+  0  1    1    1    837.5122   818.8476   0.0     3.12911  20.97  
+  0  2    0    0    6987.0490  6378.4820  -0.0    2.70989  97.00  
+  0  2    1    0    2890.4973  3259.8770  0.0     2.42380  63.39  
+  0  2    1    1    1787.6568  1674.1551  -180.0  2.21261  64.62  
+  0  2    2    0    2676.8059  3256.8520  -0.0    1.91618  35.71  
+  0  2    2    1    39.3829    43.0663    -0.0    1.80659  0.93   
+  0  3    1    1    5184.8362  5012.3659  -0.0    1.63412  100.00 
+  0  2    2    2    2016.4784  2253.0940  0.0     1.56455  11.92  
+  0  3    0    2    2996.0845  2977.7832  -0.0    1.50317  24.69  
+  0  3    1    2    493.5363   526.6229   0.0     1.44850  7.62   
+  0  3    2    1    1511.5200  1612.8522  180.0   1.44850  23.35  
+  0  4    0    0    480.1350   344.3256   -180.0  1.35494  1.67   
+  0  3    2    2    38.0741    46.4103    -0.0    1.31449  0.51   
+  0  4    1    0    94.0183    114.6032   -0.0    1.31449  0.63   
+  0  4    1    1    69.3979    62.6129    180.0   1.27745  0.90   
+  0  3    3    1    500.5286   561.9376   -0.0    1.24338  6.30   
+  0  4    0    2    894.5422   793.3344   0.0     1.21190  5.53   
+  0  4    2    0    894.5422   793.3344   0.0     1.21190  5.53   
+  0  4    1    2    2.1639     1.8357     -0.0    1.18269  0.03   
+  0  4    2    1    1450.0778  1230.1866  -180.0  1.18269  17.69  
+  0  3    3    2    716.5935   623.9322   0.0     1.15550  8.69   
+  0  4    2    2    1374.1670  928.6766   0.0     1.10631  16.82  
+  0  4    3    0    106.5321   139.6802   -0.0    1.08395  0.66   
+  0  4    1    3    60.0496    76.8277    -180.0  1.06291  0.76   
+  0  4    3    1    19.6072    25.0855    0.0     1.06291  0.25   
+  0  3    3    3    1699.4442  1375.9176  -0.0    1.04304  7.42   
+  0  5    1    1    3700.3894  2995.9389  -0.0    1.04304  48.48  
+  1  1    0    0    307.0577   242.5267   180.0   4.25752  1.16   
+  1  1    0    -1   1497.8281  1509.4485  -120.0  3.34480  3.44   
+  1  1    0    1    629.6147   634.4994   120.0   3.34480  1.44   
+  1  1    1    0    496.0535   343.8890   -155.6  2.45808  0.60   
+  1  1    0    2    417.8839   298.8520   -120.0  2.28199  0.43   
+  1  1    0    -2   120.5196   86.1903    -60.0   2.28199  0.12   
+  1  1    1    1    92.7349    96.0660    82.9    2.23764  0.18   
+  1  2    0    0    399.2701   308.9201   -0.0    2.12876  0.35   
+  1  2    0    -1   90.1319    77.2268    60.0    1.98073  0.07   
+  1  2    0    1    216.0015   185.0743   -60.0   1.98073  0.16   
+  1  1    1    2    613.3117   602.8883   9.8     1.81858  0.78   
+  1  0    0    3    70.9394    94.4539    0.0     1.80204  0.01   
+  1  2    0    -2   395.4825   364.2694   120.0   1.67240  0.21   
+  1  2    0    2    89.1277    82.0934    60.0    1.67240  0.05   
+  1  1    0    -3   260.0211   203.8550   180.0   1.65951  0.14   
+  1  1    0    3    3.2974     2.5852     0.0     1.65951  0.00   
+  1  2    1    0    23.2728    14.6471    -38.9   1.60919  0.02   
+  1  2    1    -1   499.6835   356.4103   95.9    1.54231  0.46   
+  1  2    1    1    430.0605   306.7502   -109.6  1.54231  0.39   
+  1  1    1    3    136.9561   142.5823   117.5   1.45333  0.11   
+  1  3    0    0    71.2590    76.3725    180.0   1.41917  0.03   
+  1  2    1    -2   385.2836   413.8478   -123.3  1.38272  0.29   
+  1  2    1    2    119.6259   128.4947   143.4   1.38272  0.09   
+  1  2    0    -3   273.8589   292.6715   -0.0    1.37540  0.10   
+  1  2    0    3    964.2463   1030.4844  0.0     1.37540  0.36   
+  1  3    0    -1   671.0310   815.9932   -120.0  1.37266  0.25   
+  1  3    0    1    0.8360     1.0166     -60.0   1.37266  0.00   
+  1  1    0    -4   120.7667   120.2826   -120.0  1.28818  0.04   
+  1  1    0    4    398.0481   396.4524   120.0   1.28818  0.14   
+  1  3    0    -2   136.8918   208.3560   120.0   1.25652  0.05   
+  1  3    0    2    312.0759   474.9945   -120.0  1.25652  0.11   
+  1  2    2    0    387.8696   371.1299   -16.5   1.22904  0.13   
+  1  2    1    -3   63.9821    71.0165    179.1   1.20028  0.04   
+  1  2    1    3    271.5908   301.4501   -134.8  1.20028  0.18   
+  1  2    2    1    107.9721   105.6120   88.6    1.19846  0.07   
+  1  1    1    4    471.9220   334.1867   -14.4   1.18432  0.31   
+  1  3    1    0    415.4680   361.6404   121.4   1.18082  0.27   
+  1  3    1    -1   209.9201   189.9632   -18.5   1.15362  0.14   
+  1  3    1    1    70.0690    63.4076    16.4    1.15362  0.05   
+  1  2    0    4    72.7203    70.6840    120.0   1.14099  0.02   
+  1  2    0    -4   1.5160     1.4735     -120.0  1.14099  0.00   
+  1  2    2    2    1.8381     3.3522     -9.9    1.11882  0.00   
+  1  3    0    3    71.0156    62.7375    -180.0  1.11493  0.02   
+  1  3    0    -3   7.5716     6.6890     -0.0    1.11493  0.00   
+  1  3    1    -2   219.6848   304.4168   -8.9    1.08208  0.15   
+  1  3    1    2    89.7569    124.3760   59.1    1.08208  0.06   
+  1  4    0    0    108.8167   168.2196   0.0     1.06438  0.04   
+  1  1    0    -5   415.9661   346.2831   120.0   1.04796  0.14   
+  1  1    0    5    156.0583   129.9153   -120.0  1.04796  0.05   
+  1  4    0    -1   38.0175    31.4137    60.0    1.04433  0.01   
+  1  4    0    1    350.6909   289.7750   120.0   1.04433  0.12   
+  1  2    1    -4   9.3276     10.8630    51.2    1.03493  0.01   
+  1  2    1    4    206.8612   240.9124   -129.5  1.03493  0.15   
+  2  0    0    1    1760.7694  685.7541   180.0   6.38786  0.16   
+  2  0    2    0    969.6625   396.3962   180.0   6.37466  0.03   
+  2  1    1    0    549.2777   238.2363   -0.0    6.33955  0.02   
+  2  1    -1   0    827.9147   287.4879   -0.0    6.29869  0.03   
+  2  1    1    -1   1037.1224  406.2352   180.0   5.91009  0.03   
+  2  1    -1   -1   482.5490   415.6378   -180.0  5.58552  0.02   
+  2  0    2    -1   4.7377     16.5792    0.0     4.66174  0.00   
+  2  0    2    1    3.1232     1.8371     180.0   4.37623  0.00   
+  2  2    0    -1   19310.5322 21037.4763 -0.0    4.02732  0.24   
+  2  1    -1   1    6489.2494  3767.3897  -0.0    3.85265  0.12   
+  2  1    1    1    8852.8737  10390.3834 0.0     3.77565  0.20   
+  2  1    3    0    9361.7579  5886.9121  180.0   3.68167  0.11   
+  2  1    3    -1   7390.9539  4505.3267  0.0     3.66562  0.07   
+  2  1    -3   0    15591.2561 11675.3013 180.0   3.65766  0.15   
+  2  2    0    0    1.9047     2.5781     0.0     3.63776  0.00   
+  2  1    1    -2   5696.9384  4328.5159  0.0     3.50520  0.10   
+  2  2    2    -1   4111.8691  1650.0035  180.0   3.48122  0.04   
+  2  1    -3   -1   79.2330    12.1276    0.0     3.43616  0.00   
+  2  1    -1   -2   7147.1650  5251.4578  0.0     3.37264  0.14   
+  2  2    -2   -1   267.5771   364.8637   0.0     3.33313  0.00   
+  2  2    0    -2   24784.6770 26655.4799 -180.0  3.21484  0.26   
+  2  0    0    2    38362.8902 37071.8044 -180.0  3.19393  0.86   
+  2  0    4    0    24744.5220 25362.8195 180.0   3.18733  0.19   
+  2  2    2    0    12022.7512 13873.6743 180.0   3.16977  0.11   
+  2  2    -2   0    13241.1477 14946.6082 -180.0  3.14934  0.10   
+  2  1    -3   1    15844.7178 11175.2497 -180.0  2.96418  0.12   
+  2  2    2    -2   7506.1613  7187.5067  0.0     2.95504  0.06   
+  2  0    2    -2   6874.2343  5310.5610  0.0     2.93060  0.08   
+  2  0    4    -1   9624.6592  8585.7945  0.0     2.92677  0.06   
+  2  1    3    1    9253.0085  6897.0276  180.0   2.86133  0.10   
+  2  1    3    -2   2137.1464  1923.0466  -0.0    2.83885  0.02   
+  2  2    -2   -2   222.0723   183.4547   -0.0    2.79276  0.00   
+  2  0    2    2    208.0175   191.6414   0.0     2.78600  0.00   
+  2  0    4    1    430.9781   387.5360   -0.0    2.78271  0.00   
+  2  2    0    1    102.2844   109.5836   -0.0    2.68712  0.00   
+  2  3    1    -1   346.3515   431.0071   -180.0  2.66293  0.00   
+  2  1    -3   -2   5704.0184  6171.6319  -0.0    2.63839  0.05   
+  2  3    -1   -1   28.8078    33.5476    -180.0  2.62530  0.00   
+  2  2    4    -1   17379.1647 12550.4891 -180.0  2.55995  0.08   
+  2  3    1    -2   2870.9062  1812.0722  180.0   2.53704  0.01   
+  2  1    -1   2    1086.1077  667.2869   180.0   2.51139  0.01   
+  2  2    -2   1    2608.9500  1686.7859  -180.0  2.49495  0.02   
+  2  3    -1   -2   485.9393   451.5613   180.0   2.48043  0.00   
+  2  1    1    2    133.4148   110.2849   180.0   2.46610  0.00   
+  2  2    2    1    1990.1671  1367.0046  -180.0  2.45771  0.01   
+  2  2    -4   -1   15395.1790 10453.7459 -180.0  2.44277  0.07   
+  2  1    5    -1   4043.1245  4093.1663  -0.0    2.42941  0.02   
+  2  1    5    0    48.2766    64.0884    180.0   2.41202  0.00   
+  2  2    4    0    3172.4144  3944.1458  -0.0    2.40628  0.02   
+  2  1    -5   0    1870.3275  2230.8323  180.0   2.40074  0.01   
+  2  2    -4   0    2063.1379  2079.3222  -0.0    2.38844  0.01   
+  2  3    1    0    1536.8965  1565.2946  -0.0    2.38575  0.01   
+  2  3    -1   0    1728.6479  2090.0863  -0.0    2.37918  0.01   
+  2  2    0    -3   6.3833     7.3701     180.0   2.35133  0.00   
+  2  2    4    -2   2.3964     2.9331     0.0     2.34729  0.00   
+  2  1    1    -3   109.6612   110.8373   -0.0    2.33656  0.00   
+  2  0    4    -2   1262.8542  884.3144   -180.0  2.33087  0.01   
+  2  3    3    -1   26675.1237 9809.7794  180.0   2.31766  0.10   
+  2  1    -5   -1   2726.0455  1044.9800  0.0     2.31526  0.01   
+  2  1    -1   -3   2954.9525  2291.2470  -0.0    2.27750  0.03   
+  2  2    2    -3   215.9273   155.6865   -0.0    2.26146  0.00   
+  2  3    3    -2   19.6002    15.9172    0.0     2.25070  0.00   
+  2  3    -3   -1   2793.7510  2703.2457  -180.0  2.24518  0.01   
+  2  1    -3   2    820.3354   824.7896   -0.0    2.22556  0.00   
+  2  0    4    2    5400.0899  2085.0250  0.0     2.18812  0.04   
+  2  2    -4   -2   3719.8426  1431.8638  0.0     2.18799  0.02   
+  2  1    -5   1    9636.3483  4194.8986  180.0   2.18493  0.03   
+  2  2    -2   -3   2139.1206  1851.4932  0.0     2.15451  0.01   
+  2  1    5    -2   339.4683   312.7232   -180.0  2.15169  0.00   
+  2  3    1    -3   152.1173   204.6119   0.0     2.13824  0.00   
+  2  3    -3   -2   385.6241   512.1941   180.0   2.13724  0.00   
+  2  1    3    2    168.2470   174.4523   -180.0  2.13433  0.00   
+  2  0    0    3    576.5051   454.6548   -0.0    2.12929  0.01   
+  2  0    6    0    13533.0831 11042.6256 -0.0    2.12489  0.04   
+  2  1    3    -3   660.2374   674.2906   -180.0  2.11876  0.00   
+  2  1    5    1    4358.4702  4734.7647  180.0   2.11595  0.02   
+  2  3    3    0    1381.7339  1496.6439  -180.0  2.11318  0.01   
+  2  3    -3   0    80.2897    182.7827   -180.0  2.09956  0.00   
+  2  3    -1   -3   1203.8373  2416.5634  0.0     2.08973  0.01   
+  2  2    -4   1    7304.8953  8370.0925  180.0   2.07604  0.03   
+  2  0    2    -3   253.6244   286.8930   -180.0  2.05903  0.00   
+  2  0    6    -1   68.0970    83.9001    -0.0    2.05549  0.00   
+  2  2    4    1    1904.3692  2723.1302  180.0   2.03350  0.01   
+  2  4    0    -2   1088.3778  1673.8545  -0.0    2.01366  0.00   
+  2  1    -5   -2   583.0932   976.2191   -0.0    2.00557  0.00   
+  2  4    0    -1   2197.0104  3207.5402  -0.0    2.00025  0.01   
+  2  2    0    2    638.5652   914.6787   0.0     1.99827  0.00   
+  2  1    -3   -3   1767.2984  2006.9284  -0.0    1.99351  0.01   
+  2  0    2    3    1379.0888  1320.4879  0.0     1.98235  0.01   
+  2  0    6    1    5915.4139  4760.1395  0.0     1.97919  0.02   
+  2  3    -1   1    1331.2757  1778.1424  0.0     1.97162  0.01   
+  2  3    3    -3   494.7831   747.2487   -180.0  1.97003  0.00   
+  2  3    1    1    634.2055   1049.8991  0.0     1.96352  0.00   
+  2  2    4    -3   126.4250   210.6125   -180.0  1.96339  0.00   
+  2  4    2    -2   936.0749   1505.1300  0.0     1.94723  0.00   
+  2  2    -2   2    3436.3799  4434.5615  -0.0    1.92633  0.02   
+  2  4    2    -1   149.1592   195.3738   0.0     1.92397  0.00   
+  2  2    6    -1   20.8308    25.7092    -0.0    1.91781  0.00   
+  2  4    -2   -2   9686.3336  14612.2943 -0.0    1.89414  0.02   
+  2  4    -2   -1   54.5080    83.9894    180.0   1.89341  0.00   
+  2  3    5    -1   2206.0979  3253.1319  -180.0  1.88804  0.01   
+  2  2    2    2    7589.6442  11147.4650 -0.0    1.88782  0.04   
+  2  3    -3   -3   84.1629    242.1347   -0.0    1.86184  0.00   
+  2  3    5    -2   54.1500    151.7748   -180.0  1.86122  0.00   
+  2  4    0    -3   13837.8559 17227.6438 -180.0  1.84958  0.04   
+  2  2    -6   -1   492.8976   630.1904   -180.0  1.84310  0.00   
+  2  1    -5   2    25.6544    32.7906    -180.0  1.84286  0.00   
+  2  2    6    0    4799.7629  5973.8074  -0.0    1.84084  0.01   
+  2  2    6    -2   2800.9960  2234.4122  -180.0  1.83281  0.01   
+  2  1    -1   3    3172.1808  2403.8627  -180.0  1.82957  0.02   
+  2  2    -6   0    13760.5854 11170.3478 0.0     1.82883  0.03   
+  2  2    -4   -3   419.3468   351.5785   -0.0    1.82817  0.00   
+  2  0    4    -3   7311.1450  6600.1943  180.0   1.82454  0.03   
+  2  3    -5   -1   557.2685   547.0575   -180.0  1.82305  0.00   
+  2  0    6    -2   9547.7088  9376.7847  -180.0  1.82300  0.02   
+  2  4    0    0    16770.9319 16544.7345 -0.0    1.81888  0.04   
+  2  3    -3   1    1307.7873  1388.1619  -0.0    1.81269  0.00   
+  2  4    2    -3   1557.8336  1698.2109  -0.0    1.80678  0.00   
+  2  1    1    3    10327.4006 13204.6231 -180.0  1.80269  0.07   
+  2  3    3    1    642.9679   659.8672   -0.0    1.79396  0.00   
+  2  1    5    -3   34.3240    36.9138    180.0   1.79152  0.00   
+  2  1    7    -1   409.5504   370.2527   -180.0  1.78554  0.00   
+  2  2    0    -4   32342.2682 29304.7955 0.0     1.78457  0.16   
+  2  1    7    0    2215.3788  1186.7943  -0.0    1.76994  0.01   
+  2  3    5    0    562.8465   192.4714   -180.0  1.76391  0.00   
+  2  1    -7   0    5584.8832  1861.7091  0.0     1.76369  0.01   
+  2  1    5    2    5615.0030  1478.1411  -180.0  1.75728  0.02   
+  2  3    -5   -2   921.0621   292.8600   -180.0  1.75539  0.00   
+  2  2    2    -4   9647.4650  5374.4235  180.0   1.75260  0.04   
+  2  4    2    0    5768.0405  3240.2714  180.0   1.75255  0.01   
+  2  3    -5   0    1.0365     0.6787     -180.0  1.75073  0.00   
+  2  4    -2   -3   1998.8873  1498.9920  -180.0  1.74735  0.00   
+  2  4    -2   0    1869.5698  1478.3757  -180.0  1.74562  0.00   
+  2  4    4    -2   15518.7528 11156.5991 -180.0  1.74061  0.03   
+  2  3    1    -4   20.9640    11.6942    0.0     1.73791  0.00   
+  2  1    1    -4   1732.8634  931.5858   180.0   1.73044  0.01   
+  2  0    4    3    2049.6155  1649.4123  180.0   1.72108  0.01   
+  2  1    -7   -1   674.4483   544.5769   -0.0    1.72100  0.00   
+  2  2    -4   2    6253.0542  5111.9528  -180.0  1.72066  0.02   
+  2  0    6    2    4853.6006  4043.0244  180.0   1.71979  0.02   
+  2  2    -6   -2   6736.2056  5843.5104  180.0   1.71808  0.02   
+  2  1    -3   3    4406.7142  3889.7621  0.0     1.71755  0.02   
+  2  4    4    -1   3739.5915  3425.3612  -0.0    1.71605  0.01   
+  2  3    -1   -4   29.8187    26.3196    -0.0    1.70384  0.00   
+  2  3    5    -3   2212.7714  1781.5059  180.0   1.70048  0.00   
+  2  1    -1   -4   1371.2098  1087.2281  180.0   1.69839  0.01   
+  2  2    -2   -4   5513.8533  6607.2640  -0.0    1.68632  0.03   
+  2  2    -6   1    101.6055   111.8094   180.0   1.68403  0.00   
+  2  1    -7   1    1227.1499  1037.6002  0.0     1.67991  0.00   
+  2  1    7    -2   3448.9695  3014.1863  0.0     1.67337  0.01   
+  2  4    -4   -1   3530.1848  3113.5342  -0.0    1.67328  0.01   
+  2  1    -5   -3   327.4791   322.6770   -180.0  1.66739  0.00   
+  2  2    4    2    7088.4022  6980.1241  -180.0  1.66673  0.03   
+  2  4    -4   -2   3070.3211  2996.9232  -180.0  1.66656  0.01   
+  2  1    3    3    655.7614   605.4945   0.0     1.65314  0.00   
+  2  3    3    -4   500.7155   474.5918   180.0   1.65084  0.00   
+  2  2    6    1    15.3309    15.0623    180.0   1.64996  0.00   
+  2  4    4    -3   80.6696    81.5092    0.0     1.64497  0.00   
+  2  1    3    -4   1263.8168  1267.0308  -180.0  1.64299  0.00   
+  2  2    6    -3   408.5156   438.3802   0.0     1.63845  0.00   
+  2  1    7    1    995.0581   959.6711   0.0     1.63566  0.00   
+  2  5    1    -2   55.0153    62.3555    -180.0  1.62122  0.00   
+  2  2    4    -4   10.9534    6.6299     0.0     1.60885  0.00   
+  2  3    -1   2    430.0656   237.1891   -180.0  1.60779  0.00   
+  2  4    0    -4   46.1227    25.5451    0.0     1.60742  0.00   
+  2  5    -1   -2   172.2008   104.4782   -0.0    1.60481  0.00   
+  2  3    1    2    7.0268     3.3755     -180.0  1.59704  0.00   
+  2  0    0    4    3602.2208  1719.5025  -0.0    1.59697  0.02   
+  2  0    8    0    8512.1115  4104.7411  -0.0    1.59366  0.02   
+  2  3    -5   -3   7029.6008  7048.0684  -180.0  1.58673  0.02   
+  2  4    2    -4   5381.8867  5767.4424  -180.0  1.58523  0.01   
+  2  4    4    0    74.8888    80.5872    180.0   1.58489  0.00   
+  2  3    -5   1    3404.0118  3541.7994  0.0     1.57987  0.01   
+  2  1    -7   -2   97.3188    106.0592   180.0   1.57566  0.00   
+  2  4    -4   0    904.2432   972.7791   180.0   1.57467  0.00   
+  2  4    0    1    1227.0861  1313.3627  0.0     1.57405  0.00   
+  2  0    2    -4   6296.9019  6835.8768  -180.0  1.57267  0.03   
+  2  5    1    -1   1677.4923  1838.8969  0.0     1.57223  0.00   
+  2  5    1    -3   4.2398     4.5305     0.0     1.57056  0.00   
+  2  0    8    -1   4839.4193  5105.5113  -180.0  1.56971  0.01   
+  2  3    -3   -4   201.6155   222.0271   -180.0  1.56739  0.00   
+  2  1    -3   -4   1058.1254  1168.3240  -180.0  1.56437  0.00   
+  2  5    -1   -1   3249.7348  3532.8589  -0.0    1.56314  0.01   
+  2  3    5    1    5771.3101  6630.5027  -0.0    1.55930  0.01   
+  2  2    0    3    1534.8118  1763.6711  -180.0  1.55911  0.01   
+  2  4    -4   -3   577.0871   668.2938   0.0     1.55805  0.00   
+  2  0    6    -3   44.6343    50.4752    180.0   1.55391  0.00   
+  2  5    -1   -3   2988.8505  3177.9812  180.0   1.54983  0.01   
+  2  5    3    -2   2684.5311  1684.3120  0.0     1.53962  0.00   
+  2  3    7    -1   440.8410   255.3064   -0.0    1.53554  0.00   
+  2  4    -2   -4   6975.9522  4566.3850  180.0   1.53333  0.02   
+  2  4    -2   1    598.3388   360.2122   -0.0    1.53138  0.00   
+  2  2    -2   3    5526.2970  3884.5431  0.0     1.52972  0.02   
+  2  1    -5   3    170.0730   114.2358   180.0   1.52775  0.00   
+  2  0    2    4    2848.7309  1999.2534  180.0   1.52655  0.01   
+  2  3    7    -2   2019.3472  1417.6951  180.0   1.52649  0.00   
+  2  4    2    1    77.8726    55.0425    -0.0    1.52494  0.00   
+  2  0    8    1    73.0159    53.4117    0.0     1.52385  0.00   
+  2  3    -3   2    1013.6910  713.5252   0.0     1.52351  0.00   
+  2  2    -6   -3   1421.3891  972.3599   180.0   1.52111  0.00   
+  2  1    -7   2    2851.7517  2092.8268  180.0   1.51406  0.01   
+  2  2    -4   -4   4474.5733  3475.0688  -180.0  1.51008  0.01   
+  2  2    8    -1   9290.2363  8932.7653  0.0     1.50687  0.01   
+  2  5    3    -3   10907.9721 11216.4371 -0.0    1.50125  0.02   
+  2  2    2    3    239.2054   261.4234   0.0     1.49966  0.00   
+  2  5    -3   -2   1123.2703  1283.3165  0.0     1.49852  0.00   
+  2  4    6    -2   1418.5638  1643.4734  -180.0  1.49804  0.00   
+  2  3    3    2    2442.4667  2828.3266  0.0     1.49651  0.01   
+  2  5    3    -1   1321.6913  1375.8687  180.0   1.49230  0.00   
+  2  1    7    -3   970.8679   963.7100   -0.0    1.49138  0.00   
+  2  3    5    -4   1033.5989  976.7543   0.0     1.48741  0.00   
+  2  3    -7   -1   4.6341     4.1505     -180.0  1.48641  0.00   
+  2  2    -6   2    2309.5314  2225.9899  -180.0  1.48209  0.00   
+  2  1    5    -4   613.5251   569.2303   -0.0    1.48061  0.00   
+  2  4    4    -4   1027.9118  936.8644   -0.0    1.47752  0.00   
+  2  4    6    -1   2757.8799  2425.3077  -0.0    1.47727  0.00   
+  2  2    8    -2   2624.7372  2036.6290  -0.0    1.46947  0.00   
+  2  5    -3   -1   2862.8323  2250.7625  180.0   1.46932  0.00   
+  2  0    4    -4   2218.8515  1799.2981  0.0     1.46530  0.01   
+  2  2    8    0    21368.0253 17372.8918 180.0   1.46378  0.04   
+  2  0    8    -2   3244.2964  2670.5014  0.0     1.46338  0.01   
+  2  3    7    0    1634.1144  1344.4772  -0.0    1.46164  0.00   
+  2  0    6    3    9763.6158  9727.2084  -180.0  1.45874  0.03   
+  2  2    -8   -1   292.4753   277.6153   0.0     1.45806  0.00   
+  2  2    -8   0    14494.5185 14971.6548 -180.0  1.45572  0.02   
+  2  1    5    3    81.3642    84.4701    0.0     1.45352  0.00   
+  2  3    -7   0    1732.1670  1874.7884  -0.0    1.45113  0.00   
+  2  5    -3   -3   3782.2910  3973.0050  -0.0    1.44873  0.01   
+  2  1    7    2    317.4993   339.6716   180.0   1.44736  0.00   
+  2  5    1    0    437.2516   468.7582   0.0     1.44694  0.00   
+  2  5    -1   0    259.5964   282.6566   0.0     1.44450  0.00   
+  2  3    -7   -2   376.0626   407.5222   -180.0  1.44435  0.00   
+  2  5    1    -4   347.1225   376.0669   -0.0    1.44434  0.00   
+  2  4    6    -3   5276.4244  4799.2632  180.0   1.44037  0.01   
+  2  3    7    -3   2387.1639  2066.9126  0.0     1.43858  0.00   
+  2  4    -6   -1   17284.9119 13974.0377 -0.0    1.43651  0.02   
+  2  1    -1   4    2420.9450  1747.7612  -0.0    1.43156  0.01   
+  2  2    6    2    18876.1530 14127.5120 -180.0  1.43067  0.05   
+  2  4    -6   -2   14849.7124 11494.7453 -180.0  1.42772  0.02   
+  2  3    1    -5   71.2384    54.5453    0.0     1.42498  0.00   
+  2  2    -4   3    12149.7747 9304.7725  -0.0    1.42492  0.03   
+  2  5    -1   -4   7747.2791  6191.0063  0.0     1.42367  0.01   
+  2  2    0    -5   511.6541   530.6717   -0.0    1.41970  0.00   
+  2  2    6    -4   3899.0773  4109.1661  -0.0    1.41942  0.01   
+  2  4    -4   1    2152.8582  2328.2327  -180.0  1.41643  0.00   
+  2  1    1    4    7646.3313  9765.5200  -0.0    1.41417  0.03   
+  2  2    2    -5   136.6449   102.1798   180.0   1.40774  0.00   
+  2  4    4    1    4903.4700  4251.1055  -180.0  1.40628  0.01   
+  2  1    9    -1   477.6548   313.3806   180.0   1.40427  0.00   
+  2  3    -1   -5   969.6305   559.2035   180.0   1.40173  0.00   
+  2  5    5    -2   153.0620   121.8591   180.0   1.39689  0.00   
+  2  4    -4   -4   442.0674   333.7965   -180.0  1.39638  0.00   
+  2  5    3    -4   9984.7582  10290.7248 -180.0  1.39407  0.02   
+  2  0    4    4    552.8930   603.2489   180.0   1.39300  0.00   
+  2  1    9    0    5526.4004  6061.3448  -180.0  1.39244  0.01   
+  2  0    8    2    756.2924   841.8614   -0.0    1.39135  0.00   
+  2  1    -7   -3   7.8153     8.6161     0.0     1.39082  0.00   
+  2  2    -8   -2   320.8616   389.1003   0.0     1.38958  0.00   
+  2  1    -9   0    4278.6786  5032.6219  -180.0  1.38852  0.01   
+  2  3    -5   -4   608.6716   712.8918   180.0   1.38828  0.00   
+  2  1    -5   -4   10.7772    12.2841    -0.0    1.38705  0.00   
+  2  4    6    0    6052.2587  6881.9956  0.0     1.38694  0.01   
+  2  2    -8   1    2522.4586  2583.5813  -0.0    1.38353  0.00   
+  2  3    -5   2    118.4309   107.7060   180.0   1.38139  0.00   
+  2  1    -3   4    11083.8607 11498.8556 180.0   1.38001  0.03   
+  2  3    3    -5   573.2244   601.2645   -0.0    1.37984  0.00   
+  2  5    3    0    1966.2247  2064.1961  180.0   1.37983  0.00   
+  2  2    4    3    8041.1778  7682.9819  -0.0    1.37735  0.03   
+  2  4    -6   0    2901.0502  2929.6322  0.0     1.37669  0.00   
+  2  5    -3   0    1648.1636  1846.9850  -180.0  1.37349  0.00   
+  2  4    0    -5   8296.4238  9852.1453  -0.0    1.37263  0.02   
+  2  5    5    -3   887.1918   1000.1841  -0.0    1.37203  0.00   
+  2  1    1    -5   64.4621    51.8333    180.0   1.36876  0.00   
+  2  2    8    -3   1316.9898  897.0709   0.0     1.36740  0.00   
+  2  2    -2   -5   1043.0819  890.9937   -180.0  1.36475  0.00   
+  2  1    -9   -1   2470.1916  2521.2414  180.0   1.36346  0.00   
+  2  4    2    -5   10160.4102 11335.5971 180.0   1.36264  0.02   
+  2  2    8    1    3796.2855  3611.9875  -180.0  1.35827  0.01   
+  2  5    5    -1   978.3033   870.4892   -180.0  1.35737  0.00   
+  2  4    -6   -3   5714.3827  4126.3352  180.0   1.35385  0.01   
+  2  3    -7   1    827.4348   576.4772   0.0     1.35312  0.00   
+  2  1    9    -2   18690.9365 16147.0686 0.0     1.35152  0.02   
+  2  6    0    -2   18967.7606 16981.3924 180.0   1.35133  0.02   
+  2  1    -9   1    3894.2336  3741.5161  -0.0    1.35032  0.01   
+  2  1    -1   -5   9569.9916  10683.9602 -0.0    1.34891  0.04   
+  2  3    5    2    176.2864   209.3398   0.0     1.34817  0.00   
+  2  5    -5   -2   420.3341   568.7530   180.0   1.34647  0.00   
+  2  4    0    2    11299.7610 20266.7951 180.0   1.34356  0.02   
+  2  6    0    -3   270.5796   424.9852   0.0     1.34244  0.00   
+  2  3    -7   -3   667.9514   987.1236   180.0   1.34218  0.00   
+  2  5    -3   -4   13.5624    19.4544    -0.0    1.34037  0.00   
+  2  3    7    1    696.2972   545.2034   0.0     1.33504  0.00   
+  2  1    3    4    382.2474   303.9072   180.0   1.33473  0.00   
+  2  2    4    -5   2802.0935  2138.1647  -0.0    1.33359  0.01   
+  2  6    2    -2   9098.5199  7470.5514  0.0     1.33146  0.01   
+  2  3    -1   3    719.3095   551.6386   -0.0    1.32984  0.00   
+  2  5    -5   -1   3328.8024  3077.6343  -180.0  1.32879  0.00   
+  2  1    -7   3    801.8731   845.5145   -180.0  1.32789  0.00   
+  2  1    3    -5   12244.4150 12956.3684 180.0   1.32785  0.03   
+  2  4    6    -4   1129.8145  1219.1637  0.0     1.32754  0.00   
+  2  6    2    -3   5.6054     6.0091     -0.0    1.32656  0.00   
+  2  4    -2   -5   2593.3913  3146.4347  0.0     1.32203  0.01   
+  2  1    9    1    901.8577   1105.1306  -0.0    1.32057  0.00   
+  2  4    -2   2    1794.3869  2255.4357  0.0     1.32028  0.00   
+  2  3    1    3    2551.5223  3237.6008  0.0     1.32015  0.01   
+  2  2    -6   -4   90.9541    114.0134   0.0     1.31919  0.00   
+  2  3    -3   -5   1740.3097  2179.7868  180.0   1.31918  0.00   
+  2  0    6    -4   2846.0400  3685.3963  0.0     1.31717  0.01   
+  2  0    8    -3   3294.9948  4546.6333  -0.0    1.31636  0.00   
+  2  6    -2   -2   256.7691   330.6363   180.0   1.31265  0.00   
+  2  4    2    2    452.2541   505.4413   0.0     1.30914  0.00   
+  2  5    -5   -3   6978.2269  6208.9517  0.0     1.30653  0.01   
+  2  3    7    -4   12.3942    11.5530    -180.0  1.30602  0.00   
+  2  6    0    -1   594.3976   635.2341   -0.0    1.30261  0.00   
+  2  6    -2   -3   4231.8421  4797.6968  0.0     1.30107  0.01   
+  2  1    7    -4   688.9595   816.7390   180.0   1.30069  0.00   
+  2  4    4    -5   1068.7569  839.8412   -180.0  1.29576  0.00   
+  2  5    -1   1    696.6167   560.8179   -180.0  1.29287  0.00   
+  2  5    5    -4   111.6670   102.0732   -0.0    1.29210  0.00   
+  2  5    1    1    211.2422   213.0414   180.0   1.29128  0.00   
+  2  5    1    -5   1311.4962  1297.0866  -180.0  1.28850  0.00   
+  2  1    -9   -2   7102.3487  7594.2794  0.0     1.28440  0.01   
+  2  3    -3   3    3556.8795  3821.2749  180.0   1.28422  0.01   
+  2  2    -6   3    95.5573    97.9036    -0.0    1.28363  0.00   
+  2  3    5    -5   3063.3486  3037.5557  -0.0    1.28334  0.01   
+  2  6    2    -1   2241.8679  2446.8719  180.0   1.28151  0.00   
+  2  4    8    -2   15278.3675 16043.2073 -0.0    1.27998  0.02   
+  2  6    0    -4   5017.5940  4642.8182  0.0     1.27913  0.01   
+  2  1    -5   4    0.3060     0.2762     -0.0    1.27885  0.00   
+  2  0    0    5    1679.6469  1504.7953  0.0     1.27757  0.01   
+  2  2    -8   -3   1131.3748  969.8153   0.0     1.27578  0.00   
+  2  1    -3   -5   1895.8005  1649.0848  -180.0  1.27554  0.01   
+  2  0    10   0    6004.6070  5612.4673  -0.0    1.27493  0.01   
+  2  3    9    -1   596.1352   567.6734   180.0   1.27318  0.00   
+  2  3    9    -2   172.6538   209.3409   0.0     1.27118  0.00   
+  2  6    -2   -1   482.4271   604.9530   -180.0  1.27102  0.00   
+  2  5    -1   -5   2453.1505  3287.3648  -0.0    1.27057  0.00   
+  2  4    -6   1    1572.2276  2157.0193  180.0   1.27033  0.00   
+  2  2    0    4    3590.5598  5970.9564  -0.0    1.26862  0.01   
+  2  6    2    -4   1551.0154  2642.8907  -180.0  1.26852  0.00   
+  2  0    2    -5   2250.5465  4140.6925  180.0   1.26818  0.01   
+  2  2    -8   2    8314.3213  15669.9235 0.0     1.26800  0.01   
+  2  5    5    0    812.0420   1539.1640  -0.0    1.26791  0.00   
+  2  0    10   -1   482.1402   722.1628   -180.0  1.26570  0.00   
+  2  4    8    -1   86.1892    116.1733   180.0   1.26381  0.00   
+  2  2    -4   -5   27.1170    34.2839    180.0   1.26302  0.00   
+  2  1    -9   2    306.0296   407.6104   0.0     1.26267  0.00   
+  2  6    4    -2   2753.5652  4060.9393  -0.0    1.26012  0.00   
+  2  1    7    3    951.1672   1423.0605  -180.0  1.25993  0.00   
+  2  5    -5   0    817.8946   1251.7915  -0.0    1.25974  0.00   
+  2  4    6    1    22.4887    35.4122    180.0   1.25938  0.00   
+  2  6    4    -3   3731.9987  5742.7030  -180.0  1.25904  0.00   
+  2  3    3    3    24.1584    34.1056    0.0     1.25855  0.00   
+  2  2    -2   4    2037.0636  2630.4316  180.0   1.25569  0.01   
+  2  5    3    -5   6295.4246  7849.9862  180.0   1.25548  0.01   
+  2  1    9    -3   413.0759   446.4585   -180.0  1.25310  0.00   
+  2  4    -4   2    2882.5998  2913.1494  0.0     1.24747  0.00   
+  2  4    8    -3   1363.6103  1591.0184  -180.0  1.24643  0.00   
+  2  5    -3   1    144.4372   154.1169   -180.0  1.24419  0.00   
+  2  4    -6   -4   4005.5544  4649.8078  0.0     1.24074  0.01   
+  2  1    5    -5   17.7162    20.8490    -0.0    1.24058  0.00   
+  2  6    -2   -4   96.1606    116.0421   -0.0    1.24022  0.00   
+  2  5    3    1    699.2020   865.0651   -180.0  1.23993  0.00   
+  2  0    6    4    3454.0571  4402.8269  -0.0    1.23960  0.01   
+  2  0    8    3    1965.3681  2523.8232  0.0     1.23892  0.00   
+  2  5    7    -2   37.7928    48.4702    -180.0  1.23815  0.00   
+  2  0    2    5    4.7550     6.1649     -0.0    1.23770  0.00   
+  2  3    -9   -1   1401.5121  1878.7146  -180.0  1.23697  0.00   
+  2  0    10   1    52.1725    69.0195    180.0   1.23540  0.00   
+  2  2    8    -4   0.5364     0.6712     -0.0    1.23509  0.00   
+  2  2    2    4    204.9500   202.3679   180.0   1.23305  0.00   
+  2  2    10   -1   684.9399   674.5837   -0.0    1.23266  0.00   
+  2  2    6    3    610.9562   591.5126   -0.0    1.23202  0.00   
+  2  4    -8   -1   1822.6809  1660.8265  180.0   1.22975  0.00   
+  2  4    4    2    7727.5161  7216.8110  -0.0    1.22886  0.02   
+  2  6    -4   -2   8042.3766  7429.0559  0.0     1.22874  0.01   
+  2  4    -4   -5   6865.2271  5935.8119  180.0   1.22833  0.01   
+  2  3    9    0    276.4814   207.1256   180.0   1.22722  0.00   
+  2  2    8    2    27957.1486 16367.8700 -0.0    1.22501  0.05   
+  2  3    -7   2    7.6119     4.4310     -180.0  1.22493  0.00   
+  2  5    7    -3   1367.9329  701.3947   180.0   1.22357  0.00   
+  2  5    -5   -4   968.5345   527.2945   -180.0  1.22255  0.00   
+  2  2    6    -5   167.4875   93.3157    -0.0    1.22244  0.00   
+  2  3    9    -3   6137.1297  3989.5508  -0.0    1.22187  0.01   
+  2  4    -8   -2   20924.0546 15576.6760 0.0     1.22139  0.03   
+  2  1    5    4    3664.6259  2923.6151  -180.0  1.22003  0.01   
+  2  3    -9   0    71.3240    63.1939    -0.0    1.21922  0.00   
+  2  6    -4   -3   1.6819     1.6171     -180.0  1.21643  0.00   
+  2  6    4    -1   10.9130    10.2523    180.0   1.21473  0.00   
+  2  2    10   -2   3396.7562  3195.8904  -180.0  1.21471  0.00   
+  2  3    -7   -4   11.0695    9.5153     0.0     1.21279  0.00   
+  2  6    0    0    15258.4808 13100.2263 0.0     1.21259  0.02   
+  2  1    9    2    2038.0159  1749.7864  0.0     1.21259  0.00   
+  2  0    4    -5   59.8707    51.4047    -180.0  1.21258  0.00   
+  2  1    -7   -4   784.4688   673.8718   0.0     1.21254  0.00   
+  2  6    4    -4   225.3895   199.9465   0.0     1.21185  0.00   
+  2  0    10   -2   2637.9964  2393.1814  180.0   1.21068  0.00   
+  2  3    -9   -2   2.7061     2.4088     0.0     1.20966  0.00   
+  2  5    7    -1   983.4025   919.5910   -0.0    1.20764  0.00   
+  2  5    -3   -5   1786.0588  1669.4106  -180.0  1.20756  0.00   
+  2  2    10   0    14.0409    11.8619    180.0   1.20601  0.00   
+  2  3    -5   -5   5070.3363  5223.5291  -0.0    1.20426  0.01   
+  2  4    8    0    2060.1623  2036.1638  -180.0  1.20314  0.00   
+  2  2    -10  0    1104.4821  1234.3417  180.0   1.20037  0.00   
+  2  2    -10  -1   1901.9473  1881.5821  0.0     1.19900  0.00   
+  2  2    -4   4    0.0044     0.0043     180.0   1.19841  0.00   
+  2  3    -5   3    5361.9295  5149.8089  -180.0  1.19827  0.01   
+  2  6    -4   -1   4507.0951  4013.4094  180.0   1.19705  0.01   
+  2  4    -8   0    2238.9064  1701.7086  -180.0  1.19422  0.00   
+  2  4    6    -5   6895.0396  5356.2972  -0.0    1.19366  0.01   
+  2  6    2    0    8082.5129  6359.8747  -180.0  1.19287  0.01   
+  2  3    1    -6   219.2542   172.0799   180.0   1.19278  0.00   
+  2  3    7    2    272.6048   210.6961   180.0   1.19262  0.00   
+  2  6    -2   0    2471.9262  1825.4606  -180.0  1.18959  0.00   
+  2  5    -7   -2   329.2501   235.2689   -180.0  1.18926  0.00   
+  2  5    5    -5   761.9937   652.0282   -0.0    1.18202  0.00   
+  2  6    0    -5   2158.5311  1859.8386  -0.0    1.18139  0.00   
+  2  5    -7   -1   1265.3600  1170.6276  -0.0    1.17956  0.00   
+  2  3    -1   -6   9368.8067  10651.6340 0.0     1.17652  0.03   
+  2  1    -9   -3   2935.3041  3479.3329  -0.0    1.17569  0.01   
+  2  4    0    -6   586.5623   694.8770   -180.0  1.17567  0.00   
+  2  6    2    -5   585.8620   690.4314   180.0   1.17553  0.00   
+  2  4    8    -4   5177.5452  5262.2410  180.0   1.17365  0.01   
+  2  1    -1   5    43.3727    44.3347    0.0     1.17349  0.00   
+  2  2    0    -6   3478.0655  3262.2227  -180.0  1.17258  0.01   
+  2  4    2    -6   1052.0856  785.7923   0.0     1.17185  0.00   
+  2  4    -8   -3   707.1452   512.5086   -0.0    1.17167  0.00   
+  2  1    -5   -5   7383.5025  5414.4867  -180.0  1.17131  0.02   
+  2  3    3    -6   3544.6390  3178.6335  180.0   1.16840  0.01   
+  2  5    7    -4   6553.1135  5932.4007  0.0     1.16833  0.01   
+  2  2    2    -6   487.7904   444.4424   0.0     1.16828  0.00   
+  2  0    8    -4   9233.1938  6734.2463  -180.0  1.16544  0.01   
+  2  3    5    3    14854.2710 9033.3981  -180.0  1.16397  0.04   
+  2  6    -4   -4   2188.0553  1331.0105  -180.0  1.16381  0.00   
+  2  3    7    -5   1938.8102  1180.8749  180.0   1.16377  0.00   
+  2  3    -9   1    38.2328    24.5109    -0.0    1.16177  0.00   
+  2  1    1    5    3040.6333  1984.2370  0.0     1.16142  0.01   
+  2  2    -10  1    624.3338   408.7012   -180.0  1.16134  0.00   
+  2  0    4    5    5359.4939  3674.6390  -180.0  1.16082  0.02   
+  2  6    6    -3   791.3541   572.9928   0.0     1.16041  0.00   
+  2  5    -5   1    11.0498    8.2052     180.0   1.16017  0.00   
+  2  7    1    -3   432.9079   326.8856   180.0   1.15995  0.00   
+  2  2    4    4    442.1377   334.7388   180.0   1.15990  0.00   
+  2  0    10   2    2472.9016  1953.1670  -180.0  1.15916  0.00   
+  2  5    -7   -3   17.6552    13.9221    0.0     1.15905  0.00   
+  2  6    6    -2   1361.7415  1062.5954  180.0   1.15883  0.00   
+  2  2    -10  -2   1100.6983  927.1428   -180.0  1.15763  0.00   
+  2  2    10   -3   536.4940   456.9863   180.0   1.15752  0.00   
+  2  1    -7   4    8953.0651  7894.1741  -0.0    1.15699  0.01   
+  2  1    11   -1   200.4342   172.4013   -0.0    1.15488  0.00   
+  2  5    5    1    16.2911    14.5872    180.0   1.15443  0.00   
+  2  4    0    3    413.1377   372.8509   -0.0    1.15214  0.00   
+  2  7    -1   -3   210.1178   190.7937   -0.0    1.15103  0.00   
+  2  1    -9   3    432.0509   390.2848   -180.0  1.15086  0.00   
+  2  7    1    -2   425.6256   417.6649   180.0   1.14957  0.00   
+  2  6    -2   -5   3.3721     3.3422     180.0   1.14818  0.00   
+  2  2    -8   -4   998.4000   1241.1393  -0.0    1.14713  0.00   
+  2  3    9    1    690.2274   840.9132   -180.0  1.14703  0.00   
+  2  1    -3   5    111.7963   131.0137   -0.0    1.14691  0.00   
+  2  4    -6   2    891.8785   884.2580   -180.0  1.14653  0.00   
+  2  1    11   0    732.4588   673.8595   0.0     1.14593  0.00   
+  2  3    -9   -3   6325.4327  6842.7549  -0.0    1.14539  0.01   
+  2  1    -11  0    55.6444    56.5171    180.0   1.14326  0.00   
+  2  7    -1   -2   250.1368   258.5173   180.0   1.14319  0.00   
+  2  2    10   1    1858.9437  2221.3310  -180.0  1.14260  0.00   
+  2  2    -6   -5   6875.1586  8280.7099  -0.0    1.14253  0.02   
+  2  5    -1   2    0.2086     0.2523     -180.0  1.14237  0.00   
+  2  4    -2   -6   164.8864   159.9954   -0.0    1.14109  0.00   
+  2  5    7    0    1607.0134  1584.2307  0.0     1.14103  0.00   
+  2  3    9    -4   2593.3807  3452.1120  -180.0  1.13977  0.00   
+  2  4    -2   3    508.7556   675.3480   180.0   1.13965  0.00   
+  2  2    -8   3    683.1211   940.5804   180.0   1.13923  0.00   
+  2  5    1    2    104.1135   151.0052   180.0   1.13897  0.00   
+  2  2    -2   -6   296.8271   457.5743   180.0   1.13875  0.00   
+  2  5    1    -6   65.0031    92.8501    180.0   1.13644  0.00   
+  2  6    4    0    6460.3063  9886.1889  -180.0  1.13618  0.01   
+  2  1    9    -4   3989.2135  6387.1239  180.0   1.13575  0.01   
+  2  7    1    -4   56.4531    104.3489   0.0     1.13318  0.00   
+  2  5    -7   0    266.8549   561.3250   0.0     1.13270  0.00   
+  2  6    4    -5   1624.6620  3560.8356  -0.0    1.13225  0.00   
+  2  7    3    -3   900.6355   1752.7599  180.0   1.13164  0.00   
+  2  1    7    -5   943.3813   1876.4532  -0.0    1.13113  0.00   
+  2  4    4    -6   34.9941    74.0198    180.0   1.13073  0.00   
+  2  6    -4   0    4110.4912  8996.3605  -180.0  1.13052  0.01   
+  2  1    1    -6   5.7377     12.7255    180.0   1.13041  0.00   
+  2  4    2    3    13.5186    26.9687    0.0     1.12798  0.00   
+  2  1    11   -2   1866.6288  4054.5939  -180.0  1.12721  0.00   
+  2  2    4    -6   267.4159   617.9103   -180.0  1.12706  0.00   
+  2  1    -11  -1   33.0939    80.5660    180.0   1.12692  0.00   
+  2  0    6    -5   323.0845   825.3110   -0.0    1.12677  0.00   
+  2  0    10   -3   13.8070    25.1309    180.0   1.12560  0.00   
+  2  6    6    -4   601.7715   1116.6065  -0.0    1.12535  0.00   
+  2  4    -8   1    743.9145   1428.0735  -0.0    1.12500  0.00   
+  2  4    6    2    255.6920   491.6513   180.0   1.12497  0.00   
+  2  3    -3   -6   1279.3004  2679.1058  0.0     1.12421  0.00   
+  2  1    -11  1    246.5148   520.4388   180.0   1.12385  0.00   
+  2  3    -1   4    27.9122    62.3074    180.0   1.12290  0.00   
+  2  7    -1   -4   156.1336   340.7362   180.0   1.12266  0.00   
+  2  6    -6   -2   2.7253     5.8815     -0.0    1.12259  0.00   
+  2  5    -1   -6   1604.4130  3679.1020  -180.0  1.12188  0.00   
+  2  6    6    -1   7.5168     18.5196    -180.0  1.12105  0.00   
+  2  7    3    -2   194.2814   466.2613   -180.0  1.11981  0.00   
+  2  5    -5   -5   2206.5006  3254.1700  180.0   1.11710  0.00   
+  2  1    -1   -6   1095.3882  1573.1101  -180.0  1.11699  0.00   
+  2  4    -6   -5   14.1501    12.1624    -180.0  1.11621  0.00   
+  2  5    3    -6   4839.9209  3572.8767  0.0     1.11574  0.01   
+  2  3    1    4    626.2286   557.2568   180.0   1.11489  0.00   
+  2  4    8    1    3371.6581  3030.2470  -0.0    1.11486  0.01   
+  2  1    3    5    232.9346   208.8946   -180.0  1.11404  0.00   
+  2  2    -6   4    1985.9218  1626.0861  -0.0    1.11278  0.00   
+  2  6    -6   -3   9250.7123  9170.8262  180.0   1.11104  0.01   
+  2  5    -3   2    23.8784    23.9804    -180.0  1.11049  0.00   
+  2  3    5    -6   75.0815    75.3696    -0.0    1.11017  0.00   
+  2  1    3    -6   4318.7229  3749.4968  0.0     1.10915  0.01   
+  2  7    3    -4   1013.5392  851.8273   -0.0    1.10885  0.00   
+  2  7    -3   -3   10.9475    8.0510     -0.0    1.10731  0.00   
+  2  7    1    -1   749.4337   540.2195   -180.0  1.10485  0.00   
+  2  6    0    1    3829.6262  2851.2916  180.0   1.10441  0.01   
+  2  1    11   1    441.3254   353.4958   0.0     1.10278  0.00   
+  2  7    -3   -2   8.8107     7.6618     -0.0    1.10240  0.00   
+  2  4    10   -2   302.4037   293.9448   -180.0  1.10139  0.00   
+  2  7    -1   -1   577.2049   560.8360   -180.0  1.10125  0.00   
+  2  5    3    2    95.2954    92.4856    -180.0  1.10119  0.00   
+  2  2    8    -5   3833.9862  3728.5603  180.0   1.10077  0.01   
+  2  6    -6   -1   6.3073     6.2337     0.0     1.10033  0.00   
+  2  5    -7   -4   215.3223   136.6182   0.0     1.09716  0.00   
+  2  3    -3   4    234.9634   143.6453   -0.0    1.09706  0.00   
+  2  1    7    4    109.7248   57.0295    -0.0    1.09661  0.00   
+  2  0    8    4    8655.9391  2959.2417  180.0   1.09406  0.02   
+  2  4    -8   -4   10638.2939 3685.4545  -180.0  1.09399  0.02   
+  2  4    -4   3    6057.4403  2186.7268  180.0   1.09385  0.01   
+  2  3    -7   3    5015.0241  1814.2931  0.0     1.09384  0.01   
+  2  1    9    3    848.1665   308.2223   180.0   1.09383  0.00   
+  2  2    -10  2    6.8950     3.3265     -0.0    1.09247  0.00   
+  2  2    8    3    747.2794   379.8198   0.0     1.09126  0.00   
+  2  5    9    -2   2524.6140  1582.6840  -0.0    1.09021  0.00   
+  2  4    10   -1   2.3524     1.7369     -180.0  1.08903  0.00   
+  2  6    -2   1    2.0031     1.5406     -180.0  1.08894  0.00   
+  2  1    -5   5    7072.8998  5646.2565  0.0     1.08884  0.02   
+  2  6    2    1    306.5909   245.3481   -0.0    1.08745  0.00   
+  2  2    -10  -3   764.8691   617.4947   180.0   1.08733  0.00   
+  2  5    7    -5   102.4202   91.0318    -180.0  1.08704  0.00   
+  2  6    -4   -5   319.1093   422.0173   180.0   1.08477  0.00   
+  2  3    -7   -5   2224.3485  3180.2930  0.0     1.08232  0.00   
+  2  5    9    -3   26.4458    37.0056    -180.0  1.08217  0.00   
+  2  4    10   -3   397.1827   496.5346   180.0   1.08176  0.00   
+  2  4    8    -5   247.5107   416.8216   0.0     1.08002  0.00   
+  2  7    -3   -4   282.6006   475.9937   -180.0  1.08002  0.00   
+  2  3    11   -2   733.7743   1209.7235  180.0   1.07973  0.00   
+  2  3    -9   2    750.1734   1162.0253  -0.0    1.07952  0.00   
+  2  1    -11  -2   361.9161   505.5742   -0.0    1.07909  0.00   
+  2  3    11   -1   1812.3892  2531.9784  -180.0  1.07901  0.00   
+  2  4    -4   -6   27.5046    79.4879    0.0     1.07725  0.00   
+  2  7    3    -1   200.2969   517.9063   0.0     1.07642  0.00   
+  2  7    1    -5   8.4526     25.2106    -0.0    1.07626  0.00   
+  2  5    -3   -6   333.0889   1371.1187  180.0   1.07586  0.00   
+  2  2    10   -4   687.3779   2842.5457  0.0     1.07584  0.00   
+  2  2    -4   -6   43.9289    186.5753   0.0     1.07568  0.00   
+  2  3    3    4    179.1913   560.4316   180.0   1.07511  0.00   
+  2  1    -11  2    225.9118   558.2780   -180.0  1.07370  0.00   
+  2  7    5    -3   347.8482   928.6481   180.0   1.07351  0.00   
+  2  4    4    3    304.1275   818.8776   180.0   1.07348  0.00   
+  2  1    -3   -6   78.0009    135.6225   180.0   1.07233  0.00   
+  2  6    0    -6   2.4310     4.1780     -180.0  1.07161  0.00   
+  2  1    11   -3   223.5849   540.3856   180.0   1.07008  0.00   
+  2  6    2    -6   46.8842    107.8329   0.0     1.06912  0.00   
+  2  6    -6   -4   254.2975   552.9788   0.0     1.06862  0.00   
+  2  5    9    -1   649.1744   1026.4794  0.0     1.06732  0.00   
+  2  2    6    4    2553.7755  4143.5979  0.0     1.06716  0.01   
+  2  7    -3   -1   101.6994   173.9010   0.0     1.06652  0.00   
+  2  2    0    5    1156.2769  1937.9253  0.0     1.06580  0.00   
+  2  0    6    5    225.0566   358.8678   0.0     1.06561  0.00   
+  2  7    -1   -5   2128.1074  3288.8085  0.0     1.06535  0.00   
+  2  5    5    -6   294.9856   447.2840   -180.0  1.06509  0.00   
+  2  0    0    6    33.9348    53.4823    180.0   1.06464  0.00   
+  2  0    10   3    2078.2935  3276.3246  0.0     1.06463  0.00   
+  2  4    6    -6   24.2448    31.3322    -180.0  1.06282  0.00   
+  2  6    6    -5   334.0316   434.3157   -0.0    1.06260  0.00   
+  2  0    12   0    86.2128    112.6819   180.0   1.06244  0.00   
+  2  4    -10  -1   876.8758   1132.6677  180.0   1.06171  0.00   
+  2  7    5    -2   3594.4123  4496.3914  -180.0  1.06153  0.00   
+  2  0    2    -6   611.5662   748.1993   0.0     1.06104  0.00   
+  2  5    -7   1    763.1006   969.1237   180.0   1.06052  0.00   
+  2  1    -9   -4   1311.2170  1706.8793  -180.0  1.06015  0.00   
+  2  2    -2   5    2461.3995  3313.4198  -180.0  1.05994  0.01   
+  2  3    -9   -4   10.1196    13.6703    -180.0  1.05993  0.00   
+  2  2    6    -6   196.8348   288.6216   -180.0  1.05938  0.00   
+  2  0    12   -1   940.5158   1340.4500  -0.0    1.05892  0.00   
+  2  1    -7   -5   5.2920     7.5059     -180.0  1.05860  0.00   
+  2  1    5    -6   33.3647    47.4061    -180.0  1.05858  0.00   
+  2  2    10   2    734.2218   1237.1699  -0.0    1.05797  0.00   
+  2  3    7    3    7.4205     12.9031    -180.0  1.05758  0.00   
+  2  7    3    -5   1237.5176  2239.1302  -180.0  1.05718  0.00   
+  2  6    6    0    248.9941   461.7745   -0.0    1.05659  0.00   
+  2  7    5    -4   1009.7117  2051.4003  0.0     1.05581  0.00   
+  2  4    -10  -2   1430.1734  3145.7849  0.0     1.05450  0.00   
+  2  5    7    1    16.8834    37.2884    180.0   1.05440  0.00   
+  2  6    8    -3   5060.2109  8866.7538  -0.0    1.05196  0.01   
+  2  3    -11  -1   150.2793   261.5320   -0.0    1.05193  0.00   
+  2  5    -5   2    3820.2201  5387.0808  -180.0  1.05131  0.01   
+  2  3    9    2    662.4148   862.2832   -0.0    1.05108  0.00   
+  2  3    11   -3   552.4291   673.7850   180.0   1.05082  0.00   
+  2  6    -6   0    442.8817   488.9045   -0.0    1.04978  0.00   
+  2  6    8    -2   340.9901   331.3808   0.0     1.04899  0.00   
+  2  3    11   0    436.2634   407.0557   -0.0    1.04881  0.00   
+  2  3    -5   -6   1347.8230  1235.7557  -180.0  1.04872  0.00   
+  2  4    10   0    72.4698    61.4161    -0.0    1.04771  0.00   
+  2  5    -9   -2   2567.2854  2208.3085  -0.0    1.04729  0.00   
+  2  5    9    -4   266.5034   228.7958   -180.0  1.04516  0.00   
+  2  6    -2   -6   1517.4220  1293.5044  -0.0    1.04487  0.00   
+  2  6    -4   1    3709.5447  3160.5795  -0.0    1.04485  0.01   
+  2  3    -5   4    2883.5935  2301.6767  -0.0    1.04377  0.01   
+  2  3    9    -5   2272.6452  1817.7670  180.0   1.04328  0.00   
+  2  1    5    5    2006.7796  1623.2967  -0.0    1.04294  0.01   
+  2  3    -11  0    1732.0511  1387.3612  0.0     1.04270  0.00   
+  2  2    2    5    330.1885   264.3036   0.0     1.04269  0.00   
+  2  5    -9   -1   79.6058    62.5557    0.0     1.04240  0.00   
+  2  6    4    1    1306.3778  1021.8291  -0.0    1.04223  0.00   
+  2  4    -10  0    651.4159   554.7785   -0.0    1.04034  0.00   
+  2  2    12   -1   4545.1771  3828.0670  -180.0  1.03971  0.01   
+  2  0    2    6    1753.2908  1492.8101  0.0     1.03949  0.01   
+  2  7    -5   -3   4108.8070  3517.5593  180.0   1.03943  0.01   
+  2  5    5    2    4423.9374  4324.4718  -180.0  1.03825  0.01   
+  2  4    -8   2    302.0320   298.1823   -0.0    1.03802  0.00   
+  2  6    4    -6   1266.8519  1251.2761  -180.0  1.03798  0.00   
+  2  0    12   1    349.2113   335.8693   -0.0    1.03750  0.00   
+  2  7    -5   -2   1573.9806  1492.9651  -180.0  1.03709  0.00   
+  2  7    1    0    1273.9213  1264.8986  -0.0    1.03656  0.00   
+  2  1    -9   4    2.5847     2.8086     180.0   1.03594  0.00   
+  2  1    11   2    1514.1982  1702.3367  180.0   1.03580  0.00   
+  2  7    -1   0    1522.4168  1823.6465  -0.0    1.03529  0.00   
+  2  4    10   -4   7.9789     9.1218     0.0     1.03486  0.00   
+  2  3    -11  -2   1182.1710  1522.0493  -180.0  1.03326  0.00   
+  3  1    1    0    1093.8782  1272.1776  -0.0    3.25230  0.03   
+  3  1    0    1    671.5168   492.3011   -0.0    2.48917  0.02   
+  3  2    0    0    227.3732   149.2708   -0.0    2.29972  0.00   
+  3  1    1    1    800.9722   374.9784   180.0   2.18915  0.02   
+  3  2    1    0    129.7520   152.8703   0.0     2.05694  0.00   
+  3  2    1    1    847.7959   880.4203   -0.0    1.68916  0.03   
+  3  2    2    0    963.5094   1143.5960  -0.0    1.62615  0.01   
+  3  0    0    2    1535.0492  1417.8449  -0.0    1.48006  0.00   
+  3  3    1    0    346.8820   356.8940   -0.0    1.45447  0.00   
+  3  2    2    1    36.7387    28.2517    180.0   1.42525  0.00   
+  3  3    0    1    939.5432   1055.6715  -0.0    1.36139  0.01   
+  3  1    1    2    442.1448   541.6074   -0.0    1.34713  0.00   
+  3  3    1    1    37.5538    32.7691    0.0     1.30540  0.00   
+  3  3    2    0    16.8965    15.0349    180.0   1.27566  0.00   
+  3  2    0    2    131.9178   145.3422   -0.0    1.24459  0.00   
+  3  2    1    2    37.9946    42.1715    0.0     1.20138  0.00   
+  3  3    2    1    199.7072   154.5400   -0.0    1.17150  0.00   
+  3  4    0    0    435.9820   422.3977   -0.0    1.14986  0.00   
+  3  4    1    0    96.3191    78.7453    180.0   1.11553  0.00   
+  3  2    2    2    1444.0197  562.7763   -0.0    1.09457  0.01   
+  3  3    3    0    454.6558   592.6505   -0.0    1.08410  0.00   
+  3  4    1    1    333.4768   271.8535   -0.0    1.04387  0.01   
+  3  3    1    2    229.2504   220.8817   -0.0    1.03740  0.00   
+  4  1    1    0    8044.7648  5231.9807  0.0     5.76931  0.01   
+  4  1    1    -1   2237.9666  1404.8565  0.0     5.75562  0.00   
+  4  0    0    2    12790.2916 6634.9821  0.0     5.70281  0.01   
+  4  2    0    0    625.8682   777.2638   180.0   5.29777  0.00   
+  4  2    0    -2   8230.5686  11497.9523 0.0     5.25570  0.00   
+  4  1    1    1    3044.2609  5913.5157  -180.0  4.69973  0.00   
+  4  1    1    -2   198.2013   470.9294   -180.0  4.67759  0.00   
+  4  1    1    2    1584.8515  1808.3292  -180.0  3.63025  0.00   
+  4  1    1    -3   5521.1711  6211.9688  180.0   3.61325  0.00   
+  4  0    2    0    9958.2235  1740.1438  180.0   3.43920  0.00   
+  4  3    1    -1   2052.9785  1014.8005  -0.0    3.40289  0.00   
+  4  3    1    -2   5548.2637  3185.9766  180.0   3.39446  0.00   
+  4  0    2    1    4234.2242  5012.7687  -0.0    3.29276  0.00   
+  4  2    0    2    10721.6100 11585.4987 -0.0    3.21822  0.00   
+  4  2    0    -4   4985.1459  4993.6085  180.0   3.18996  0.00   
+  4  3    1    0    1994.9549  2136.8151  0.0     3.14187  0.00   
+  4  3    1    -3   2547.6759  2673.2736  180.0   3.12208  0.00   
+  4  4    0    -2   110074.2817 80809.4369 180.0   2.97592  0.02   
+  4  2    2    -1   98230.9176 75082.5724 -0.0    2.97781  0.04   
+  4  0    2    2    916.1500   793.6721   0.0     2.94509  0.00   
+  4  2    2    0    1879.0267  1811.0116  0.0     2.88466  0.00   
+  4  2    2    -2   547.8400   529.7071   -0.0    2.87781  0.00   
+  4  1    1    3    3094.1270  2485.3141  -0.0    2.86465  0.00   
+  4  1    1    -4   7283.0712  5798.6010  -0.0    2.85294  0.00   
+  4  0    0    4    12939.7422 10329.8968 -0.0    2.85141  0.00   
+  4  3    1    1    3777.3368  3752.3989  -180.0  2.75636  0.00   
+  4  3    1    -4   2739.6597  3259.7661  -0.0    2.73414  0.00   
+  4  4    0    0    64886.0291 70960.6376 0.0     2.64889  0.01   
+  4  2    2    1    125220.4531 133105.8360 0.0     2.64490  0.04   
+  4  2    2    -3   60743.9411 66299.3101 -180.0  2.63437  0.02   
+  4  4    0    -4   126099.1785 140270.1926 180.0   2.62785  0.02   
+  4  0    2    3    21810.8694 14193.3935 180.0   2.55049  0.01   
+  4  3    1    2    8335.5202  9771.8878  -180.0  2.37480  0.00   
+  4  3    1    -5   5232.1900  5854.1041  -0.0    2.35492  0.00   
+  4  2    2    2    128.6644   143.9167   -180.0  2.34986  0.00   
+  4  2    2    -4   865.5857   881.6893   180.0   2.33880  0.00   
+  4  1    1    4    3169.2885  2965.0251  -0.0    2.33627  0.00   
+  4  1    1    -5   494.9175   299.6305   -0.0    2.32809  0.00   
+  4  4    2    -2   1704.3586  1407.2856  -0.0    2.25040  0.00   
+  4  5    1    -2   2184.1979  2119.9402  180.0   2.24094  0.00   
+  4  5    1    -3   537.3547   538.2185   180.0   2.23692  0.00   
+  4  1    3    0    54.1638    52.5740    0.0     2.24093  0.00   
+  4  1    3    -1   4281.0219  4191.7021  -0.0    2.24013  0.00   
+  4  4    2    -1   964.2653   918.1472   0.0     2.21092  0.00   
+  4  4    2    -3   12890.3343 13289.7843 -0.0    2.20476  0.00   
+  4  0    2    4    1281.3101  967.7406   180.0   2.19509  0.00   
+  4  5    1    -1   17084.1284 11504.4667 -0.0    2.16275  0.00   
+  4  1    3    1    1472.8084  1033.7998  -0.0    2.15985  0.00   
+  4  1    3    -2   14818.7279 10989.5160 0.0     2.15769  0.00   
+  4  5    1    -4   789.7581   708.4659   -180.0  2.15197  0.00   
+  4  2    0    4    1382.7309  1631.2791  0.0     2.13699  0.00   
+  4  2    0    -6   8019.3622  7199.2402  0.0     2.12316  0.00   
+  4  4    2    0    390.7062   728.3368   -180.0  2.09858  0.00   
+  4  4    2    -4   320.7563   548.2406   -180.0  2.08808  0.00   
+  4  4    0    2    291024.5879 285615.0180 180.0   2.06893  0.02   
+  4  2    2    3    294379.9898 293002.6542 0.0     2.06451  0.05   
+  4  2    2    -5   248823.9919 297100.5659 0.0     2.05450  0.04   
+  4  4    0    -6   246483.5386 301606.5195 -180.0  2.04894  0.02   
+  4  3    1    3    873.5916   1081.2889  -180.0  2.04816  0.00   
+  4  3    1    -6   105.2136   154.5562   -0.0    2.03175  0.00   
+  4  5    1    0    459.3435   770.1564   180.0   2.02518  0.00   
+  4  1    3    2    9610.6323  14047.1698 -0.0    2.02043  0.00   
+  4  1    3    -3   874.3027   1240.8061  -0.0    2.01749  0.00   
+  4  5    1    -5   9303.3428  14125.1550 -0.0    2.01048  0.00   
+  4  3    3    -1   7662.1363  7033.5856  -0.0    1.97856  0.00   
+  4  3    3    -2   198.3810   188.4026   0.0     1.97690  0.00   
+  4  1    1    5    3056.5150  4614.7955  180.0   1.96139  0.00   
+  4  6    0    -2   637.2240   968.3799   180.0   1.95782  0.00   
+  4  1    1    -6   1058.2849  1560.8017  -0.0    1.95547  0.00   
+  4  6    0    -4   11152.5918 17212.7823 -180.0  1.95140  0.00   
+  4  4    2    1    13621.0692 20964.7061 -0.0    1.94284  0.00   
+  4  4    2    -5   56.7690    70.8523    180.0   1.93036  0.00   
+  4  3    3    0    7547.2947  9851.7693  180.0   1.92310  0.00   
+  4  3    3    -3   2206.8390  2772.7220  -0.0    1.91854  0.00   
+  4  0    0    6    1331.2590  1705.8756  -0.0    1.90094  0.00   
+  4  0    2    5    70.3815    90.1884    -180.0  1.90098  0.00   
+  4  5    1    1    1171.2150  2498.8683  -180.0  1.85943  0.00   
+  4  1    3    3    2211.5244  3430.5540  0.0     1.85393  0.00   
+  4  1    3    -4   395.5266   509.7607   -180.0  1.85074  0.00   
+  4  5    1    -6   2279.8444  2891.1577  -180.0  1.84353  0.00   
+  4  3    3    1    3554.6973  3301.2065  -0.0    1.82358  0.00   
+  4  3    3    -4   15472.2042 15091.0574 -180.0  1.81711  0.00   
+  4  2    2    4    1976.8066  2006.2475  180.0   1.81513  0.00   
+  4  2    2    -6   101.8955   110.8852   -0.0    1.80663  0.00   
+  4  3    1    4    1398.3718  1171.2955  -0.0    1.78224  0.00   
+  4  4    2    2    884.2266   570.0798   -0.0    1.77286  0.00   
+  4  3    1    -7   1409.4597  720.2705   -180.0  1.76902  0.00   
+  4  6    0    0    79564.4271 33062.0174 180.0   1.76592  0.00   
+  4  4    2    -6   4379.9099  1197.3043  -0.0    1.76023  0.00   
+  4  6    0    -6   3.8631     2.0530     0.0     1.75190  0.00   
+  4  6    2    -3   444665.0849 369463.6328 -180.0  1.71851  0.05   
+  4  0    4    0    433236.4610 349863.5489 -180.0  1.71960  0.02   
+  4  6    2    -2   460.0287   389.2193   -0.0    1.70144  0.00   
+  4  6    2    -4   2002.3442  1557.3296  180.0   1.69723  0.00   
+  4  0    4    1    3963.3672  3266.6769  -0.0    1.70038  0.00   
+  4  3    3    2    4474.2965  3605.3646  -0.0    1.69906  0.00   
+  4  3    3    -5   11499.0414 10541.7011 0.0     1.69173  0.00   
+  4  5    1    2    2621.1101  2565.7099  -180.0  1.69028  0.00   
+  4  1    1    6    685.4062   742.0669   -0.0    1.68540  0.00   
+  4  1    3    4    42.1339    45.0799    -0.0    1.68478  0.00   
+  4  1    1    -7   13517.0692 12424.5444 -180.0  1.68096  0.00   
+  4  1    3    -5   4885.9524  4687.0100  0.0     1.68171  0.00   
+  4  5    1    -7   340.2745   265.4106   -180.0  1.67494  0.00   
+  4  0    2    6    1159.0757  1004.4694  0.0     1.66371  0.00   
+  4  2    4    -1   3057.3681  2851.3584  180.0   1.65203  0.00   
+  4  6    2    -1   881.4406   864.7978   -180.0  1.64927  0.00   
+  4  7    1    -3   35.3354    35.3863    180.0   1.64764  0.00   
+  4  5    3    -2   337.2765   336.8162   -180.0  1.64796  0.00   
+  4  7    1    -4   553.2002   555.9037   -0.0    1.64540  0.00   
+  4  5    3    -3   1224.2191  1232.9682  -180.0  1.64636  0.00   
+  4  0    4    2    609.0628   613.4118   -180.0  1.64638  0.00   
+  4  6    2    -5   502.7451   504.1972   -180.0  1.64161  0.00   
+  4  2    4    0    769.0151   755.5233   -0.0    1.63560  0.00   
+  4  2    4    -2   4590.0127  4473.9753  180.0   1.63434  0.00   
+  4  7    1    -2   3654.1213  3561.9732  180.0   1.61641  0.00   
+  4  5    3    -1   1005.0415  967.0214   0.0     1.61610  0.00   
+  4  7    1    -5   1356.3496  914.2042   -0.0    1.61010  0.00   
+  4  5    3    -4   5258.8793  3834.7604  -180.0  1.61159  0.00   
+  4  4    0    4    100308.2785 64365.6929 180.0   1.60911  0.00   
+  4  4    2    3    44.8174    27.4278    180.0   1.60794  0.00   
+  4  2    2    5    59975.8467 37151.5471 -180.0  1.60584  0.01   
+  4  2    2    -7   119317.5287 66528.8930 0.0     1.59877  0.01   
+  4  4    2    -7   5208.7979  2578.9270  -0.0    1.59617  0.00   
+  4  4    0    -8   74957.8571 36898.8655 0.0     1.59498  0.00   
+  4  2    4    1    2441.6300  1930.1723  0.0     1.58794  0.00   
+  4  2    4    -3   1973.1031  1881.2909  0.0     1.58565  0.00   
+  4  2    0    6    27274.5693 28902.0696 -0.0    1.57545  0.00   
+  4  6    2    0    298.9117   317.2177   -0.0    1.57094  0.00   
+  4  2    0    -8   4626.8238  4970.9680  -180.0  1.56767  0.00   
+  4  3    1    5    1617.2618  1738.8731  180.0   1.56818  0.00   
+  4  3    3    3    456.0774   485.8360   0.0     1.56658  0.00   
+  4  0    4    3    2738.8489  2921.6975  -0.0    1.56679  0.00   
+  4  6    2    -6   1124.2948  1245.1059  -180.0  1.56104  0.00   
+  4  3    3    -6   1336.7271  1493.4630  -180.0  1.55920  0.00   
+  4  3    1    -8   1653.0306  1856.4706  0.0     1.55752  0.00   
+  4  7    1    -1   1816.0982  2038.2115  -0.0    1.55703  0.00   
+  4  5    3    0    3379.3290  3764.9574  180.0   1.55622  0.00   
+  4  7    1    -6   3913.0005  3771.5315  -180.0  1.54766  0.00   
+  4  5    3    -5   1382.2717  1406.9228  0.0     1.54952  0.00   
+  4  5    1    3    1231.5970  786.5305   0.0     1.53183  0.00   
+  4  1    3    5    10.6181    7.3706     -180.0  1.52671  0.00   
+  4  1    3    -6   1647.4680  1157.5408  0.0     1.52392  0.00   
+  4  5    1    -8   7.9286     5.3959     0.0     1.51787  0.00   
+  4  2    4    2    6154.1501  4268.8139  180.0   1.51666  0.00   
+  4  2    4    -4   3423.3683  2493.6843  -0.0    1.51368  0.00   
+  4  6    0    2    9252.3187  8920.3709  180.0   1.50424  0.00   
+  4  6    0    -8   4514.8939  4369.8954  -180.0  1.48983  0.00   
+  4  8    0    -4   21178.7319 19996.1970 0.0     1.48796  0.00   
+  4  4    4    -2   21465.7232 20545.4757 -0.0    1.48890  0.00   
+  4  7    1    0    557.5613   520.8465   0.0     1.47828  0.00   
+  4  6    2    1    562.9946   503.5585   180.0   1.47737  0.00   
+  4  5    3    1    1666.2466  1471.1042  180.0   1.47712  0.00   
+  4  4    4    -1   202.8609   180.7352   180.0   1.47730  0.00   
+  4  1    1    7    10780.5574 9080.5953  -0.0    1.47519  0.00   
+  4  4    4    -3   1976.7645  1670.8759  180.0   1.47546  0.00   
+  4  1    1    -8   9414.5139  7394.5831  0.0     1.47176  0.00   
+  4  0    2    7    3182.3455  2502.8143  180.0   1.47248  0.00   
+  4  0    4    4    750.1892   590.3690   180.0   1.47255  0.00   
+  4  5    3    -6   0.2235     0.1799     -180.0  1.46911  0.00   
+  4  7    1    -7   284.1084   230.9464   -180.0  1.46708  0.00   
+  4  6    2    -7   1320.3169  1071.6736  180.0   1.46642  0.00   
+  4  4    2    4    325.2109   309.2371   -180.0  1.45747  0.00   
+  4  4    2    -8   287.2153   302.2854   -180.0  1.44695  0.00   
+  4  8    0    -2   50756.0860 52191.8116 0.0     1.44319  0.00   
+  4  4    4    0    40386.7986 40462.2403 -180.0  1.44233  0.00   
+  4  8    0    -6   48834.6492 39406.4023 -180.0  1.43636  0.00   
+  4  4    4    -4   61959.6383 54182.6466 0.0     1.43890  0.01   
+  4  3    3    4    5578.5118  4626.4893  -180.0  1.43753  0.00   
+  4  2    2    6    1.1137     0.8090     -180.0  1.43232  0.00   
+  4  3    3    -7   1947.9614  1449.5464  0.0     1.43056  0.00   
+  4  2    4    3    3652.6873  2705.9280  180.0   1.43112  0.00   
+  4  2    2    -8   2379.4448  1820.4550  -0.0    1.42647  0.00   
+  4  2    4    -5   2191.4278  1676.3137  180.0   1.42778  0.00   
+  4  0    0    8    345923.3240 266682.9411 -0.0    1.42570  0.01   
+  4  3    1    6    1097.7223  938.8478   180.0   1.39505  0.00   
+  4  5    1    4    682.5362   766.3681   0.0     1.38984  0.00   
+  4  7    1    1    44.4115    50.1895    -180.0  1.38930  0.00   
+  4  3    1    -9   648.2171   706.6839   -0.0    1.38639  0.00   
+  4  4    4    1    3216.6946  3628.8070  -0.0    1.38867  0.00   
+  4  5    3    2    395.7154   443.1806   -180.0  1.38795  0.00   
+  4  1    3    6    3028.3971  3155.0437  0.0     1.38524  0.00   
+  4  4    4    -5   1215.2968  1225.7411  0.0     1.38410  0.00   
+  4  1    3    -7   482.0953   485.9616   -180.0  1.38278  0.00   
+  4  5    3    -7   1073.3447  1074.8978  180.0   1.37942  0.00   
+  4  7    1    -8   234.3600   230.7902   0.0     1.37736  0.00   
+  4  5    1    -9   3210.6143  3153.8678  -0.0    1.37751  0.00   
+  4  6    2    2    260.2225   255.4568   -180.0  1.37818  0.00   
+  4  0    4    5    336.9208   361.3752   -180.0  1.37315  0.00   
+  4  6    2    -8   3.8235     2.8810     0.0     1.36707  0.00   
+  4  8    2    -4   915.4945   736.5865   180.0   1.36563  0.00   
+  4  7    3    -3   3460.0946  3194.1659  -180.0  1.36405  0.00   
+  4  7    3    -4   449.5450   461.8667   -180.0  1.36278  0.00   
+  4  1    5    0    4835.7393  4390.0706  -180.0  1.36423  0.00   
+  4  1    5    -1   62.4662    57.6803    -0.0    1.36405  0.00   
+  4  8    2    -3   2174.1122  1916.8044  180.0   1.35737  0.00   
+  4  8    2    -5   18497.4332 14106.0917 180.0   1.35452  0.00   
+  4  7    3    -2   5409.8118  6964.4536  0.0     1.34617  0.00   
+  4  1    5    1    5565.3261  7469.3772  0.0     1.34529  0.00   
+  4  7    3    -5   1669.7288  2386.7429  180.0   1.34252  0.00   
+  4  1    5    -2   2046.7359  2814.0666  180.0   1.34477  0.00   
+  4  2    4    4    168.0656   205.1051   -180.0  1.33972  0.00   
+  4  2    4    -6   4984.5829  4283.2439  180.0   1.33629  0.00   
+  4  8    2    -2   231.6036   191.7748   0.0     1.33077  0.00   
+  4  8    2    -6   103.7081   116.3047   0.0     1.32541  0.00   
+  4  8    0    0    110915.0785 126382.7897 0.0     1.32444  0.00   
+  4  4    2    5    11233.8747 12817.6384 0.0     1.32439  0.00   
+  4  4    4    2    94782.9783 114087.3943 0.0     1.32245  0.01   
+  4  0    2    8    293.1319   368.5862   180.0   1.31702  0.00   
+  4  4    4    -6   96606.3673 120807.8853 0.0     1.31718  0.01   
+  4  3    3    5    1021.5421  1247.3478  -0.0    1.31793  0.00   
+  4  4    2    -9   4451.8002  5520.1830  180.0   1.31518  0.00   
+  4  8    0    -8   112636.6820 138633.6310 -0.0    1.31393  0.00   
+  4  3    3    -8   6120.1915  7102.5115  180.0   1.31158  0.00   
+  4  7    3    -1   899.3538   1031.0978  180.0   1.31129  0.00   
+  4  1    1    8    140.5640   157.0086   180.0   1.31039  0.00   
+  4  1    1    -9   782.2802   715.2756   180.0   1.30766  0.00   
+  4  1    5    2    1617.0087  1747.1162  180.0   1.30952  0.00   
+  4  1    5    -3   7309.6831  7354.0579  -0.0    1.30871  0.00   
+  4  7    3    -6   8418.5817  7526.8654  -0.0    1.30568  0.00   
+  4  6    4    -3   2271.5028  2359.0079  -0.0    1.29943  0.00   
+  4  9    1    -4   993.8937   837.5850   0.0     1.29744  0.00   
+  4  9    1    -5   322.2010   255.6466   0.0     1.29604  0.00   
+  4  7    1    2    4676.5624  3966.6339  -180.0  1.29754  0.00   
+  4  3    5    -1   715.6072   625.4942   0.0     1.29791  0.00   
+  4  3    5    -2   2611.2991  2200.0985  -0.0    1.29744  0.00   
+  4  5    3    3    422.1538   335.5917   180.0   1.29613  0.00   
+  4  6    4    -2   28.5102    25.6472    0.0     1.29200  0.00   
+  4  4    0    6    19418.1948 18456.6618 180.0   1.29066  0.00   
+  4  6    4    -4   7505.3606  7146.1392  -0.0    1.29015  0.00   
+  4  8    2    -1   9216.1752  8895.7730  180.0   1.28889  0.00   
+  4  5    3    -8   3666.0110  3483.3406  180.0   1.28764  0.00   
+  4  7    1    -9   141.7616   133.1010   180.0   1.28566  0.00   
+  4  2    2    7    16753.1829 16148.0723 -0.0    1.28836  0.00   
+  4  2    2    -9   19692.8814 19762.2271 0.0     1.28349  0.00   
+  4  8    2    -7   413.4276   427.8887   -180.0  1.28160  0.00   
+  4  9    1    -3   5422.2655  5483.9741  180.0   1.28233  0.00   
+  4  4    0    -10  19831.8607 20600.9233 -180.0  1.28092  0.00   
+  4  3    5    0    705.4383   724.7677   -0.0    1.28187  0.00   
+  4  9    1    -6   202.6249   185.4937   -0.0    1.27827  0.00   
+  4  6    2    3    0.3733     0.3796     180.0   1.28017  0.00   
+  4  3    5    -3   5889.4716  6070.8578  -0.0    1.28052  0.00   
+  4  0    4    6    129.1532   119.0527   180.0   1.27524  0.00   
+  4  6    2    -9   340.8846   464.1730   180.0   1.26949  0.00   
+  4  6    4    -1   325.9191   482.4167   -180.0  1.26870  0.00   
+  4  6    4    -5   394.1737   581.9483   -180.0  1.26521  0.00   
+  4  5    1    5    3125.0711  4609.6049  180.0   1.26532  0.00   
+  4  6    0    4    4912.3760  7252.6974  180.0   1.26520  0.00   
+  4  7    3    0    597.0087   802.1220   180.0   1.26320  0.00   
+  4  1    3    7    5872.0890  8434.1606  -0.0    1.26128  0.00   
+  4  1    5    3    24.7383    35.5210    180.0   1.26076  0.00   
+  4  1    3    -8   2159.3551  3100.1996  180.0   1.25913  0.00   
+  4  1    5    -4   2158.3097  3118.0662  180.0   1.25975  0.00   
+  4  7    3    -7   1818.8891  2417.3561  180.0   1.25619  0.00   
+  4  5    1    -10  5954.2315  7031.4223  -180.0  1.25458  0.00   
+  4  6    0    -10  110.6597   117.8504   180.0   1.25319  0.00   
+  4  3    1    7    1463.9864  1612.5904  -0.0    1.25354  0.00   
+  4  9    1    -2   371.5141   360.5869   0.0     1.25235  0.00   
+  4  3    5    1    9265.0817  8385.0852  0.0     1.25109  0.00   
+  4  4    4    3    18.2573    16.4474    0.0     1.24960  0.00   
+  4  9    1    -7   7789.9482  8689.1629  -180.0  1.24607  0.00   
+  4  3    5    -4   1229.6763  1097.1260  -0.0    1.24899  0.00   
+  4  3    1    -10  2715.4672  2985.7659  180.0   1.24641  0.00   
+  4  2    4    5    1285.7693  1155.1937  0.0     1.24861  0.00   
+  4  2    4    -7   708.0020   793.2047   0.0     1.24528  0.00   
+  4  4    4    -7   5981.2484  6550.3571  -0.0    1.24405  0.00   
+  4  2    0    8    24.8484    27.7535    -0.0    1.24197  0.00   
+  4  2    0    -10  1596.5486  2004.4109  180.0   1.23706  0.00   
+  4  8    2    0    593.4599   731.1716   180.0   1.23596  0.00   
+  4  6    4    0    14692.8900 14169.4044 -0.0    1.23199  0.00   
+  4  8    2    -8   821.9978   625.1878   180.0   1.22740  0.00   
+  4  6    4    -6   174.0768   129.7157   -180.0  1.22720  0.00   
+  4  9    1    -1   3038.4681  2729.5167  -0.0    1.21052  0.00   
+  4  3    3    6    948.7460   851.1980   0.0     1.21008  0.00   
+  4  4    2    6    459.1313   412.0139   -0.0    1.20837  0.00   
+  4  7    1    3    81.2715    73.3386    180.0   1.20806  0.00   
+  4  3    5    2    4208.0252  3760.4381  0.0     1.20861  0.00   
+  4  5    3    4    8523.9936  7539.6385  -180.0  1.20667  0.00   
+  4  7    3    1    3111.4862  2736.4548  180.0   1.20632  0.00   
+  4  3    5    -5   55.5542    48.9345    180.0   1.20597  0.00   
+  4  3    3    -9   983.4468   945.9331   -0.0    1.20442  0.00   
+  4  9    1    -8   2334.2278  2311.4455  0.0     1.20259  0.00   
+  4  1    5    4    3993.5331  3957.3115  180.0   1.20344  0.00   
+  4  4    2    -10  157.8938   165.3839   -0.0    1.20037  0.00   
+  4  1    5    -5   659.1539   659.9451   0.0     1.20232  0.00   
+  4  7    3    -8   5.7046     5.4194     0.0     1.19848  0.00   
+  4  5    3    -9   315.3304   300.8337   180.0   1.19858  0.00   
+  4  7    1    -10  9472.0336  8271.1701  -180.0  1.19674  0.00   
+  4  0    2    9    386.7348   269.5507   -0.0    1.18913  0.00   
+  4  5    5    -2   4286.9273  3037.7651  -0.0    1.18980  0.00   
+  4  5    5    -3   0.1460     0.1021     -0.0    1.18920  0.00   
+  4  6    2    4    392.3798   267.9044   180.0   1.18740  0.00   
+  4  10   0    -4   9288.7641  6762.8489  0.0     1.18513  0.00   
+  4  10   0    -6   13573.6235 11025.9166 0.0     1.18275  0.00   
+  4  6    4    1    1820.2853  1322.2815  0.0     1.18528  0.00   
+  4  0    4    7    352.5160   286.3541   180.0   1.18275  0.00   
+  4  6    4    -7   1939.3722  1786.9978  0.0     1.17960  0.00   
+  4  6    2    -10  2.2423     2.2486     -0.0    1.17746  0.00   
+  4  1    1    9    123.8397   122.6226   -0.0    1.17803  0.00   
+  4  8    0    2    30852.0403 31177.0851 180.0   1.17726  0.00   
+  4  5    5    -1   7361.0000  7344.2509  -180.0  1.17765  0.00   
+  4  1    1    -10  708.7808   763.0113   180.0   1.17581  0.00   
+  4  8    2    1    5462.0375  5820.5557  -180.0  1.17634  0.00   
+  4  5    5    -4   5180.5971  5578.1067  -0.0    1.17590  0.00   
+  4  4    4    4    32771.9070 33833.4889 0.0     1.17493  0.00   
+  4  4    4    -8   33526.7919 28622.9953 -180.0  1.16940  0.00   
+  4  8    2    -9   9987.6217  8385.4389  180.0   1.16713  0.00   
+  4  8    0    -10  48770.6673 38153.4334 0.0     1.16621  0.00   
+  4  2    2    8    115.0422   100.3620   0.0     1.16813  0.00   
+  4  2    2    -10  855.6298   559.6416   -0.0    1.16405  0.00   
+  4  2    4    6    20580.9262 13819.5238 180.0   1.16164  0.00   
+  4  9    1    0    241.9935   175.9402   180.0   1.16041  0.00   
+  4  2    4    -8   3048.2336  2422.3664  0.0     1.15851  0.00   
+  4  3    5    3    3878.1979  3145.9058  0.0     1.15806  0.00   
+  4  5    1    6    59.0567    50.4302    0.0     1.15711  0.00   
+  4  3    5    -6   59.8099    52.2732    -0.0    1.15507  0.00   
+  4  9    1    -9   611.3095   563.7453   180.0   1.15145  0.00   
+  4  1    3    8    3082.8641  2765.5276  0.0     1.15358  0.00   
+  4  5    5    0    7456.2351  6688.2411  -0.0    1.15386  0.00   
+  4  1    3    -9   1.4576     1.3388     -0.0    1.15172  0.00   
+  4  5    5    -5   9224.6662  8534.2396  -180.0  1.15112  0.00   
+  4  5    1    -11  1427.6473  1511.2943  0.0     1.14780  0.00   
+  4  9    3    -4   382.5908   425.5769   0.0     1.14472  0.00   
+  4  0    6    0    2556.4729  2626.6424  -0.0    1.14640  0.00   
+  4  9    3    -5   60.3998    64.6877    -0.0    1.14375  0.00   
+  4  7    3    2    4411.1622  4898.1563  -0.0    1.14478  0.00   
+  4  0    0    10   359.6922   424.1063   -0.0    1.14056  0.00   
+  4  1    5    5    4669.0087  5066.0483  -0.0    1.14168  0.00   
+  4  10   0    -2   11637.1657 15912.5149 0.0     1.13915  0.00   
+  4  1    5    -6   4479.7930  5328.6002  180.0   1.14051  0.00   
+  4  0    6    1    1427.1979  1658.5210  180.0   1.14065  0.00   
+  4  7    3    -9   3309.9498  4654.6447  180.0   1.13660  0.00   
+  4  3    1    8    47.8754    68.5418    180.0   1.13641  0.00   
+  4  10   0    -8   767.7368   1439.4845  0.0     1.13285  0.00   
+  4  9    3    -3   882.7041   1421.7922  -180.0  1.13430  0.00   
+  4  9    3    -6   943.2937   1849.0487  -0.0    1.13149  0.00   
+  4  3    1    -11  14.5459    30.9448    0.0     1.13047  0.00   
+  4  6    4    2    1445.7892  2830.3188  0.0     1.13219  0.00   
+  4  6    4    -8   1030.9424  2097.5313  -0.0    1.12601  0.00   
+  4  10   2    -5   3205.8646  6217.2778  0.0     1.12490  0.00   
+  4  8    4    -4   2155.0235  4152.8328  -180.0  1.12520  0.00   
+  4  2    6    -1   1831.0988  3598.0405  180.0   1.12571  0.00   
+  4  7    1    4    2442.5790  4920.7864  -0.0    1.12379  0.00   
+  4  0    6    2    689.8554   1385.4812  -180.0  1.12392  0.00   
+  4  5    3    5    953.9377   1971.7468  -180.0  1.12247  0.00   
+  4  10   2    -4   4.1792     9.0549     180.0   1.12047  0.00   
+  4  8    4    -3   1526.1802  3319.4383  -180.0  1.12057  0.00   
+  4  10   2    -6   113.4701   172.3151   180.0   1.11846  0.00   
+  4  5    5    1    329.0620   713.6507   0.0     1.12049  0.00   
+  4  8    4    -5   601.0722   1030.3969  180.0   1.11896  0.00   
+  4  2    6    0    2462.2406  5334.0481  180.0   1.12047  0.00   
+  4  2    6    -2   476.0666   997.1586   180.0   1.12006  0.00   
+  4  5    5    -6   2056.5584  2510.7097  0.0     1.11698  0.00   
+  4  5    3    -10  1793.2344  1594.6441  -0.0    1.11496  0.00   
+  4  7    1    -11  2404.4809  2075.3693  180.0   1.11327  0.00   
+  4  3    3    7    7949.9921  7170.6448  0.0     1.11422  0.00   
+  4  9    3    -2   2325.6027  2014.1740  0.0     1.11339  0.00   
+  4  8    2    2    136.2664   120.4664   0.0     1.11381  0.00   
+  4  9    3    -7   2036.1763  1744.1969  -180.0  1.10897  0.00   
+  4  3    3    -10  302.0077   264.2339   -0.0    1.10921  0.00   
+  4  4    2    7    11933.7861 9269.2326  0.0     1.10772  0.00   
+  4  8    2    -10  48.5523    36.3377    0.0     1.10444  0.00   
+  4  10   2    -3   49190.1442 35058.8019 -180.0  1.10556  0.00   
+  4  9    1    1    5319.6466  3795.6991  -180.0  1.10551  0.00   
+  4  8    4    -2   41071.8314 29350.7262 -180.0  1.10546  0.00   
+  4  2    6    1    37611.7107 27709.5445 -180.0  1.10478  0.00   
+  4  10   2    -7   38838.6374 34855.8200 0.0     1.10171  0.00   
+  4  8    4    -6   35546.7742 30117.1572 0.0     1.10238  0.00   
+  4  2    6    -3   39470.2807 29988.3819 0.0     1.10401  0.00   
+  4  4    2    -11  2345.9570  2171.0819  -0.0    1.10078  0.00   
+  4  3    5    4    88.2863    70.8198    0.0     1.10291  0.00   
+  4  6    2    5    148392.5477 132137.7368 -180.0  1.10183  0.01   
+  4  4    4    5    3027.0864  2701.2482  180.0   1.10180  0.00   
+  4  3    5    -7   3165.6798  2946.5109  0.0     1.09975  0.00   
+  4  9    1    -10  533.6385   278.2739   0.0     1.09606  0.00   
+  4  0    4    8    193350.0995 134162.4401 -180.0  1.09754  0.01   
+  4  4    4    -9   244.2672   134.2238   0.0     1.09647  0.00   
+  4  0    6    3    4872.9784  3417.0093  -0.0    1.09759  0.00   
+  4  6    2    -11  311618.7823 149486.2917 -180.0  1.09275  0.02   
+  4  9    3    -1   851.0714   1112.5481  0.0     1.08368  0.00   
+  4  0    2    10   98.6406    133.9402   0.0     1.08258  0.00   
+  4  10   2    -2   681.7972   877.0100   -0.0    1.08138  0.00   
+  4  7    3    3    4568.6708  5994.2685  180.0   1.08192  0.00   
+  4  8    4    -1   4.9980     6.5294     0.0     1.08110  0.00   
+  4  2    4    7    105.9594   144.1187   180.0   1.08079  0.00   
+  4  9    3    -8   8.3528     17.0104    180.0   1.07799  0.00   
+  4  5    5    2    3519.2311  5322.5321  0.0     1.08004  0.00   
+  4  2    6    2    315.4128   480.5787   0.0     1.07993  0.00   
+  4  2    4    -9   625.4760   1305.3409  -180.0  1.07791  0.00   
+  4  1    5    6    4641.7890  7519.7479  180.0   1.07876  0.00   
+  4  2    6    -4   1985.6419  3166.0314  -0.0    1.07885  0.00   
+  4  10   2    -8   110.5471   300.2563   0.0     1.07598  0.00   
+  4  8    4    -7   371.4595   885.2685   -0.0    1.07679  0.00   
+  4  1    5    -7   4995.7924  11225.7617 0.0     1.07759  0.00   
+  4  5    5    -7   6.0807     16.4677    0.0     1.07600  0.00   
+  4  6    4    3    556.3942   1520.7877  -180.0  1.07594  0.00   
+  4  7    3    -10  5633.5866  12239.5298 0.0     1.07376  0.00   
+  4  6    0    6    435.1676   878.9653   180.0   1.07274  0.00   
+  4  6    4    -9   387.1432   817.2868   -180.0  1.06958  0.00   
+  4  1    1    10   1233.9242  2600.7823  -180.0  1.06954  0.00   
+  4  11   1    -5   84.1190    156.1615   180.0   1.06831  0.00   
+  4  11   1    -6   3.3757     5.6244     -180.0  1.06735  0.00   
+  4  4    6    -2   1176.6070  2501.0589  -180.0  1.06977  0.00   
+  4  1    1    -11  24.8202    42.1353    0.0     1.06771  0.00   
+  4  7    5    -3   677.3376   1332.3819  -180.0  1.06866  0.00   
+  4  4    0    8    12278.2075 23540.6218 -0.0    1.06850  0.00   
+  4  7    5    -4   95.1684    168.7551   180.0   1.06805  0.00   
+  4  2    2    9    14614.0045 24399.9566 -0.0    1.06684  0.00   
+  4  6    0    -12  2166.4816  2924.7731  -180.0  1.06332  0.00   
+  4  4    6    -1   1.3163     2.0675     -0.0    1.06544  0.00   
+  4  2    2    -11  15510.5604 21011.1835 -180.0  1.06338  0.00   
+  4  4    6    -3   1873.9920  2839.1017  180.0   1.06475  0.00   
+  4  4    0    -12  21733.2698 28246.9030 -180.0  1.06158  0.00   
+  4  5    1    7    2424.2952  3264.8798  0.0     1.06327  0.00   
+  4  0    6    4    1216.8728  1681.5177  0.0     1.06365  0.00   
+  4  11   1    -4   3736.1708  5085.4725  0.0     1.06000  0.00   
+  4  1    3    9    1202.8215  1612.9219  0.0     1.06019  0.00   
+  4  10   0    0    577.0001   814.1249   0.0     1.05955  0.00   
+  4  7    5    -2   1.2094     1.6464     -0.0    1.06000  0.00   
+  4  11   1    -7   38.1606    65.5221    -180.0  1.05720  0.00   
+  4  1    3    -10  1585.2430  2359.9917  0.0     1.05857  0.00   
+  4  7    5    -5   2505.7984  3887.4922  -180.0  1.05821  0.00   
+  4  5    1    -12  1074.4873  2091.1612  -180.0  1.05519  0.00   
+  4  10   0    -10  3512.0281  4622.1342  0.0     1.05114  0.00   
+  4  4    6    0    1019.2939  1598.6611  0.0     1.05210  0.00   
+  4  8    2    3    16710.9754 22529.9236 180.0   1.05126  0.00   
+  4  10   2    -1   53276.8078 57768.9447 0.0     1.04971  0.00   
+  4  4    6    -4   957.0183   1175.6125  0.0     1.05076  0.00   
+  4  8    4    0    60231.7076 62127.9689 -180.0  1.04929  0.00   
+  4  9    1    2    138.1075   132.1767   -0.0    1.04876  0.00   
+  4  9    3    0    2672.4283  2352.9775  0.0     1.04729  0.00   
+  4  2    6    3    63414.2317 56115.4778 -180.0  1.04772  0.00   
+  4  7    1    5    1181.7548  1023.3072  0.0     1.04609  0.00   
+  4  2    6    -5   64806.6808 56409.7526 -180.0  1.04641  0.00   
+  4  3    5    5    4229.5955  3659.9420  -0.0    1.04604  0.00   
+  4  10   2    -9   81872.5048 66942.7235 0.0     1.04314  0.01   
+  4  8    4    -8   81283.3843 67443.7666 -180.0  1.04404  0.01   
+  4  5    3    6    1641.3423  1401.6133  -180.0  1.04487  0.00   
+  4  8    2    -11  5.9622     4.8366     0.0     1.04207  0.00   
+  4  11   1    -3   33.1865    27.1213    180.0   1.04304  0.00   
+  4  3    5    -8   469.7345   383.3221   -0.0    1.04286  0.00   
+  4  7    5    -1   5721.6693  4660.7467  -180.0  1.04272  0.00   
+  4  9    3    -9   578.0950   491.9475   -180.0  1.04069  0.00   
+  4  9    1    -11  5523.3576  4912.6119  180.0   1.03923  0.00   
+  4  11   1    -8   5691.4898  5299.0210  0.0     1.03860  0.00   
+  4  7    5    -6   23.8319    20.5777    180.0   1.03989  0.00   
+  4  5    3    -11  173.5421   166.7199   -0.0    1.03799  0.00   
+  4  7    1    -12  558.4325   562.7233   -180.0  1.03648  0.00   
+  4  3    1    9    1035.9546  984.7090   -180.0  1.03827  0.00   
+_reflns_number_total  1184
+_reflns_d_resolution_low    6.388
+_reflns_d_resolution_high   1.033
+
+# POWDER DATA TABLE
+_pd_meas_2theta_range_min  10.01313
+_pd_meas_2theta_range_max  119.99238
+_pd_meas_2theta_range_inc  0.02626
+_pd_proc_2theta_range_min  9.98829
+_pd_proc_2theta_range_max  119.96754
+_pd_proc_2theta_range_inc  0.02626
+_pd_proc_number_of_points  4189
+
+loop_
+   _pd_meas_intensity_total
+   _pd_calc_intensity_total
+   _pd_proc_intensity_bkg_calc
+   _pd_proc_ls_weight
+  2696         0            0           0         
+  2569         0            0           0         
+  2604         0            0           0         
+  2714         0            0           0         
+  2632         0            0           0         
+  2676         0            0           0         
+  2690         0            0           0         
+  2568         0            0           0         
+  2654         0            0           0         
+  2582         0            0           0         
+  2628         0            0           0         
+  2572         0            0           0         
+  2569         0            0           0         
+  2545         0            0           0         
+  2564         0            0           0         
+  2513         0            0           0         
+  2570         0            0           0         
+  2469         0            0           0         
+  2422         0            0           0         
+  2583         0            0           0         
+  2458         0            0           0         
+  2486         0            0           0         
+  2577         0            0           0         
+  2520         0            0           0         
+  2454         0            0           0         
+  2431         0            0           0         
+  2502         0            0           0         
+  2390         0            0           0         
+  2528         0            0           0         
+  2438         0            0           0         
+  2430         0            0           0         
+  2468         0            0           0         
+  2453         0            0           0         
+  2416         0            0           0         
+  2369         0            0           0         
+  2420         0            0           0         
+  2376         0            0           0         
+  2340         0            0           0         
+  2422         0            0           0         
+  2394         0            0           0         
+  2349         0            0           0         
+  2402         0            0           0         
+  2431         0            0           0         
+  2336         0            0           0         
+  2385         0            0           0         
+  2274         0            0           0         
+  2307         0            0           0         
+  2322         0            0           0         
+  2255         0            0           0         
+  2310         0            0           0         
+  2318         0            0           0         
+  2395         0            0           0         
+  2323         0            0           0         
+  2270         0            0           0         
+  2323         0            0           0         
+  2296         0            0           0         
+  2265         0            0           0         
+  2315         0            0           0         
+  2273         0            0           0         
+  2360         0            0           0         
+  2244         0            0           0         
+  2227         0            0           0         
+  2301         0            0           0         
+  2246         0            0           0         
+  2245         0            0           0         
+  2205         0            0           0         
+  2251         0            0           0         
+  2234         0            0           0         
+  2232         0            0           0         
+  2171         0            0           0         
+  2224         0            0           0         
+  2078         0            0           0         
+  2160         0            0           0         
+  2195         0            0           0         
+  2160         0            0           0         
+  2187         0            0           0         
+  2195         0            0           0         
+  2141         0            0           0         
+  2151         0            0           0         
+  2185         0            0           0         
+  2133         0            0           0         
+  2206         0            0           0         
+  2119         0            0           0         
+  2086         0            0           0         
+  2052         0            0           0         
+  2189         0            0           0         
+  2089         0            0           0         
+  2097         0            0           0         
+  2082         0            0           0         
+  2122         0            0           0         
+  2045         0            0           0         
+  2035         0            0           0         
+  2043         0            0           0         
+  2064         0            0           0         
+  2102         0            0           0         
+  2093         0            0           0         
+  2002         0            0           0         
+  2034         0            0           0         
+  2032         0            0           0         
+  2050         0            0           0         
+  2075         0            0           0         
+  1953         0            0           0         
+  2041         0            0           0         
+  2070         0            0           0         
+  2052         0            0           0         
+  1987         0            0           0         
+  2026         0            0           0         
+  2034         0            0           0         
+  2025         0            0           0         
+  2033         0            0           0         
+  2016         0            0           0         
+  1940         0            0           0         
+  1986         0            0           0         
+  1994         0            0           0         
+  1979         0            0           0         
+  1967         0            0           0         
+  1966         0            0           0         
+  1968         0            0           0         
+  1945         0            0           0         
+  2010         0            0           0         
+  1940         0            0           0         
+  1987         0            0           0         
+  1963         0            0           0         
+  1835         0            0           0         
+  1984         0            0           0         
+  1860         0            0           0         
+  1832         0            0           0         
+  1840         0            0           0         
+  1877         0            0           0         
+  1929         0            0           0         
+  1944         0            0           0         
+  1881         0            0           0         
+  1869         0            0           0         
+  1802         0            0           0         
+  1901         0            0           0         
+  1819         0            0           0         
+  1829         0            0           0         
+  1877         0            0           0         
+  1875         0            0           0         
+  1876         0            0           0         
+  1870         0            0           0         
+  1893         0            0           0         
+  1852         0            0           0         
+  1783         0            0           0         
+  1830         0            0           0         
+  1865         0            0           0         
+  1837         0            0           0         
+  1794         0            0           0         
+  1807         0            0           0         
+  1799         0            0           0         
+  1779         0            0           0         
+  1784         0            0           0         
+  1716         0            0           0         
+  1804         0            0           0         
+  1803         0            0           0         
+  1775         0            0           0         
+  1815         0            0           0         
+  1785         0            0           0         
+  1802         0            0           0         
+  1676         0            0           0         
+  1728         0            0           0         
+  1842         0            0           0         
+  1768         0            0           0         
+  1830         0            0           0         
+  1766         0            0           0         
+  1768         0            0           0         
+  1773         0            0           0         
+  1789         0            0           0         
+  1807         0            0           0         
+  1728         0            0           0         
+  1726         0            0           0         
+  1767         0            0           0         
+  1797         0            0           0         
+  1663         0            0           0         
+  1654         0            0           0         
+  1714         0            0           0         
+  1693         0            0           0         
+  1704         0            0           0         
+  1647         0            0           0         
+  1646         0            0           0         
+  1666         0            0           0         
+  1659         0            0           0         
+  1647         0            0           0         
+  1638         0            0           0         
+  1660         0            0           0         
+  1754         0            0           0         
+  1616         1622.1557    1621.67137  0.00061881 
+  1656         1618.90134   1618.39894  0.00060386 
+  1692         1615.65442   1615.13277  0.00059102 
+  1652         1612.41504   1611.87284  0.00060533 
+  1652         1609.18333   1608.61914  0.00060533 
+  1626         1605.95941   1605.37166  0.00061501 
+  1595         1602.74344   1602.13038  0.00062696 
+  1632         1599.5356    1598.89532  0.00061275 
+  1615         1596.33609   1595.66644  0.0006192 
+  1627         1593.14516   1592.44374  0.00061463 
+  1664         1589.96307   1589.22722  0.00060096 
+  1604         1586.79014   1586.01686  0.00062344 
+  1576         1583.62675   1582.81265  0.00063452 
+  1630         1580.47333   1579.61458  0.0006135 
+  1679         1577.33041   1576.42265  0.00059559 
+  1502         1574.19858   1573.23685  0.00066578 
+  1617         1571.0786    1570.05715  0.00061843 
+  1620         1567.97133   1566.88357  0.00061728 
+  1560         1564.87785   1563.71607  0.00064103 
+  1645         1561.79948   1560.55467  0.0006079 
+  1552         1558.73782   1557.39934  0.00064433 
+  1593         1555.6949    1554.25008  0.00062775 
+  1604         1552.67329   1551.10687  0.00062344 
+  1546         1549.67626   1547.96971  0.00064683 
+  1599         1546.70813   1544.8386   0.00062539 
+  1561         1543.7746    1541.71351  0.00064061 
+  1608         1540.8835    1538.59444  0.00062189 
+  1581         1538.04584   1535.48138  0.00063251 
+  1488         1535.27771   1532.37432  0.00067204 
+  1592         1532.60387   1529.27325  0.00062814 
+  1562         1530.06554   1526.17816  0.0006402 
+  1602         1527.74096   1523.08905  0.00062422 
+  1556         1525.80081   1520.0059   0.00064267 
+  1620         1524.59438   1516.9287   0.00061728 
+  1602         1524.44413   1513.85745  0.00062422 
+  1572         1524.74294   1510.79213  0.00063613 
+  1586         1526.48634   1507.73273  0.00063052 
+  1602         1530.13817   1504.67926  0.00062422 
+  1502         1533.70652   1501.63169  0.00066578 
+  1596         1540.24822   1498.59002  0.00062657 
+  1538         1547.95869   1495.55423  0.0006502 
+  1552         1558.89216   1492.52433  0.00064433 
+  1627         1573.79373   1489.50029  0.00061463 
+  1720         1594.27508   1486.48211  0.0005814 
+  1675         1620.40129   1483.46979  0.00059701 
+  1724         1644.77835   1480.46331  0.00058005 
+  1707         1637.11996   1477.46266  0.00058582 
+  1674         1599.20649   1474.46783  0.00059737 
+  1663         1557.20499   1471.47882  0.00060132 
+  1508         1530.01422   1468.49561  0.00066313 
+  1560         1515.74658   1465.5182   0.00064103 
+  1496         1504.19093   1462.54658  0.00066845 
+  1521         1494.59443   1459.58073  0.00065746 
+  1569         1487.94113   1456.62065  0.00063735 
+  1540         1483.07883   1453.66633  0.00064935 
+  1516         1474.70002   1450.71776  0.00065963 
+  1528         1464.63894   1447.77493  0.00065445 
+  1463         1455.91314   1444.83783  0.00068353 
+  1400         1449.71069   1441.90645  0.00071429 
+  1422         1445.01214   1438.98079  0.00070323 
+  1433         1441.01816   1436.06083  0.00069784 
+  1433         1437.3804    1433.14657  0.00069784 
+  1457         1433.95167   1430.23799  0.00068634 
+  1421         1430.65985   1427.3351   0.00070373 
+  1438         1427.46434   1424.43786  0.00069541 
+  1435         1424.34024   1421.54629  0.00069686 
+  1470         1421.27146   1418.66037  0.00068027 
+  1375         1418.24711   1415.78009  0.00072727 
+  1463         1415.25996   1412.90544  0.00068353 
+  1354         1412.30401   1410.03641  0.00073855 
+  1455         1409.37588   1407.173    0.00068729 
+  1364         1406.47251   1404.31519  0.00073314 
+  1453         1403.59218   1401.46298  0.00068823 
+  1360         1400.73476   1398.61636  0.00073529 
+  1442         1397.89744   1395.77531  0.00069348 
+  1454         1395.08179   1392.93984  0.00068776 
+  1383         1392.28725   1390.10992  0.00072307 
+  1444         1389.51557   1387.28556  0.00069252 
+  1370         1386.76884   1384.46674  0.00072993 
+  1419         1384.05049   1381.65345  0.00070472 
+  1414         1381.36598   1378.84569  0.00070721 
+  1404         1378.72469   1376.04344  0.00071225 
+  1398         1376.14461   1373.2467   0.00071531 
+  1413         1373.66461   1370.45546  0.00070771 
+  1389         1371.3601    1367.6697   0.00071994 
+  1382         1369.27944   1364.88943  0.00072359 
+  1375         1367.32485   1362.11463  0.00072727 
+  1392         1365.79133   1359.34529  0.00071839 
+  1376         1364.44774   1356.58141  0.00072674 
+  1417         1363.36696   1353.82297  0.00070572 
+  1433         1362.89507   1351.06997  0.00069784 
+  1354         1362.62103   1348.3224   0.00073855 
+  1409         1363.52587   1345.58024  0.00070972 
+  1430         1365.1025    1342.8435   0.0006993 
+  1364         1368.04886   1340.11216  0.00073314 
+  1381         1369.9404    1337.38621  0.00072411 
+  1400         1365.18843   1334.66564  0.00071429 
+  1352         1355.99183   1331.95045  0.00073964 
+  1299         1347.14155   1329.24063  0.00076982 
+  1318         1341.62798   1326.53617  0.00075873 
+  1346         1338.8764    1323.83705  0.00074294 
+  1347         1337.84239   1321.14328  0.00074239 
+  1334         1338.06965   1318.45484  0.00074963 
+  1362         1339.17379   1315.77172  0.00073421 
+  1405         1340.77669   1313.09391  0.00071174 
+  1304         1343.11184   1310.42142  0.00076687 
+  1281         1347.04692   1307.75422  0.00078064 
+  1412         1353.25195   1305.09231  0.00070822 
+  1312         1360.95721   1302.43568  0.0007622 
+  1383         1368.51196   1299.78432  0.00072307 
+  1341         1374.95776   1297.13823  0.00074571 
+  1352         1378.43723   1294.49739  0.00073964 
+  1320         1376.0271    1291.86179  0.00075758 
+  1399         1367.54583   1289.23144  0.0007148 
+  1379         1356.19065   1286.60631  0.00072516 
+  1355         1345.91584   1283.98641  0.00073801 
+  1459         1338.32082   1281.37171  0.0006854 
+  1380         1332.79152   1278.76222  0.00072464 
+  1334         1328.46513   1276.15793  0.00074963 
+  1336         1323.82948   1273.55882  0.0007485 
+  1365         1316.81792   1270.96489  0.0007326 
+  1380         1307.27993   1268.37614  0.00072464 
+  1331         1296.98188   1265.79254  0.00075131 
+  1294         1287.81768   1263.21409  0.0007728 
+  1310         1280.59511   1260.64079  0.00076336 
+  1258         1275.06854   1258.07263  0.00079491 
+  1337         1270.78065   1255.5096   0.00074794 
+  1257         1267.897     1252.95168  0.00079554 
+  1315         1265.56241   1250.39887  0.00076046 
+  1188         1264.06587   1247.85117  0.00084175 
+  1198         1263.67934   1245.30856  0.00083472 
+  1186         1263.76341   1242.77104  0.00084317 
+  1308         1265.83118   1240.2386   0.00076453 
+  1232         1268.33706   1237.71122  0.00081169 
+  1228         1269.22091   1235.18891  0.00081433 
+  1195         1262.17551   1232.67165  0.00083682 
+  1237         1251.32554   1230.15943  0.00080841 
+  1243         1240.95941   1227.65225  0.00080451 
+  1274         1233.83625   1225.1501   0.00078493 
+  1216         1229.0346    1222.65296  0.00082237 
+  1249         1225.29376   1220.16084  0.00080064 
+  1292         1222.03733   1217.67372  0.00077399 
+  1152         1219.03612   1215.1916   0.00086806 
+  1219         1216.18863   1212.71446  0.00082034 
+  1210         1213.44298   1210.24231  0.00082645 
+  1141         1210.76994   1207.77512  0.00087642 
+  1225         1208.15082   1205.31289  0.00081633 
+  1157         1205.57512   1202.85562  0.0008643 
+  1187         1203.0351    1200.40329  0.00084246 
+  1168         1200.5263    1197.9559   0.00085616 
+  1206         1198.04572   1195.51344  0.00082919 
+  1205         1195.5916    1193.0759   0.00082988 
+  1143         1193.16318   1190.64328  0.00087489 
+  1231         1190.76056   1188.21556  0.00081235 
+  1186         1188.38466   1185.79273  0.00084317 
+  1159         1186.03728   1183.3748   0.00086281 
+  1197         1183.72126   1180.96175  0.00083542 
+  1164         1181.44071   1178.55356  0.00085911 
+  1228         1179.20148   1176.15025  0.00081433 
+  1208         1177.01178   1173.75179  0.00082781 
+  1124         1174.88324   1171.35817  0.00088968 
+  1087         1172.8323    1168.9694   0.00091996 
+  1186         1170.88185   1166.58546  0.00084317 
+  1159         1169.06176   1164.20635  0.00086281 
+  1162         1167.40446   1161.83205  0.00086059 
+  1153         1165.93967   1159.46256  0.0008673 
+  1132         1164.72263   1157.09787  0.00088339 
+  1125         1163.88027   1154.73797  0.00088889 
+  1107         1163.58826   1152.38285  0.00090334 
+  1113         1163.98013   1150.03252  0.00089847 
+  1147         1165.02468   1147.68695  0.00087184 
+  1114         1166.47826   1145.34614  0.00089767 
+  1191         1168.11526   1143.01008  0.00083963 
+  1095         1170.22772   1140.67877  0.00091324 
+  1087         1173.47497   1138.3522   0.00091996 
+  1140         1177.79833   1136.03035  0.00087719 
+  1183         1181.93742   1133.71323  0.00084531 
+  1108         1184.80727   1131.40082  0.00090253 
+  1079         1184.87698   1129.09311  0.00092678 
+  1177         1179.8867    1126.7901   0.00084962 
+  1154         1170.14071   1124.49178  0.00086655 
+  1145         1158.2527    1122.19814  0.00087336 
+  1090         1146.99909   1119.90918  0.00091743 
+  1137         1137.79165   1117.62488  0.00087951 
+  1089         1130.60039   1115.34524  0.00091827 
+  1074         1124.90841   1113.07025  0.0009311 
+  1100         1120.23579   1110.7999   0.00090909 
+  1114         1116.24182   1108.53418  0.00089767 
+  1085         1112.70386   1106.2731   0.00092166 
+  1040         1109.47944   1104.01663  0.00096154 
+  1058         1106.47676   1101.76477  0.00094518 
+  1061         1103.63564   1099.51752  0.00094251 
+  1084         1100.91536   1097.27487  0.00092251 
+  1069         1098.28755   1095.0368   0.00093545 
+  1052         1095.74699   1092.80331  0.00095057 
+  1049         1093.24914   1090.5744   0.00095329 
+  1099         1090.80538   1088.35005  0.00090992 
+  1064         1088.39258   1086.13025  0.00093985 
+  1031         1086.01188   1083.91501  0.00096993 
+  1019         1083.65834   1081.70431  0.00098135 
+  1077         1081.32813   1079.49814  0.00092851 
+  1047         1079.01821   1077.2965   0.00095511 
+  1054         1076.72612   1075.09938  0.00094877 
+  1055         1074.44988   1072.90677  0.00094787 
+  1011         1072.18789   1070.71867  0.00098912 
+  1019         1069.93882   1068.53506  0.00098135 
+  1046         1067.70156   1066.35594  0.00095602 
+  1002         1065.4752    1064.1813   0.000998  
+  1051         1063.25897   1062.01113  0.00095147 
+  1017         1061.05224   1059.84543  0.00098328 
+  1041         1058.85527   1057.68419  0.00096061 
+  1060         1056.66597   1055.5274   0.0009434 
+  1009         1054.48478   1053.37505  0.00099108 
+  1063         1052.31174   1051.22714  0.00094073 
+  1026         1050.14579   1049.08366  0.00097466 
+  1047         1047.98707   1046.94459  0.00095511 
+  1087         1045.83538   1044.80994  0.00091996 
+  1093         1043.69055   1042.6797   0.00091491 
+  1041         1041.55244   1040.55385  0.00096061 
+  986          1039.42093   1038.43239  0.0010142 
+  988          1037.29593   1036.31532  0.00101215 
+  1009         1035.18191   1034.20262  0.00099108 
+  1065         1033.06974   1032.09429  0.00093897 
+  1025         1030.96392   1029.99032  0.00097561 
+  1001         1028.86671   1027.89071  0.000999  
+  1013         1026.77357   1025.79544  0.00098717 
+  1021         1024.68961   1023.70451  0.00097943 
+  1019         1022.60925   1021.61791  0.00098135 
+  943          1020.54389   1019.53564  0.00106045 
+  930          1018.47661   1017.45768  0.00107527 
+  984          1016.41598   1015.38403  0.00101626 
+  933          1014.36575   1013.31468  0.00107181 
+  941          1012.31894   1011.24962  0.0010627 
+  967          1010.27932   1009.18885  0.00103413 
+  980          1008.24714   1007.13237  0.00102041 
+  1001         1006.2227    1005.08015  0.000999  
+  966          1004.20636   1003.0322   0.0010352 
+  992          1002.19855   1000.98851  0.00100806 
+  974          1000.19979   998.94906   0.00102669 
+  1035         998.2107     996.91386   0.00096618 
+  934          996.23202    994.8829    0.00107066 
+  979          994.26493    992.85616   0.00102145 
+  974          992.30997    990.83365   0.00102669 
+  969          990.36875    988.81535   0.00103199 
+  1007         988.44308    986.80126   0.00099305 
+  972          986.53472    984.79136   0.00102881 
+  992          984.6464     982.78566   0.00100806 
+  972          982.78139    980.78414   0.00102881 
+  966          980.94389    978.7868    0.0010352 
+  947          979.13974    976.79364   0.00105597 
+  945          977.37542    974.80463   0.0010582 
+  979          975.66095    972.81978   0.00102145 
+  962          974.00979    970.83908   0.0010395 
+  957          972.44003    968.86252   0.00104493 
+  949          970.97852    966.8901    0.00105374 
+  937          969.66461    964.92181   0.00106724 
+  997          968.55747    962.95763   0.00100301 
+  955          967.74721    960.99757   0.00104712 
+  951          967.36909    959.04161   0.00105152 
+  940          967.61315    957.08976   0.00106383 
+  965          968.69468    955.14199   0.00103627 
+  962          970.67606    953.19831   0.0010395 
+  946          973.13677    951.25871   0.00105708 
+  963          975.49125    949.32318   0.00103842 
+  980          978.09886    947.39172   0.00102041 
+  967          981.85304    945.46431   0.00103413 
+  897          986.56931    943.54095   0.00111483 
+  947          989.4239     941.62163   0.00105597 
+  933          987.15772    939.70635   0.00107181 
+  938          980.16138    937.79509   0.0010661 
+  914          970.83046    935.88786   0.00109409 
+  930          961.5693     933.98465   0.00107527 
+  863          953.64919    932.08544   0.00115875 
+  912          947.11915    930.19023   0.00109649 
+  930          941.76559    928.29901   0.00107527 
+  918          937.20459    926.41178   0.00108932 
+  877          933.19597    924.52853   0.00114025 
+  928          929.69528    922.64926   0.00107759 
+  890          926.5757     920.77395   0.0011236 
+  931          923.80459    918.9026    0.00107411 
+  877          921.26939    917.0352    0.00114025 
+  862          918.89675    915.17174   0.00116009 
+  895          916.64051    913.31223   0.00111732 
+  901          914.46442    911.45664   0.00110988 
+  893          912.35202    909.60499   0.00111982 
+  904          910.29062    907.75724   0.00110619 
+  884          908.26856    905.91341   0.00113122 
+  851          906.27996    904.07348   0.00117509 
+  913          904.31842    902.23745   0.00109529 
+  889          902.3802     900.40531   0.00112486 
+  894          900.46205    898.57706   0.00111857 
+  859          898.56138    896.75268   0.00116414 
+  856          896.67615    894.93217   0.00116822 
+  887          894.80473    893.11552   0.0011274 
+  855          892.94579    891.30273   0.00116959 
+  857          891.09825    889.49379   0.00116686 
+  897          889.26124    887.68869   0.00111483 
+  893          887.43403    885.88742   0.00111982 
+  861          885.61603    884.08999   0.00116144 
+  865          883.80676    882.29638   0.00115607 
+  795          882.00582    880.50658   0.00125786 
+  845          880.21288    878.72059   0.00118343 
+  820          878.42769    876.93841   0.00121951 
+  866          876.65005    875.16002   0.00115473 
+  887          874.87979    873.38542   0.0011274 
+  844          873.11681    871.6146    0.00118483 
+  839          871.36104    869.84756   0.0011919 
+  897          869.61244    868.08428   0.00111483 
+  830          867.871      866.32477   0.00120482 
+  859          866.13678    864.56901   0.00116414 
+  843          864.40982    862.817     0.00118624 
+  879          862.69025    861.06874   0.00113766 
+  854          860.98711    859.32421   0.00117096 
+  910          859.2876     857.5834    0.0010989 
+  830          857.59122    855.84632   0.00120482 
+  839          855.90749    854.11296   0.0011919 
+  832          854.22616    852.38331   0.00120192 
+  810          852.55259    850.65735   0.00123457 
+  868          850.89083    848.9351    0.00115207 
+  812          849.23938    847.21653   0.00123153 
+  868          847.59794    845.50165   0.00115207 
+  816          845.96851    843.79044   0.00122549 
+  736          844.35792    842.0829    0.0013587 
+  851          842.75547    840.37902   0.00117509 
+  813          841.1682     838.6788    0.00123001 
+  853          839.60067    836.98224   0.00117233 
+  823          838.05104    835.28931   0.00121507 
+  825          836.52061    833.60002   0.00121212 
+  813          835.01892    831.91437   0.00123001 
+  810          833.54181    830.23233   0.00123457 
+  815          832.09278    828.55392   0.00122699 
+  822          830.64788    826.87911   0.00121655 
+  863          829.2155     825.20791   0.00115875 
+  797          827.82086    823.54031   0.00125471 
+  846          826.4747     821.8763    0.00118203 
+  802          825.19594    820.21588   0.00124688 
+  782          823.99279    818.55903   0.00127877 
+  798          822.87658    816.90576   0.00125313 
+  808          821.86503    815.25606   0.00123762 
+  838          820.9844     813.60991   0.00119332 
+  799          820.27144    811.96732   0.00125156 
+  820          819.77804    810.32827   0.00121951 
+  802          819.57983    808.69277   0.00124688 
+  811          819.79157    807.06079   0.00123305 
+  760          820.5957     805.43235   0.00131579 
+  864          822.30175    803.80743   0.00115741 
+  808          825.50548    802.18602   0.00123762 
+  826          831.60422    800.56813   0.00121065 
+  858          843.96114    798.95373   0.0011655 
+  879          867.07862    797.34283   0.00113766 
+  877          895.10228    795.73542   0.00114025 
+  912          945.82016    794.1315    0.00109649 
+  1020         1012.25752   792.53105   0.00098039 
+  1146         1094.72828   790.93408   0.0008726 
+  1222         1229.76177   789.34057   0.00081833 
+  1541         1377.93693   787.75051   0.00064893 
+  1640         1468.77692   786.16391   0.00060976 
+  1485         1336.33859   784.58076   0.0006734 
+  1283         1189.57505   783.00104   0.00077942 
+  898          1022.80233   781.42476   0.00111359 
+  859          906.10536    779.85191   0.00116414 
+  864          852.46672    778.28248   0.00115741 
+  817          826.48316    776.71646   0.00122399 
+  838          811.42211    775.15385   0.00119332 
+  810          801.45505    773.59465   0.00123457 
+  874          794.28209    772.03884   0.00114416 
+  843          788.78876    770.48642   0.00118624 
+  857          784.37154    768.93739   0.00116686 
+  813          780.67603    767.39173   0.00123001 
+  846          777.48658    765.84945   0.00118203 
+  837          774.66289    764.31053   0.00119474 
+  829          772.11124    762.77497   0.00120627 
+  809          769.76817    761.24276   0.00123609 
+  824          767.58766    759.7139    0.00121359 
+  827          765.53646    758.18839   0.00120919 
+  748          763.59127    756.66621   0.0013369 
+  809          761.73502    755.14735   0.00123609 
+  735          759.9533     753.63182   0.00136054 
+  780          758.23691    752.11961   0.00128205 
+  852          756.57865    750.61071   0.00117371 
+  727          754.9733     749.10511   0.00137552 
+  741          753.41738    747.60281   0.00134953 
+  765          751.92669    746.10381   0.00130719 
+  771          750.46487    744.60809   0.00129702 
+  793          749.05018    743.11565   0.00126103 
+  794          747.69334    741.62649   0.00125945 
+  767          746.3797     740.14059   0.00130378 
+  770          745.12296    738.65796   0.0012987 
+  749          743.92978    737.17859   0.00133511 
+  742          742.80929    735.70246   0.00134771 
+  702          741.82679    734.22958   0.0014245 
+  746          740.89291    732.75994   0.00134048 
+  724          740.08243    731.29354   0.00138122 
+  750          739.46452    729.83036   0.00133333 
+  783          739.00295    728.3704    0.00127714 
+  775          738.79566    726.91365   0.00129032 
+  746          738.935      725.46012   0.00134048 
+  768          739.53802    724.00978   0.00130208 
+  742          740.81561    722.56265   0.00134771 
+  773          743.11143    721.11871   0.00129366 
+  775          747.07445    719.67795   0.00129032 
+  786          754.06137    718.24037   0.00127226 
+  773          767.04087    716.80597   0.00129366 
+  760          790.59553    715.37473   0.00131579 
+  833          822.0773     713.94666   0.00120048 
+  893          864.32225    712.52174   0.00111982 
+  935          941.78171    711.09997   0.00106952 
+  1070         1020.99499   709.68135   0.00093458 
+  1138         1143.47629   708.26586   0.00087873 
+  1155         1259.63776   706.85351   0.0008658 
+  1087         1261.0343    705.44429   0.00091996 
+  958          1147.60608   704.03819   0.00104384 
+  876          1029.20676   702.6352    0.00114155 
+  726          899.30291    701.23532   0.00137741 
+  782          813.53235    699.83855   0.00127877 
+  709          769.96591    698.44487   0.00141044 
+  709          746.78184    697.05429   0.00141044 
+  723          732.74883    695.6668    0.00138313 
+  704          723.27205    694.28238   0.00142045 
+  726          716.37489    692.90104   0.00137741 
+  676          711.06758    691.52277   0.00147929 
+  709          706.79763    690.14757   0.00141044 
+  700          703.23525    688.77542   0.00142857 
+  698          700.17426    687.40632   0.00143266 
+  703          697.479      686.04027   0.00142248 
+  653          695.05855    684.67727   0.00153139 
+  659          692.84987    683.31729   0.00151745 
+  734          690.80754    681.96035   0.0013624 
+  695          688.89929    680.60643   0.00143885 
+  660          687.10132    679.25553   0.00151515 
+  705          685.39603    677.90764   0.00141844 
+  735          683.77056    676.56276   0.00136054 
+  691          682.21554    675.22089   0.00144718 
+  661          680.72444    673.882     0.00151286 
+  714          679.29318    672.54611   0.00140056 
+  657          677.92016    671.2132    0.00152207 
+  713          676.60491    669.88327   0.00140252 
+  681          675.3503     668.55632   0.00146843 
+  725          674.1617     667.23233   0.00137931 
+  735          673.04749    665.9113    0.00136054 
+  696          672.02133    664.59323   0.00143678 
+  693          671.1036     663.27811   0.001443  
+  640          670.32555    661.96594   0.0015625 
+  655          669.73614    660.65671   0.00152672 
+  663          669.41543    659.35041   0.0015083 
+  680          669.5054     658.04704   0.00147059 
+  675          670.2915     656.7466    0.00148148 
+  707          672.39795    655.44907   0.00141443 
+  722          677.14268    654.15445   0.00138504 
+  762          685.13426    652.86275   0.00131234 
+  775          695.10319    651.57394   0.00129032 
+  833          713.82253    650.28803   0.00120048 
+  887          737.7964     649.00501   0.0011274 
+  969          767.70599    647.72487   0.00103199 
+  901          804.36342    646.44762   0.00110988 
+  847          809.0912     645.17324   0.00118064 
+  833          779.45194    643.90172   0.00120048 
+  695          748.02276    642.63307   0.00143885 
+  686          712.16288    641.36728   0.00145773 
+  687          684.71652    640.10434   0.0014556 
+  683          670.49051    638.84425   0.00146413 
+  668          663.29343    637.587     0.00149701 
+  647          659.42428    636.33258   0.0015456 
+  602          657.39132    635.081     0.00166113 
+  688          656.67497    633.83224   0.00145349 
+  666          657.18177    632.5863    0.0015015 
+  688          659.12252    631.34318   0.00145349 
+  642          663.12755    630.10287   0.00155763 
+  665          670.7044     628.86536   0.00150376 
+  671          685.11771    627.63064   0.00149031 
+  684          710.98406    626.39872   0.00146199 
+  723          745.27874    625.16959   0.00138313 
+  759          798.28001    623.94325   0.00131752 
+  876          883.30368    622.71968   0.00114155 
+  944          974.35649    621.49888   0.00105932 
+  1068         1107.18308   620.28085   0.00093633 
+  1067         1162.96562   619.06557   0.00093721 
+  1016         1082.96903   617.85306   0.00098425 
+  841          979.30507    616.6433    0.00118906 
+  777          866.9569     615.43628   0.001287  
+  661          760.80556    614.232     0.00151286 
+  692          701.77221    613.03046   0.00144509 
+  647          671.7784     611.83165   0.0015456 
+  645          655.03302    610.63556   0.00155039 
+  582          644.47435    609.44219   0.00171821 
+  625          637.21328    608.25154   0.0016    
+  642          631.94484    607.06359   0.00155763 
+  601          627.953      605.87835   0.00166389 
+  621          624.85609    604.6958    0.00161031 
+  638          622.42961    603.51595   0.0015674 
+  607          620.5523     602.33879   0.00164745 
+  603          619.15716    601.16431   0.00165837 
+  606          618.24218    599.99251   0.00165017 
+  666          617.86018    598.82339   0.0015015 
+  601          618.17552    597.65692   0.00166389 
+  602          619.53943    596.49313   0.00166113 
+  654          622.73564    595.33198   0.00152905 
+  600          629.14634    594.1735    0.00166667 
+  661          639.25368    593.01765   0.00151286 
+  670          653.34257    591.86445   0.00149254 
+  718          678.51732    590.71389   0.00139276 
+  736          708.23239    589.56596   0.0013587 
+  838          751.7147     588.42065   0.00119332 
+  924          787.15649    587.27797   0.00108225 
+  996          789.02944    586.1379    0.00100402 
+  946          791.7599     585.00044   0.00105708 
+  1046         800.55716    583.86559   0.00095602 
+  1066         828.99394    582.73334   0.00093809 
+  1147         863.58705    581.60369   0.00087184 
+  1213         895.23368    580.47663   0.0008244 
+  1086         921.20964    579.35215   0.00092081 
+  864          879.9757     578.23026   0.00115741 
+  814          808.45964    577.11094   0.0012285 
+  655          749.7073     575.99419   0.00152672 
+  663          688.23879    574.88001   0.0015083 
+  626          648.20026    573.76839   0.00159744 
+  588          628.34281    572.65932   0.00170068 
+  580          618.76257    571.55281   0.00172414 
+  637          613.94406    570.44884   0.00156986 
+  559          611.24838    569.34742   0.00178891 
+  585          609.61383    568.24852   0.0017094 
+  630          608.74757    567.15216   0.0015873 
+  586          608.57076    566.05833   0.00170648 
+  594          608.00842    564.96702   0.0016835 
+  595          605.29229    563.87822   0.00168067 
+  565          600.43423    562.79194   0.00176991 
+  587          594.47231    561.70816   0.00170358 
+  553          588.06191    560.62688   0.00180832 
+  558          582.11622    559.5481    0.00179211 
+  596          577.23069    558.47181   0.00167785 
+  596          573.3847     557.39801   0.00167785 
+  563          570.32975    556.32669   0.0017762 
+  586          567.83138    555.25785   0.00170648 
+  574          565.72023    554.19148   0.00174216 
+  540          563.88324    553.12758   0.00185185 
+  552          562.24683    552.06613   0.00181159 
+  583          560.76323    551.00715   0.00171527 
+  589          559.40124    549.95062   0.00169779 
+  569          558.14066    548.89654   0.00175747 
+  579          556.96886    547.8449    0.00172712 
+  581          555.87888    546.7957    0.00172117 
+  564          554.87318    545.74893   0.00177305 
+  564          553.94472    544.70459   0.00177305 
+  571          553.10539    543.66268   0.00175131 
+  544          552.37206    542.62318   0.00183824 
+  557          551.75937    541.5861    0.00179533 
+  575          551.30529    540.55143   0.00173913 
+  540          551.06439    539.51916   0.00185185 
+  563          551.12712    538.4893    0.0017762 
+  564          551.64883    537.46182   0.00177305 
+  578          552.93421    536.43674   0.0017301 
+  596          555.65599    535.41405   0.00167785 
+  520          561.27161    534.39373   0.00192308 
+  585          571.90936    533.3758    0.0017094 
+  628          585.60379    532.36023   0.00159236 
+  632          603.61756    531.34703   0.00158228 
+  624          640.32012    530.33619   0.00160256 
+  666          674.90249    529.32771   0.0015015 
+  713          701.9833     528.32159   0.00140252 
+  714          690.0693     527.31781   0.00140056 
+  666          655.22264    526.31637   0.0015015 
+  647          630.4145     525.31727   0.0015456 
+  569          596.82909    524.32051   0.00175747 
+  581          576.02868    523.32608   0.00172117 
+  619          570.71392    522.33397   0.00161551 
+  658          570.51851    521.34418   0.00151976 
+  642          571.3283     520.35671   0.00155763 
+  619          565.31604    519.37155   0.00161551 
+  617          556.30183    518.38869   0.00162075 
+  613          549.34593    517.40813   0.00163132 
+  603          540.95379    516.42988   0.00165837 
+  612          535.22402    515.45391   0.00163399 
+  582          531.94783    514.48024   0.00171821 
+  610          529.94676    513.50884   0.00163934 
+  576          528.62336    512.53973   0.00173611 
+  629          527.73849    511.57289   0.00158983 
+  599          527.1759     510.60831   0.00166945 
+  593          526.84524    509.64601   0.00168634 
+  643          526.70056    508.68596   0.00155521 
+  711          526.70372    507.72817   0.00140647 
+  703          526.61557    506.77263   0.00142248 
+  678          526.2608     505.81934   0.00147493 
+  660          525.74033    504.86829   0.00151515 
+  626          525.19121    503.91948   0.00159744 
+  647          524.79941    502.9729    0.0015456 
+  587          524.68929    502.02855   0.00170358 
+  576          525.00919    501.08642   0.00173611 
+  567          525.84519    500.14652   0.00176367 
+  549          527.26502    499.20883   0.00182149 
+  559          529.35243    498.27334   0.00178891 
+  590          532.24487    497.34007   0.00169492 
+  552          536.14374    496.409     0.00181159 
+  608          540.9825     495.48012   0.00164474 
+  525          545.9562     494.55344   0.00190476 
+  558          549.96506    493.62895   0.00179211 
+  566          553.23345    492.70664   0.00176678 
+  577          557.42637    491.78651   0.0017331 
+  609          564.55722    490.86856   0.00164204 
+  564          577.85969    489.95277   0.00177305 
+  590          600.08694    489.03915   0.00169492 
+  644          627.08973    488.1277    0.0015528 
+  862          673.95743    487.2184    0.00116009 
+  905          741.46364    486.31126   0.00110497 
+  976          796.25595    485.40626   0.00102459 
+  876          824.48486    484.50341   0.00114155 
+  850          808.15709    483.6027    0.00117647 
+  889          819.81395    482.70412   0.00112486 
+  865          857.39813    481.80768   0.00115607 
+  953          971.35908    480.91336   0.00104932 
+  1239         1205.04916   480.02116   0.0008071 
+  1708         1545.17732   479.13109   0.00058548 
+  2305         2192.08056   478.24312   0.00043384 
+  3208         2948.05735   477.35727   0.00031172 
+  4100         3921.61284   476.47352   0.0002439 
+  4036         4022.72001   475.59188   0.00024777 
+  2938         3170.94285   474.71233   0.00034037 
+  2384         2689.51633   473.83487   0.00041946 
+  1679         1995.0244    472.9595    0.00059559 
+  945          1288.57211   472.08621   0.0010582 
+  653          937.69958    471.21501   0.00153139 
+  594          776.55097    470.34588   0.0016835 
+  583          690.76783    469.47882   0.00171527 
+  549          637.90583    468.61383   0.00182149 
+  525          603.18678    467.7509    0.00190476 
+  531          579.34616    466.89002   0.00188324 
+  533          562.47689    466.0312    0.00187617 
+  505          550.44849    465.17444   0.0019802 
+  478          542.09491    464.31971   0.00209205 
+  548          536.76245    463.46703   0.00182482 
+  518          533.85404    462.61639   0.0019305 
+  509          532.14505    461.76778   0.00196464 
+  535          529.71517    460.92119   0.00186916 
+  521          525.81249    460.07664   0.00191939 
+  530          521.23827    459.2341    0.00188679 
+  497          516.44718    458.39358   0.00201207 
+  486          511.93288    457.55507   0.00205761 
+  492          508.4653     456.71857   0.00203252 
+  461          506.42297    455.88407   0.0021692 
+  505          505.88001    455.05157   0.0019802 
+  474          506.95111    454.22107   0.0021097 
+  531          510.00272    453.39256   0.00188324 
+  515          515.83223    452.56603   0.00194175 
+  552          525.85822    451.74149   0.00181159 
+  526          542.01253    450.91893   0.00190114 
+  531          564.72429    450.09834   0.00188324 
+  542          590.33606    449.27972   0.00184502 
+  584          620.39067    448.46307   0.00171233 
+  651          655.62945    447.64838   0.0015361 
+  645          669.75753    446.83565   0.00155039 
+  638          653.59741    446.02488   0.0015674 
+  619          632.81986    445.21605   0.00161551 
+  585          608.34153    444.40917   0.0017094 
+  473          581.46432    443.60424   0.00211416 
+  544          564.02648    442.80124   0.00183824 
+  549          557.51085    442.00017   0.00182149 
+  513          561.37027    441.20104   0.00194932 
+  512          576.66066    440.40383   0.00195312 
+  589          608.9498     439.60854   0.00169779 
+  636          665.7326     438.81517   0.00157233 
+  734          739.0611     438.02372   0.0013624 
+  875          846.69127    437.23417   0.00114286 
+  1018         1018.51209   436.44653   0.00098232 
+  1152         1155.19677   435.66079   0.00086806 
+  1181         1200.16027   434.87695   0.00084674 
+  1014         1123.75494   434.09501   0.00098619 
+  993          1105.26644   433.31495   0.00100705 
+  984          1134.11725   432.53678   0.00101626 
+  1047         1211.74875   431.76049   0.00095511 
+  1381         1407.96551   430.98608   0.00072411 
+  1893         1856.52232   430.21354   0.00052826 
+  2379         2302.8542    429.44287   0.00042034 
+  3125         2551.96418   428.67407   0.00032   
+  2900         2375.50014   427.90714   0.00034483 
+  2289         2147.05492   427.14205   0.00043687 
+  1808         1891.11576   426.37883   0.0005531 
+  1326         1439.6858    425.61745   0.00075415 
+  1046         1149.18885   424.85792   0.00095602 
+  749          976.41621    424.10024   0.00133511 
+  744          872.45937    423.34439   0.00134409 
+  785          861.17436    422.59038   0.00127389 
+  785          871.48162    421.83819   0.00127389 
+  757          854.68158    421.08784   0.001321  
+  752          791.87268    420.33931   0.00132979 
+  707          752.152      419.59259   0.00141443 
+  736          719.77459    418.8477    0.0013587 
+  707          692.63524    418.10461   0.00141443 
+  755          700.09308    417.36333   0.0013245 
+  691          755.84405    416.62386   0.00144718 
+  711          826.84848    415.88618   0.00140647 
+  771          880.07292    415.15031   0.00129702 
+  819          889.14798    414.41622   0.001221  
+  865          932.84655    413.68392   0.00115607 
+  961          1072.05742   412.95341   0.00104058 
+  1325         1335.70686   412.22468   0.00075472 
+  1819         1747.64493   411.49773   0.00054975 
+  2786         2563.42136   410.77254   0.00035894 
+  4142         3595.22489   410.04913   0.00024143 
+  5255         4681.78017   409.32749   0.00019029 
+  4609         4310.9057    408.6076    0.00021697 
+  3339         3302.71274   407.88948   0.00029949 
+  2841         2919.99663   407.17311   0.00035199 
+  1945         2085.67985   406.45849   0.00051414 
+  1026         1274.76105   405.74561   0.00097466 
+  722          898.77515    405.03448   0.00138504 
+  642          730.31885    404.32509   0.00155763 
+  608          640.0142     403.61744   0.00164474 
+  479          584.18438    402.91152   0.00208768 
+  474          546.75565    402.20732   0.0021097 
+  502          520.22466    401.50485   0.00199203 
+  474          500.59771    400.8041    0.0021097 
+  452          485.57569    400.10507   0.00221239 
+  469          473.75233    399.40775   0.0021322 
+  434          464.22801    398.71215   0.00230415 
+  461          456.40703    398.01824   0.0021692 
+  449          449.8676     397.32604   0.00222717 
+  453          444.32155    396.63554   0.00220751 
+  475          439.55685    395.94674   0.00210526 
+  431          435.41821    395.25962   0.00232019 
+  460          431.78359    394.57419   0.00217391 
+  443          428.56451    393.89045   0.00225734 
+  438          425.69059    393.20839   0.00228311 
+  461          423.10687    392.528     0.0021692 
+  459          420.76969    391.84929   0.00217865 
+  451          418.64404    391.17225   0.00221729 
+  394          416.70167    390.49687   0.00253807 
+  411          414.92001    389.82316   0.00243309 
+  413          413.28046    389.1511    0.00242131 
+  414          411.7679     388.4807    0.00241546 
+  411          410.37093    387.81195   0.00243309 
+  402          409.07847    387.14485   0.00248756 
+  389          407.88334    386.47939   0.00257069 
+  416          406.77966    385.81558   0.00240385 
+  396          405.76334    385.1534    0.00252525 
+  410          404.82634    384.49286   0.00243902 
+  371          403.97657    383.83394   0.00269542 
+  353          403.20713    383.17665   0.00283286 
+  406          402.52389    382.52099   0.00246305 
+  409          401.92751    381.86694   0.00244499 
+  369          401.4226     381.21451   0.00271003 
+  454          401.01573    380.56369   0.00220264 
+  413          400.7158     379.91448   0.00242131 
+  405          400.53457    379.26688   0.00246914 
+  377          400.48718    378.62088   0.00265252 
+  416          400.59323    377.97648   0.00240385 
+  379          400.87794    377.33367   0.00263852 
+  403          401.37442    376.69245   0.00248139 
+  383          402.1241     376.05282   0.00261097 
+  381          403.18324    375.41478   0.00262467 
+  402          404.62579    374.77831   0.00248756 
+  364          406.55143    374.14342   0.00274725 
+  427          409.0961     373.51011   0.00234192 
+  446          412.45009    372.87837   0.00224215 
+  445          416.88442    372.24819   0.00224719 
+  455          422.79715    371.61958   0.0021978 
+  450          430.78673    370.99253   0.00222222 
+  430          441.75513    370.36703   0.00232558 
+  545          457.14791    369.74309   0.00183486 
+  486          479.0832     369.1207    0.00205761 
+  529          510.62297    368.49986   0.00189036 
+  563          555.35173    367.88055   0.0017762 
+  573          614.74728    367.26279   0.0017452 
+  653          680.52952    366.64656   0.00153139 
+  716          729.00173    366.03187   0.00139665 
+  824          741.07645    365.4187    0.00121359 
+  851          725.73558    364.80706   0.00117509 
+  901          699.52941    364.19695   0.00110988 
+  1042         669.88905    363.58835   0.00095969 
+  1089         643.89056    362.98127   0.00091827 
+  969          643.69881    362.3757    0.00103199 
+  876          663.31601    361.77164   0.00114155 
+  800          669.062      361.16909   0.00125   
+  731          635.72182    360.56804   0.00136799 
+  630          617.53293    359.96848   0.0015873 
+  568          619.5882     359.37043   0.00176056 
+  535          595.7243     358.77386   0.00186916 
+  521          548.52193    358.17879   0.00191939 
+  481          509.21069    357.5852    0.002079  
+  497          486.67436    356.99309   0.00201207 
+  478          460.93825    356.40247   0.00209205 
+  423          437.55121    355.81331   0.00236407 
+  479          427.46344    355.22563   0.00208768 
+  418          429.07733    354.63942   0.00239234 
+  474          441.90476    354.05468   0.0021097 
+  532          465.46043    353.4714    0.0018797 
+  688          508.53936    352.88958   0.00145349 
+  635          557.95564    352.30921   0.0015748 
+  745          595.4454     351.7303    0.00134228 
+  678          596.25274    351.15284   0.00147493 
+  588          577.51388    350.57682   0.00170068 
+  518          537.16732    350.00225   0.0019305 
+  471          493.82171    349.42911   0.00212314 
+  403          456.86533    348.85742   0.00248139 
+  389          420.80112    348.28715   0.00257069 
+  393          397.93669    347.71832   0.00254453 
+  378          385.50377    347.15091   0.0026455 
+  366          378.27267    346.58493   0.00273224 
+  353          373.58226    346.02037   0.00283286 
+  362          370.27889    345.45722   0.00276243 
+  377          367.84064    344.89549   0.00265252 
+  354          365.99962    344.33517   0.00282486 
+  358          364.61393    343.77626   0.0027933 
+  396          363.61554    343.21875   0.00252525 
+  363          362.9889     342.66265   0.00275482 
+  338          362.75303    342.10794   0.00295858 
+  348          362.93543    341.55463   0.00287356 
+  388          363.48785    341.00271   0.00257732 
+  384          364.10592    340.45217   0.00260417 
+  360          364.43639    339.90303   0.00277778 
+  349          364.56007    339.35526   0.00286533 
+  367          364.78133    338.80888   0.0027248 
+  350          365.13149    338.26387   0.00285714 
+  366          365.80695    337.72024   0.00273224 
+  369          367.3956     337.17797   0.00271003 
+  381          370.65736    336.63707   0.00262467 
+  371          376.82102    336.09754   0.00269542 
+  405          388.16798    335.55937   0.00246914 
+  391          406.81614    335.02255   0.00255754 
+  498          431.70738    334.48709   0.00200803 
+  563          471.59948    333.95298   0.0017762 
+  639          511.35719    333.42021   0.00156495 
+  559          519.95407    332.8888    0.00178891 
+  576          493.81657    332.35872   0.00173611 
+  512          478.67734    331.82999   0.00195312 
+  501          463.05123    331.30259   0.00199601 
+  429          430.9266     330.77652   0.002331  
+  422          405.45467    330.25178   0.00236967 
+  413          390.89749    329.72837   0.00242131 
+  402          382.68453    329.20629   0.00248756 
+  431          378.58742    328.68552   0.00232019 
+  402          378.88655    328.16607   0.00248756 
+  382          382.97002    327.64794   0.0026178 
+  398          384.1484     327.13112   0.00251256 
+  380          376.91399    326.6156    0.00263158 
+  364          369.98295    326.1014    0.00274725 
+  356          365.57703    325.58849   0.00280899 
+  342          358.96941    325.07689   0.00292398 
+  377          352.22366    324.56658   0.00265252 
+  337          348.17517    324.05756   0.00296736 
+  334          346.27929    323.54984   0.00299401 
+  364          344.81016    323.0434    0.00274725 
+  331          343.788      322.53825   0.00302115 
+  318          343.03248    322.03438   0.00314465 
+  333          342.67114    321.53179   0.003003  
+  334          342.24019    321.03048   0.00299401 
+  329          341.92145    320.53043   0.00303951 
+  338          341.70178    320.03166   0.00295858 
+  339          341.57217    319.53416   0.00294985 
+  355          341.53265    319.03792   0.0028169 
+  336          341.59299    318.54294   0.00297619 
+  339          341.77497    318.04921   0.00294985 
+  335          342.12963    317.55675   0.00298507 
+  373          342.75661    317.06553   0.00268097 
+  338          343.70973    316.57557   0.00295858 
+  363          344.86179    316.08685   0.00275482 
+  356          346.715      315.59938   0.00280899 
+  349          348.81313    315.11314   0.00286533 
+  383          350.22331    314.62815   0.00261097 
+  381          352.56602    314.14439   0.00262467 
+  325          356.07405    313.66186   0.00307692 
+  342          357.44875    313.18056   0.00292398 
+  374          357.92308    312.70048   0.0026738 
+  355          357.19461    312.22163   0.0028169 
+  370          355.98371    311.744     0.0027027 
+  359          355.56253    311.26759   0.00278552 
+  378          355.15971    310.7924    0.0026455 
+  370          355.02454    310.31841   0.0027027 
+  358          355.98324    309.84564   0.0027933 
+  378          357.75012    309.37407   0.0026455 
+  333          360.15899    308.9037    0.003003  
+  360          363.20675    308.43454   0.00277778 
+  350          366.97137    307.96657   0.00285714 
+  387          371.48283    307.4998    0.00258398 
+  407          376.47146    307.03422   0.002457  
+  381          381.23759    306.56984   0.00262467 
+  380          385.40238    306.10663   0.00263158 
+  382          389.50963    305.64461   0.0026178 
+  372          394.05036    305.18378   0.00268817 
+  409          399.09895    304.72412   0.00244499 
+  414          404.98557    304.26563   0.00241546 
+  405          412.23982    303.80832   0.00246914 
+  430          421.24661    303.35218   0.00232558 
+  416          432.31448    302.89721   0.00240385 
+  399          445.81077    302.4434    0.00250627 
+  420          462.17472    301.99075   0.00238095 
+  467          481.79152    301.53927   0.00214133 
+  442          504.87743    301.08893   0.00226244 
+  474          532.04079    300.63976   0.0021097 
+  484          565.16828    300.19173   0.00206612 
+  499          606.9665     299.74485   0.00200401 
+  564          660.85299    299.29912   0.00177305 
+  576          732.20432    298.85452   0.00173611 
+  771          829.91526    298.41107   0.00129702 
+  897          968.89514    297.96876   0.00111483 
+  1161         1176.72551   297.52758   0.00086133 
+  1527         1513.33808   297.08753   0.00065488 
+  2190         2133.71744   296.64861   0.00045662 
+  3355         3404.45872   296.21082   0.00029806 
+  5429         5664.53552   295.77415   0.0001842 
+  9393         8880.79627   295.3386    0.00010646 
+  14841        14538.13666  294.90417   0.00006738 
+  20573        18479.66319  294.47086   0.00004861 
+  20638        15364.38047  294.03866   0.00004845 
+  13984        11600.22546  293.60757   0.00007151 
+  11012        10870.9753   293.17759   0.00009081 
+  10378        8796.83093   292.74871   0.00009636 
+  6126         4840.01674   292.32094   0.00016324 
+  2506         2713.55757   291.89426   0.00039904 
+  1333         1790.89514   291.46868   0.00075019 
+  1161         1333.99976   291.0442    0.00086133 
+  917          1066.31434   290.62081   0.00109051 
+  789          893.53976    290.19851   0.00126743 
+  780          775.03147    289.77729   0.00128205 
+  659          690.16626    289.35716   0.00151745 
+  602          627.17801    288.93811   0.00166113 
+  535          578.41211    288.52014   0.00186916 
+  537          540.348      288.10324   0.0018622 
+  486          510.46588    287.68742   0.00205761 
+  523          486.30094    287.27267   0.00191205 
+  432          466.66771    286.85899   0.00231481 
+  480          450.9029     286.44637   0.00208333 
+  425          438.30886    286.03482   0.00235294 
+  381          428.38535    285.62433   0.00262467 
+  410          420.85322    285.2149    0.00243902 
+  403          415.63771    284.80652   0.00248139 
+  362          412.80399    284.39919   0.00276243 
+  358          412.20481    283.99292   0.0027933 
+  381          414.2458     283.58769   0.00262467 
+  412          418.96958    283.18351   0.00242718 
+  407          425.41558    282.78038   0.002457  
+  364          436.68242    282.37828   0.00274725 
+  416          455.43256    281.97722   0.00240385 
+  438          482.94389    281.57719   0.00228311 
+  489          522.13193    281.1782    0.00204499 
+  534          574.28641    280.78024   0.00187266 
+  588          635.23446    280.38331   0.00170068 
+  678          696.86399    279.9874    0.00147493 
+  681          744.82051    279.59252   0.00146843 
+  741          763.99409    279.19865   0.00134953 
+  779          764.60369    278.8058    0.0012837 
+  817          767.9286     278.41397   0.00122399 
+  826          773.93421    278.02315   0.00121065 
+  782          791.1552     277.63335   0.00127877 
+  683          778.05932    277.24454   0.00146413 
+  652          735.62244    276.85675   0.00153374 
+  686          712.10335    276.46996   0.00145773 
+  616          701.34493    276.08417   0.00162338 
+  572          670.90832    275.69937   0.00174825 
+  611          628.25728    275.31557   0.00163666 
+  541          580.09942    274.93277   0.00184843 
+  471          536.18983    274.55096   0.00212314 
+  449          497.07591    274.17013   0.00222717 
+  403          458.89376    273.79029   0.00248139 
+  414          423.87326    273.41143   0.00241546 
+  361          395.43771    273.03356   0.00277008 
+  352          373.82789    272.65666   0.00284091 
+  375          357.65008    272.28074   0.00266667 
+  356          345.47991    271.9058    0.00280899 
+  348          336.05521    271.53182   0.00287356 
+  314          328.63781    271.15882   0.00318471 
+  329          322.63917    270.78678   0.00303951 
+  310          317.68121    270.4157    0.00322581 
+  326          313.52151    270.04559   0.00306748 
+  320          309.97497    269.67643   0.003125  
+  293          306.91285    269.30824   0.00341297 
+  345          304.2336     268.941     0.00289855 
+  322          301.88143    268.57471   0.00310559 
+  311          299.79513    268.20937   0.00321543 
+  268          297.92974    267.84497   0.00373134 
+  281          296.26151    267.48153   0.00355872 
+  286          294.76155    267.11902   0.0034965 
+  303          293.41135    266.75746   0.00330033 
+  313          292.19689    266.39684   0.00319489 
+  295          291.10834    266.03715   0.00338983 
+  333          290.13266    265.67839   0.003003  
+  290          289.28193    265.32057   0.00344828 
+  284          288.55123    264.96367   0.00352113 
+  289          287.94426    264.60771   0.00346021 
+  301          287.48635    264.25266   0.00332226 
+  308          287.18907    263.89854   0.00324675 
+  325          287.09442    263.54534   0.00307692 
+  294          287.26374    263.19305   0.00340136 
+  301          287.79716    262.84168   0.00332226 
+  299          288.86241    262.49123   0.00334448 
+  309          290.77929    262.14168   0.00323625 
+  328          294.21648    261.79304   0.00304878 
+  322          300.6937     261.44531   0.00310559 
+  326          313.33736    261.09848   0.00306748 
+  336          335.44573    260.75256   0.00297619 
+  381          361.10553    260.40753   0.00262467 
+  458          394.51347    260.0634    0.00218341 
+  463          411.89476    259.72016   0.00215983 
+  404          386.61631    259.37782   0.00247525 
+  428          370.79831    259.03637   0.00233645 
+  434          373.25508    258.6958    0.00230415 
+  402          359.75979    258.35613   0.00248756 
+  370          337.28759    258.01733   0.0027027 
+  355          321.88988    257.67942   0.0028169 
+  363          312.28587    257.34238   0.00275482 
+  345          305.6186     257.00622   0.00289855 
+  328          299.79759    256.67094   0.00304878 
+  311          294.86171    256.33653   0.00321543 
+  337          291.99592    256.00299   0.00296736 
+  307          291.68032    255.67031   0.00325733 
+  360          292.68579    255.33851   0.00277778 
+  336          295.5566     255.00756   0.00297619 
+  311          293.90754    254.67748   0.00321543 
+  312          288.1571     254.34826   0.00320513 
+  287          285.47197    254.01989   0.00348432 
+  279          284.20395    253.69238   0.00358423 
+  283          280.17235    253.36572   0.00353357 
+  285          276.37073    253.03991   0.00350877 
+  263          274.18458    252.71495   0.00380228 
+  295          273.16776    252.39084   0.00338983 
+  279          272.47995    252.06757   0.00358423 
+  282          272.11604    251.74514   0.0035461 
+  294          272.03261    251.42356   0.00340136 
+  264          272.29302    251.10281   0.00378788 
+  259          273.11446    250.78289   0.003861  
+  283          274.92052    250.46381   0.00353357 
+  318          277.78195    250.14556   0.00314465 
+  284          281.01209    249.82814   0.00352113 
+  325          284.87098    249.51155   0.00307692 
+  307          284.0884     249.19578   0.00325733 
+  313          281.42798    248.88084   0.00319489 
+  298          281.09152    248.56671   0.0033557 
+  285          281.63957    248.2534    0.00350877 
+  288          280.41426    247.94091   0.00347222 
+  314          280.34014    247.62924   0.00318471 
+  342          282.59377    247.31837   0.00292398 
+  354          287.64259    247.00832   0.00282486 
+  401          295.79942    246.69908   0.00249377 
+  328          306.78188    246.39064   0.00304878 
+  352          322.13683    246.083     0.00284091 
+  343          335.41835    245.77617   0.00291545 
+  380          350.03082    245.47014   0.00263158 
+  423          361.05897    245.1649    0.00236407 
+  396          356.56435    244.86046   0.00252525 
+  391          343.94243    244.55681   0.00255754 
+  366          335.97644    244.25396   0.00273224 
+  345          327.96966    243.95189   0.00289855 
+  332          316.37232    243.65062   0.00301205 
+  288          306.41393    243.35012   0.00347222 
+  311          300.25302    243.05041   0.00321543 
+  266          295.50515    242.75149   0.0037594 
+  305          292.67801    242.45334   0.00327869 
+  286          292.00157    242.15597   0.0034965 
+  305          292.35115    241.85937   0.00327869 
+  302          292.98907    241.56355   0.00331126 
+  292          294.8821     241.2685    0.00342466 
+  307          298.35215    240.97422   0.00325733 
+  324          303.52859    240.68071   0.00308642 
+  319          311.0079     240.38796   0.0031348 
+  322          322.07949    240.09597   0.00310559 
+  361          340.27402    239.80475   0.00277008 
+  393          376.61331    239.51428   0.00254453 
+  469          441.25171    239.22458   0.0021322 
+  612          512.11494    238.93562   0.00163399 
+  788          610.62384    238.64743   0.00126904 
+  797          604.91184    238.35998   0.00125471 
+  670          524.33089    238.07328   0.00149254 
+  618          500.06089    237.78733   0.00161812 
+  628          517.30302    237.50213   0.00159236 
+  605          472.50048    237.21767   0.00165289 
+  569          426.81645    236.93395   0.00175747 
+  645          416.28801    236.65097   0.00155039 
+  834          430.17193    236.36873   0.00119904 
+  849          459.91971    236.08722   0.00117786 
+  720          498.32294    235.80645   0.00138889 
+  642          541.69479    235.52641   0.00155763 
+  717          556.11196    235.2471    0.0013947 
+  629          573.61891    234.96852   0.00158983 
+  604          617.91341    234.69067   0.00165563 
+  627          681.43957    234.41353   0.0015949 
+  709          756.02033    234.13713   0.00141044 
+  788          876.07891    233.86144   0.00126904 
+  1046         1074.05641   233.58647   0.00095602 
+  1393         1404.89026   233.31222   0.00071788 
+  2099         2024.74608   233.03868   0.00047642 
+  3598         3340.10311   232.76585   0.00027793 
+  5468         5986.05313   232.49374   0.00018288 
+  8845         9109.47575   232.22234   0.00011306 
+  12371        13525.18772  231.95164   0.00008083 
+  12154        14138.68957  231.68165   0.00008228 
+  8306         9629.48553   231.41236   0.00012039 
+  6666         7811.04444   231.14377   0.00015002 
+  6612         8557.05288   230.87589   0.00015124 
+  5111         6628.3426    230.6087    0.00019566 
+  2651         3545.33286   230.34221   0.00037722 
+  1312         2032.52682   230.07641   0.0007622 
+  893          1373.0619    229.8113    0.00111982 
+  792          1038.90736   229.54689   0.00126263 
+  641          842.86786    229.28316   0.00156006 
+  604          719.79877    229.02012   0.00165563 
+  547          638.50241    228.75776   0.00182815 
+  490          582.93041    228.49609   0.00204082 
+  472          530.74199    228.2351    0.00211864 
+  467          487.77343    227.97479   0.00214133 
+  408          459.3087     227.71516   0.00245098 
+  377          438.98754    227.4562    0.00265252 
+  353          410.12261    227.19792   0.00283286 
+  385          383.07631    226.94031   0.0025974 
+  337          364.7523     226.68337   0.00296736 
+  336          351.87415    226.4271    0.00297619 
+  325          339.17118    226.1715    0.00307692 
+  315          329.59446    225.91656   0.0031746 
+  329          324.83865    225.66228   0.00303951 
+  316          323.59099    225.40867   0.00316456 
+  323          325.1754     225.15572   0.00309598 
+  338          322.38495    224.90342   0.00295858 
+  331          318.61933    224.65178   0.00302115 
+  310          313.37206    224.4008    0.00322581 
+  325          309.57287    224.15047   0.00307692 
+  297          307.60378    223.90079   0.003367  
+  301          307.92599    223.65175   0.00332226 
+  292          307.68367    223.40337   0.00342466 
+  268          301.59697    223.15563   0.00373134 
+  290          295.53974    222.90854   0.00344828 
+  286          291.62406    222.66209   0.0034965 
+  258          287.64566    222.41627   0.00387597 
+  238          280.52984    222.1711    0.00420168 
+  256          273.81144    221.92657   0.00390625 
+  262          268.31313    221.68267   0.00381679 
+  266          263.56928    221.4394    0.0037594 
+  262          259.6649     221.19676   0.00381679 
+  268          256.63531    220.95476   0.00373134 
+  256          254.37537    220.71338   0.00390625 
+  253          252.77467    220.47263   0.00395257 
+  231          251.78068    220.23251   0.004329  
+  282          251.39527    219.99301   0.0035461 
+  219          251.61146    219.75413   0.00456621 
+  241          252.22033    219.51587   0.00414938 
+  275          252.57022    219.27823   0.00363636 
+  235          251.94583    219.04121   0.00425532 
+  223          250.53382    218.8048    0.0044843 
+  245          249.02257    218.569     0.00408163 
+  269          247.52707    218.33382   0.00371747 
+  236          245.74834    218.09924   0.00423729 
+  236          243.83344    217.86528   0.00423729 
+  225          242.16961    217.63192   0.00444444 
+  224          240.92053    217.39916   0.00446429 
+  257          240.08956    217.16701   0.00389105 
+  220          239.70178    216.93546   0.00454545 
+  260          239.78282    216.70451   0.00384615 
+  236          239.81299    216.47416   0.00423729 
+  207          240.73011    216.24441   0.00483092 
+  217          241.69705    216.01525   0.00460829 
+  223          242.43606    215.78668   0.0044843 
+  250          242.26195    215.55871   0.004     
+  261          242.41203    215.33132   0.00383142 
+  230          243.56805    215.10453   0.00434783 
+  275          245.18439    214.87832   0.00363636 
+  253          245.6698     214.65269   0.00395257 
+  224          242.82917    214.42765   0.00446429 
+  248          240.83968    214.2032    0.00403226 
+  242          240.7862     213.97932   0.00413223 
+  272          241.54984    213.75602   0.00367647 
+  276          242.15043    213.5333    0.00362319 
+  341          245.53163    213.31115   0.00293255 
+  323          254.5344     213.08958   0.00309598 
+  419          271.03676    212.86858   0.00238663 
+  477          291.05894    212.64816   0.00209644 
+  464          311.03289    212.4283    0.00215517 
+  496          304.23795    212.20901   0.00201613 
+  412          288.605      211.99028   0.00242718 
+  427          281.13363    211.77212   0.00234192 
+  450          279.27827    211.55453   0.00222222 
+  355          267.20068    211.33749   0.0028169 
+  303          252.60088    211.12101   0.00330033 
+  271          242.76774    210.9051    0.00369004 
+  282          237.05379    210.68974   0.0035461 
+  266          234.30428    210.47493   0.0037594 
+  271          233.34747    210.26068   0.00369004 
+  261          233.70478    210.04698   0.00383142 
+  262          235.16376    209.83383   0.00381679 
+  242          236.89886    209.62123   0.00413223 
+  216          237.15857    209.40918   0.00462963 
+  267          236.03878    209.19768   0.00374532 
+  227          235.32336    208.98671   0.00440529 
+  259          235.35829    208.7763    0.003861  
+  251          235.24002    208.56642   0.00398406 
+  235          234.91724    208.35708   0.00425532 
+  237          235.28221    208.14828   0.00421941 
+  257          236.85088    207.94002   0.00389105 
+  252          240.00455    207.73229   0.00396825 
+  243          245.56612    207.5251    0.00411523 
+  268          255.66629    207.31844   0.00373134 
+  296          275.92994    207.11231   0.00337838 
+  305          318.23193    206.90671   0.00327869 
+  396          385.93651    206.70164   0.00252525 
+  531          463.69888    206.4971    0.00188324 
+  736          512.12037    206.29308   0.0013587 
+  655          441.04022    206.08958   0.00152672 
+  510          406.16179    205.88661   0.00196078 
+  494          418.38263    205.68415   0.00202429 
+  500          420.27929    205.48222   0.002     
+  406          351.11416    205.2808    0.00246305 
+  335          301.65695    205.0799    0.00298507 
+  273          281.1418     204.87951   0.003663  
+  256          267.64311    204.67964   0.00390625 
+  246          253.01138    204.48028   0.00406504 
+  237          243.56131    204.28143   0.00421941 
+  219          238.36691    204.08308   0.00456621 
+  239          235.49424    203.88525   0.0041841 
+  247          233.91356    203.68792   0.00404858 
+  253          233.19995    203.4911    0.00395257 
+  233          233.11041    203.29478   0.00429185 
+  232          233.41474    203.09896   0.00431034 
+  252          233.69448    202.90364   0.00396825 
+  272          233.64918    202.70882   0.00367647 
+  261          234.02913    202.5145    0.00383142 
+  253          234.90738    202.32067   0.00395257 
+  234          236.03856    202.12734   0.0042735 
+  255          237.21906    201.9345    0.00392157 
+  211          238.85041    201.74215   0.00473934 
+  296          241.01658    201.55029   0.00337838 
+  269          243.64779    201.35893   0.00371747 
+  268          246.90349    201.16805   0.00373134 
+  247          251.49965    200.97765   0.00404858 
+  252          258.4545     200.78775   0.00396825 
+  241          267.278      200.59832   0.00414938 
+  282          277.00327    200.40938   0.0035461 
+  315          282.23276    200.22091   0.0031746 
+  284          286.72736    200.03293   0.00352113 
+  296          299.18892    199.84543   0.00337838 
+  298          323.8244     199.6584    0.0033557 
+  354          358.53748    199.47184   0.00282486 
+  399          395.67054    199.28576   0.00250627 
+  416          413.84602    199.10016   0.00240385 
+  369          377.90292    198.91502   0.00271003 
+  345          362.8233     198.73036   0.00289855 
+  345          370.95077    198.54616   0.00289855 
+  369          381.94435    198.36243   0.00271003 
+  320          366.37247    198.17916   0.003125  
+  363          359.11666    197.99636   0.00275482 
+  364          367.10863    197.81402   0.00274725 
+  386          385.52981    197.63215   0.00259067 
+  367          411.99973    197.45073   0.0027248 
+  425          446.36612    197.26978   0.00235294 
+  533          488.26811    197.08928   0.00187617 
+  574          545.19059    196.90923   0.00174216 
+  635          626.45983    196.72965   0.0015748 
+  723          744.44823    196.55051   0.00138313 
+  882          922.10385    196.37183   0.00113379 
+  1185         1213.7158    196.1936    0.00084388 
+  1810         1758.84825   196.01582   0.00055249 
+  2999         2923.69273   195.83849   0.00033344 
+  5474         5345.40419   195.66161   0.00018268 
+  9407         8568.37018   195.48517   0.0001063 
+  13490        12136.39564  195.30917   0.00007413 
+  12446        10493.98346  195.13362   0.00008035 
+  7468         6910.93002   194.95852   0.0001339 
+  6205         6160.7719    194.78385   0.00016116 
+  7094         6928.70941   194.60962   0.00014096 
+  6394         6046.26321   194.43583   0.0001564 
+  3387         3364.41199   194.26248   0.00029525 
+  1634         1893.62331   194.08956   0.000612  
+  876          1247.04142   193.91708   0.00114155 
+  679          928.15584    193.74503   0.00147275 
+  527          742.40197    193.57341   0.00189753 
+  451          622.1594     193.40222   0.00221729 
+  408          539.02856    193.23147   0.00245098 
+  405          479.37174    193.06114   0.00246914 
+  387          435.73679    192.89123   0.00258398 
+  347          403.65459    192.72175   0.00288184 
+  344          380.61977    192.5527    0.00290698 
+  341          365.73322    192.38407   0.00293255 
+  412          359.26882    192.21586   0.00242718 
+  402          361.30202    192.04808   0.00248756 
+  540          367.13237    191.88071   0.00185185 
+  799          368.3185     191.71376   0.00125156 
+  996          365.03117    191.54723   0.00100402 
+  724          352.92786    191.38111   0.00138122 
+  515          344.74257    191.2154    0.00194175 
+  534          336.31962    191.05012   0.00187266 
+  634          318.0501     190.88524   0.00157729 
+  523          297.45671    190.72077   0.00191205 
+  354          281.54617    190.55671   0.00282486 
+  315          271.14466    190.39307   0.0031746 
+  296          259.09963    190.22982   0.00337838 
+  267          248.70871    190.06699   0.00374532 
+  245          241.77724    189.90456   0.00408163 
+  246          237.04601    189.74253   0.00406504 
+  247          233.57254    189.58091   0.00404858 
+  260          230.91186    189.41968   0.00384615 
+  238          228.86493    189.25886   0.00420168 
+  231          227.35865    189.09844   0.004329  
+  233          226.39328    188.93841   0.00429185 
+  209          226.03666    188.77878   0.00478469 
+  219          226.40932    188.61954   0.00456621 
+  220          227.66257    188.4607    0.00454545 
+  269          229.83749    188.30225   0.00371747 
+  272          232.51829    188.1442    0.00367647 
+  283          234.66631    187.98653   0.00353357 
+  288          235.69067    187.82926   0.00347222 
+  265          236.47434    187.67237   0.00377358 
+  259          237.95106    187.51587   0.003861  
+  266          239.67206    187.35976   0.0037594 
+  303          240.67226    187.20403   0.00330033 
+  272          241.83205    187.04868   0.00367647 
+  253          244.49594    186.89372   0.00395257 
+  260          247.68503    186.73914   0.00384615 
+  228          244.7703     186.58494   0.00438596 
+  231          236.197      186.43111   0.004329  
+  243          230.96284    186.27767   0.00411523 
+  257          228.16577    186.1246    0.00389105 
+  209          225.01078    185.97191   0.00478469 
+  223          218.93779    185.8196    0.0044843 
+  231          214.11967    185.66765   0.004329  
+  200          211.02669    185.51608   0.005     
+  193          208.94728    185.36488   0.00518135 
+  195          207.75795    185.21405   0.00512821 
+  214          207.24131    185.06359   0.0046729 
+  192          207.32314    184.9135    0.00520833 
+  205          208.10496    184.76378   0.00487805 
+  202          209.76239    184.61442   0.0049505 
+  208          212.21342    184.46542   0.00480769 
+  191          215.1423     184.31679   0.0052356 
+  189          217.14051    184.16853   0.00529101 
+  198          219.52691    184.02062   0.00505051 
+  222          224.46717    183.87307   0.0045045 
+  227          232.77132    183.72588   0.00440529 
+  263          248.67482    183.57906   0.00380228 
+  302          281.87686    183.43258   0.00331126 
+  378          337.16373    183.28647   0.0026455 
+  471          399.0768     183.14071   0.00212314 
+  542          414.35546    182.9953    0.00184502 
+  535          372.48325    182.85025   0.00186916 
+  446          376.36939    182.70554   0.00224215 
+  424          381.77121    182.56119   0.00235849 
+  395          364.24633    182.41719   0.00253165 
+  365          317.56111    182.27353   0.00273973 
+  334          289.85441    182.13023   0.00299401 
+  293          279.42086    181.98727   0.00341297 
+  243          263.47711    181.84465   0.00411523 
+  246          253.73519    181.70238   0.00406504 
+  241          257.01119    181.56046   0.00414938 
+  262          263.96781    181.41887   0.00381679 
+  264          253.6469     181.27763   0.00378788 
+  246          243.64163    181.13673   0.00406504 
+  242          239.5452     180.99616   0.00413223 
+  220          237.28077    180.85594   0.00454545 
+  214          229.98063    180.71605   0.0046729 
+  196          219.70921    180.5765    0.00510204 
+  220          213.64193    180.43728   0.00454545 
+  204          208.13369    180.2984    0.00490196 
+  218          203.76429    180.15985   0.00458716 
+  206          201.21996    180.02163   0.00485437 
+  179          199.81557    179.88374   0.00558659 
+  187          199.06563    179.74619   0.00534759 
+  227          198.76148    179.60896   0.00440529 
+  176          198.86232    179.47206   0.00568182 
+  186          199.37305    179.33548   0.00537634 
+  158          199.91466    179.19924   0.00632911 
+  178          199.93186    179.06331   0.00561798 
+  201          200.00664    178.92772   0.00497512 
+  184          200.49884    178.79244   0.00543478 
+  189          201.42226    178.65749   0.00529101 
+  193          202.54345    178.52286   0.00518135 
+  179          204.20909    178.38855   0.00558659 
+  190          207.41714    178.25455   0.00526316 
+  181          213.55926    178.12088   0.00552486 
+  190          222.754      177.98752   0.00526316 
+  216          225.83631    177.85448   0.00462963 
+  197          220.42511    177.72175   0.00507614 
+  177          217.88339    177.58934   0.00564972 
+  191          220.12476    177.45724   0.0052356 
+  209          223.85683    177.32546   0.00478469 
+  214          223.18029    177.19398   0.0046729 
+  188          222.11693    177.06282   0.00531915 
+  209          223.59886    176.93196   0.00478469 
+  228          227.38842    176.80142   0.00438596 
+  241          233.50946    176.67118   0.00414938 
+  239          243.04334    176.54124   0.0041841 
+  286          258.76024    176.41162   0.0034965 
+  258          284.87771    176.2823    0.00387597 
+  287          316.15405    176.15328   0.00348432 
+  286          323.26313    176.02456   0.0034965 
+  301          322.29773    175.89615   0.00332226 
+  332          339.0297     175.76804   0.00301205 
+  329          375.19969    175.64022   0.00303951 
+  361          418.83104    175.51271   0.00277008 
+  442          458.69744    175.3855    0.00226244 
+  614          501.46694    175.25858   0.00162866 
+  665          541.15932    175.13196   0.00150376 
+  674          580.3441     175.00563   0.00148368 
+  693          630.06773    174.8796    0.001443  
+  690          683.80854    174.75386   0.00144928 
+  745          710.97415    174.62842   0.00134228 
+  805          693.35063    174.50326   0.00124224 
+  771          654.54538    174.3784    0.00129702 
+  658          624.72261    174.25383   0.00151976 
+  658          608.6399     174.12954   0.00151976 
+  580          595.56876    174.00555   0.00172414 
+  530          583.95636    173.88184   0.00188679 
+  530          586.37513    173.75842   0.00188679 
+  498          610.61845    173.63528   0.00200803 
+  494          648.45296    173.51243   0.00202429 
+  506          676.16946    173.38987   0.00197628 
+  562          673.07109    173.26758   0.00177936 
+  605          651.99345    173.14558   0.00165289 
+  609          638.53047    173.02386   0.00164204 
+  555          638.08557    172.90242   0.0018018 
+  575          632.60344    172.78125   0.00173913 
+  535          602.22176    172.66037   0.00186916 
+  531          549.0857     172.53977   0.00188324 
+  482          492.95735    172.41944   0.00207469 
+  414          448.0827     172.29938   0.00241546 
+  366          413.32355    172.17961   0.00273224 
+  323          380.02867    172.0601    0.00309598 
+  300          345.2796     171.94087   0.00333333 
+  261          313.31741    171.82192   0.00383142 
+  231          287.44854    171.70323   0.004329  
+  226          267.79567    171.58482   0.00442478 
+  233          253.17741    171.46667   0.00429185 
+  213          242.42043    171.34879   0.00469484 
+  180          234.78385    171.23119   0.00555556 
+  221          230.16806    171.11385   0.00452489 
+  205          229.37096    170.99677   0.00487805 
+  224          233.43594    170.87996   0.00446429 
+  209          236.70091    170.76342   0.00478469 
+  217          228.04767    170.64714   0.00460829 
+  216          218.45259    170.53113   0.00462963 
+  206          214.51774    170.41537   0.00485437 
+  201          214.98864    170.29988   0.00497512 
+  197          213.35011    170.18465   0.00507614 
+  187          207.22155    170.06968   0.00534759 
+  212          202.61636    169.95497   0.00471698 
+  161          200.27226    169.84052   0.00621118 
+  153          199.36656    169.72632   0.00653595 
+  155          199.46573    169.61238   0.00645161 
+  187          200.50407    169.4987    0.00534759 
+  210          202.36734    169.38527   0.0047619 
+  183          204.40164    169.2721    0.00546448 
+  190          205.36043    169.15918   0.00526316 
+  195          204.7597     169.04651   0.00512821 
+  187          203.55532    168.9341    0.00534759 
+  206          202.83603    168.82194   0.00485437 
+  199          202.82135    168.71002   0.00502513 
+  201          203.51594    168.59836   0.00497512 
+  204          205.57325    168.48694   0.00490196 
+  187          208.037      168.37578   0.00534759 
+  181          206.7121     168.26486   0.00552486 
+  184          205.06037    168.15418   0.00543478 
+  200          205.3264     168.04376   0.005     
+  188          206.09825    167.93357   0.00531915 
+  190          205.24404    167.82364   0.00526316 
+  198          202.45546    167.71394   0.00505051 
+  206          201.23888    167.60449   0.00485437 
+  175          202.26948    167.49528   0.00571429 
+  165          202.24565    167.38631   0.00606061 
+  183          198.29444    167.27758   0.00546448 
+  209          195.30878    167.16909   0.00478469 
+  168          195.81775    167.06084   0.00595238 
+  197          200.52212    166.95283   0.00507614 
+  207          207.6031     166.84505   0.00483092 
+  191          209.77122    166.73751   0.0052356 
+  178          206.63422    166.63021   0.00561798 
+  176          204.49357    166.52314   0.00568182 
+  202          201.99944    166.41631   0.0049505 
+  190          203.34021    166.30971   0.00526316 
+  188          206.33363    166.20334   0.00531915 
+  205          212.63121    166.09721   0.00487805 
+  218          217.5293     165.99131   0.00458716 
+  222          208.54709    165.88563   0.0045045 
+  215          198.8076     165.78019   0.00465116 
+  184          195.70868    165.67498   0.00543478 
+  199          197.89991    165.56999   0.00502513 
+  187          199.19055    165.46524   0.00534759 
+  182          195.21605    165.36071   0.00549451 
+  175          192.54158    165.2564    0.00571429 
+  191          193.11148    165.15232   0.0052356 
+  197          196.93116    165.04847   0.00507614 
+  172          205.31233    164.94484   0.00581395 
+  230          222.09199    164.84144   0.00434783 
+  233          253.19685    164.73825   0.00429185 
+  299          301.44392    164.63529   0.00334448 
+  397          357.50592    164.53255   0.00251889 
+  418          341.11985    164.43003   0.00239234 
+  393          301.40257    164.32774   0.00254453 
+  311          279.41968    164.22566   0.00321543 
+  294          280.35107    164.12379   0.00340136 
+  302          288.8284     164.02215   0.00331126 
+  309          263.28233    163.92073   0.00323625 
+  294          236.21154    163.81952   0.00340136 
+  246          217.37006    163.71852   0.00406504 
+  193          208.76263    163.61774   0.00518135 
+  220          207.29938    163.51718   0.00454545 
+  180          204.21043    163.41683   0.00555556 
+  155          198.7372     163.31669   0.00645161 
+  196          194.1292     163.21677   0.00510204 
+  190          191.9771     163.11705   0.00526316 
+  158          192.29709    163.01755   0.00632911 
+  178          191.29489    162.91826   0.00561798 
+  177          190.09944    162.81918   0.00564972 
+  193          190.38334    162.72031   0.00518135 
+  176          192.8943     162.62164   0.00568182 
+  166          193.65031    162.52319   0.0060241 
+  192          190.82004    162.42494   0.00520833 
+  176          189.00851    162.32689   0.00568182 
+  192          188.93017    162.22906   0.00520833 
+  180          189.94461    162.13142   0.00555556 
+  172          189.25134    162.034     0.00581395 
+  142          187.63216    161.93677   0.00704225 
+  176          186.75963    161.83975   0.00568182 
+  177          186.56383    161.74293   0.00564972 
+  190          186.63879    161.64632   0.00526316 
+  179          187.33425    161.5499    0.00558659 
+  199          188.59113    161.45369   0.00502513 
+  173          190.35067    161.35767   0.00578035 
+  177          192.13921    161.26186   0.00564972 
+  183          193.33073    161.16624   0.00546448 
+  173          194.09921    161.07082   0.00578035 
+  174          195.5279     160.9756    0.00574713 
+  184          198.64634    160.88058   0.00543478 
+  208          202.79534    160.78575   0.00480769 
+  191          203.92605    160.69111   0.0052356 
+  173          203.65293    160.59668   0.00578035 
+  181          205.62017    160.50243   0.00552486 
+  190          209.81863    160.40838   0.00526316 
+  174          214.04724    160.31453   0.00574713 
+  183          214.61812    160.22086   0.00546448 
+  197          212.73662    160.12739   0.00507614 
+  197          211.28299    160.03411   0.00507614 
+  172          211.05647    159.94102   0.00581395 
+  203          211.45093    159.84812   0.00492611 
+  201          211.55626    159.75541   0.00497512 
+  240          211.37657    159.66289   0.00416667 
+  199          211.6194     159.57055   0.00502513 
+  196          212.77156    159.47841   0.00510204 
+  172          214.95568    159.38645   0.00581395 
+  215          218.17344    159.29468   0.00465116 
+  199          222.44581    159.20309   0.00502513 
+  215          227.87124    159.11169   0.00465116 
+  236          234.65384    159.02047   0.00423729 
+  242          243.16784    158.92944   0.00413223 
+  215          254.12938    158.83859   0.00465116 
+  267          268.98993    158.74792   0.00374532 
+  289          290.38888    158.65744   0.00346021 
+  245          320.62292    158.56714   0.00408163 
+  328          349.61118    158.47702   0.00304878 
+  348          365.31614    158.38708   0.00287356 
+  367          388.49835    158.29732   0.0027248 
+  346          429.24933    158.20774   0.00289017 
+  403          490.11714    158.11833   0.00248139 
+  403          571.81691    158.02911   0.00248139 
+  469          683.34739    157.94006   0.0021322 
+  635          863.6965     157.8512    0.0015748 
+  895          1181.13976   157.7625    0.00111732 
+  1541         1816.34663   157.67399   0.00064893 
+  2746         3280.15253   157.58565   0.00036417 
+  4822         6447.12809   157.49748   0.00020738 
+  6966         9542.68774   157.40949   0.00014355 
+  6813         6865.78346   157.32167   0.00014678 
+  4202         3979.53927   157.23403   0.00023798 
+  2843         3222.98202   157.14656   0.00035174 
+  3109         4167.60071   157.05926   0.00032165 
+  3795         5311.82777   156.97213   0.0002635 
+  3453         3667.88469   156.88518   0.0002896 
+  2074         1980.72927   156.79839   0.00048216 
+  1051         1179.60626   156.71178   0.00095147 
+  709          817.02717    156.62533   0.00141044 
+  465          626.48156    156.53905   0.00215054 
+  413          511.09371    156.45295   0.00242131 
+  349          435.12651    156.36701   0.00286533 
+  345          382.24371    156.28123   0.00289855 
+  317          343.87552    156.19563   0.00315457 
+  247          315.15728    156.11019   0.00404858 
+  253          293.15055    156.02491   0.00395257 
+  260          275.99025    155.9398    0.00384615 
+  230          262.42625    155.85486   0.00434783 
+  216          251.61027    155.77008   0.00462963 
+  236          243.05314    155.68546   0.00423729 
+  214          236.59603    155.60101   0.0046729 
+  209          232.36594    155.51672   0.00478469 
+  253          231.00272    155.43259   0.00395257 
+  234          234.34942    155.34863   0.0042735 
+  247          246.25322    155.26482   0.00404858 
+  228          269.60651    155.18118   0.00438596 
+  191          283.80013    155.09769   0.0052356 
+  213          263.46839    155.01437   0.00469484 
+  217          243.68047    154.9312    0.00460829 
+  205          240.25257    154.8482    0.00487805 
+  248          252.70198    154.76535   0.00403226 
+  213          272.33574    154.68266   0.00469484 
+  266          291.09614    154.60012   0.0037594 
+  234          325.89155    154.51774   0.0042735 
+  255          333.51601    154.43552   0.00392157 
+  260          286.97549    154.35346   0.00384615 
+  227          251.39009    154.27155   0.00440529 
+  218          242.77793    154.18979   0.00458716 
+  223          254.17369    154.10819   0.0044843 
+  235          256.60781    154.02674   0.00425532 
+  201          230.25317    153.94545   0.00497512 
+  207          206.25482    153.86431   0.00483092 
+  175          192.53664    153.78332   0.00571429 
+  180          184.92402    153.70248   0.00555556 
+  148          180.28912    153.62179   0.00675676 
+  178          177.13879    153.54126   0.00561798 
+  177          174.82479    153.46087   0.00564972 
+  169          173.03076    153.38064   0.00591716 
+  155          171.58529    153.30055   0.00645161 
+  147          170.38647    153.22062   0.00680272 
+  151          169.37024    153.14083   0.00662252 
+  166          168.49377    153.06119   0.0060241 
+  169          167.72969    152.98169   0.00591716 
+  160          167.05733    152.90235   0.00625   
+  175          166.46292    152.82315   0.00571429 
+  162          165.93504    152.7441    0.00617284 
+  152          165.47043    152.66519   0.00657895 
+  162          165.05916    152.58643   0.00617284 
+  157          164.7033     152.50781   0.00636943 
+  178          164.40019    152.42934   0.00561798 
+  163          164.15493    152.35101   0.00613497 
+  137          163.97705    152.27283   0.00729927 
+  156          163.88514    152.19479   0.00641026 
+  161          163.91531    152.11689   0.00621118 
+  162          164.15066    152.03913   0.00617284 
+  156          164.73142    151.96152   0.00641026 
+  145          165.7101     151.88404   0.00689655 
+  154          166.39324    151.80671   0.00649351 
+  152          166.2883     151.72952   0.00657895 
+  172          166.17266    151.65247   0.00581395 
+  149          166.35544    151.57555   0.00671141 
+  145          166.77986    151.49878   0.00689655 
+  158          167.25435    151.42215   0.00632911 
+  151          167.57968    151.34565   0.00662252 
+  148          168.19099    151.26929   0.00675676 
+  169          169.336      151.19307   0.00591716 
+  141          170.97343    151.11699   0.0070922 
+  158          173.19206    151.04104   0.00632911 
+  161          176.62441    150.96523   0.00621118 
+  173          183.02429    150.88955   0.00578035 
+  200          196.00947    150.81401   0.005     
+  267          221.03782    150.73861   0.00374532 
+  248          254.29051    150.66334   0.00403226 
+  213          254.37512    150.5882    0.00469484 
+  208          224.3735     150.5132    0.00480769 
+  193          206.16407    150.43833   0.00518135 
+  205          204.97385    150.36359   0.00487805 
+  203          215.80934    150.28898   0.00492611 
+  180          218.13833    150.21451   0.00555556 
+  184          202.71733    150.14017   0.00543478 
+  171          191.16693    150.06596   0.00584795 
+  177          187.28607    149.99188   0.00564972 
+  172          188.63832    149.91794   0.00581395 
+  163          196.12316    149.84412   0.00613497 
+  180          201.84921    149.77043   0.00555556 
+  189          193.57131    149.69687   0.00529101 
+  208          184.43741    149.62344   0.00480769 
+  189          180.59458    149.55014   0.00529101 
+  170          181.81926    149.47697   0.00588235 
+  172          184.9762     149.40392   0.00581395 
+  178          182.02088    149.331     0.00561798 
+  172          177.21272    149.25821   0.00581395 
+  171          175.80972    149.18555   0.00584795 
+  182          178.05261    149.11301   0.00549451 
+  167          183.20931    149.04059   0.00598802 
+  217          187.18325    148.96831   0.00460829 
+  227          190.2736     148.89615   0.00440529 
+  257          200.14845    148.82411   0.00389105 
+  282          221.48364    148.75219   0.0035461 
+  266          248.82485    148.68041   0.0037594 
+  249          257.37503    148.60874   0.00401606 
+  268          239.72239    148.5372    0.00373134 
+  223          226.76537    148.46578   0.0044843 
+  303          232.2788     148.39448   0.00330033 
+  327          255.69346    148.32331   0.0030581 
+  307          285.85171    148.25225   0.00325733 
+  305          297.96392    148.18132   0.00327869 
+  275          296.02001    148.11051   0.00363636 
+  271          295.43939    148.03982   0.00369004 
+  280          292.81475    147.96925   0.00357143 
+  361          316.16387    147.8988    0.00277008 
+  402          383.33876    147.82847   0.00248756 
+  486          523.12692    147.75826   0.00205761 
+  661          759.11982    147.68816   0.00151286 
+  791          827.96899    147.61819   0.00126422 
+  768          598.81327    147.54834   0.00130208 
+  527          440.43995    147.4786    0.00189753 
+  438          406.63939    147.40898   0.00228311 
+  431          469.88491    147.33947   0.00232019 
+  479          535.66812    147.27009   0.00208768 
+  446          436.92972    147.20082   0.00224215 
+  361          324.52711    147.13166   0.00277008 
+  266          265.39844    147.06263   0.0037594 
+  208          234.59344    146.9937    0.00480769 
+  210          218.79012    146.9249    0.0047619 
+  186          212.53945    146.8562    0.00537634 
+  206          214.34937    146.78763   0.00485437 
+  215          226.0895     146.71916   0.00465116 
+  246          256.48296    146.65081   0.00406504 
+  318          325.9234     146.58257   0.00314465 
+  388          404.71292    146.51445   0.00257732 
+  357          357.21687    146.44644   0.00280112 
+  300          294.46436    146.37854   0.00333333 
+  318          290.36782    146.31076   0.00314465 
+  349          345.59443    146.24308   0.00286533 
+  359          444.26219    146.17552   0.00278552 
+  366          446.63026    146.10807   0.00273224 
+  315          344.72372    146.04073   0.0031746 
+  251          275.69931    145.97349   0.00398406 
+  221          253.89701    145.90637   0.00452489 
+  214          263.89794    145.83936   0.0046729 
+  203          272.34717    145.77246   0.00492611 
+  201          243.9338     145.70567   0.00497512 
+  184          210.68683    145.63899   0.00543478 
+  157          190.86587    145.57242   0.00636943 
+  153          180.76937    145.50595   0.00653595 
+  150          175.98632    145.43959   0.00666667 
+  200          174.14654    145.37334   0.005     
+  193          172.55405    145.3072    0.00518135 
+  162          170.13377    145.24117   0.00617284 
+  159          168.8057     145.17524   0.00628931 
+  178          168.96461    145.10942   0.00561798 
+  171          170.44257    145.0437    0.00584795 
+  166          172.91635    144.97809   0.0060241 
+  153          175.8023     144.91259   0.00653595 
+  172          180.58714    144.84719   0.00581395 
+  164          189.34648    144.7819    0.00609756 
+  198          205.36799    144.71671   0.00505051 
+  271          236.31582    144.65162   0.00369004 
+  327          296.6788     144.58664   0.0030581 
+  362          395.34565    144.52177   0.00276243 
+  400          455.02883    144.457     0.0025    
+  421          382.28325    144.39233   0.0023753 
+  394          302.85315    144.32776   0.00253807 
+  346          273.21774    144.2633    0.00289017 
+  308          287.25832    144.19894   0.00324675 
+  307          320.23743    144.13468   0.00325733 
+  325          300.70733    144.07052   0.00307692 
+  254          245.14136    144.00647   0.00393701 
+  205          207.15147    143.94251   0.00487805 
+  207          187.48119    143.87866   0.00483092 
+  161          176.37743    143.81491   0.00621118 
+  166          169.79554    143.75126   0.0060241 
+  169          165.56675    143.6877    0.00591716 
+  181          162.72483    143.62425   0.00552486 
+  172          160.78794    143.5609    0.00581395 
+  164          159.49229    143.49765   0.00609756 
+  139          159.06992    143.4345    0.00719424 
+  160          158.70596    143.37144   0.00625   
+  169          158.88387    143.30849   0.00591716 
+  161          159.90424    143.24563   0.00621118 
+  171          161.94609    143.18287   0.00584795 
+  199          163.42067    143.12021   0.00502513 
+  166          162.81728    143.05765   0.0060241 
+  190          162.64607    142.99518   0.00526316 
+  183          163.92974    142.93281   0.00546448 
+  192          166.48429    142.87054   0.00520833 
+  204          169.35085    142.80837   0.00490196 
+  189          170.50584    142.74629   0.00529101 
+  197          170.54698    142.6843    0.00507614 
+  179          171.58684    142.62242   0.00558659 
+  194          172.00423    142.56063   0.00515464 
+  199          169.13263    142.49893   0.00502513 
+  215          166.28026    142.43733   0.00465116 
+  221          164.62385    142.37582   0.00452489 
+  249          164.07718    142.31441   0.00401606 
+  265          164.41148    142.25309   0.00377358 
+  262          163.96005    142.19187   0.00381679 
+  278          163.53322    142.13074   0.00359712 
+  255          165.54302    142.0697    0.00392157 
+  279          168.98787    142.00876   0.00358423 
+  278          168.56322    141.94791   0.00359712 
+  263          166.49914    141.88715   0.00380228 
+  249          167.23601    141.82649   0.00401606 
+  295          171.65687    141.76592   0.00338983 
+  278          182.28328    141.70544   0.00359712 
+  253          200.54608    141.64505   0.00395257 
+  219          216.84939    141.58476   0.00456621 
+  201          207.62696    141.52455   0.00497512 
+  205          188.34996    141.46444   0.00487805 
+  195          178.24142    141.40442   0.00512821 
+  185          177.95212    141.34449   0.00540541 
+  206          185.17098    141.28465   0.00485437 
+  203          189.45304    141.2249    0.00492611 
+  208          182.61853    141.16524   0.00480769 
+  175          175.81111    141.10567   0.00571429 
+  192          170.69929    141.04618   0.00520833 
+  169          168.48525    140.98679   0.00591716 
+  179          166.9259     140.92749   0.00558659 
+  157          164.99665    140.86828   0.00636943 
+  173          165.21001    140.80916   0.00578035 
+  154          166.81498    140.75012   0.00649351 
+  181          170.19201    140.69117   0.00552486 
+  172          178.22369    140.63231   0.00581395 
+  201          191.5478     140.57354   0.00497512 
+  189          202.2502     140.51486   0.00529101 
+  191          192.9261     140.45626   0.0052356 
+  202          179.11477    140.39776   0.0049505 
+  206          172.78081    140.33933   0.00485437 
+  211          173.49403    140.281     0.00473934 
+  216          179.11247    140.22275   0.00462963 
+  201          180.65285    140.16459   0.00497512 
+  175          173.2866     140.10652   0.00571429 
+  186          166.88202    140.04853   0.00537634 
+  198          163.75424    139.99062   0.00505051 
+  171          162.69135    139.93281   0.00584795 
+  209          162.82012    139.87508   0.00478469 
+  180          163.87677    139.81743   0.00555556 
+  208          166.0316     139.75987   0.00480769 
+  190          169.73897    139.70239   0.00526316 
+  214          174.53463    139.645     0.0046729 
+  203          176.37954    139.58769   0.00492611 
+  200          175.62006    139.53047   0.005     
+  219          176.3812     139.47333   0.00456621 
+  223          179.30034    139.41627   0.0044843 
+  229          184.24891    139.3593    0.00436681 
+  257          190.38446    139.30241   0.00389105 
+  212          195.80337    139.24561   0.00471698 
+  241          202.24936    139.18889   0.00414938 
+  282          211.78174    139.13225   0.0035461 
+  308          225.32102    139.07569   0.00324675 
+  297          244.30577    139.01922   0.003367  
+  345          271.18128    138.96283   0.00289855 
+  372          310.93021    138.90652   0.00268817 
+  403          368.70898    138.8503    0.00248139 
+  498          441.15484    138.79415   0.00200803 
+  574          509.94491    138.73809   0.00174216 
+  674          566.70097    138.68211   0.00148368 
+  722          605.0099     138.62621   0.00138504 
+  708          623.55874    138.57039   0.00141243 
+  645          613.41644    138.51465   0.00155039 
+  608          576.57629    138.45899   0.00164474 
+  527          537.81004    138.40342   0.00189753 
+  499          505.56261    138.34792   0.00200401 
+  530          472.34336    138.2925    0.00188679 
+  456          436.9734     138.23717   0.00219298 
+  406          391.32123    138.18191   0.00246305 
+  375          339.96691    138.12674   0.00266667 
+  313          297.18572    138.07164   0.00319489 
+  262          263.86432    138.01662   0.00381679 
+  233          238.00461    137.96169   0.00429185 
+  211          219.34364    137.90683   0.00473934 
+  199          205.90606    137.85205   0.00502513 
+  215          195.96763    137.79735   0.00465116 
+  186          188.41368    137.74272   0.00537634 
+  156          182.54936    137.68818   0.00641026 
+  197          177.92694    137.63372   0.00507614 
+  162          174.25149    137.57933   0.00617284 
+  180          171.32625    137.52502   0.00555556 
+  178          169.02261    137.47079   0.00561798 
+  176          167.26528    137.41663   0.00568182 
+  169          166.0143     137.36256   0.00591716 
+  169          165.2178     137.30856   0.00591716 
+  167          164.9083     137.25464   0.00598802 
+  167          165.35541    137.20079   0.00598802 
+  169          166.94301    137.14702   0.00591716 
+  162          170.01413    137.09333   0.00617284 
+  180          173.28526    137.03972   0.00555556 
+  179          173.99863    136.98618   0.00558659 
+  187          175.15316    136.93272   0.00534759 
+  166          178.10956    136.87933   0.0060241 
+  189          177.78354    136.82602   0.00529101 
+  187          174.95961    136.77279   0.00534759 
+  226          173.38314    136.71963   0.00442478 
+  203          172.29614    136.66655   0.00492611 
+  169          172.93582    136.61354   0.00591716 
+  192          175.05603    136.56061   0.00520833 
+  202          175.91792    136.50775   0.0049505 
+  178          176.85526    136.45497   0.00561798 
+  198          180.14992    136.40226   0.00505051 
+  188          186.14602    136.34963   0.00531915 
+  222          195.22057    136.29707   0.0045045 
+  210          208.18122    136.24459   0.0047619 
+  218          226.82526    136.19218   0.00458716 
+  231          250.20866    136.13984   0.004329  
+  283          268.06628    136.08758   0.00353357 
+  250          267.6798     136.03539   0.004     
+  278          257.7305     135.98328   0.00359712 
+  227          256.47233    135.93124   0.00440529 
+  217          270.68687    135.87928   0.00460829 
+  248          281.17828    135.82738   0.00403226 
+  222          265.61459    135.77556   0.0045045 
+  198          241.73242    135.72382   0.00505051 
+  228          222.57066    135.67214   0.00438596 
+  204          213.39921    135.62054   0.00490196 
+  212          213.57225    135.56901   0.00471698 
+  182          211.35628    135.51756   0.00549451 
+  170          199.85619    135.46618   0.00588235 
+  178          190.26503    135.41487   0.00561798 
+  175          184.80496    135.36363   0.00571429 
+  182          181.39389    135.31246   0.00549451 
+  179          177.79459    135.26137   0.00558659 
+  163          174.79695    135.21035   0.00613497 
+  196          173.42693    135.1594    0.00510204 
+  190          173.30182    135.10852   0.00526316 
+  192          174.08405    135.05771   0.00520833 
+  214          175.70554    135.00697   0.0046729 
+  209          178.22257    134.95631   0.00478469 
+  253          183.72979    134.90572   0.00395257 
+  221          195.96706    134.85519   0.00452489 
+  236          221.24538    134.80474   0.00423729 
+  251          266.10726    134.75436   0.00398406 
+  294          324.76288    134.70405   0.00340136 
+  325          329.25377    134.65381   0.00307692 
+  320          267.64172    134.60364   0.003125  
+  282          229.16404    134.55355   0.0035461 
+  233          221.39883    134.50352   0.00429185 
+  235          235.52095    134.45356   0.00425532 
+  238          262.22971    134.40367   0.00420168 
+  266          265.171      134.35386   0.0037594 
+  254          243.01317    134.30411   0.00393701 
+  216          239.89183    134.25443   0.00462963 
+  213          243.6446     134.20482   0.00469484 
+  239          225.88491    134.15528   0.0041841 
+  210          204.54152    134.10581   0.0047619 
+  194          194.05864    134.05641   0.00515464 
+  224          193.44911    134.00708   0.00446429 
+  183          200.37639    133.95782   0.00546448 
+  194          206.53463    133.90863   0.00515464 
+  189          200.32349    133.8595    0.00529101 
+  209          192.54334    133.81045   0.00478469 
+  233          191.9734     133.76146   0.00429185 
+  220          201.22665    133.71254   0.00454545 
+  286          224.01889    133.66369   0.0034965 
+  294          247.32518    133.61491   0.00340136 
+  274          231.2663     133.5662    0.00364964 
+  194          207.23659    133.51756   0.00515464 
+  227          196.83795    133.46898   0.00440529 
+  196          197.36096    133.42047   0.00510204 
+  230          207.23742    133.37203   0.00434783 
+  235          219.09928    133.32366   0.00425532 
+  208          212.15708    133.27536   0.00480769 
+  232          200.9956     133.22712   0.00431034 
+  211          196.92754    133.17895   0.00473934 
+  204          197.90624    133.13085   0.00490196 
+  199          200.19874    133.08282   0.00502513 
+  206          201.11571    133.03485   0.00485437 
+  206          202.67817    132.98695   0.00485437 
+  217          205.83382    132.93912   0.00460829 
+  229          209.8057     132.89135   0.00436681 
+  224          213.96824    132.84366   0.00446429 
+  216          218.53604    132.79602   0.00462963 
+  222          222.85753    132.74846   0.0045045 
+  217          227.99979    132.70096   0.00460829 
+  236          234.54956    132.65353   0.00423729 
+  240          242.18362    132.60617   0.00416667 
+  224          250.58198    132.55887   0.00446429 
+  229          260.32497    132.51164   0.00436681 
+  256          271.88446    132.46448   0.00390625 
+  291          285.66564    132.41738   0.00343643 
+  279          302.36242    132.37034   0.00358423 
+  314          323.05031    132.32338   0.00318471 
+  371          347.38134    132.27648   0.00269542 
+  404          372.47486    132.22965   0.00247525 
+  441          401.35152    132.18288   0.00226757 
+  514          438.66352    132.13618   0.00194553 
+  485          486.98933    132.08954   0.00206186 
+  567          549.83332    132.04297   0.00176367 
+  512          632.12365    131.99646   0.00195312 
+  607          740.38153    131.95002   0.00164745 
+  726          888.56682    131.90365   0.00137741 
+  868          1101.40887   131.85734   0.00115207 
+  1155         1423.32222   131.8111    0.0008658 
+  1765         1943.84379   131.76492   0.00056657 
+  2968         2878.33294   131.71881   0.00033693 
+  5375         4811.48193   131.67276   0.00018605 
+  10059        9058.46446   131.62678   0.00009941 
+  15681        16501.88207  131.58086   0.00006377 
+  18827        18706.2602   131.53501   0.00005312 
+  14310        11640.64343  131.48922   0.00006988 
+  8342         6759.43598   131.4435    0.00011988 
+  5748         5137.16544   131.39784   0.00017397 
+  6186         5853.70998   131.35225   0.00016166 
+  8158         8760.52828   131.30672   0.00012258 
+  9404         10386.60564  131.26125   0.00010634 
+  7549         6813.35866   131.21586   0.00013247 
+  4426         3726.13005   131.17052   0.00022594 
+  2208         2220.86754   131.12525   0.0004529 
+  1298         1509.41398   131.08004   0.00077042 
+  921          1128.63616   131.0349    0.00108578 
+  683          898.58713    130.98982   0.00146413 
+  595          747.61711    130.94481   0.00168067 
+  498          639.04227    130.89986   0.00200803 
+  448          554.52656    130.85498   0.00223214 
+  380          488.4969     130.81015   0.00263158 
+  402          438.02474    130.7654    0.00248756 
+  317          399.76991    130.7207    0.00315457 
+  293          370.13218    130.67607   0.00341297 
+  288          344.9224     130.63151   0.00347222 
+  279          321.37658    130.58701   0.00358423 
+  285          300.16117    130.54257   0.00350877 
+  259          282.17932    130.49819   0.003861  
+  262          267.25288    130.45388   0.00381679 
+  247          254.86717    130.40963   0.00404858 
+  221          244.50892    130.36545   0.00452489 
+  207          235.78222    130.32133   0.00483092 
+  242          228.40293    130.27727   0.00413223 
+  182          222.10906    130.23328   0.00549451 
+  216          216.8517     130.18935   0.00462963 
+  197          211.96881    130.14548   0.00507614 
+  187          207.47082    130.10167   0.00534759 
+  210          203.37908    130.05793   0.0047619 
+  179          199.8574     130.01425   0.00558659 
+  200          197.01523    129.97064   0.005     
+  205          194.87624    129.92709   0.00487805 
+  176          193.50326    129.8836    0.00568182 
+  201          192.63731    129.84017   0.00497512 
+  193          192.41029    129.79681   0.00518135 
+  202          192.96562    129.75351   0.0049505 
+  222          194.6648     129.71027   0.0045045 
+  215          198.11061    129.6671    0.00465116 
+  245          203.59552    129.62398   0.00408163 
+  248          208.32534    129.58093   0.00403226 
+  274          206.56154    129.53795   0.00364964 
+  305          203.07674    129.49502   0.00327869 
+  299          201.47584    129.45216   0.00334448 
+  264          202.04764    129.40936   0.00378788 
+  247          204.63655    129.36663   0.00404858 
+  217          206.99074    129.32395   0.00460829 
+  218          204.62289    129.28134   0.00458716 
+  258          198.64681    129.23879   0.00387597 
+  274          192.99068    129.19631   0.00364964 
+  262          188.93542    129.15388   0.00381679 
+  249          186.75671    129.11152   0.00401606 
+  219          185.82763    129.06922   0.00456621 
+  199          185.29995    129.02698   0.00502513 
+  211          185.12177    128.98481   0.00473934 
+  228          186.03853    128.94269   0.00438596 
+  211          188.82408    128.90064   0.00473934 
+  174          193.59392    128.85865   0.00574713 
+  198          199.22733    128.81672   0.00505051 
+  249          203.45133    128.77486   0.00401606 
+  274          205.04373    128.73306   0.00364964 
+  258          206.12197    128.69132   0.00387597 
+  309          208.5554     128.64964   0.00323625 
+  301          207.28186    128.60802   0.00332226 
+  342          202.74815    128.56646   0.00292398 
+  315          200.20312    128.52497   0.0031746 
+  308          198.90939    128.48354   0.00324675 
+  299          198.49566    128.44217   0.00334448 
+  262          199.57975    128.40086   0.00381679 
+  263          196.06721    128.35962   0.00380228 
+  273          185.40073    128.31843   0.003663  
+  261          176.52142    128.27731   0.00383142 
+  247          171.44146    128.23625   0.00404858 
+  231          168.94713    128.19525   0.004329  
+  214          168.25871    128.15431   0.0046729 
+  208          167.64869    128.11343   0.00480769 
+  198          164.9412     128.07262   0.00505051 
+  177          162.79638    128.03187   0.00564972 
+  192          163.11617    127.99118   0.00520833 
+  190          166.64423    127.95055   0.00526316 
+  187          174.68722    127.90998   0.00534759 
+  177          186.28991    127.86947   0.00564972 
+  164          190.55672    127.82903   0.00609756 
+  172          187.55721    127.78864   0.00581395 
+  180          187.69993    127.74832   0.00555556 
+  165          183.41659    127.70806   0.00606061 
+  146          176.30792    127.66786   0.00684932 
+  183          174.63771    127.62772   0.00546448 
+  156          175.34696    127.58765   0.00641026 
+  159          172.53908    127.54763   0.00628931 
+  172          170.96312    127.50768   0.00581395 
+  172          170.09087    127.46779   0.00581395 
+  171          166.7424     127.42795   0.00584795 
+  185          165.57616    127.38818   0.00540541 
+  169          167.40644    127.34848   0.00591716 
+  144          166.62778    127.30883   0.00694444 
+  176          162.69161    127.26924   0.00568182 
+  163          160.39934    127.22972   0.00613497 
+  150          160.50257    127.19025   0.00666667 
+  164          162.72027    127.15085   0.00609756 
+  156          166.90409    127.11151   0.00641026 
+  151          171.4993     127.07223   0.00662252 
+  172          174.31237    127.03301   0.00581395 
+  181          177.4367     126.99386   0.00552486 
+  177          182.5324     126.95476   0.00564972 
+  175          189.69696    126.91573   0.00571429 
+  206          199.6465     126.87675   0.00485437 
+  200          215.85385    126.83784   0.005     
+  229          234.55875    126.79899   0.00436681 
+  218          233.82428    126.7602    0.00458716 
+  205          221.46735    126.72147   0.00487805 
+  228          216.38367    126.6828    0.00438596 
+  195          221.18294    126.64419   0.00512821 
+  250          235.05534    126.60565   0.004     
+  269          254.4057     126.56716   0.00371747 
+  231          266.97963    126.52874   0.004329  
+  254          273.20404    126.49038   0.00393701 
+  235          289.01138    126.45208   0.00425532 
+  290          323.51863    126.41384   0.00344828 
+  355          384.997      126.37566   0.0028169 
+  488          494.73075    126.33754   0.00204918 
+  762          710.66147    126.29948   0.00131234 
+  1209         1178.33009   126.26149   0.00082713 
+  1807         2080.15118   126.22355   0.0005534 
+  2108         2756.66767   126.18568   0.00047438 
+  1917         1992.45628   126.14787   0.00052165 
+  1215         1190.96307   126.11011   0.00082305 
+  810          839.711      126.07242   0.00123457 
+  779          791.30827    126.03479   0.0012837 
+  911          1010.39019   125.99723   0.00109769 
+  1135         1449.48609   125.95972   0.00088106 
+  1146         1422.35004   125.92227   0.0008726 
+  843          911.76864    125.88489   0.00118624 
+  546          586.60976    125.84756   0.0018315 
+  381          436.73337    125.8103    0.00262467 
+  297          352.26043    125.7731    0.003367  
+  286          293.49571    125.73596   0.0034965 
+  246          255.81708    125.69888   0.00406504 
+  210          232.48484    125.66186   0.0047619 
+  194          219.49904    125.6249    0.00515464 
+  201          214.01       125.58801   0.00497512 
+  198          208.729      125.55117   0.00505051 
+  198          196.67427    125.5144    0.00505051 
+  166          184.6733     125.47769   0.0060241 
+  157          175.99106    125.44103   0.00636943 
+  173          169.84156    125.40444   0.00578035 
+  139          165.40674    125.36791   0.00719424 
+  162          162.11854    125.33144   0.00617284 
+  150          159.69484    125.29504   0.00666667 
+  164          158.11755    125.25869   0.00609756 
+  160          157.60213    125.22241   0.00625   
+  168          158.85341    125.18618   0.00595238 
+  159          161.39476    125.15002   0.00628931 
+  152          162.91888    125.11392   0.00657895 
+  167          160.3963     125.07788   0.00598802 
+  133          157.57541    125.0419    0.0075188 
+  155          156.48265    125.00598   0.00645161 
+  149          156.92911    124.97013   0.00671141 
+  158          158.73236    124.93433   0.00632911 
+  156          161.83296    124.8986    0.00641026 
+  166          164.34132    124.86292   0.0060241 
+  157          166.57104    124.82731   0.00636943 
+  161          171.40822    124.79176   0.00621118 
+  197          180.89856    124.75627   0.00507614 
+  206          198.58463    124.72084   0.00485437 
+  266          233.82329    124.68548   0.0037594 
+  327          307.30823    124.65017   0.0030581 
+  436          441.65595    124.61493   0.00229358 
+  562          544.07809    124.57975   0.00177936 
+  636          440.45508    124.54463   0.00157233 
+  561          315.70999    124.50957   0.00178253 
+  440          256.31269    124.47457   0.00227273 
+  314          245.15231    124.43963   0.00318471 
+  314          273.77501    124.40476   0.00318471 
+  404          335.72222    124.36994   0.00247525 
+  382          349.43132    124.33519   0.0026178 
+  374          275.088      124.3005    0.0026738 
+  343          215.24526    124.26587   0.00291545 
+  242          184.74554    124.2313    0.00413223 
+  220          170.1489     124.19679   0.00454545 
+  191          162.65352    124.16235   0.0052356 
+  171          157.73601    124.12796   0.00584795 
+  192          154.45384    124.09364   0.00520833 
+  181          153.08673    124.05938   0.00552486 
+  176          154.31959    124.02518   0.00568182 
+  184          158.70804    123.99104   0.00543478 
+  168          163.42284    123.95697   0.00595238 
+  162          160.90788    123.92295   0.00617284 
+  188          155.26203    123.889     0.00531915 
+  174          152.40308    123.85511   0.00574713 
+  188          152.70036    123.82128   0.00531915 
+  184          156.02043    123.78751   0.00543478 
+  199          163.47036    123.75381   0.00502513 
+  195          172.48677    123.72016   0.00512821 
+  153          171.88425    123.68658   0.00653595 
+  179          162.63927    123.65306   0.00558659 
+  174          156.15367    123.6196    0.00574713 
+  168          154.71185    123.5862    0.00595238 
+  199          157.77752    123.55287   0.00502513 
+  192          165.81248    123.5196    0.00520833 
+  174          174.50748    123.48638   0.00574713 
+  175          170.69886    123.45323   0.00571429 
+  183          159.98452    123.42015   0.00546448 
+  168          153.09475    123.38712   0.00595238 
+  159          150.60677    123.35416   0.00628931 
+  161          151.44524    123.32126   0.00621118 
+  147          154.71895    123.28842   0.00680272 
+  183          156.47216    123.25564   0.00546448 
+  190          153.03532    123.22292   0.00526316 
+  150          149.25118    123.19027   0.00666667 
+  154          147.89805    123.15768   0.00649351 
+  186          148.26612    123.12515   0.00537634 
+  133          148.16605    123.09268   0.0075188 
+  126          147.18603    123.06028   0.00793651 
+  190          146.18246    123.02793   0.00526316 
+  157          145.60007    122.99565   0.00636943 
+  158          145.83496    122.96343   0.00632911 
+  157          146.86235    122.93128   0.00636943 
+  174          148.31499    122.89919   0.00574713 
+  173          149.24557    122.86715   0.00578035 
+  171          149.82493    122.83518   0.00584795 
+  152          150.67172    122.80328   0.00657895 
+  166          151.85118    122.77143   0.0060241 
+  175          153.53104    122.73965   0.00571429 
+  173          156.06943    122.70793   0.00578035 
+  159          159.79288    122.67627   0.00628931 
+  174          163.87956    122.64468   0.00574713 
+  158          165.65732    122.61315   0.00632911 
+  197          166.20869    122.58168   0.00507614 
+  194          167.82773    122.55027   0.00515464 
+  203          171.00642    122.51893   0.00492611 
+  203          176.07697    122.48764   0.00492611 
+  208          183.74333    122.45643   0.00480769 
+  249          194.48735    122.42527   0.00401606 
+  258          206.94402    122.39417   0.00387597 
+  263          215.5194     122.36314   0.00380228 
+  244          218.22408    122.33218   0.00409836 
+  270          223.92964    122.30127   0.0037037 
+  259          236.25468    122.27043   0.003861  
+  261          256.43795    122.23965   0.00383142 
+  297          286.82417    122.20893   0.003367  
+  322          328.04359    122.17828   0.00310559 
+  363          371.05103    122.14769   0.00275482 
+  377          420.40311    122.11716   0.00265252 
+  399          502.88045    122.08669   0.00250627 
+  621          648.40461    122.05629   0.00161031 
+  924          922.1542     122.02595   0.00108225 
+  1724         1491.85882   121.99567   0.00058005 
+  3082         2678.39388   121.96546   0.00032446 
+  4542         4434.93403   121.93531   0.00022017 
+  4165         4413.24196   121.90522   0.0002401 
+  2717         2717.51544   121.8752    0.00036805 
+  1696         1652.87807   121.84524   0.00058962 
+  1252         1254.61849   121.81534   0.00079872 
+  1314         1279.39181   121.78551   0.00076104 
+  1839         1722.61761   121.75574   0.00054377 
+  2367         2495.99938   121.72603   0.00042248 
+  2144         2380.39184   121.69639   0.00046642 
+  1335         1472.52491   121.66681   0.00074906 
+  829          887.0258     121.63729   0.00120627 
+  543          606.44315    121.60784   0.00184162 
+  423          463.95235    121.57845   0.00236407 
+  339          378.2777     121.54912   0.00294985 
+  280          325.58314    121.51986   0.00357143 
+  268          290.2545     121.49066   0.00373134 
+  228          260.48266    121.46152   0.00438596 
+  217          237.45336    121.43245   0.00460829 
+  171          220.98898    121.40344   0.00584795 
+  201          208.48112    121.3745    0.00497512 
+  144          199.23576    121.34562   0.00694444 
+  203          193.50386    121.3168    0.00492611 
+  184          189.20938    121.28805   0.00543478 
+  178          183.87309    121.25936   0.00561798 
+  156          179.10512    121.23073   0.00641026 
+  177          174.33028    121.20217   0.00564972 
+  186          170.84999    121.17367   0.00537634 
+  171          167.76858    121.14524   0.00584795 
+  171          165.69628    121.11687   0.00584795 
+  170          165.18       121.08857   0.00588235 
+  178          165.89       121.06032   0.00561798 
+  166          166.60719    121.03215   0.0060241 
+  160          166.50881    121.00403   0.00625   
+  157          165.46383    120.97599   0.00636943 
+  161          163.75201    120.948     0.00621118 
+  145          161.29456    120.92008   0.00689655 
+  161          158.08403    120.89222   0.00621118 
+  127          155.46338    120.86443   0.00787402 
+  181          153.71853    120.83671   0.00552486 
+  158          152.37791    120.80904   0.00632911 
+  148          151.15036    120.78144   0.00675676 
+  160          150.06879    120.75391   0.00625   
+  169          148.94745    120.72644   0.00591716 
+  159          147.62441    120.69903   0.00628931 
+  177          147.0491     120.67169   0.00564972 
+  154          147.96347    120.64442   0.00649351 
+  144          150.25725    120.61721   0.00694444 
+  163          151.63604    120.59006   0.00613497 
+  134          151.40269    120.56298   0.00746269 
+  148          152.51317    120.53596   0.00675676 
+  156          154.90587    120.50901   0.00641026 
+  184          156.21558    120.48212   0.00543478 
+  150          155.57226    120.4553    0.00666667 
+  162          154.29152    120.42854   0.00617284 
+  127          153.35914    120.40185   0.00787402 
+  135          153.10639    120.37522   0.00740741 
+  155          155.21319    120.34866   0.00645161 
+  170          158.44049    120.32216   0.00588235 
+  169          158.0488     120.29573   0.00591716 
+  159          154.4504     120.26936   0.00628931 
+  172          151.11186    120.24306   0.00581395 
+  148          149.11131    120.21682   0.00675676 
+  141          148.30499    120.19065   0.0070922 
+  144          148.38154    120.16454   0.00694444 
+  148          148.84034    120.1385    0.00675676 
+  161          148.16412    120.11252   0.00621118 
+  150          146.54685    120.08661   0.00666667 
+  164          145.63719    120.06077   0.00609756 
+  149          145.54858    120.03499   0.00671141 
+  167          145.70144    120.00927   0.00598802 
+  149          145.65771    119.98362   0.00671141 
+  168          145.45372    119.95804   0.00595238 
+  147          145.62349    119.93252   0.00680272 
+  142          146.91264    119.90707   0.00704225 
+  176          149.87652    119.88168   0.00568182 
+  173          153.1685     119.85636   0.00578035 
+  151          152.5788     119.83111   0.00662252 
+  155          149.45687    119.80592   0.00645161 
+  152          147.39634    119.78079   0.00657895 
+  156          146.90501    119.75573   0.00641026 
+  141          147.90644    119.73074   0.0070922 
+  166          150.52701    119.70582   0.0060241 
+  179          154.69226    119.68096   0.00558659 
+  168          159.00577    119.65616   0.00595238 
+  156          163.65612    119.63143   0.00641026 
+  173          169.02975    119.60677   0.00578035 
+  200          176.6185     119.58218   0.005     
+  202          191.5252     119.55765   0.0049505 
+  238          206.8869     119.53318   0.00420168 
+  238          202.64561    119.50878   0.00420168 
+  192          187.75396    119.48445   0.00520833 
+  198          178.68451    119.46019   0.00505051 
+  210          176.77371    119.43599   0.0047619 
+  208          178.76594    119.41186   0.00480769 
+  219          184.35992    119.38779   0.00456621 
+  205          193.22418    119.36379   0.00487805 
+  195          196.80414    119.33986   0.00512821 
+  196          195.72677    119.31599   0.00510204 
+  210          201.33786    119.29219   0.0047619 
+  188          216.04579    119.26846   0.00531915 
+  192          224.79951    119.24479   0.00520833 
+  220          215.01967    119.22119   0.00454545 
+  236          204.50076    119.19766   0.00423729 
+  235          202.3592     119.17419   0.00425532 
+  219          208.99114    119.15079   0.00456621 
+  234          225.26157    119.12746   0.0042735 
+  226          251.33299    119.1042    0.00442478 
+  278          272.95844    119.081     0.00359712 
+  251          272.42499    119.05786   0.00398406 
+  273          269.81524    119.0348    0.003663  
+  277          279.78112    119.0118    0.00361011 
+  310          305.96537    118.98887   0.00322581 
+  353          346.14249    118.96601   0.00283286 
+  361          367.96594    118.94321   0.00277008 
+  307          373.01815    118.92048   0.00325733 
+  341          389.52023    118.89782   0.00293255 
+  362          427.2662     118.87522   0.00276243 
+  447          494.89916    118.85269   0.00223714 
+  511          603.25171    118.83023   0.00195695 
+  723          779.01755    118.80784   0.00138313 
+  1080         1075.89635   118.78551   0.00092593 
+  1772         1643.55574   118.76325   0.00056433 
+  3105         2843.12881   118.74106   0.00032206 
+  4822         4986.85622   118.71894   0.00020738 
+  5387         6243.06168   118.69688   0.00018563 
+  3959         4379.80178   118.67489   0.00025259 
+  2521         2558.75519   118.65297   0.00039667 
+  1601         1697.64649   118.63112   0.00062461 
+  1426         1447.24101   118.60934   0.00070126 
+  1674         1653.53045   118.58762   0.00059737 
+  2281         2400.7792    118.56597   0.0004384 
+  2800         3348.49511   118.54439   0.00035714 
+  2435         2856.04268   118.52287   0.00041068 
+  1535         1718.86615   118.50142   0.00065147 
+  906          1043.36109   118.48005   0.00110375 
+  628          713.66463    118.45873   0.00159236 
+  467          545.56697    118.43749   0.00214133 
+  372          448.91554    118.41632   0.00268817 
+  305          386.91521    118.39521   0.00327869 
+  288          343.85965    118.37417   0.00347222 
+  271          312.86961    118.3532    0.00369004 
+  300          291.14376    118.3323    0.00333333 
+  293          277.15477    118.31147   0.00341297 
+  284          268.40994    118.2907    0.00352113 
+  265          259.46852    118.27      0.00377358 
+  279          251.04844    118.24937   0.00358423 
+  240          245.09732    118.22881   0.00416667 
+  253          239.93273    118.20832   0.00395257 
+  256          233.39046    118.1879    0.00390625 
+  264          227.26516    118.16754   0.00378788 
+  275          225.80432    118.14725   0.00363636 
+  242          229.39556    118.12704   0.00413223 
+  243          234.7748     118.10689   0.00411523 
+  215          231.03909    118.08681   0.00465116 
+  234          216.77544    118.06679   0.0042735 
+  195          203.41701    118.04685   0.00512821 
+  195          193.22427    118.02697   0.00512821 
+  233          186.72554    118.00717   0.00429185 
+  209          184.42866    117.98743   0.00478469 
+  202          186.23177    117.96776   0.0049505 
+  249          188.0794     117.94816   0.00401606 
+  223          184.38082    117.92863   0.0044843 
+  229          180.6592     117.90917   0.00436681 
+  210          182.37366    117.88978   0.0047619 
+  230          190.59582    117.87045   0.00434783 
+  231          203.23259    117.8512    0.004329  
+  269          218.52454    117.83201   0.00371747 
+  236          222.39095    117.8129    0.00423729 
+  225          205.40601    117.79385   0.00444444 
+  242          189.55889    117.77487   0.00413223 
+  228          183.63103    117.75596   0.00438596 
+  228          187.03068    117.73712   0.00438596 
+  209          198.85063    117.71835   0.00478469 
+  245          217.57203    117.69965   0.00408163 
+  237          234.13603    117.68102   0.00421941 
+  251          230.55784    117.66246   0.00398406 
+  239          220.33303    117.64397   0.0041841 
+  292          218.7917     117.62554   0.00342466 
+  294          225.04272    117.60719   0.00340136 
+  296          235.33216    117.5889    0.00337838 
+  259          247.31125    117.57069   0.003861  
+  289          252.32496    117.55255   0.00346021 
+  297          240.03692    117.53447   0.003367  
+  280          224.94014    117.51647   0.00357143 
+  237          215.40865    117.49853   0.00421941 
+  241          205.99444    117.48066   0.00414938 
+  230          199.15269    117.46287   0.00434783 
+  210          196.17208    117.44514   0.0047619 
+  213          194.54551    117.42749   0.00469484 
+  229          188.23496    117.4099    0.00436681 
+  194          178.89688    117.39238   0.00515464 
+  186          173.48842    117.37494   0.00537634 
+  193          170.86126    117.35756   0.00518135 
+  145          170.8736     117.34025   0.00689655 
+  145          175.40099    117.32302   0.00689655 
+  174          176.71356    117.30585   0.00574713 
+  171          166.43565    117.28875   0.00584795 
+  140          154.98509    117.27173   0.00714286 
+  143          148.82691    117.25477   0.00699301 
+  148          147.11823    117.23789   0.00675676 
+  167          149.19917    117.22107   0.00598802 
+  155          155.06895    117.20433   0.00645161 
+  173          161.9389     117.18765   0.00578035 
+  164          162.92255    117.17105   0.00609756 
+  142          160.10064    117.15452   0.00704225 
+  151          163.18873    117.13805   0.00662252 
+  161          176.27731    117.12166   0.00621118 
+  157          196.89035    117.10534   0.00636943 
+  173          203.35856    117.08909   0.00578035 
+  149          185.05773    117.07291   0.00671141 
+  165          165.7734     117.0568    0.00606061 
+  143          153.86943    117.04076   0.00699301 
+  132          148.82623    117.02479   0.00757576 
+  148          149.68585    117.00889   0.00675676 
+  135          156.21092    116.99306   0.00740741 
+  142          164.57514    116.97731   0.00704225 
+  163          161.93035    116.96162   0.00613497 
+  173          150.10278    116.94601   0.00578035 
+  115          140.61089    116.93046   0.00869565 
+  139          135.04184    116.91499   0.00719424 
+  139          131.93252    116.89959   0.00719424 
+  109          130.22291    116.88426   0.00917431 
+  128          129.38384    116.869     0.0078125 
+  143          129.23505    116.85381   0.00699301 
+  144          129.74076    116.83869   0.00694444 
+  137          131.08028    116.82364   0.00729927 
+  140          133.96678    116.80867   0.00714286 
+  117          138.26969    116.79376   0.00854701 
+  140          139.7023     116.77893   0.00714286 
+  105          135.75452    116.76417   0.00952381 
+  134          131.62816    116.74948   0.00746269 
+  143          129.40995    116.73486   0.00699301 
+  122          128.69796    116.72031   0.00819672 
+  153          128.96632    116.70583   0.00653595 
+  131          130.10836    116.69143   0.00763359 
+  133          131.82626    116.67709   0.0075188 
+  150          131.69981    116.66283   0.00666667 
+  133          129.62428    116.64864   0.0075188 
+  132          128.24004    116.63452   0.00757576 
+  146          127.85743    116.62047   0.00684932 
+  141          127.20474    116.6065    0.0070922 
+  135          125.98574    116.59259   0.00740741 
+  121          124.95754    116.57876   0.00826446 
+  128          124.36068    116.565     0.0078125 
+  130          124.12788    116.55131   0.00769231 
+  122          124.19401    116.53769   0.00819672 
+  134          124.5401     116.52414   0.00746269 
+  146          124.96493    116.51067   0.00684932 
+  134          124.98187    116.49727   0.00746269 
+  124          124.81482    116.48394   0.00806452 
+  110          124.9212     116.47068   0.00909091 
+  126          125.39811    116.45749   0.00793651 
+  136          126.21449    116.44437   0.00735294 
+  127          127.2058     116.43133   0.00787402 
+  145          128.17483    116.41836   0.00689655 
+  145          129.55026    116.40546   0.00689655 
+  137          132.19947    116.39263   0.00729927 
+  157          137.09826    116.37988   0.00636943 
+  140          145.26619    116.3672    0.00714286 
+  134          154.45844    116.35458   0.00746269 
+  139          155.72573    116.34205   0.00719424 
+  152          151.39941    116.32958   0.00657895 
+  141          150.13109    116.31718   0.0070922 
+  161          151.63003    116.30486   0.00621118 
+  137          151.41574    116.29261   0.00729927 
+  155          148.71533    116.28043   0.00645161 
+  143          148.72012    116.26833   0.00699301 
+  132          150.26347    116.2563    0.00757576 
+  171          148.22918    116.24434   0.00584795 
+  149          145.23025    116.23245   0.00671141 
+  117          145.27024    116.22063   0.00854701 
+  143          147.59468    116.20889   0.00699301 
+  143          149.71049    116.19722   0.00699301 
+  145          151.84615    116.18562   0.00689655 
+  154          154.15574    116.17409   0.00649351 
+  132          152.87681    116.16264   0.00757576 
+  156          151.46501    116.15126   0.00641026 
+  128          154.17755    116.13995   0.0078125 
+  158          158.43384    116.12871   0.00632911 
+  149          157.27846    116.11755   0.00671141 
+  149          153.97769    116.10646   0.00671141 
+  133          153.94845    116.09544   0.0075188 
+  156          156.35863    116.0845    0.00641026 
+  165          159.10669    116.07362   0.00606061 
+  152          164.6433     116.06282   0.00657895 
+  190          176.56535    116.0521    0.00526316 
+  212          197.55885    116.04144   0.00471698 
+  216          232.35924    116.03086   0.00462963 
+  279          294.60275    116.02035   0.00358423 
+  298          377.08331    116.00992   0.0033557 
+  324          374.48809    115.99956   0.00308642 
+  304          291.82858    115.98927   0.00328947 
+  279          234.12613    115.97905   0.00358423 
+  254          211.00058    115.96891   0.00393701 
+  249          212.36069    115.95883   0.00401606 
+  232          236.20935    115.94884   0.00431034 
+  251          283.78013    115.93891   0.00398406 
+  261          331.52122    115.92906   0.00383142 
+  248          314.30389    115.91928   0.00403226 
+  230          255.26638    115.90958   0.00434783 
+  248          216.92354    115.89994   0.00403226 
+  196          203.16996    115.89038   0.00510204 
+  234          207.54053    115.8809    0.0042735 
+  247          226.54471    115.87148   0.00404858 
+  268          249.37406    115.86214   0.00373134 
+  271          258.86723    115.85288   0.00369004 
+  233          264.65052    115.84368   0.00429185 
+  299          296.0478     115.83456   0.00334448 
+  368          375.48808    115.82552   0.00271739 
+  433          463.11643    115.81654   0.00230947 
+  431          424.4235     115.80764   0.00232019 
+  368          333.88987    115.79882   0.00271739 
+  302          284.08638    115.79006   0.00331126 
+  304          268.25456    115.78138   0.00328947 
+  256          284.79758    115.77277   0.00390625 
+  306          344.4294     115.76424   0.00326797 
+  360          451.91075    115.75578   0.00277778 
+  354          514.10519    115.74739   0.00282486 
+  357          426.24533    115.73908   0.00280112 
+  259          311.07048    115.73084   0.003861  
+  212          243.06199    115.72268   0.00471698 
+  196          212.15488    115.71458   0.00510204 
+  211          204.78672    115.70656   0.00473934 
+  165          216.74713    115.69862   0.00606061 
+  191          245.37385    115.69075   0.0052356 
+  195          255.30634    115.68295   0.00512821 
+  190          219.66318    115.67522   0.00526316 
+  200          184.22985    115.66757   0.005     
+  167          163.33179    115.65999   0.00598802 
+  148          152.10071    115.65249   0.00675676 
+  180          146.11194    115.64506   0.00555556 
+  162          142.62727    115.6377    0.00617284 
+  162          139.89049    115.63042   0.00617284 
+  165          137.8714     115.62321   0.00606061 
+  156          136.88808    115.61608   0.00641026 
+  151          136.92383    115.60902   0.00662252 
+  147          137.99292    115.60203   0.00680272 
+  166          140.30295    115.59511   0.0060241 
+  141          143.67967    115.58827   0.0070922 
+  171          146.55541    115.58151   0.00584795 
+  158          149.11212    115.57481   0.00632911 
+  159          154.02057    115.5682    0.00628931 
+  166          162.33375    115.56165   0.0060241 
+  164          173.7198     115.55518   0.00609756 
+  159          186.03312    115.54878   0.00628931 
+  186          188.33084    115.54246   0.00537634 
+  151          183.94452    115.53621   0.00662252 
+  160          181.93721    115.53003   0.00625   
+  163          179.7388     115.52393   0.00613497 
+  162          175.14761    115.5179    0.00617284 
+  142          170.7247     115.51195   0.00704225 
+  158          169.12598    115.50607   0.00632911 
+  175          170.67811    115.50027   0.00571429 
+  160          170.18044    115.49453   0.00625   
+  171          166.9375     115.48888   0.00584795 
+  146          166.6621     115.48329   0.00684932 
+  156          168.39528    115.47778   0.00641026 
+  152          166.75879    115.47235   0.00657895 
+  178          161.63282    115.46699   0.00561798 
+  163          157.90102    115.4617    0.00613497 
+  129          156.96704    115.45648   0.00775194 
+  145          159.84816    115.45135   0.00689655 
+  190          168.77971    115.44628   0.00526316 
+  227          188.69295    115.44129   0.00440529 
+  285          229.69352    115.43637   0.00350877 
+  346          300.60462    115.43153   0.00289017 
+  425          353.15775    115.42676   0.00235294 
+  384          303.50631    115.42207   0.00260417 
+  311          240.34072    115.41745   0.00321543 
+  271          207.26336    115.4129    0.00369004 
+  240          192.21458    115.40843   0.00416667 
+  243          189.87247    115.40403   0.00411523 
+  304          202.71192    115.39971   0.00328947 
+  388          236.9735     115.39546   0.00257732 
+  372          283.82748    115.39128   0.00268817 
+  380          292.21098    115.38718   0.00263158 
+  285          270.56087    115.38315   0.00350877 
+  221          238.90578    115.3792    0.00452489 
+  210          210.88735    115.37532   0.0047619 
+  195          195.51402    115.37152   0.00512821 
+  212          190.4596     115.36779   0.00471698 
+  221          196.90585    115.36413   0.00452489 
+  223          217.38283    115.36055   0.0044843 
+  220          241.09901    115.35704   0.00454545 
+  194          241.35049    115.35361   0.00515464 
+  212          220.00123    115.35025   0.00471698 
+  176          198.21763    115.34697   0.00568182 
+  193          186.51412    115.34376   0.00518135 
+  176          181.88406    115.34062   0.00568182 
+  182          180.59516    115.33756   0.00549451 
+  168          183.43227    115.33457   0.00595238 
+  164          188.91471    115.33166   0.00609756 
+  167          186.68605    115.32882   0.00598802 
+  172          176.52641    115.32606   0.00581395 
+  137          169.74694    115.32337   0.00729927 
+  152          169.79507    115.32075   0.00657895 
+  163          177.14866    115.31821   0.00613497 
+  165          192.43077    115.31575   0.00606061 
+  154          211.4038     115.31335   0.00649351 
+  132          212.5112     115.31103   0.00757576 
+  148          191.11163    115.30879   0.00675676 
+  134          171.2271     115.30662   0.00746269 
+  148          159.72547    115.30453   0.00675676 
+  151          153.66233    115.30251   0.00662252 
+  153          151.52315    115.30056   0.00653595 
+  151          154.34651    115.29869   0.00662252 
+  132          162.07634    115.29689   0.00757576 
+  122          167.10188    115.29517   0.00819672 
+  128          159.33271    115.29352   0.0078125 
+  130          147.7253     115.29194   0.00769231 
+  125          139.84229    115.29044   0.008     
+  124          135.04187    115.28902   0.00806452 
+  117          131.64699    115.28767   0.00854701 
+  130          129.24263    115.28639   0.00769231 
+  128          127.68314    115.28519   0.0078125 
+  133          126.72161    115.28406   0.0075188 
+  121          126.17352    115.28301   0.00826446 
+  131          125.92074    115.28203   0.00763359 
+  127          125.88737    115.28112   0.00787402 
+  125          125.83957    115.28029   0.008     
+  121          126.06211    115.27953   0.00826446 
+  133          126.44117    115.27885   0.0075188 
+  147          127.16443    115.27824   0.00680272 
+  118          128.33864    115.27771   0.00847458 
+  125          129.48783    115.27725   0.008     
+  135          130.20637    115.27687   0.00740741 
+  149          131.35128    115.27656   0.00671141 
+  121          133.46387    115.27632   0.00826446 
+  149          134.78435    115.27616   0.00671141 
+  129          133.67669    115.27607   0.00775194 
+  157          132.74386    115.27606   0.00636943 
+  158          133.66884    115.27612   0.00632911 
+  154          136.77274    115.27626   0.00649351 
+  167          141.73737    115.27647   0.00598802 
+  134          145.95531    115.27675   0.00746269 
+  132          145.25659    115.27711   0.00757576 
+  140          142.58561    115.27755   0.00714286 
+  150          140.68744    115.27805   0.00666667 
+  183          140.28711    115.27863   0.00546448 
+  164          141.97788    115.27929   0.00609756 
+  166          145.81281    115.28002   0.0060241 
+  154          153.25819    115.28083   0.00649351 
+  172          164.79039    115.28171   0.00581395 
+  192          178.48677    115.28266   0.00520833 
+  191          194.5576     115.28369   0.0052356 
+  174          202.99502    115.28479   0.00574713 
+  161          190.38793    115.28597   0.00621118 
+  161          173.14755    115.28722   0.00621118 
+  164          162.84257    115.28854   0.00609756 
+  192          159.43676    115.28994   0.00520833 
+  130          161.56382    115.29141   0.00769231 
+  167          168.00408    115.29296   0.00598802 
+  155          178.67986    115.29458   0.00645161 
+  180          191.87046    115.29628   0.00555556 
+  207          197.26226    115.29805   0.00483092 
+  194          192.89581    115.29989   0.00515464 
+  176          187.63163    115.30181   0.00568182 
+  181          184.82591    115.30381   0.00552486 
+  167          185.13599    115.30587   0.00598802 
+  174          188.58213    115.30801   0.00574713 
+  144          194.25409    115.31023   0.00694444 
+  167          200.26896    115.31252   0.00598802 
+  184          203.96367    115.31488   0.00543478 
+  198          202.0019     115.31732   0.00505051 
+  204          196.17443    115.31983   0.00490196 
+  158          191.97162    115.32242   0.00632911 
+  191          192.16843    115.32508   0.0052356 
+  182          196.85189    115.32781   0.00549451 
+  171          201.47041    115.33062   0.00584795 
+  173          200.79314    115.3335    0.00578035 
+  183          198.95827    115.33646   0.00546448 
+  185          197.88873    115.33949   0.00540541 
+  194          194.01968    115.3426    0.00515464 
+  174          190.91194    115.34577   0.00574713 
+  199          193.07644    115.34903   0.00502513 
+  198          201.06325    115.35235   0.00505051 
+  191          212.76923    115.35575   0.0052356 
+  192          221.87945    115.35923   0.00520833 
+  178          222.68096    115.36278   0.00561798 
+  178          220.25112    115.3664    0.00561798 
+  163          218.19234    115.3701    0.00613497 
+  189          217.33174    115.37387   0.00529101 
+  190          225.99157    115.37771   0.00526316 
+  247          254.09807    115.38163   0.00404858 
+  269          313.95725    115.38562   0.00371747 
+  368          400.01639    115.38969   0.00271739 
+  386          413.37072    115.39383   0.00259067 
+  306          334.80851    115.39804   0.00326797 
+  217          269.94034    115.40233   0.00460829 
+  190          232.64227    115.40669   0.00526316 
+  162          212.37447    115.41113   0.00617284 
+  191          205.29112    115.41563   0.0052356 
+  200          212.59529    115.42022   0.005     
+  235          238.85352    115.42487   0.00425532 
+  214          272.53532    115.4296    0.0046729 
+  252          258.48838    115.43441   0.00396825 
+  193          215.04933    115.43929   0.00518135 
+  168          184.84826    115.44424   0.00595238 
+  153          167.57773    115.44926   0.00653595 
+  150          157.44149    115.45436   0.00666667 
+  134          151.18126    115.45953   0.00746269 
+  131          147.20021    115.46478   0.00763359 
+  124          144.46272    115.4701    0.00806452 
+  149          141.98906    115.47549   0.00671141 
+  145          139.63285    115.48096   0.00689655 
+  138          137.78611    115.4865    0.00724638 
+  140          136.68126    115.49211   0.00714286 
+  139          136.62483    115.4978    0.00719424 
+  141          138.07185    115.50356   0.0070922 
+  154          141.36816    115.50939   0.00649351 
+  141          144.94729    115.5153    0.0070922 
+  132          144.33501    115.52128   0.00757576 
+  140          140.39081    115.52734   0.00714286 
+  130          136.93741    115.53346   0.00769231 
+  141          134.47348    115.53967   0.0070922 
+  144          132.65565    115.54594   0.00694444 
+  132          131.54761    115.55229   0.00757576 
+  169          131.44901    115.55871   0.00591716 
+  138          132.48236    115.5652    0.00724638 
+  152          133.59111    115.57177   0.00657895 
+  130          132.7426     115.57841   0.00769231 
+  109          131.04399    115.58513   0.00917431 
+  147          130.03814    115.59191   0.00680272 
+  137          129.43617    115.59877   0.00729927 
+  120          129.0107     115.60571   0.00833333 
+  110          129.44539    115.61271   0.00909091 
+  144          131.30291    115.61979   0.00694444 
+  133          134.07361    115.62695   0.0075188 
+  123          134.79139    115.63417   0.00813008 
+  129          132.36499    115.64147   0.00775194 
+  118          129.45791    115.64884   0.00847458 
+  119          127.60157    115.65629   0.00840336 
+  100          126.65567    115.66381   0.01      
+  121          126.29064    115.6714    0.00826446 
+  131          126.61513    115.67906   0.00763359 
+  125          127.76952    115.6868    0.008     
+  130          129.38085    115.69461   0.00769231 
+  126          129.87301    115.70249   0.00793651 
+  145          128.79905    115.71045   0.00689655 
+  127          127.39364    115.71848   0.00787402 
+  106          126.31336    115.72658   0.00943396 
+  123          125.63449    115.73475   0.00813008 
+  135          125.34902    115.743     0.00740741 
+  138          125.47736    115.75132   0.00724638 
+  121          125.85083    115.75971   0.00826446 
+  123          125.78377    115.76817   0.00813008 
+  122          125.17354    115.77671   0.00819672 
+  137          124.66234    115.78532   0.00729927 
+  138          124.39684    115.794     0.00724638 
+  127          124.30503    115.80276   0.00787402 
+  136          124.39079    115.81158   0.00735294 
+  135          124.7445     115.82048   0.00740741 
+  122          125.47493    115.82945   0.00819672 
+  132          126.5081     115.8385    0.00757576 
+  135          127.1969     115.84762   0.00740741 
+  130          127.26787    115.8568    0.00769231 
+  134          127.49118    115.86607   0.00746269 
+  120          128.20986    115.8754    0.00833333 
+  141          129.44432    115.88481   0.0070922 
+  123          131.09836    115.89428   0.00813008 
+  118          132.96805    115.90384   0.00847458 
+  142          135.09913    115.91346   0.00704225 
+  149          137.60239    115.92315   0.00671141 
+  152          140.58792    115.93292   0.00657895 
+  126          144.56495    115.94276   0.00793651 
+  137          150.99857    115.95267   0.00729927 
+  166          162.3634     115.96265   0.0060241 
+  165          182.65215    115.97271   0.00606061 
+  229          214.70406    115.98284   0.00436681 
+  206          240.84149    115.99304   0.00485437 
+  201          223.51342    116.00331   0.00497512 
+  205          190.18848    116.01365   0.00487805 
+  172          168.71019    116.02407   0.00581395 
+  174          158.12636    116.03455   0.00574713 
+  165          154.47072    116.04511   0.00606061 
+  181          156.18335    116.05574   0.00552486 
+  172          163.99145    116.06644   0.00581395 
+  175          179.2213     116.07722   0.00571429 
+  205          194.85587    116.08806   0.00487805 
+  199          191.90494    116.09898   0.00502513 
+  189          182.09406    116.10997   0.00529101 
+  167          180.13732    116.12103   0.00598802 
+  155          178.84878    116.13216   0.00645161 
+  172          171.68524    116.14336   0.00581395 
+  164          164.69626    116.15464   0.00609756 
+  169          160.17503    116.16598   0.00591716 
+  180          155.54753    116.1774    0.00555556 
+  165          152.03544    116.18889   0.00606061 
+  161          151.5253     116.20045   0.00621118 
+  152          154.53903    116.21208   0.00657895 
+  139          160.62324    116.22378   0.00719424 
+  152          165.71485    116.23556   0.00657895 
+  144          165.64339    116.2474    0.00694444 
+  155          165.03159    116.25932   0.00645161 
+  153          168.05155    116.2713    0.00653595 
+  144          174.26827    116.28336   0.00694444 
+  164          179.95807    116.29549   0.00609756 
+  154          177.70666    116.30769   0.00649351 
+  192          172.18889    116.31996   0.00520833 
+  175          169.83379    116.3323    0.00571429 
+  164          169.64229    116.34472   0.00609756 
+  186          173.93239    116.3572    0.00537634 
+  229          188.74362    116.36976   0.00436681 
+  250          221.8001     116.38238   0.004     
+  277          271.45868    116.39508   0.00361011 
+  309          286.01959    116.40784   0.00323625 
+  237          242.3293     116.42068   0.00421941 
+  227          201.37758    116.43359   0.00440529 
+  200          179.82297    116.44657   0.005     
+  174          170.93376    116.45962   0.00574713 
+  190          170.20448    116.47274   0.00526316 
+  205          175.62258    116.48593   0.00487805 
+  196          187.28324    116.49919   0.00510204 
+  192          206.8787     116.51252   0.00520833 
+  213          214.58661    116.52592   0.00469484 
+  191          190.75243    116.53939   0.0052356 
+  166          165.56826    116.55293   0.0060241 
+  170          151.47834    116.56654   0.00588235 
+  170          145.1809     116.58023   0.00588235 
+  129          143.14033    116.59398   0.00775194 
+  160          142.57821    116.6078    0.00625   
+  154          141.68113    116.62169   0.00649351 
+  118          140.60565    116.63566   0.00847458 
+  145          139.05063    116.64969   0.00689655 
+  146          137.54883    116.66379   0.00684932 
+  147          137.67599    116.67796   0.00680272 
+  127          139.86468    116.69221   0.00787402 
+  142          143.55697    116.70652   0.00704225 
+  149          146.72152    116.7209    0.00671141 
+  125          146.74752    116.73535   0.008     
+  142          145.77968    116.74987   0.00704225 
+  160          147.56792    116.76446   0.00625   
+  146          154.13736    116.77912   0.00684932 
+  144          167.15108    116.79385   0.00694444 
+  142          186.22462    116.80865   0.00704225 
+  173          203.38957    116.82352   0.00578035 
+  137          211.15347    116.83846   0.00729927 
+  158          204.35592    116.85347   0.00632911 
+  127          184.79478    116.86855   0.00787402 
+  139          166.52426    116.88369   0.00719424 
+  129          155.59322    116.89891   0.00775194 
+  147          151.40116    116.91419   0.00680272 
+  157          152.84072    116.92955   0.00636943 
+  130          159.20217    116.94497   0.00769231 
+  165          167.18306    116.96046   0.00606061 
+  135          171.3089     116.97602   0.00740741 
+  122          168.95788    116.99165   0.00819672 
+  145          159.20198    117.00735   0.00689655 
+  99           148.38624    117.02312   0.01010101 
+  131          140.88679    117.03896   0.00763359 
+  144          136.43131    117.05486   0.00694444 
+  124          133.93577    117.07084   0.00806452 
+  131          132.63231    117.08688   0.00763359 
+  141          132.14555    117.10299   0.0070922 
+  130          132.11594    117.11917   0.00769231 
+  129          132.06029    117.13542   0.00775194 
+  129          131.86213    117.15174   0.00775194 
+  123          131.82297    117.16813   0.00813008 
+  127          132.16833    117.18458   0.00787402 
+  126          132.93368    117.20111   0.00793651 
+  127          134.1558     117.2177    0.00787402 
+  122          136.04563    117.23436   0.00819672 
+  142          139.13637    117.25108   0.00704225 
+  120          143.8402     117.26788   0.00833333 
+  164          148.62804    117.28474   0.00609756 
+  131          150.36172    117.30168   0.00763359 
+  137          150.00826    117.31868   0.00729927 
+  125          150.4737     117.33575   0.008     
+  141          150.48005    117.35288   0.0070922 
+  135          148.6355     117.37009   0.00740741 
+  147          147.80704    117.38736   0.00680272 
+  153          149.89202    117.4047    0.00653595 
+  138          155.90476    117.42211   0.00724638 
+  140          167.36013    117.43958   0.00714286 
+  155          186.63593    117.45712   0.00645161 
+  182          218.64567    117.47473   0.00549451 
+  187          260.92449    117.49241   0.00534759 
+  194          271.23197    117.51016   0.00515464 
+  180          238.74572    117.52797   0.00555556 
+  183          211.33348    117.54585   0.00546448 
+  196          195.74819    117.5638    0.00510204 
+  161          181.98073    117.58182   0.00621118 
+  168          171.25792    117.5999    0.00595238 
+  147          167.92325    117.61805   0.00680272 
+  158          173.69256    117.63627   0.00632911 
+  151          189.3781     117.65455   0.00662252 
+  187          204.42491    117.6729    0.00534759 
+  152          195.80695    117.69132   0.00657895 
+  163          178.26541    117.7098    0.00613497 
+  158          167.51607    117.72836   0.00632911 
+  159          159.63102    117.74697   0.00628931 
+  157          151.63694    117.76566   0.00636943 
+  148          145.45574    117.78441   0.00675676 
+  150          141.64275    117.80323   0.00666667 
+  126          139.44682    117.82212   0.00793651 
+  149          138.16652    117.84107   0.00671141 
+  143          137.35136    117.86009   0.00699301 
+  143          136.77714    117.87917   0.00699301 
+  122          136.36487    117.89833   0.00819672 
+  138          136.06096    117.91754   0.00724638 
+  145          135.96821    117.93683   0.00689655 
+  138          136.22925    117.95618   0.00724638 
+  153          136.8695     117.9756    0.00653595 
+  143          137.87327    117.99508   0.00699301 
+  154          139.23609    118.01463   0.00649351 
+  180          141.00792    118.03425   0.00555556 
+  150          143.36246    118.05393   0.00666667 
+  158          146.60275    118.07368   0.00632911 
+  163          150.71364    118.09349   0.00613497 
+  156          154.23782    118.11337   0.00641026 
+  129          156.26737    118.13331   0.00775194 
+  138          158.88574    118.15332   0.00724638 
+  171          163.16543    118.1734    0.00584795 
+  136          168.47223    118.19354   0.00735294 
+  163          174.82766    118.21375   0.00613497 
+  161          183.68806    118.23402   0.00621118 
+  178          196.68607    118.25436   0.00561798 
+  199          215.97427    118.27477   0.00502513 
+  193          244.85437    118.29524   0.00518135 
+  301          289.51435    118.31577   0.00332226 
+  358          366.17271    118.33637   0.0027933 
+  562          510.71814    118.35704   0.00177936 
+  798          778.66061    118.37777   0.00125313 
+  1052         1151.90623   118.39856   0.00095057 
+  1046         1232.80958   118.41942   0.00095602 
+  737          890.1101     118.44035   0.00135685 
+  514          587.36755    118.46134   0.00194553 
+  398          423.91702    118.4824    0.00251256 
+  314          348.41992    118.50352   0.00318471 
+  313          323.65763    118.5247    0.00319489 
+  358          338.93062    118.54595   0.0027933 
+  411          405.57254    118.56726   0.00243309 
+  512          546.74802    118.58864   0.00195312 
+  617          717.73252    118.61009   0.00162075 
+  567          685.33936    118.63159   0.00176367 
+  410          495.3556     118.65317   0.00243902 
+  311          357.31156    118.6748    0.00321543 
+  254          283.78989    118.69651   0.00393701 
+  228          242.15201    118.71827   0.00438596 
+  212          214.71929    118.7401    0.00471698 
+  187          196.24054    118.76199   0.00534759 
+  161          182.68089    118.78395   0.00621118 
+  188          173.37111    118.80597   0.00531915 
+  152          167.27579    118.82806   0.00657895 
+  151          162.36196    118.85021   0.00662252 
+  166          159.25191    118.87242   0.0060241 
+  149          158.63909    118.8947    0.00671141 
+  139          158.49641    118.91704   0.00719424 
+  117          155.48144    118.93944   0.00854701 
+  132          150.89258    118.96191   0.00757576 
+  131          146.73974    118.98445   0.00763359 
+  134          142.85573    119.00704   0.00746269 
+  139          139.79649    119.0297    0.00719424 
+  124          137.73508    119.05242   0.00806452 
+  118          136.42453    119.07521   0.00847458 
+  133          135.72166    119.09806   0.0075188 
+  129          135.50467    119.12097   0.00775194 
+  152          135.38064    119.14394   0.00657895 
+  130          134.9675     119.16698   0.00769231 
+  135          134.65503    119.19008   0.00740741 
+  133          134.83122    119.21325   0.0075188 
+  151          135.53252    119.23647   0.00662252 
+  127          136.51297    119.25976   0.00787402 
+  110          137.48184    119.28312   0.00909091 
+  153          138.34618    119.30653   0.00653595 
+  145          139.13516    119.33001   0.00689655 
+  144          139.41542    119.35355   0.00694444 
+  109          139.14113    119.37716   0.00917431 
+  148          139.07433    119.40082   0.00675676 
+  147          139.72423    119.42455   0.00680272 
+  144          141.39724    119.44834   0.00694444 
+  133          144.46282    119.47219   0.0075188 
+  160          149.50032    119.49611   0.00625   
+  174          157.65266    119.52009   0.00574713 
+  175          170.87398    119.54413   0.00571429 
+  201          192.29413    119.56823   0.00497512 
+  216          222.53118    119.59239   0.00462963 
+  209          241.36098    119.61662   0.00478469 
+  189          229.46669    119.64091   0.00529101 
+  208          206.92939    119.66526   0.00480769 
+  195          186.68918    119.68967   0.00512821 
+  186          171.10855    119.71414   0.00537634 
+  183          162.19838    119.73867   0.00546448 
+  158          159.44515    119.76327   0.00632911 
+  151          162.04985    119.78793   0.00662252 
+  184          170.50485    119.81265   0.00543478 
+  170          184.88031    119.83743   0.00588235 
+  201          195.0587     119.86227   0.00497512 
+  215          191.58554    119.88717   0.00465116 
+  187          185.23378    119.91214   0.00534759 
+  211          183.62695    119.93716   0.00473934 
+  209          187.4698     119.96225   0.00478469 
+  209          189.43284    119.9874    0.00478469 
+  233          179.33047    120.01261   0.00429185 
+  202          165.04027    120.03788   0.0049505 
+  185          154.87311    120.06321   0.00540541 
+  204          149.29767    120.0886    0.00490196 
+  189          146.96556    120.11405   0.00529101 
+  191          146.79723    120.13957   0.0052356 
+  203          148.73658    120.16514   0.00492611 
+  221          153.63829    120.19078   0.00452489 
+  229          161.65587    120.21647   0.00436681 
+  218          169.18366    120.24223   0.00458716 
+  231          171.54383    120.26804   0.004329  
+  217          172.43482    120.29392   0.00460829 
+  197          174.64966    120.31985   0.00507614 
+  174          174.15232    120.34585   0.00574713 
+  171          166.85669    120.37191   0.00584795 
+  158          158.94603    120.39802   0.00632911 
+  191          155.06432    120.4242    0.0052356 
+  172          155.22519    120.45044   0.00581395 
+  165          156.59255    120.47673   0.00606061 
+  177          155.48188    120.50309   0.00564972 
+  163          153.76505    120.52951   0.00613497 
+  153          154.0846     120.55598   0.00653595 
+  161          155.78839    120.58252   0.00621118 
+  143          156.45229    120.60911   0.00699301 
+  154          153.54006    120.63577   0.00649351 
+  142          149.7964     120.66248   0.00704225 
+  169          147.99014    120.68926   0.00591716 
+  138          148.2668     120.71609   0.00724638 
+  122          149.35845    120.74298   0.00819672 
+  169          149.23703    120.76993   0.00591716 
+  163          148.29866    120.79694   0.00613497 
+  152          148.04925    120.82401   0.00657895 
+  147          148.78768    120.85114   0.00680272 
+  133          150.39642    120.87833   0.0075188 
+  152          152.83094    120.90558   0.00657895 
+  160          156.17112    120.93288   0.00625   
+  160          160.63719    120.96025   0.00625   
+  180          166.55037    120.98767   0.00555556 
+  172          174.01531    121.01515   0.00581395 
+  169          182.24067    121.04269   0.00591716 
+  182          191.12688    121.07029   0.00549451 
+  197          203.03423    121.09795   0.00507614 
+  223          220.47673    121.12566   0.0044843 
+  264          246.34274    121.15344   0.00378788 
+  320          285.70481    121.18127   0.003125  
+  381          348.45443    121.20916   0.00262467 
+  568          454.09697    121.23711   0.00176056 
+  771          638.04544    121.26512   0.00129702 
+  1218         959.65126    121.29318   0.00082102 
+  1674         1435.91628   121.3213    0.00059737 
+  1801         1663.63942   121.34948   0.00055525 
+  1373         1278.42098   121.37772   0.00072833 
+  928          837.8234     121.40602   0.00107759 
+  638          579.89397    121.43437   0.0015674 
+  512          452.89944    121.46279   0.00195312 
+  440          399.71906    121.49126   0.00227273 
+  408          395.17176    121.51978   0.00245098 
+  501          439.76366    121.54837   0.00199601 
+  642          552.41422    121.57701   0.00155763 
+  831          756.41783    121.60571   0.00120337 
+  938          934.32147    121.63447   0.0010661 
+  785          807.89737    121.66328   0.00127389 
+  625          560.11833    121.69215   0.0016    
+  437          394.54999    121.72108   0.00228833 
+  330          304.18562    121.75007   0.0030303 
+  233          255.05139    121.77911   0.00429185 
+  219          226.23831    121.80821   0.00456621 
+  202          207.23125    121.83736   0.0049505 
+  162          192.78659    121.86658   0.00617284 
+  203          181.72981    121.89585   0.00492611 
+  190          173.6554     121.92517   0.00526316 
+  195          167.72006    121.95456   0.00512821 
+  189          163.23681    121.98399   0.00529101 
+  170          159.83595    122.01349   0.00588235 
+  158          157.41128    122.04304   0.00632911 
+  173          156.04732    122.07265   0.00578035 
+  166          155.91826    122.10232   0.0060241 
+  149          156.98514    122.13204   0.00671141 
+  178          158.95614    122.16182   0.00561798 
+  154          162.0867     122.19165   0.00649351 
+  169          164.77763    122.22154   0.00591716 
+  151          162.97217    122.25149   0.00662252 
+  143          158.41628    122.28149   0.00699301 
+  170          155.09821    122.31155   0.00588235 
+  147          153.61466    122.34166   0.00680272 
+  173          152.69792    122.37183   0.00578035 
+  149          151.61736    122.40206   0.00671141 
+  165          151.32727    122.43234   0.00606061 
+  158          152.58474    122.46267   0.00632911 
+  167          155.70945    122.49307   0.00598802 
+  143          160.46477    122.52351   0.00699301 
+  160          165.28112    122.55402   0.00625   
+  142          170.38244    122.58458   0.00704225 
+  144          180.2765     122.61519   0.00694444 
+  169          200.42016    122.64586   0.00591716 
+  194          234.73203    122.67658   0.00515464 
+  239          269.46947    122.70736   0.0041841 
+  252          261.83462    122.7382    0.00396825 
+  213          224.37189    122.76908   0.00469484 
+  234          196.46044    122.80003   0.0042735 
+  176          183.56392    122.83103   0.00568182 
+  163          181.8982     122.86208   0.00613497 
+  190          188.95599    122.89319   0.00526316 
+  188          203.10879    122.92435   0.00531915 
+  207          215.31694    122.95557   0.00483092 
+  211          218.71702    122.98684   0.00473934 
+  206          224.31738    123.01817   0.00485437 
+  214          224.89434    123.04955   0.0046729 
+  174          206.51428    123.08099   0.00574713 
+  222          186.86316    123.11248   0.0045045 
+  187          174.2291     123.14402   0.00534759 
+  156          166.84926    123.17562   0.00641026 
+  184          164.20805    123.20728   0.00543478 
+  171          165.79123    123.23898   0.00584795 
+  168          169.18422    123.27074   0.00595238 
+  177          167.25198    123.30256   0.00564972 
+  174          160.08877    123.33443   0.00574713 
+  177          153.93932    123.36635   0.00564972 
+  166          150.85991    123.39833   0.0060241 
+  153          150.449      123.43036   0.00653595 
+  140          151.63823    123.46244   0.00714286 
+  169          153.09836    123.49458   0.00591716 
+  163          154.67002    123.52677   0.00613497 
+  133          156.5944     123.55902   0.0075188 
+  181          157.15812    123.59132   0.00552486 
+  153          156.59123    123.62367   0.00653595 
+  171          157.01106    123.65607   0.00584795 
+  147          156.40314    123.68853   0.00680272 
+  151          152.8202     123.72104   0.00662252 
+  161          148.95242    123.75361   0.00621118 
+  159          146.71136    123.78623   0.00628931 
+  185          146.13533    123.8189    0.00540541 
+  170          146.69625    123.85162   0.00588235 
+  153          147.94744    123.8844    0.00653595 
+  170          149.34436    123.91723   0.00588235 
+  164          149.93245    123.95011   0.00609756 
+  180          150.51289    123.98305   0.00555556 
+  146          151.68776    124.01604   0.00684932 
+  165          152.03543    124.04908   0.00606061 
+  146          151.41489    124.08217   0.00684932 
+  149          150.98726    124.11532   0.00671141 
+  156          150.43572    124.14852   0.00641026 
+  161          149.61165    124.18177   0.00621118 
+  154          149.12883    124.21507   0.00649351 
+  176          149.25041    124.24843   0.00568182 
+  176          149.94332    124.28184   0.00568182 
+  171          151.11941    124.3153    0.00584795 
+  187          152.73878    124.34881   0.00534759 
+  179          154.814      124.38238   0.00558659 
+  179          157.39732    124.41599   0.00558659 
+  181          160.52548    124.44966   0.00552486 
+  177          164.08181    124.48338   0.00564972 
+  166          167.68197    124.51716   0.0060241 
+  194          171.68722    124.55098   0.00515464 
+  180          176.69315    124.58486   0.00555556 
+  219          183.14028    124.61879   0.00456621 
+  226          191.40643    124.65277   0.00442478 
+  265          202.32357    124.6868    0.00377358 
+  210          217.04289    124.72088   0.0047619 
+  292          237.8364     124.75502   0.00342466 
+  398          268.74375    124.7892    0.00251256 
+  409          315.42788    124.82344   0.00244499 
+  540          377.43624    124.85773   0.00185185 
+  590          428.29521    124.89207   0.00169492 
+  679          461.96573    124.92646   0.00147275 
+  822          530.29281    124.96091   0.00121655 
+  973          681.39013    124.9954    0.00102775 
+  1334         979.55734    125.02995   0.00074963 
+  1833         1515.18217   125.06454   0.00054555 
+  2354         2216.26969   125.09919   0.00042481 
+  2402         2359.83993   125.13389   0.00041632 
+  1879         1736.26295   125.16864   0.0005322 
+  1312         1158.09299   125.20344   0.0007622 
+  967          836.14346    125.23829   0.00103413 
+  810          672.63472    125.27319   0.00123457 
+  704          595.23423    125.30814   0.00142045 
+  730          592.248      125.34315   0.00136986 
+  773          662.41211    125.3782    0.00129366 
+  1003         795.33973    125.4133    0.00099701 
+  1221         1020.88566   125.44846   0.000819  
+  1399         1313.60656   125.48366   0.0007148 
+  1307         1296.6889    125.51892   0.00076511 
+  1028         942.16945    125.55423   0.00097276 
+  744          641.42339    125.58958   0.00134409 
+  515          466.67886    125.62499   0.00194175 
+  377          372.65788    125.66045   0.00265252 
+  306          323.95068    125.69595   0.00326797 
+  290          302.49199    125.73151   0.00344828 
+  319          295.72094    125.76712   0.0031348 
+  261          281.09238    125.80277   0.00383142 
+  249          253.77845    125.83848   0.00401606 
+  254          231.41546    125.87424   0.00393701 
+  228          218.3885     125.91005   0.00438596 
+  255          212.84782    125.9459    0.00392157 
+  217          213.42825    125.98181   0.00460829 
+  222          218.85066    126.01777   0.0045045 
+  171          223.42985    126.05377   0.00584795 
+  216          218.37243    126.08983   0.00462963 
+  199          208.05848    126.12593   0.00502513 
+  186          200.59214    126.16209   0.00537634 
+  184          195.41254    126.19829   0.00543478 
+  152          189.89885    126.23455   0.00657895 
+  168          185.16799    126.27085   0.00595238 
+  182          182.34374    126.3072    0.00549451 
+  170          181.46206    126.34361   0.00588235 
+  190          182.83692    126.38006   0.00526316 
+  167          186.81958    126.41656   0.00598802 
+  170          191.25632    126.45311   0.00588235 
+  153          191.46403    126.48971   0.00653595 
+  178          187.69164    126.52636   0.00561798 
+  135          183.45891    126.56305   0.00740741 
+  171          180.99835    126.5998    0.00584795 
+  184          180.38274    126.6366    0.00543478 
+  150          180.88866    126.67344   0.00666667 
+  184          179.84204    126.71033   0.00543478 
+  175          177.70607    126.74728   0.00571429 
+  208          177.76388    126.78427   0.00480769 
+  236          180.78666    126.82131   0.00423729 
+  238          185.44278    126.8584    0.00420168 
+  245          187.53021    126.89553   0.00408163 
+  194          182.62535    126.93272   0.00515464 
+  196          174.52262    126.96995   0.00510204 
+  190          168.61157    127.00724   0.00526316 
+  178          166.20648    127.04457   0.00561798 
+  154          166.24837    127.08195   0.00649351 
+  151          166.53843    127.11938   0.00662252 
+  189          166.58371    127.15686   0.00529101 
+  173          167.77957    127.19438   0.00578035 
+  201          170.57068    127.23196   0.00497512 
+  207          174.70226    127.26958   0.00483092 
+  207          179.05465    127.30725   0.00483092 
+  181          181.44829    127.34497   0.00552486 
+  186          180.35744    127.38274   0.00537634 
+  175          174.3473     127.42055   0.00571429 
+  163          166.85036    127.45841   0.00613497 
+  135          161.54556    127.49633   0.00740741 
+  153          158.74698    127.53428   0.00653595 
+  163          157.6869     127.57229   0.00613497 
+  156          157.67471    127.61035   0.00641026 
+  157          158.35207    127.64845   0.00636943 
+  138          159.74364    127.6866    0.00724638 
+  177          162.17787    127.7248    0.00564972 
+  175          165.93113    127.76305   0.00571429 
+  164          170.14163    127.80134   0.00609756 
+  158          172.62362    127.83969   0.00632911 
+  189          172.32754    127.87808   0.00529101 
+  173          168.94401    127.91652   0.00578035 
+  165          165.17471    127.955     0.00606061 
+  197          164.06212    127.99354   0.00507614 
+  188          166.57738    128.03212   0.00531915 
+  215          172.90996    128.07075   0.00465116 
+  205          181.16514    128.10942   0.00487805 
+  259          184.40037    128.14815   0.003861  
+  225          178.97074    128.18692   0.00444444 
+  185          171.36614    128.22574   0.00540541 
+  184          166.49727    128.2646    0.00543478 
+  209          164.2497     128.30352   0.00478469 
+  175          162.43518    128.34248   0.00571429 
+  206          160.79815    128.38149   0.00485437 
+  192          160.86559    128.42054   0.00520833 
+  182          163.47098    128.45965   0.00549451 
+  201          169.05129    128.4988    0.00497512 
+  224          177.28334    128.53799   0.00446429 
+  220          184.50703    128.57724   0.00454545 
+  218          185.75466    128.61653   0.00458716 
+  239          183.50508    128.65587   0.0041841 
+  210          180.2301     128.69526   0.0047619 
+  175          174.58275    128.73469   0.00571429 
+  193          168.95224    128.77417   0.00518135 
+  180          165.57573    128.8137    0.00555556 
+  172          164.41855    128.85327   0.00581395 
+  184          164.86777    128.89289   0.00543478 
+  200          166.95654    128.93256   0.005     
+  167          170.63854    128.97228   0.00598802 
+  164          174.73385    129.01204   0.00609756 
+  227          177.92276    129.05185   0.00440529 
+  190          180.5717     129.0917    0.00526316 
+  215          183.72381    129.13161   0.00465116 
+  213          186.70365    129.17156   0.00469484 
+  215          190.30773    129.21155   0.00465116 
+  213          196.66958    129.2516    0.00469484 
+  190          206.71159    129.29169   0.00526316 
+  227          221.09534    129.33182   0.00440529 
+  250          240.0859     129.37201   0.004     
+  267          262.61199    129.41224   0.00374532 
+  297          293.22345    129.45252   0.003367  
+  358          345.26227    129.49284   0.0027933 
+  524          440.24988    129.53321   0.0019084 
+  703          614.04424    129.57363   0.00142248 
+  1040         903.08071    129.61409   0.00096154 
+  1317         1208.25076   129.6546    0.0007593 
+  1252         1164.19981   129.69516   0.00079872 
+  1062         844.96541    129.73576   0.00094162 
+  723          589.91121    129.77641   0.00138313 
+  562          447.29445    129.81711   0.00177936 
+  411          376.68992    129.85785   0.00243309 
+  351          348.15232    129.89864   0.002849  
+  325          351.85343    129.93948   0.00307692 
+  400          388.2868     129.98036   0.0025    
+  485          452.96402    130.02129   0.00206186 
+  623          543.28025    130.06226   0.00160514 
+  733          675.77766    130.10328   0.00136426 
+  745          741.5272     130.14435   0.00134228 
+  677          611.0446     130.18547   0.0014771 
+  537          443.7531     130.22663   0.0018622 
+  389          335.31897    130.26783   0.00257069 
+  292          274.73939    130.30909   0.00342466 
+  233          241.90536    130.35039   0.00429185 
+  217          225.50905    130.39173   0.00460829 
+  223          220.57138    130.43313   0.0044843 
+  231          222.0794     130.47456   0.004329  
+  221          217.25706    130.51605   0.00452489 
+  210          201.67576    130.55758   0.0047619 
+  216          186.701      130.59916   0.00462963 
+  199          176.57947    130.64078   0.00502513 
+  170          170.27528    130.68245   0.00588235 
+  165          166.20758    130.72417   0.00606061 
+  166          163.10736    130.76593   0.0060241 
+  175          160.1803     130.80774   0.00571429 
+  159          157.29905    130.8496    0.00628931 
+  152          154.82554    130.8915    0.00657895 
+  153          152.95782    130.93345   0.00653595 
+  153          151.63327    130.97544   0.00653595 
+  164          150.69697    131.01748   0.00609756 
+  142          150.01343    131.05957   0.00704225 
+  158          149.62043    131.1017    0.00632911 
+  148          149.67649    131.14388   0.00675676 
+  118          150.27055    131.1861    0.00847458 
+  148          151.35657    131.22838   0.00675676 
+  131          152.52736    131.27069   0.00763359 
+  149          152.80932    131.31306   0.00671141 
+  127          151.92891    131.35547   0.00787402 
+  178          150.91218    131.39792   0.00561798 
+  145          150.30288    131.44043   0.00689655 
+  172          150.37953    131.48297   0.00581395 
+  173          151.51809    131.52557   0.00578035 
+  160          153.78562    131.56821   0.00625   
+  146          156.72153    131.6109    0.00684932 
+  142          158.0472     131.65363   0.00704225 
+  158          156.20231    131.69641   0.00632911 
+  161          153.57123    131.73924   0.00621118 
+  140          151.81835    131.78211   0.00714286 
+  130          150.6005     131.82503   0.00769231 
+  140          149.67805    131.86799   0.00714286 
+  154          149.34064    131.911     0.00649351 
+  135          149.7281     131.95406   0.00740741 
+  150          151.12697    131.99716   0.00666667 
+  165          153.96913    132.04031   0.00606061 
+  155          158.69322    132.08351   0.00645161 
+  163          165.51671    132.12675   0.00613497 
+  179          173.41857    132.17004   0.00558659 
+  153          179.41266    132.21338   0.00653595 
+  166          178.25162    132.25676   0.0060241 
+  155          170.61652    132.30018   0.00645161 
+  151          163.21498    132.34366   0.00662252 
+  145          158.88302    132.38718   0.00689655 
+  184          157.60926    132.43074   0.00543478 
+  195          159.10676    132.47436   0.00512821 
+  179          162.69111    132.51802   0.00558659 
+  199          165.27222    132.56172   0.00502513 
+  182          164.35683    132.60547   0.00549451 
+  140          163.57301    132.64927   0.00714286 
+  155          165.50449    132.69312   0.00645161 
+  152          168.62079    132.73701   0.00657895 
+  148          169.11843    132.78095   0.00675676 
+  175          166.31574    132.82493   0.00571429 
+  134          162.3188     132.86896   0.00746269 
+  147          159.08417    132.91304   0.00680272 
+  168          157.29323    132.95716   0.00595238 
+  141          156.80755    133.00133   0.0070922 
+  135          157.04451    133.04555   0.00740741 
+  144          156.17664    133.08982   0.00694444 
+  144          153.4715     133.13413   0.00694444 
+  140          150.95916    133.17848   0.00714286 
+  141          149.72365    133.22289   0.0070922 
+  135          149.74657    133.26734   0.00740741 
+  147          150.71983    133.31183   0.00680272 
+  149          151.98878    133.35638   0.00671141 
+  179          153.2057     133.40097   0.00558659 
+  146          155.14885    133.4456    0.00684932 
+  137          158.61515    133.49029   0.00729927 
+  179          163.76417    133.53502   0.00558659 
+  158          168.82001    133.5798    0.00632911 
+  157          170.10805    133.62462   0.00636943 
+  143          167.54299    133.66949   0.00699301 
+  166          162.63653    133.71441   0.0060241 
+  130          156.76199    133.75938   0.00769231 
+  129          152.07504    133.80439   0.00775194 
+  156          149.15215    133.84945   0.00641026 
+  166          147.65191    133.89455   0.0060241 
+  138          147.24113    133.93971   0.00724638 
+  137          147.78913    133.98491   0.00729927 
+  148          149.36058    134.03016   0.00675676 
+  146          151.96494    134.07545   0.00684932 
+  126          154.76686    134.12079   0.00793651 
+  137          155.95516    134.16618   0.00729927 
+  136          155.36727    134.21162   0.00735294 
+  144          153.76488    134.2571    0.00694444 
+  167          151.86185    134.30263   0.00598802 
+  136          150.83454    134.34821   0.00735294 
+  128          150.97991    134.39384   0.0078125 
+  124          151.86946    134.43951   0.00806452 
+  149          152.39897    134.48523   0.00671141 
+  145          151.99377    134.531     0.00689655 
+  136          151.68767    134.57682   0.00735294 
+  163          151.93941    134.62268   0.00613497 
+  151          152.67313    134.66859   0.00662252 
+  141          154.06101    134.71455   0.0070922 
+  151          155.83947    134.76056   0.00662252 
+  155          158.16032    134.80661   0.00645161 
+  133          160.29736    134.85272   0.0075188 
+  153          159.54839    134.89887   0.00653595 
+  130          156.29286    134.94507   0.00769231 
+  148          153.32403    134.99131   0.00675676 
+  126          151.26877    135.03761   0.00793651 
+  138          149.60306    135.08395   0.00724638 
+  129          148.48628    135.13034   0.00775194 
+  133          148.01807    135.17678   0.0075188 
+  137          148.01376    135.22326   0.00729927 
+  132          148.3585     135.2698    0.00757576 
+  142          149.1756     135.31638   0.00704225 
+  124          150.3541     135.36301   0.00806452 
+  144          151.76593    135.40969   0.00694444 
+  138          152.15923    135.45642   0.00724638 
+  153          151.41474    135.5032    0.00653595 
+  150          151.15333    135.55002   0.00666667 
+  143          152.04793    135.5969    0.00699301 
+  143          153.0943     135.64382   0.00699301 
+  144          152.80868    135.69079   0.00694444 
+  126          151.4144     135.73781   0.00793651 
+  132          149.79818    135.78488   0.00757576 
+  136          148.48075    135.832     0.00735294 
+  134          147.93577    135.87917   0.00746269 
+  143          148.10061    135.92638   0.00699301 
+  144          148.90056    135.97365   0.00694444 
+  156          150.30488    136.02096   0.00641026 
+  141          152.23524    136.06832   0.0070922 
+  152          154.43176    136.11574   0.00657895 
+  140          156.61572    136.1632    0.00714286 
+  155          158.27615    136.21071   0.00645161 
+  138          159.24972    136.25827   0.00724638 
+  152          160.1432     136.30588   0.00657895 
+  145          160.5777     136.35354   0.00689655 
+  147          159.0626     136.40125   0.00680272 
+  153          156.25609    136.44901   0.00653595 
+  123          153.78283    136.49682   0.00813008 
+  129          152.21485    136.54467   0.00775194 
+  161          151.58275    136.59258   0.00621118 
+  132          151.74737    136.64054   0.00757576 
+  144          152.45038    136.68855   0.00694444 
+  137          153.41544    136.73661   0.00729927 
+  156          154.51941    136.78472   0.00641026 
+  155          156.0943     136.83287   0.00645161 
+  129          158.55819    136.88108   0.00775194 
+  145          160.69091    136.92934   0.00689655 
+  150          159.97543    136.97765   0.00666667 
+  131          156.86276    137.02601   0.00763359 
+  153          153.77744    137.07442   0.00653595 
+  146          151.65132    137.12289   0.00684932 
+  132          150.42449    137.1714    0.00757576 
+  145          149.83203    137.21996   0.00689655 
+  116          149.63673    137.26858   0.00862069 
+  136          149.67188    137.31724   0.00735294 
+  146          149.88399    137.36596   0.00684932 
+  138          150.34425    137.41473   0.00724638 
+  142          151.08146    137.46355   0.00704225 
+  146          151.80412    137.51242   0.00684932 
+  147          151.80774    137.56134   0.00680272 
+  132          150.98937    137.61031   0.00757576 
+  130          150.20907    137.65933   0.00769231 
+  145          149.77226    137.70841   0.00689655 
+  139          149.46083    137.75754   0.00719424 
+  136          149.37305    137.80672   0.00735294 
+  148          149.65816    137.85595   0.00675676 
+  135          150.35169    137.90523   0.00740741 
+  120          151.55081    137.95457   0.00833333 
+  150          153.47417    138.00396   0.00666667 
+  142          156.36168    138.0534    0.00704225 
+  138          160.0193     138.10289   0.00724638 
+  157          162.86487    138.15244   0.00636943 
+  133          162.72578    138.20204   0.0075188 
+  141          160.48391    138.25169   0.0070922 
+  146          158.6527     138.30139   0.00684932 
+  153          158.18986    138.35115   0.00653595 
+  196          159.17643    138.40095   0.00510204 
+  181          161.46411    138.45082   0.00552486 
+  187          164.02507    138.50073   0.00534759 
+  184          165.72333    138.5507    0.00543478 
+  202          167.71559    138.60072   0.0049505 
+  180          171.88463    138.6508    0.00555556 
+  157          176.84136    138.70093   0.00636943 
+  168          178.21415    138.75111   0.00595238 
+  162          174.81157    138.80135   0.00617284 
+  157          169.86678    138.85164   0.00636943 
+  158          165.84687    138.90198   0.00632911 
+  166          163.4275     138.95238   0.0060241 
+  167          162.32267    139.00283   0.00598802 
+  174          162.36104    139.05334   0.00574713 
+  171          163.31912    139.1039    0.00584795 
+  185          164.51101    139.15452   0.00540541 
+  190          165.65509    139.20519   0.00526316 
+  178          167.35701    139.25591   0.00561798 
+  187          169.41081    139.30669   0.00534759 
+  202          170.31128    139.35753   0.0049505 
+  165          168.8526     139.40842   0.00606061 
+  162          166.69262    139.45936   0.00617284 
+  191          165.51368    139.51036   0.0052356 
+  174          165.79836    139.56142   0.00574713 
+  163          167.4632     139.61253   0.00613497 
+  172          170.48086    139.6637    0.00581395 
+  197          174.3935     139.71492   0.00507614 
+  141          177.03205    139.7662    0.0070922 
+  176          176.53641    139.81753   0.00568182 
+  173          174.83021    139.86892   0.00578035 
+  173          173.95756    139.92037   0.00578035 
+  163          174.03998    139.97187   0.00613497 
+  160          174.96013    140.02343   0.00625   
+  165          177.03999    140.07505   0.00606061 
+  180          180.62514    140.12672   0.00555556 
+  187          185.99312    140.17845   0.00534759 
+  164          192.99479    140.23024   0.00609756 
+  198          200.02183    140.28208   0.00505051 
+  249          205.16314    140.33399   0.00401606 
+  205          209.38012    140.38595   0.00487805 
+  193          213.81013    140.43796   0.00518135 
+  212          219.06153    140.49004   0.00471698 
+  244          226.90903    140.54217   0.00409836 
+  267          238.90263    140.59436   0.00374532 
+  267          256.29267    140.64661   0.00374532 
+  307          281.07585    140.69891   0.00325733 
+  365          317.02281    140.75128   0.00273973 
+  421          371.3745     140.8037    0.0023753 
+  588          458.13541    140.85618   0.00170068 
+  875          603.36543    140.90872   0.00114286 
+  1252         849.1944     140.96132   0.00079872 
+  1829         1233.11306   141.01398   0.00054675 
+  2411         1632.53358   141.0667    0.00041477 
+  2438         1620.11417   141.11948   0.00041017 
+  1873         1220.1183    141.17231   0.0005339 
+  1360         854.75852    141.22521   0.00073529 
+  976          629.57095    141.27817   0.00102459 
+  694          503.81       141.33118   0.00144092 
+  631          436.39621    141.38426   0.00158479 
+  536          404.31169    141.43739   0.00186567 
+  522          398.29629    141.49059   0.00191571 
+  547          418.8082     141.54385   0.00182815 
+  641          475.55957    141.59717   0.00156006 
+  766          587.63682    141.65054   0.00130548 
+  1114         771.17043    141.70398   0.00089767 
+  1263         956.25016    141.75749   0.00079177 
+  1281         927.60518    141.81105   0.00078064 
+  1080         717.16922    141.86467   0.00092593 
+  755          531.91063    141.91836   0.0013245 
+  617          416.88879    141.9721    0.00162075 
+  491          350.71359    142.02591   0.00203666 
+  396          312.55778    142.07978   0.00252525 
+  317          290.05212    142.13372   0.00315457 
+  320          276.62294    142.18771   0.003125  
+  265          268.63514    142.24177   0.00377358 
+  275          263.61294    142.29589   0.00363636 
+  279          259.27453    142.35008   0.00358423 
+  246          253.89012    142.40432   0.00406504 
+  238          247.11729    142.45863   0.00420168 
+  243          239.52357    142.51301   0.00411523 
+  204          231.99267    142.56744   0.00490196 
+  249          225.36158    142.62195   0.00401606 
+  246          220.08038    142.67651   0.00406504 
+  212          215.33709    142.73114   0.00471698 
+  237          210.55255    142.78583   0.00421941 
+  218          206.64746    142.84059   0.00458716 
+  208          204.2333     142.89541   0.00480769 
+  190          203.12476    142.9503    0.00526316 
+  199          202.80318    143.00526   0.00502513 
+  198          202.6499     143.06027   0.00505051 
+  181          202.10592    143.11536   0.00552486 
+  218          200.91721    143.17051   0.00458716 
+  173          199.30681    143.22572   0.00578035 
+  194          197.77622    143.281     0.00515464 
+  196          196.856      143.33635   0.00510204 
+  174          196.86447    143.39176   0.00574713 
+  178          197.5182     143.44724   0.00561798 
+  161          198.38778    143.50278   0.00621118 
+  175          199.66003    143.5584    0.00571429 
+  205          201.20719    143.61408   0.00487805 
+  181          202.21273    143.66983   0.00552486 
+  208          201.79524    143.72564   0.00480769 
+  162          199.64984    143.78152   0.00617284 
+  170          196.18604    143.83747   0.00588235 
+  184          192.17666    143.89349   0.00543478 
+  191          188.39938    143.94958   0.0052356 
+  182          185.36644    144.00573   0.00549451 
+  217          183.27255    144.06196   0.00460829 
+  202          182.18125    144.11825   0.0049505 
+  209          182.09433    144.17461   0.00478469 
+  176          182.95876    144.23104   0.00568182 
+  213          184.65939    144.28754   0.00469484 
+  203          186.97559    144.34411   0.00492611 
+  257          189.57403    144.40075   0.00389105 
+  247          192.12215    144.45746   0.00404858 
+  277          194.48455    144.51424   0.00361011 
+  296          196.73577    144.57109   0.00337838 
+  324          198.97896    144.62801   0.00308642 
+  377          201.47359    144.685     0.00265252 
+  443          204.75649    144.74207   0.00225734 
+  456          208.38322    144.7992    0.00219298 
+  392          209.72548    144.85641   0.00255102 
+  353          207.34763    144.91368   0.00283286 
+  284          203.69226    144.97103   0.00352113 
+  297          201.64809    145.02846   0.003367  
+  256          201.84695    145.08595   0.00390625 
+  266          203.44165    145.14352   0.0037594 
+  248          205.14247    145.20116   0.00403226 
+  263          205.81543    145.25887   0.00380228 
+  248          204.97911    145.31666   0.00403226 
+  280          202.92023    145.37452   0.00357143 
+  302          200.36507    145.43245   0.00331126 
+  310          198.15488    145.49046   0.00322581 
+  320          196.74324    145.54854   0.003125  
+  314          195.33307    145.6067    0.00318471 
+  266          192.65023    145.66493   0.0037594 
+  248          189.06811    145.72324   0.00403226 
+  247          185.97983    145.78162   0.00404858 
+  215          184.151      145.84007   0.00465116 
+  203          183.49951    145.89861   0.00492611 
+  200          183.46625    145.95721   0.005     
+  213          183.34129    146.0159    0.00469484 
+  197          182.44712    146.07466   0.00507614 
+  182          180.41859    146.1335    0.00549451 
+  188          177.73113    146.19241   0.00531915 
+  201          175.28846    146.2514    0.00497512 
+  212          173.70473    146.31047   0.00471698 
+  203          173.34684    146.36962   0.00492611 
+  203          174.44158    146.42884   0.00492611 
+  196          176.66641    146.48814   0.00510204 
+  160          178.06637    146.54752   0.00625   
+  193          176.16139    146.60698   0.00518135 
+  167          172.00904    146.66652   0.00598802 
+  164          168.20656    146.72614   0.00609756 
+  199          165.65278    146.78584   0.00502513 
+  177          164.18281    146.84561   0.00564972 
+  157          163.36398    146.90547   0.00636943 
+  179          162.8889     146.9654    0.00558659 
+  168          162.72428    147.02542   0.00595238 
+  201          162.76142    147.08552   0.00497512 
+  161          162.95376    147.1457    0.00621118 
+  173          163.57935    147.20595   0.00578035 
+  173          164.87151    147.26629   0.00578035 
+  155          166.49094    147.32672   0.00645161 
+  145          167.19163    147.38722   0.00689655 
+  153          166.31686    147.44781   0.00653595 
+  156          164.99839    147.50848   0.00641026 
+  175          164.23319    147.56923   0.00571429 
+  155          164.22753    147.63006   0.00645161 
+  151          164.9492     147.69098   0.00662252 
+  141          166.40576    147.75198   0.0070922 
+  160          168.69281    147.81307   0.00625   
+  163          171.9799     147.87424   0.00613497 
+  188          176.58656    147.9355    0.00531915 
+  183          183.2949     147.99683   0.00546448 
+  164          193.76102    148.05826   0.00609756 
+  191          210.75567    148.11977   0.0052356 
+  227          237.07523    148.18136   0.00440529 
+  236          267.98418    148.24305   0.00423729 
+  220          277.65254    148.30481   0.00454545 
+  230          254.55002    148.36667   0.00434783 
+  223          226.83479    148.42861   0.0044843 
+  186          209.05047    148.49063   0.00537634 
+  150          200.52595    148.55275   0.00666667 
+  171          198.86113    148.61495   0.00584795 
+  188          203.1285     148.67724   0.00531915 
+  189          214.121      148.73962   0.00529101 
+  223          234.05749    148.80209   0.0044843 
+  208          264.87158    148.86464   0.00480769 
+  232          301.31622    148.92729   0.00431034 
+  275          320.31063    148.99002   0.00363636 
+  256          309.66942    149.05285   0.00390625 
+  294          290.74579    149.11576   0.00340136 
+  248          266.41616    149.17877   0.00403226 
+  247          237.06918    149.24186   0.00404858 
+  210          214.18076    149.30505   0.0047619 
+  210          200.04975    149.36833   0.0047619 
+  178          192.33221    149.43169   0.00561798 
+  180          189.11507    149.49516   0.00555556 
+  177          189.63499    149.55871   0.00564972 
+  166          194.13101    149.62235   0.0060241 
+  189          203.47991    149.68609   0.00529101 
+  183          217.91241    149.74993   0.00546448 
+  189          232.8661     149.81385   0.00529101 
+  187          234.98268    149.87787   0.00534759 
+  203          220.90006    149.94198   0.00492611 
+  205          204.61066    150.00619   0.00487805 
+  217          193.12026    150.07049   0.00460829 
+  181          185.67696    150.13489   0.00552486 
+  187          180.21163    150.19938   0.00534759 
+  171          175.96374    150.26397   0.00584795 
+  187          172.88046    150.32866   0.00534759 
+  159          170.7975     150.39344   0.00628931 
+  155          169.50252    150.45832   0.00645161 
+  165          168.81881    150.52329   0.00606061 
+  140          168.57332    150.58837   0.00714286 
+  155          168.54397    150.65354   0.00645161 
+  130          168.52254    150.7188    0.00769231 
+  163          168.41114    150.78417   0.00613497 
+  147          168.18785    150.84964   0.00680272 
+  150          167.99902    150.9152    0.00666667 
+  165          168.0595     150.98087   0.00606061 
+  148          168.2727     151.04663   0.00675676 
+  174          168.41107    151.1125    0.00574713 
+  157          168.65319    151.17846   0.00636943 
+  153          169.34982    151.24453   0.00653595 
+  141          170.55772    151.3107    0.0070922 
+  147          171.45786    151.37696   0.00680272 
+  132          170.9026     151.44334   0.00757576 
+  153          169.29068    151.50981   0.00653595 
+  139          167.80051    151.57639   0.00719424 
+  141          166.81095    151.64306   0.0070922 
+  130          166.01054    151.70985   0.00769231 
+  149          165.18233    151.77673   0.00671141 
+  157          164.54231    151.84372   0.00636943 
+  138          164.30626    151.91082   0.00724638 
+  170          164.53364    151.97802   0.00588235 
+  167          165.21913    152.04532   0.00598802 
+  155          166.33042    152.11274   0.00645161 
+  131          167.84171    152.18025   0.00763359 
+  136          169.58777    152.24788   0.00735294 
+  136          170.79556    152.31561   0.00735294 
+  135          170.37698    152.38344   0.00740741 
+  140          168.55176    152.45139   0.00714286 
+  157          166.60076    152.51944   0.00636943 
+  151          165.17476    152.5876    0.00662252 
+  145          164.19266    152.65587   0.00689655 
+  167          163.45324    152.72425   0.00598802 
+  166          162.9319     152.79274   0.0060241 
+  150          162.58457    152.86134   0.00666667 
+  170          162.36437    152.93004   0.00588235 
+  164          162.32282    152.99886   0.00609756 
+  166          162.49441    153.06779   0.0060241 
+  142          162.85983    153.13683   0.00704225 
+  158          163.34058    153.20599   0.00632911 
+  175          163.7469     153.27525   0.00571429 
+  148          163.81311    153.34463   0.00675676 
+  147          163.50304    153.41412   0.00680272 
+  146          163.13139    153.48373   0.00684932 
+  162          162.95159    153.55344   0.00617284 
+  159          163.0262     153.62328   0.00628931 
+  154          163.33258    153.69322   0.00649351 
+  147          163.76949    153.76328   0.00680272 
+  139          164.14284    153.83346   0.00719424 
+  151          164.36984    153.90375   0.00662252 
+  157          164.57567    153.97416   0.00636943 
+  157          164.87081    154.04469   0.00636943 
+  163          165.28971    154.11533   0.00613497 
+  156          165.83968    154.18609   0.00641026 
+  152          166.51171    154.25697   0.00657895 
+  162          167.29573    154.32797   0.00617284 
+  151          168.1416     154.39909   0.00662252 
+  154          168.89932    154.47032   0.00649351 
+  165          169.51736    154.54168   0.00606061 
+  163          170.18002    154.61315   0.00613497 
+  161          171.12701    154.68475   0.00621118 
+  179          172.56555    154.75646   0.00558659 
+  173          174.68411    154.8283    0.00578035 
+  162          177.68461    154.90026   0.00617284 
+  166          181.63116    154.97234   0.0060241 
+  203          185.69771    155.04455   0.00492611 
+  172          187.7683     155.11687   0.00581395 
+  165          186.78115    155.18933   0.00606061 
+  171          184.48565    155.2619    0.00584795 
+  165          182.6166     155.3346    0.00606061 
+  177          181.65821    155.40742   0.00564972 
+  175          181.61828    155.48037   0.00571429 
+  168          182.52819    155.55345   0.00595238 
+  152          184.4291     155.62665   0.00657895 
+  157          186.87395    155.69998   0.00636943 
+  185          188.87905    155.77344   0.00540541 
+  186          190.35352    155.84702   0.00537634 
+  168          192.03343    155.92073   0.00595238 
+  171          194.2358     155.99457   0.00584795 
+  199          197.41554    156.06854   0.00502513 
+  202          201.81321    156.14264   0.0049505 
+  171          206.94572    156.21687   0.00584795 
+  167          212.36793    156.29123   0.00598802 
+  178          216.51588    156.36572   0.00561798 
+  187          215.8597     156.44034   0.00534759 
+  218          211.48993    156.51509   0.00458716 
+  187          208.88425    156.58998   0.00534759 
+  187          210.59239    156.66499   0.00534759 
+  182          217.25577    156.74015   0.00549451 
+  221          229.76157    156.81543   0.00452489 
+  252          250.48651    156.89085   0.00396825 
+  259          283.08773    156.9664    0.003861  
+  283          323.83349    157.04209   0.00353357 
+  328          343.21117    157.11792   0.00304878 
+  260          317.59467    157.19388   0.00384615 
+  243          278.19141    157.26998   0.00411523 
+  238          250.12447    157.34621   0.00420168 
+  195          234.29299    157.42258   0.00512821 
+  213          225.2127     157.49909   0.00469484 
+  207          218.33047    157.57574   0.00483092 
+  190          213.45055    157.65253   0.00526316 
+  210          211.1792     157.72946   0.0047619 
+  195          210.67764    157.80653   0.00512821 
+  218          211.9507     157.88374   0.00458716 
+  233          216.67282    157.96109   0.00429185 
+  210          226.83035    158.03858   0.0047619 
+  211          243.68148    158.11621   0.00473934 
+  266          262.28854    158.19399   0.0037594 
+  238          264.9346     158.27191   0.00420168 
+  227          248.40147    158.34997   0.00440529 
+  235          230.7864     158.42818   0.00425532 
+  215          219.04854    158.50653   0.00465116 
+  216          210.85113    158.58503   0.00462963 
+  177          203.79906    158.66367   0.00564972 
+  171          198.05639    158.74246   0.00584795 
+  180          194.15811    158.8214    0.00555556 
+  174          191.5552     158.90048   0.00574713 
+  211          189.41112    158.97971   0.00473934 
+  176          187.51336    159.05909   0.00568182 
+  159          185.91124    159.13862   0.00628931 
+  198          184.52242    159.2183    0.00505051 
+  190          183.50397    159.29813   0.00526316 
+  153          183.16081    159.37811   0.00653595 
+  186          183.5833     159.45824   0.00537634 
+  174          184.57758    159.53852   0.00574713 
+  181          185.6502     159.61896   0.00552486 
+  170          186.12592    159.69954   0.00588235 
+  182          185.59316    159.78028   0.00549451 
+  180          184.19783    159.86118   0.00555556 
+  191          182.89174    159.94222   0.0052356 
+  163          181.78092    160.02343   0.00613497 
+  140          180.58062    160.10479   0.00714286 
+  157          179.48891    160.1863    0.00636943 
+  186          178.77316    160.26797   0.00537634 
+  144          178.29422    160.3498    0.00694444 
+  178          177.94085    160.43179   0.00561798 
+  177          177.88168    160.51393   0.00564972 
+  174          178.25418    160.59624   0.00574713 
+  171          178.95453    160.6787    0.00584795 
+  150          179.52202    160.76133   0.00666667 
+  152          179.48125    160.84411   0.00657895 
+  160          179.04184    160.92705   0.00625   
+  159          178.72387    161.01016   0.00628931 
+  159          178.89499    161.09343   0.00628931 
+  152          179.50729    161.17686   0.00657895 
+  197          180.3614     161.26046   0.00507614 
+  166          181.26086    161.34422   0.0060241 
+  170          182.06014    161.42814   0.00588235 
+  154          182.29849    161.51223   0.00649351 
+  175          181.77654    161.59649   0.00571429 
+  158          181.05417    161.68091   0.00632911 
+  149          180.65333    161.7655    0.00671141 
+  167          180.71278    161.85026   0.00598802 
+  194          181.13932    161.93518   0.00515464 
+  191          181.69404    162.02027   0.0052356 
+  160          182.1895     162.10554   0.00625   
+  173          182.74012    162.19097   0.00578035 
+  185          183.55488    162.27658   0.00540541 
+  183          184.75316    162.36235   0.00546448 
+  161          186.43182    162.4483    0.00621118 
+  180          188.73203    162.53442   0.00555556 
+  155          191.83248    162.62071   0.00645161 
+  177          195.81514    162.70718   0.00564972 
+  173          200.38034    162.79382   0.00578035 
+  174          204.61932    162.88063   0.00574713 
+  167          207.1888     162.96763   0.00598802 
+  189          208.08624    163.05479   0.00529101 
+  192          209.05298    163.14214   0.00520833 
+  189          210.86607    163.22966   0.00529101 
+  178          212.42418    163.31736   0.00561798 
+  199          212.52284    163.40524   0.00502513 
+  205          211.67194    163.4933    0.00487805 
+  197          210.96641    163.58153   0.00507614 
+  188          211.00445    163.66995   0.00531915 
+  200          212.04587    163.75855   0.005     
+  200          214.23682    163.84734   0.005     
+  195          217.61597    163.9363    0.00512821 
+  217          222.13324    164.02545   0.00460829 
+  209          227.56737    164.11478   0.00478469 
+  208          233.24871    164.2043    0.00480769 
+  215          237.96738    164.294     0.00465116 
+  215          241.10002    164.38388   0.00465116 
+  216          243.41223    164.47396   0.00462963 
+  207          245.72723    164.56422   0.00483092 
+  254          248.06282    164.65467   0.00393701 
+  252          250.1217     164.74531   0.00396825 
+  275          252.24179    164.83613   0.00363636 
+  249          255.34397    164.92715   0.00401606 
+  284          260.99699    165.01836   0.00352113 
+  318          271.26509    165.10975   0.00314465 
+  350          287.2458     165.20134   0.00285714 
+  367          305.05616    165.29313   0.0027248 
+  343          312.38073    165.3851    0.00291545 
+  367          304.49995    165.47727   0.0027248 
+  304          292.80508    165.56963   0.00328947 
+  340          284.65237    165.66219   0.00294118 
+  295          280.25773    165.75495   0.00338983 
+  284          278.21765    165.8479    0.00352113 
+  310          277.8318     165.94105   0.00322581 
+  316          279.05859    166.0344    0.00316456 
+  283          281.84889    166.12794   0.00353357 
+  312          285.99811    166.22169   0.00320513 
+  318          291.26056    166.31563   0.00314465 
+  314          297.81092    166.40978   0.00318471 
+  338          306.56316    166.50413   0.00295858 
+  359          318.65461    166.59868   0.00278552 
+  349          334.02151    166.69343   0.00286533 
+  414          348.65036    166.78839   0.00241546 
+  348          357.50436    166.88355   0.00287356 
+  385          364.32732    166.97891   0.0025974 
+  393          375.47784    167.07448   0.00254453 
+  428          393.26252    167.17026   0.00233645 
+  446          418.08035    167.26625   0.00224215 
+  481          450.28902    167.36244   0.002079  
+  517          491.58342    167.45884   0.00193424 
+  572          545.32808    167.55545   0.00174825 
+  666          613.05827    167.65228   0.0015015 
+  742          692.11351    167.74931   0.00134771 
+  967          788.04223    167.84655   0.00103413 
+  1068         922.28879    167.94401   0.00093633 
+  1351         1124.10247   168.04168   0.00074019 
+  1847         1437.83487   168.13956   0.00054142 
+  2572         1938.88353   168.23766   0.0003888 
+  3766         2738.79217   168.33597   0.00026553 
+  5245         3919.30828   168.4345    0.00019066 
+  6497         5188.75849   168.53325   0.00015392 
+  6313         5503.44862   168.63221   0.0001584 
+  5066         4493.82637   168.73139   0.00019739 
+  3862         3211.52517   168.8308    0.00025893 
+  2961         2270.82161   168.93042   0.00033772 
+  2240         1679.27315   169.03026   0.00044643 
+  1807         1322.99899   169.13032   0.0005534 
+  1451         1110.69375   169.23061   0.00068918 
+  1246         985.39305    169.33111   0.00080257 
+  1217         921.08486    169.43185   0.00082169 
+  1146         911.81586    169.5328    0.0008726 
+  1288         962.80391    169.63398   0.0007764 
+  1427         1093.27344   169.73539   0.00070077 
+  1822         1342.2118    169.83703   0.00054885 
+  2243         1765.09973   169.93889   0.00044583 
+  2780         2374.49975   170.04098   0.00035971 
+  3124         2914.61545   170.1433    0.0003201 
+  3213         2837.64006   170.24585   0.00031124 
+  2581         2215.21877   170.34863   0.00038745 
+  1986         1590.97198   170.45164   0.00050352 
+  1516         1156.41441   170.55488   0.00065963 
+  1109         880.47128    170.65836   0.00090171 
+  896          706.17181    170.76207   0.00111607 
+  718          593.00404    170.86602   0.00139276 
+  633          516.21742    170.9702    0.00157978 
+  519          461.01637    171.07462   0.00192678 
+  488          418.56208    171.17927   0.00204918 
+  405          384.16675    171.28416   0.00246914 
+  368          356.26051    171.3893    0.00271739 
+  379          334.16005    171.49467   0.00263852 
+  349          316.97762    171.60028   0.00286533 
+  326          303.8197     171.70613   0.00306748 
+  294          294.00051    171.81223   0.00340136 
+  289          286.84184    171.91857   0.00346021 
+  244          281.17749    172.02515   0.00409836 
+  277          275.49701    172.13197   0.00361011 
+  268          269.44848    172.23905   0.00373134 
+  261          263.88366    172.34636   0.00383142 
+  263          259.58015    172.45393   0.00380228 
+  260          256.68612    172.56174   0.00384615 
+  274          254.50909    172.66981   0.00364964 
+  288          251.96637    172.77812   0.00347222 
+  255          248.32713    172.88668   0.00392157 
+  272          243.62976    172.99549   0.00367647 
+  255          238.78447    173.10456   0.00392157 
+  227          234.75506    173.21388   0.00440529 
+  225          231.86765    173.32345   0.00444444 
+  238          229.93222    173.43328   0.00420168 
+  221          228.87873    173.54336   0.00452489 
+  233          228.86778    173.6537    0.00429185 
+  243          229.72488    173.7643    0.00411523 
+  238          230.86741    173.87515   0.00420168 
+  223          232.10193    173.98627   0.0044843 
+  216          234.03822    174.09764   0.00462963 
+  227          237.98283    174.20927   0.00440529 
+  234          245.36219    174.32117   0.0042735 
+  238          257.05039    174.43333   0.00420168 
+  241          272.19745    174.54575   0.00414938 
+  299          283.5585     174.65844   0.00334448 
+  227          279.23321    174.77139   0.00440529 
+  260          262.14815    174.88461   0.00384615 
+  290          244.94798    174.9981    0.00344828 
+  233          232.63428    175.11185   0.00429185 
+  212          224.72651    175.22588   0.00471698 
+  221          219.91755    175.34017   0.00452489 
+  227          217.40623    175.45473   0.00440529 
+  196          216.81775    175.56957   0.00510204 
+  213          217.99955    175.68467   0.00469484 
+  207          220.94508    175.80006   0.00483092 
+  201          225.92631    175.91571   0.00497512 
+  210          233.76553    176.03164   0.0047619 
+  210          245.81187    176.14785   0.0047619 
+  214          263.94071    176.26433   0.0046729 
+#--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--#
+
+# start Validation Reply Form
+_vrf_PLAT741_NEW1minmill_phase_0 # for all atoms in 0_pyrite
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+# start Validation Reply Form
+_vrf_PLAT741_NEW1minmill_phase_1 # for all atoms in 1_quartz
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT741_NEW1minmill_phase_3 # for all atoms in 3_pyrrhotite
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT741_NEW1minmill_phase_4 # for all atoms in 4_rutile
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT741_NEW1minmill_phase_2 # for all atoms in 2_albite
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT155_NEW1minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT141_NEW1minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT142_NEW1minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT143_NEW1minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT144_NEW1minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT145_NEW1minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT146_NEW1minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT151_NEW1minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+# end Validation Reply Form

--- a/data/hamish/vb5042sup6.cif
+++ b/data/hamish/vb5042sup6.cif
@@ -1,0 +1,6669 @@
+
+data_NEW2minmill_publ
+_audit_creation_method  "created in GSAS-II"
+_audit_creation_date  2021-08-04T18:30
+_audit_author_name  "McDougall, Hamish"
+_audit_update_record
+   "2021-08-04T18:30  Initial software-generated CIF"
+_pd_block_id  2021-08-04T18:30|NEW2minmill|McDougallHamish|Overall
+# GSAS-II edited template follows Publication_Template
+#=============================================================================
+# this information describes the project, paper etc. for the CIF             #
+# Acta Cryst. Section C papers and editorial correspondence is generated     #
+# from the information in this section                                       #
+#                                                                            #
+#   (from)   CIF submission form for Rietveld refinements (Acta Cryst. C)    #
+#                                                 Version 14 December 1998   #
+#=============================================================================
+# 1. SUBMISSION DETAILS
+
+_publ_contact_author_name            "Suzanne Neville; Vanessa Peterson; Christophe Didier"   # Name of author for correspondence
+_publ_contact_author_address             # Address of author for correspondence
+; ?
+;
+_publ_contact_author_email           "s.neville@unsw.edu.au; vanessa.peterson@ansto.gov.au; drchristophedidier@gmail.com"
+_publ_contact_author_fax             ?
+_publ_contact_author_phone           ?
+
+_publ_contact_letter
+; ?
+;
+   
+_publ_requested_journal              ?
+_publ_requested_coeditor_name        ?
+_publ_requested_category             ?   # Acta C: one of CI/CM/CO/FI/FM/FO
+
+#==============================================================================
+
+# 2. PROCESSING SUMMARY (IUCr Office Use Only)
+
+_journal_data_validation_number      ?
+
+_journal_date_recd_electronic        ?
+_journal_date_to_coeditor            ?
+_journal_date_from_coeditor          ?
+_journal_date_accepted               ?
+_journal_date_printers_first         ?
+_journal_date_printers_final         ?
+_journal_date_proofs_out             ?
+_journal_date_proofs_in              ?
+_journal_coeditor_name               ?
+_journal_coeditor_code               ?
+_journal_coeditor_notes
+; ?
+;
+_journal_techeditor_code             ?
+_journal_techeditor_notes
+; ?
+;
+_journal_coden_ASTM                  ?
+_journal_name_full                   ?
+_journal_year                        ?
+_journal_volume                      ?
+_journal_issue                       ?
+_journal_page_first                  ?
+_journal_page_last                   ?
+_journal_paper_category              ?
+_journal_suppl_publ_number           ?
+_journal_suppl_publ_pages            ?
+
+#==============================================================================
+
+# 3. TITLE AND AUTHOR LIST
+
+_publ_section_title
+; ?
+;
+_publ_section_title_footnote
+; ?
+;         
+ 
+# The loop structure below should contain the names and addresses of all 
+# authors, in the required order of publication. Repeat as necessary.
+
+loop_
+	_publ_author_name
+        _publ_author_footnote
+	_publ_author_address
+ ?                                   #<--'Last name, first name' 
+; ?
+;
+; ?
+;
+
+#==============================================================================
+
+# 4. TEXT
+
+_publ_section_synopsis
+;  ?
+;
+_publ_section_abstract                         
+; ?
+;          
+_publ_section_comment                          
+; ?
+;
+_publ_section_exptl_prep      # Details of the preparation of the sample(s)
+                              # should be given here. 
+; ?
+;
+_publ_section_exptl_refinement                  
+; ?
+;
+_publ_section_references
+; ?
+;
+_publ_section_figure_captions
+; ?
+;
+_publ_section_acknowledgements
+; ?
+;
+
+#=============================================================================
+# 5. OVERALL REFINEMENT & COMPUTING DETAILS
+
+_refine_special_details
+; ?
+;
+_pd_proc_ls_special_details
+; ?
+;
+
+# The following items are used to identify the programs used.
+_computing_molecular_graphics     ?
+_computing_publication_material   ?
+
+_refine_ls_weighting_scheme       ?        
+_refine_ls_weighting_details      ?
+_refine_ls_hydrogen_treatment     ?        
+_refine_ls_extinction_method      ?        
+_refine_ls_extinction_coef        ?         
+_refine_ls_number_constraints     ?        
+
+_refine_ls_restrained_S_all       ?        
+_refine_ls_restrained_S_obs       ?
+
+#==============================================================================
+# 6. SAMPLE PREPARATION DATA
+
+# (In the unusual case where multiple samples are used in a single
+#  Rietveld study, this information should be moved into the phase
+#  blocks)
+
+# The following three fields describe the preparation of the material.
+# The cooling rate is in K/min.  The pressure at which the sample was  
+# prepared is in kPa.  The temperature of preparation is in K.
+               
+_pd_prep_cool_rate                N/A        
+_pd_prep_pressure                 101.3        
+_pd_prep_temperature              298        
+
+_pd_char_colour                   ?       # use ICDD colour descriptions
+
+data_NEW2minmill_overall
+_pd_proc_info_datetime  2021-08-04T18:30
+_pd_calc_method  "Rietveld Refinement"
+_computing_structure_refinement
+   "GSAS-II (Toby & Von Dreele, J. Appl. Cryst. 46, 544-549, 2013)"
+_refine_ls_number_parameters  31
+_refine_ls_goodness_of_fit_all  2.540
+_refine_ls_shift/su_max  1.0720
+
+# OVERALL WEIGHTED R-FACTOR
+_refine_ls_wR_factor_obs  0.10293
+_refine_ls_matrix_type  full
+# POINTERS TO PHASE AND HISTOGRAM BLOCKS
+loop_   _pd_phase_block_id
+  2021-08-04T18:30|NEW2minmill|phase_0|McDougallHamish
+  2021-08-04T18:30|NEW2minmill|phase_2|McDougallHamish
+  2021-08-04T18:30|NEW2minmill|phase_4|McDougallHamish
+  2021-08-04T18:30|NEW2minmill|phase_1|McDougallHamish
+  2021-08-04T18:30|NEW2minmill|phase_3|McDougallHamish
+_pd_block_diffractogram_id
+;
+2021-08-04T18:30|NEW2minmill|McDougallHamish|PANalytical,Co-EmpyreanII_hist_0
+;
+
+data_NEW2minmill_phase_0
+# Information for phase 0
+_pd_block_id  2021-08-04T18:30|NEW2minmill|phase_0|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for FeS2 follows
+_pd_phase_name  FeS2
+_cell_length_a  5.419509(28)
+_cell_length_b  5.419509(28)
+_cell_length_c  5.419509(28)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  90
+_cell_volume  159.1768(25)
+_exptl_crystal_density_diffrn  5.0060
+_symmetry_cell_setting  cubic
+_symmetry_space_group_name_H-M  "P a -3"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  z,x,y
+     3  y,z,x
+     4  1/2+x,y,1/2-z
+     5  1/2-z,1/2+x,y
+     6  y,1/2-z,1/2+x
+     7  -z,1/2+x,1/2-y
+     8  1/2-y,-z,1/2+x
+     9  1/2+y,1/2-z,-x
+    10  -x,1/2+y,1/2-z
+    11  1/2-z,-x,1/2+y
+    12  1/2+x,1/2-y,-z
+    13  -x,-y,-z
+    14  -z,-x,-y
+    15  -y,-z,-x
+    16  1/2-x,-y,1/2+z
+    17  1/2+z,1/2-x,-y
+    18  -y,1/2+z,1/2-x
+    19  z,1/2-x,1/2+y
+    20  1/2+y,z,1/2-x
+    21  1/2-y,1/2+z,x
+    22  x,1/2-y,1/2+z
+    23  1/2+z,x,1/2-y
+    24  1/2-x,1/2+y,z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Fe1    Fe   0.00000     0.00000     0.00000     1.000      Uiso 0.0063(4)  4   
+S2     S    0.38541(12) 0.38541     0.38541     1.000      Uiso 0.0053(4)  8   
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Fe   4      11.7695    7.3573     3.5222     2.3045     4.7611     0.3072     15.3535    76.8805    1.0369     0.945
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S    8      6.9053     5.2034     1.4379     1.5863     1.4679     22.2151    0.2536     56.172     0.8669     0.2847
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Fe S2"
+_chemical_formula_weight  119.97
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Fe1    S2     2.26586(18)   1_555    4_455 yes
+  Fe1    S2     2.26586(18)   1_555    5_545 yes
+  Fe1    S2     2.26586(18)   1_555    6_554 yes
+  Fe1    S2     2.26586(18)   1_555    7_545 yes
+  Fe1    S2     2.26586(18)   1_555    8_554 yes
+  Fe1    S2     2.2659(6)    1_555    9_455 yes
+  S2     Fe1    2.26586(18)   1_555    4_555 yes
+  S2     Fe1    2.26586(18)   1_555    5_555 yes
+  S2     Fe1    2.2659(6)    1_555    6_555 yes
+  S2     S2     2.1513(8)    1_555   13_666 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.2643(21), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW2minmill_phase_2
+# Information for phase 2
+_pd_block_id  2021-08-04T18:30|NEW2minmill|phase_2|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for NaAlSi3O8 follows
+_pd_phase_name  NaAlSi3O8
+_cell_length_a  8.137
+_cell_length_b  12.785
+_cell_length_c  7.1583
+_cell_angle_alpha  94.26
+_cell_angle_beta   116.6
+_cell_angle_gamma  87.71
+_cell_volume  664.008
+_exptl_crystal_density_diffrn  2.6230
+_symmetry_cell_setting  triclinic
+_symmetry_space_group_name_H-M  "C -1"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -x,-y,-z
+     3  1/2+x,1/2+y,z
+     4  1/2-x,1/2-y,-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Al1    Al3+ 0.00887     0.16846     0.20805     1.000      Uani 0.007      4   
+Si1    Si4+ 0.00375     0.82051     0.23737     1.000      Uani 0.006      4   
+Si2    Si4+ 0.69162     0.11021     0.31466     1.000      Uani 0.006      4   
+Si3    Si4+ 0.68129     0.88190     0.36076     1.000      Uani 0.006      4   
+Na1    Na1+ 0.26799     0.98865     0.14650     1.000      Uani 0.031      4   
+O1     O2-  0.00490     0.13103     0.96660     1.000      Uani 0.012      4   
+O2     O2-  0.59176     0.99756     0.28040     1.000      Uani 0.008      4   
+O3     O2-  0.81230     0.10966     0.19010     1.000      Uani 0.014      4   
+O4     O2-  0.82000     0.85101     0.25870     1.000      Uani 0.018      4   
+O5     O2-  0.01288     0.30238     0.27060     1.000      Uani 0.011      4   
+O6     O2-  0.02329     0.69368     0.22910     1.000      Uani 0.011      4   
+O7     O2-  0.20780     0.10896     0.38900     1.000      Uani 0.011      4   
+O8     O2-  0.18400     0.86817     0.43620     1.000      Uani 0.012      4   
+
+loop_
+   _atom_site_aniso_label
+   _atom_site_aniso_U_11
+   _atom_site_aniso_U_22
+   _atom_site_aniso_U_33
+   _atom_site_aniso_U_12
+   _atom_site_aniso_U_13
+   _atom_site_aniso_U_23
+Al1    0.0074      0.0068      0.0061      -0.0009     0.0031      0.0004      
+Si1    0.0068      0.0065      0.0055      0.0011      0.0030      0.0008      
+Si2    0.0061      0.0055      0.0073      -0.0002     0.0025      0.0004      
+Si3    0.0060      0.0055      0.0074      0.0006      0.0028      0.0009      
+Na1    0.0136      0.0471      0.0315      -0.0050     0.0084      -0.0219     
+O1     0.0164      0.0122      0.0074      -0.0002     0.0067      0.0014      
+O2     0.0074      0.0056      0.0119      0.0003      0.0033      0.0020      
+O3     0.0117      0.0130      0.0162      -0.0040     0.0093      -0.0017     
+O4     0.0134      0.0179      0.0216      0.0046      0.0129      0.0020      
+O5     0.0103      0.0076      0.0150      -0.0020     0.0052      -0.0009     
+O6     0.0101      0.0071      0.0145      0.0022      0.0034      0.0012      
+O7     0.0120      0.0129      0.0080      0.0024      0.0013      0.0015      
+O8     0.0140      0.0140      0.0084      -0.0026     -0.0002     -0.0006     
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Al   4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Na   4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  O    32     ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si   12     ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Al Na O8 Si3"
+_chemical_formula_weight  262.22
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Al1    O1     1.74519      1_555    1_554 yes
+  Al1    O3     1.7429       1_555    1_455 yes
+  Al1    O5     1.73509      1_555    1_555 yes
+  Al1    O7     1.74556      1_555    1_555 yes
+  Si1    O1     1.59985      1_555    2_566 yes
+  Si1    O4     1.59997      1_555    1_455 yes
+  Si1    O6     1.62225      1_555    1_555 yes
+  Si1    O8     1.61907      1_555    1_555 yes
+  Si2    O2     1.63011      1_555    1_545 yes
+  Si2    O3     1.59435      1_555    1_555 yes
+  Si2    O6     1.61836      1_555    3_545 yes
+  Si2    O8     1.6168       1_555    2_666 yes
+  Si3    O2     1.64718      1_555    1_555 yes
+  Si3    O4     1.61975      1_555    1_555 yes
+  Si3    O5     1.59682      1_555    3_555 yes
+  Si3    O7     1.60203      1_555    2_666 yes
+  Na1    O1     2.66887      1_555    1_564 yes
+  Na1    O1     2.53079      1_555    2_566 yes
+  Na1    O2     2.3704       1_555    1_555 yes
+  Na1    O3     2.45321      1_555    2_665 yes
+  Na1    O7     2.43384      1_555    1_565 yes
+  O1     Al1    1.74519      1_555    1_556 yes
+  O1     Si1    1.59985      1_555    2_566 yes
+  O1     Na1    2.66887      1_555    1_546 yes
+  O1     Na1    2.53079      1_555    2_566 yes
+  O2     Si2    1.63011      1_555    1_565 yes
+  O2     Si3    1.64718      1_555    1_555 yes
+  O2     Na1    2.3704       1_555    1_555 yes
+  O3     Al1    1.7429       1_555    1_655 yes
+  O3     Si2    1.59435      1_555    1_555 yes
+  O3     Na1    2.45321      1_555    2_665 yes
+  O4     Si1    1.59997      1_555    1_655 yes
+  O4     Si3    1.61975      1_555    1_555 yes
+  O5     Al1    1.73509      1_555    1_555 yes
+  O5     Si3    1.59682      1_555    3_445 yes
+  O6     Si1    1.62225      1_555    1_555 yes
+  O6     Si2    1.61836      1_555    3_455 yes
+  O7     Al1    1.74556      1_555    1_555 yes
+  O7     Si3    1.60203      1_555    2_666 yes
+  O7     Na1    2.43384      1_555    1_545 yes
+  O8     Si1    1.61907      1_555    1_555 yes
+  O8     Si2    1.6168       1_555    2_666 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Al1    O3     102.836       1_554  1_555    1_455 yes
+  O1     Al1    O5     116.047       1_554  1_555    1_555 yes
+  O3     Al1    O5     112.215       1_455  1_555    1_555 yes
+  O1     Al1    O7     104.004       1_554  1_555    1_555 yes
+  O3     Al1    O7     111.151       1_455  1_555    1_555 yes
+  O5     Al1    O7     110.14        1_555  1_555    1_555 yes
+  O1     Si1    O4     109.433       2_566  1_555    1_455 yes
+  O1     Si1    O6     112.47        2_566  1_555    1_555 yes
+  O4     Si1    O6     108.187       1_455  1_555    1_555 yes
+  O1     Si1    O8     107.176       2_566  1_555    1_555 yes
+  O4     Si1    O8     111.446       1_455  1_555    1_555 yes
+  O6     Si1    O8     108.16        1_555  1_555    1_555 yes
+  O2     Si2    O3     111.144       1_545  1_555    1_555 yes
+  O2     Si2    O6     104.24        1_545  1_555    3_545 yes
+  O3     Si2    O6     112.114       1_555  1_555    3_545 yes
+  O2     Si2    O8     106.97        1_545  1_555    2_666 yes
+  O3     Si2    O8     111.591       1_555  1_555    2_666 yes
+  O6     Si2    O8     110.422       3_545  1_555    2_666 yes
+  O2     Si3    O4     107.269       1_555  1_555    1_555 yes
+  O2     Si3    O5     105.914       1_555  1_555    3_555 yes
+  O4     Si3    O5     110.224       1_555  1_555    3_555 yes
+  O2     Si3    O7     108.565       1_555  1_555    2_666 yes
+  O4     Si3    O7     110.208       1_555  1_555    2_666 yes
+  O5     Si3    O7     114.328       3_555  1_555    2_666 yes
+  Al1    O1     Si1    141.397       1_556  1_555    2_566 yes
+  Si2    O2     Si3    130.019       1_565  1_555    1_555 yes
+  Si2    O2     Na1    120.351       1_565  1_555    1_555 yes
+  Si3    O2     Na1    108.811       1_555  1_555    1_555 yes
+  Al1    O3     Si2    139.461       1_655  1_555    1_555 yes
+  Si1    O4     Si3    161.151       1_655  1_555    1_555 yes
+  Al1    O5     Si3    129.689       1_555  1_555    3_445 yes
+  Si1    O6     Si2    135.676       1_555  1_555    3_455 yes
+  Al1    O7     Si3    133.943       1_555  1_555    2_666 yes
+  Si1    O8     Si2    151.747       1_555  1_555    2_666 yes
+_pd_proc_ls_pref_orient_corr  none
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.171(12), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW2minmill_phase_4
+# Information for phase 4
+_pd_block_id  2021-08-04T18:30|NEW2minmill|phase_4|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Pyrrhotite 4M follows
+_pd_phase_name  "Pyrrhotite 4M"
+_cell_length_a  11.927(18)
+_cell_length_b  6.8693(28)
+_cell_length_c  12.820(21)
+_cell_angle_alpha  90
+_cell_angle_beta   117.20(4)
+_cell_angle_gamma  90
+_cell_volume  934.14(31)
+_exptl_crystal_density_diffrn  4.6034
+_symmetry_cell_setting  monoclinic
+_symmetry_space_group_name_H-M  "C 2/c"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -x,y,1/2-z
+     3  -x,-y,-z
+     4  x,-y,1/2+z
+     5  1/2+x,1/2+y,z
+     6  1/2-x,1/2+y,1/2-z
+     7  1/2-x,1/2-y,-z
+     8  1/2+x,1/2-y,1/2+z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+S1     S    0.01800     0.38330     0.11960     1.000      Uiso 0.010      8   
+S2     S    0.02910     0.11420     0.63900     1.000      Uiso 0.010      8   
+Fe3    Fe   0.10860     0.10250     0.49980     1.000      Uiso 0.010      8   
+S4     S    0.23410     0.13550     0.38260     1.000      Uiso 0.010      8   
+Fe5    Fe   0.24180     0.36600     0.24680     1.000      Uiso 0.010      8   
+S6     S    0.26790     0.13400     0.12360     1.000      Uiso 0.010      8   
+Fe7    Fe   0.38720     0.15000     0.01260     1.000      Uiso 0.010      8   
+Fe8    Fe   0.00000     0.14720     0.25000     1.000      Uiso 0.010      4   
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Fe   28     11.7695    7.3573     3.5222     2.3045     4.7611     0.3072     15.3535    76.8805    1.0369     0.945
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S    32     6.9053     5.2034     1.4379     1.5863     1.4679     22.2151    0.2536     56.172     0.8669     0.2847
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Fe7 S8"
+_chemical_formula_weight  647.41
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  S1     Fe3    2.49607      1_555    2_555 yes
+  S1     Fe5    2.41207      1_555    1_555 yes
+  S1     Fe7    2.39063      1_555    5_455 yes
+  S1     Fe7    2.44033      1_555    7_555 yes
+  S1     Fe8    2.40819      1_555    1_555 yes
+  S2     Fe3    2.3743       1_555    1_555 yes
+  S2     Fe3    2.32539      1_555    3_556 yes
+  S2     Fe5    2.44341      1_555    7_556 yes
+  S2     Fe7    2.36776      1_555    8_456 yes
+  S2     Fe8    2.41276      1_555    3_556 yes
+  Fe3    S1     2.49607      1_555    2_555 yes
+  Fe3    S2     2.3743       1_555    1_555 yes
+  Fe3    S2     2.32539      1_555    3_556 yes
+  Fe3    S6     2.45171      1_555    4_556 yes
+  S4     Fe5    2.38595      1_555    1_555 yes
+  Fe5    S1     2.41207      1_555    1_555 yes
+  Fe5    S2     2.44341      1_555    7_556 yes
+  Fe5    S4     2.38595      1_555    1_555 yes
+  Fe5    S6     2.3624       1_555    1_555 yes
+  S6     Fe3    2.45171      1_555    4_555 yes
+  S6     Fe5    2.3624       1_555    1_555 yes
+  S6     Fe7    2.43165      1_555    1_555 yes
+  S6     Fe7    2.39145      1_555    7_555 yes
+  Fe7    S1     2.39063      1_555    5_545 yes
+  Fe7    S1     2.44033      1_555    7_555 yes
+  Fe7    S2     2.36776      1_555    8_555 yes
+  Fe7    S6     2.43165      1_555    1_555 yes
+  Fe7    S6     2.39145      1_555    7_555 yes
+  Fe8    S1     2.40819      1_555    1_555 yes
+  Fe8    S1     2.40819      1_555    2_555 yes
+  Fe8    S2     2.41276      1_555    3_556 yes
+  Fe8    S2     2.41276      1_555    4_555 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.049(4), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW2minmill_phase_1
+# Information for phase 1
+_pd_block_id  2021-08-04T18:30|NEW2minmill|phase_1|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for SiO2 follows
+_pd_phase_name  SiO2
+_cell_length_a  4.9149(4)
+_cell_length_b  4.9149(4)
+_cell_length_c  5.4057(3)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  120
+_cell_volume  113.084(8)
+_exptl_crystal_density_diffrn  2.6468
+_symmetry_cell_setting  trigonal
+_symmetry_space_group_name_H-M  "P 32 2 1"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -y,x-y,2/3+z
+     3  y-x,-x,1/3+z
+     4  y,x,-z
+     5  -x,y-x,2/3-z
+     6  x-y,-y,1/3-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Si1    Si4+ 0.47000     0.00000     0.66670     1.000      Uani 0.006      3   
+O1     O2-  0.41460     0.26780     0.78543     1.000      Uani 0.011      6   
+
+loop_
+   _atom_site_aniso_label
+   _atom_site_aniso_U_11
+   _atom_site_aniso_U_22
+   _atom_site_aniso_U_33
+   _atom_site_aniso_U_12
+   _atom_site_aniso_U_13
+   _atom_site_aniso_U_23
+Si1    0.0073      0.0059      0.0053      0.0029      0.0003      0.0006      
+O1     0.0120      0.0105      0.0118      0.0065      -0.0029     -0.0040     
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  O    6      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si   3      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  3
+_chemical_formula_sum  "O2 Si"
+_chemical_formula_weight  60.08
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Si1    O1     1.60525      1_555    1_555 yes
+  Si1    O1     1.61159      1_555    2_654 yes
+  Si1    O1     1.61134      1_555    5_656 yes
+  Si1    O1     1.60539      1_555    6_556 yes
+  O1     Si1    1.60525      1_555    1_555 yes
+  O1     Si1    1.61159      1_555    3_665 yes
+  O1     Si1    1.61134      1_555    5_666 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Si1    O1     110.256       1_555  1_555    2_654 yes
+  O1     Si1    O1     108.745       1_555  1_555    5_656 yes
+  O1     Si1    O1     109.685       2_654  1_555    5_656 yes
+  O1     Si1    O1     109.161       1_555  1_555    6_556 yes
+  O1     Si1    O1     108.725       2_654  1_555    6_556 yes
+  O1     Si1    O1     110.262       5_656  1_555    6_556 yes
+  Si1    O1     Si1    143.832       1_555  1_555    3_665 yes
+  Si1    O1     Si1    143.836       1_555  1_555    5_666 yes
+  Si1    O1     Si1    0.009         3_665  1_555    5_666 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.220(12), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW2minmill_phase_3
+# Information for phase 3
+_pd_block_id  2021-08-04T18:30|NEW2minmill|phase_3|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for TiO2 follows
+_pd_phase_name  TiO2
+_cell_length_a  4.5979(16)
+_cell_length_b  4.5979(16)
+_cell_length_c  2.9608(14)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  90
+_cell_volume  62.59(3)
+_exptl_crystal_density_diffrn  4.2393
+_symmetry_cell_setting  tetragonal
+_symmetry_space_group_name_H-M  "P 42/m n m"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  1/2-y,1/2+x,1/2+z
+     3  -x,-y,z
+     4  1/2+y,1/2-x,1/2+z
+     5  1/2-x,1/2+y,1/2+z
+     6  -y,-x,z
+     7  1/2+x,1/2-y,1/2+z
+     8  y,x,z
+     9  -x,-y,-z
+    10  1/2+y,1/2-x,1/2-z
+    11  x,y,-z
+    12  1/2-y,1/2+x,1/2-z
+    13  1/2+x,1/2-y,1/2-z
+    14  y,x,-z
+    15  1/2-x,1/2+y,1/2-z
+    16  -y,-x,-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Ti1    Ti4+ 0.00000     0.00000     0.00000     1.000      Uani 0.006      2   
+O1     O2-  0.30493     0.30493     0.00000     1.000      Uani 0.006      4   
+
+loop_
+   _atom_site_aniso_label
+   _atom_site_aniso_U_11
+   _atom_site_aniso_U_22
+   _atom_site_aniso_U_33
+   _atom_site_aniso_U_12
+   _atom_site_aniso_U_13
+   _atom_site_aniso_U_23
+Ti1    0.0070      0.0070      0.0047      -0.0002     0.0000      0.0000      
+O1     0.0060      0.0060      0.0045      -0.0019     0.0000      0.0000      
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  O    4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Ti   2      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  2
+_chemical_formula_sum  "O2 Ti"
+_chemical_formula_weight  79.9
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Ti1    O1     1.98276      1_555    1_555 yes
+  Ti1    O1     1.94948      1_555    2_544 yes
+  Ti1    O1     1.94948      1_555    2_545 yes
+  Ti1    O1     1.98276      1_555    3_555 yes
+  Ti1    O1     1.94948      1_555    4_454 yes
+  Ti1    O1     1.94948      1_555    4_455 yes
+  O1     Ti1    1.98276      1_555    1_555 yes
+  O1     Ti1    1.94948      1_555    2_554 yes
+  O1     Ti1    1.94948      1_555    2_555 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Ti1    O1     90            1_555  1_555    2_544 yes
+  O1     Ti1    O1     90            1_555  1_555    2_545 yes
+  O1     Ti1    O1     98.82         2_544  1_555    2_545 yes
+  O1     Ti1    O1     180           1_555  1_555    3_555 yes
+  O1     Ti1    O1     90            2_544  1_555    3_555 yes
+  O1     Ti1    O1     90            2_545  1_555    3_555 yes
+  O1     Ti1    O1     90            1_555  1_555    4_454 yes
+  O1     Ti1    O1     81.18         2_544  1_555    4_454 yes
+  O1     Ti1    O1     180           2_545  1_555    4_454 yes
+  O1     Ti1    O1     90            3_555  1_555    4_454 yes
+  O1     Ti1    O1     90            1_555  1_555    4_455 yes
+  O1     Ti1    O1     180           2_544  1_555    4_455 yes
+  O1     Ti1    O1     81.18         2_545  1_555    4_455 yes
+  O1     Ti1    O1     90            3_555  1_555    4_455 yes
+  O1     Ti1    O1     98.82         4_454  1_555    4_455 yes
+  Ti1    O1     Ti1    130.59        1_555  1_555    2_554 yes
+  Ti1    O1     Ti1    130.59        1_555  1_555    2_555 yes
+  Ti1    O1     Ti1    98.82         2_554  1_555    2_555 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.13(4), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW2minmill_pwd_0
+_pd_proc_ls_profile_function
+;
+Finger-Cox-Jephcoat function parameters U, V, W, X, Y, SH/L:
+  peak variance(Gauss) = Utan(Th)^2^+Vtan(Th)+W:
+  peak HW(Lorentz) = X/cos(Th)+Ytan(Th); SH/L = S/L+H/L
+  U, V, W in (centideg)^2^, X & Y in centideg
+    0.000, 0.000, 1.089, 0.882, 1.689, 0.058, 
+;
+# Information for histogram 0: PWDR BAT3_2min_milla_30mm_MonicaHamish_Ruoming_step size 0_2_min_mill_a.xrdml Scan 1
+_pd_block_id
+;
+2021-08-04T18:30|NEW2minmill|McDougallHamish|PANalytical,Co-EmpyreanII_hist_0
+;
+# GSAS-II edited template follows Instrument_Template
+#==============================================================================
+# 9. INSTRUMENT CHARACTERIZATION
+
+_exptl_special_details
+; ?
+;
+
+# if regions of the data are excluded, the reason(s) are supplied here:
+_pd_proc_info_excluded_regions
+; ?
+;
+
+# The following item is used to identify the equipment used to record 
+# the powder pattern when the diffractogram was measured at a laboratory 
+# other than the authors' home institution, e.g. when neutron or synchrotron
+# radiation is used.
+
+_pd_instr_location
+; ?
+;
+_pd_calibration_special_details           # description of the method used
+                                          # to calibrate the instrument
+; ?
+;
+
+_diffrn_source                    Co-Ka       
+_diffrn_source_target             Co
+_diffrn_source_type               Graded_Flat
+_diffrn_measurement_device_type   Panalytical_Reflection_Transmission       
+_diffrn_detector                  PIXcel1D      
+_diffrn_detector_type             Empyrean_II       # make or model of detector
+
+_pd_meas_scan_method              ?       # options are 'step', 'cont',
+                                          # 'tof', 'fixed' or
+                                          # 'disp' (= dispersive)
+_pd_meas_special_details
+;  ?
+;
+
+# The following two items identify the program(s) used (if appropriate).
+_computing_data_collection        ?        
+_computing_data_reduction         ?                   
+
+# Describe any processing performed on the data, prior to refinement.
+# For example: a manual Lp correction or a precomputed absorption correction
+_pd_proc_info_data_reduction      ?
+
+# The following item is used for angular dispersive measurements only.
+
+_diffrn_radiation_monochromator   ?        
+
+# The following items are used to define the size of the instrument.
+# Not all distances are appropriate for all instrument types.
+
+_pd_instr_dist_src/mono           ?
+_pd_instr_dist_mono/spec          ?
+_pd_instr_dist_src/spec           ?
+_pd_instr_dist_spec/anal          ?
+_pd_instr_dist_anal/detc          ?
+_pd_instr_dist_spec/detc          ?
+
+# 10. Specimen size and mounting information
+
+# The next three fields give the specimen dimensions in mm.  The equatorial 
+# plane contains the incident and diffracted beam.
+
+_pd_spec_size_axial               ?       # perpendicular to 
+                                          # equatorial plane
+
+_pd_spec_size_equat               ?       # parallel to 
+                                          # scattering vector 
+                                          # in transmission
+
+_pd_spec_size_thick               ?       # parallel to 
+                                          # scattering vector 
+                                          # in reflection
+
+_pd_spec_mounting                         # This field should be
+                                          # used to give details of the 
+                                          # container.
+; ?
+;
+
+_pd_spec_mount_mode               ?       # options are 'reflection' 
+                                          # or 'transmission'
+    
+_pd_spec_shape                    ?       # options are 'cylinder' 
+                                          # 'flat_sheet' or 'irregular'
+
+
+loop_
+     _atom_type_symbol
+     _atom_type_scat_dispersion_real
+     _atom_type_scat_dispersion_imag
+     _atom_type_scat_dispersion_source
+  Al        0.255   0.328   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Fe       -3.332   0.490   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Na        0.167   0.167   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  O         0.063   0.044   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S         0.371   0.733   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si        0.298   0.438   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Ti       -0.063   2.321   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+_diffrn_radiation_type  K\a~1,2~
+loop_
+   _diffrn_radiation_wavelength
+   _diffrn_radiation_wavelength_wt
+   _diffrn_radiation_wavelength_id
+  1.78892         1.0             1     
+  1.79278         0.5000          2     
+
+# PHASE TABLE
+loop_
+   _pd_phase_id
+   _pd_phase_block_id
+   _pd_phase_mass_%
+  0  2021-08-04T18:30|NEW2minmill|phase_0|McDougallHamish  0.776(3)
+  2  2021-08-04T18:30|NEW2minmill|phase_2|McDougallHamish  0.1086(26)
+  4  2021-08-04T18:30|NEW2minmill|phase_4|McDougallHamish  0.0440(14)
+  1  2021-08-04T18:30|NEW2minmill|phase_1|McDougallHamish  0.0646(10)
+  3  2021-08-04T18:30|NEW2minmill|phase_3|McDougallHamish  0.0064(7)
+loop_
+   _gsas_proc_phase_R_F_factor
+   _gsas_proc_phase_R_Fsqd_factor
+   _gsas_proc_phase_id
+   _gsas_proc_phase_block_id
+    0.03669  0.08611  0  2021-08-04T18:30|NEW2minmill|phase_0|McDougallHamish
+    0.08136  0.18791  2  2021-08-04T18:30|NEW2minmill|phase_2|McDougallHamish
+    0.06571  0.11431  4  2021-08-04T18:30|NEW2minmill|phase_4|McDougallHamish
+    0.07936  0.21331  1  2021-08-04T18:30|NEW2minmill|phase_1|McDougallHamish
+    0.06162  0.12220  3  2021-08-04T18:30|NEW2minmill|phase_3|McDougallHamish
+_pd_proc_ls_prof_R_factor     0.07717
+_pd_proc_ls_prof_wR_factor    0.10293
+_gsas_proc_ls_prof_R_B_factor   0.09857
+_gsas_proc_ls_prof_wR_B_factor  0.12507
+_pd_proc_ls_prof_wR_expected  0.04068
+_diffrn_radiation_probe  x-ray
+_diffrn_radiation_polarisn_ratio  0.7000
+_pd_proc_ls_background_function
+;
+Background function: "chebyschev-1" function with 7 terms:
+    441.7(15), -516.8(24), 391.3(23), -201.4(20), 106.7(19), 
+    -34.6(14), 13.8(13), 
+;
+_diffrn_ambient_temperature  300
+_diffrn_ambient_pressure  100
+
+# STRUCTURE FACTOR TABLE
+loop_
+   _pd_refln_phase_id
+   _refln_index_h
+   _refln_index_k
+   _refln_index_l
+   _refln_F_squared_meas
+   _refln_F_squared_calc
+   _refln_phase_calc
+   _refln_d_spacing
+   _gsas_i100_meas
+  0  1    1    1    965.4302   845.6058   0.0     3.12895  25.38  
+  0  2    0    0    6862.9192  6423.2830  -0.0    2.70975  100.00 
+  0  2    1    0    3761.3126  3393.7780  0.0     2.42368  86.57  
+  0  2    1    1    1782.5766  1744.8952  -180.0  2.21251  67.62  
+  0  2    2    0    3082.3406  3376.4171  -0.0    1.91609  43.15  
+  0  2    2    1    40.6730    42.0768    -0.0    1.80650  1.01   
+  0  3    1    1    4825.2164  5347.8502  -0.0    1.63404  97.64  
+  0  2    2    2    2236.6680  2390.6180  0.0     1.56448  13.88  
+  0  3    0    2    3162.9932  3201.5825  -0.0    1.50310  27.34  
+  0  3    1    2    575.8989   596.5668   0.0     1.44842  9.33   
+  0  3    2    1    1675.8909  1736.0355  180.0   1.44842  27.16  
+  0  4    0    0    430.3698   407.5986   -180.0  1.35488  1.57   
+  0  3    2    2    40.4160    46.8285    -0.0    1.31442  0.57   
+  0  4    1    0    101.6887   117.8228   -0.0    1.31442  0.71   
+  0  4    1    1    63.4246    64.4449    180.0   1.27739  0.86   
+  0  3    3    1    591.6096   592.2572   -0.0    1.24332  7.82   
+  0  4    0    2    979.9400   889.6544   0.0     1.21184  6.35   
+  0  4    2    0    979.9400   889.6544   0.0     1.21184  6.35   
+  0  4    1    2    1.7306     1.7712     -0.0    1.18263  0.02   
+  0  4    2    1    1394.6990  1427.4381  -180.0  1.18263  17.85  
+  0  3    3    2    752.7469   729.9380   0.0     1.15544  9.58   
+  0  4    2    2    1126.4083  1051.7125  0.0     1.10625  14.46  
+  0  4    3    0    133.7114   148.3047   -0.0    1.08390  0.87   
+  0  4    1    3    77.3070    81.6638    -180.0  1.06285  1.03   
+  0  4    3    1    26.5656    28.0628    0.0     1.06285  0.35   
+  0  3    3    3    1847.9613  1618.5630  -0.0    1.04298  8.46   
+  0  5    1    1    3937.7804  3448.9606  -0.0    1.04298  54.11  
+  1  1    0    0    265.5469   242.5017   180.0   4.25639  0.68   
+  1  1    0    1    717.0683   634.4313   120.0   3.34415  1.12   
+  1  1    0    -1   1705.8547  1509.2673  -120.0  3.34415  2.67   
+  1  1    1    0    401.2670   343.7722   -155.6  2.45743  0.33   
+  1  1    0    -2   96.6524    86.1421    -60.0   2.28168  0.07   
+  1  1    0    2    335.3049   298.8427   -120.0  2.28168  0.23   
+  1  1    1    1    100.4215   96.0360    82.9    2.23711  0.13   
+  1  2    0    0    326.7152   308.9287   0.0     2.12820  0.20   
+  1  2    0    -1   68.6499    77.2019    60.0    1.98026  0.04   
+  1  2    0    1    164.4591   184.9464   -60.0   1.98026  0.09   
+  1  1    1    2    585.8090   602.7489   9.8     1.81825  0.51   
+  1  0    0    3    73.9176    94.4702    0.0     1.80189  0.01   
+  1  2    0    2    113.5032   82.0653    60.0    1.67207  0.04   
+  1  2    0    -2   503.6147   364.1246   120.0   1.67207  0.18   
+  1  1    0    -3   195.1883   203.8210   180.0   1.65932  0.07   
+  1  1    0    3    2.4727     2.5820     0.0     1.65932  0.00   
+  1  2    1    0    16.7661    14.6336    -38.9   1.60877  0.01   
+  1  2    1    -1   326.3551   356.2509   95.9    1.54193  0.20   
+  1  2    1    1    280.9515   306.6880   -109.6  1.54193  0.18   
+  1  1    1    3    144.6091   142.5492   117.5   1.45312  0.08   
+  1  3    0    0    83.7612    76.3346    180.0   1.41880  0.02   
+  1  2    1    -2   324.7861   413.7275   -123.3  1.38241  0.17   
+  1  2    1    2    100.8308   128.4429   143.4   1.38241  0.05   
+  1  2    0    -3   186.8663   292.6402   -0.0    1.37518  0.05   
+  1  2    0    3    657.8352   1030.1967  0.0     1.37518  0.17   
+  1  3    0    -1   564.6776   815.6481   -120.0  1.37232  0.15   
+  1  3    0    1    0.7013     1.0131     -60.0   1.37232  0.00   
+  1  1    0    -4   129.7332   120.2777   -120.0  1.28805  0.03   
+  1  1    0    4    427.5343   396.3738   120.0   1.28805  0.10   
+  1  3    0    -2   222.5709   208.2536   120.0   1.25624  0.05   
+  1  3    0    2    507.4733   474.8292   -120.0  1.25624  0.12   
+  1  2    2    0    311.7651   370.9709   -16.5   1.22872  0.07   
+  1  2    1    -3   66.9574    70.9898    179.1   1.20006  0.03   
+  1  2    1    3    284.2047   301.3205   -134.8  1.20006  0.13   
+  1  2    2    1    92.4183    105.5589   88.6    1.19815  0.04   
+  1  1    1    4    333.3075   334.1040   -14.4   1.18417  0.15   
+  1  3    1    0    357.9161   361.4386   121.4   1.18051  0.16   
+  1  3    1    -1   200.7100   189.8528   -18.5   1.15333  0.09   
+  1  3    1    1    67.0181    63.3928    16.4    1.15333  0.03   
+  1  2    0    -4   1.1393     1.4721     -120.0  1.14084  0.00   
+  1  2    0    4    54.6853    70.6614    120.0   1.14084  0.01   
+  1  2    2    2    3.3441     3.3484     -9.8    1.11856  0.00   
+  1  3    0    3    74.8372    62.7056    -180.0  1.11472  0.02   
+  1  3    0    -3   7.9750     6.6822     -0.0    1.11472  0.00   
+  1  3    1    -2   232.3302   304.2534   -8.9    1.08182  0.10   
+  1  3    1    2    94.9244    124.3104   59.1    1.08182  0.04   
+  1  4    0    0    139.6793   168.1434   0.0     1.06410  0.03   
+  1  1    0    -5   378.8904   346.2031   120.0   1.04786  0.09   
+  1  1    0    5    142.1607   129.8963   -120.0  1.04786  0.03   
+  1  4    0    -1   36.4646    31.3968    60.0    1.04406  0.01   
+  1  4    0    1    336.3343   289.5912   120.0   1.04406  0.08   
+  1  2    1    4    148.5739   240.8323   -129.5  1.03477  0.07   
+  1  2    1    -4   6.7001     10.8606    51.2    1.03477  0.00   
+  2  0    0    1    1843.9762  685.7541   180.0   6.38786  0.09   
+  2  0    2    0    1008.1778  396.3962   180.0   6.37466  0.02   
+  2  1    1    0    552.1706   238.2363   -0.0    6.33955  0.01   
+  2  1    -1   0    634.6479   287.4879   -0.0    6.29869  0.01   
+  2  1    1    -1   1023.8206  406.2352   180.0   5.91009  0.02   
+  2  1    -1   -1   741.8423   415.6378   -180.0  5.58552  0.02   
+  2  0    2    -1   10.2388    16.5792    0.0     4.66174  0.00   
+  2  0    2    1    1.0273     1.8371     180.0   4.37623  0.00   
+  2  2    0    -1   19775.7552 21037.4763 -0.0    4.02732  0.16   
+  2  1    -1   1    5454.4244  3767.3897  -0.0    3.85265  0.06   
+  2  1    1    1    12021.5287 10390.3834 0.0     3.77565  0.16   
+  2  1    3    0    9321.4927  5886.9121  180.0   3.68167  0.07   
+  2  1    3    -1   6949.8120  4505.3267  0.0     3.66562  0.05   
+  2  1    -3   0    13988.5097 11675.3013 180.0   3.65766  0.09   
+  2  2    0    0    1.3528     2.5781     0.0     3.63776  0.00   
+  2  1    1    -2   5818.5735  4328.5159  0.0     3.50520  0.06   
+  2  2    2    -1   2553.2400  1650.0035  180.0   3.48122  0.01   
+  2  1    -3   -1   78.0944    12.1276    0.0     3.43616  0.00   
+  2  1    -1   -2   5427.6234  5251.4578  0.0     3.37264  0.06   
+  2  2    -2   -1   346.0304   364.8637   0.0     3.33313  0.00   
+  2  2    0    -2   22175.2387 26655.4799 -180.0  3.21484  0.15   
+  2  0    0    2    38980.4499 37071.8044 -180.0  3.19393  0.48   
+  2  0    4    0    26154.0059 25362.8195 180.0   3.18733  0.13   
+  2  2    2    0    16086.8365 13873.6743 180.0   3.16977  0.09   
+  2  2    -2   0    16483.6303 14946.6082 -180.0  3.14934  0.08   
+  2  1    -3   1    11765.3692 11175.2497 -180.0  2.96418  0.06   
+  2  2    2    -2   6634.1920  7187.5067  0.0     2.95504  0.03   
+  2  0    2    -2   5799.8786  5310.5610  0.0     2.93060  0.04   
+  2  0    4    -1   8151.7504  8585.7945  0.0     2.92677  0.03   
+  2  1    3    1    6236.6840  6897.0276  180.0   2.86133  0.04   
+  2  1    3    -2   1685.1360  1923.0466  -0.0    2.83885  0.01   
+  2  2    -2   -2   166.9524   183.4547   -0.0    2.79276  0.00   
+  2  0    2    2    180.4216   191.6414   0.0     2.78600  0.00   
+  2  0    4    1    353.8645   387.5360   -0.0    2.78271  0.00   
+  2  2    0    1    109.8515   109.5836   -0.0    2.68712  0.00   
+  2  3    1    -1   399.3014   431.0071   -180.0  2.66293  0.00   
+  2  1    -3   -2   6719.0914  6171.6319  -0.0    2.63839  0.04   
+  2  3    -1   -1   41.5985    33.5476    -180.0  2.62530  0.00   
+  2  2    4    -1   15867.5191 12550.4891 -180.0  2.55995  0.05   
+  2  3    1    -2   2433.3634  1812.0722  180.0   2.53704  0.01   
+  2  1    -1   2    1205.2696  667.2869   180.0   2.51139  0.01   
+  2  2    -2   1    2105.5635  1686.7859  -180.0  2.49495  0.01   
+  2  3    -1   -2   546.7046   451.5613   180.0   2.48043  0.00   
+  2  1    1    2    129.2951   110.2849   180.0   2.46610  0.00   
+  2  2    2    1    1594.5516  1367.0046  -180.0  2.45771  0.01   
+  2  2    -4   -1   11502.9103 10453.7459 -180.0  2.44277  0.03   
+  2  1    5    -1   4610.7195  4093.1663  -0.0    2.42941  0.01   
+  2  1    5    0    58.0510    64.0884    180.0   2.41202  0.00   
+  2  2    4    0    3644.1525  3944.1458  -0.0    2.40628  0.01   
+  2  1    -5   0    2134.4420  2230.8323  180.0   2.40074  0.01   
+  2  2    -4   0    2406.7775  2079.3222  -0.0    2.38844  0.01   
+  2  3    1    0    1882.7766  1565.2946  -0.0    2.38575  0.01   
+  2  3    -1   0    2343.8334  2090.0863  -0.0    2.37918  0.01   
+  2  2    0    -3   9.0569     7.3701     180.0   2.35133  0.00   
+  2  2    4    -2   3.0729     2.9331     0.0     2.34729  0.00   
+  2  1    1    -3   119.0629   110.8373   -0.0    2.33656  0.00   
+  2  0    4    -2   1309.8432  884.3144   -180.0  2.33087  0.00   
+  2  3    3    -1   19581.6420 9809.7794  180.0   2.31766  0.05   
+  2  1    -5   -1   2134.6567  1044.9800  0.0     2.31526  0.01   
+  2  1    -1   -3   2483.3500  2291.2470  -0.0    2.27750  0.01   
+  2  2    2    -3   178.5831   155.6865   -0.0    2.26146  0.00   
+  2  3    3    -2   19.6905    15.9172    0.0     2.25070  0.00   
+  2  3    -3   -1   3210.8535  2703.2457  -180.0  2.24518  0.01   
+  2  1    -3   2    840.2647   824.7896   -0.0    2.22556  0.00   
+  2  0    4    2    1853.5992  2085.0250  0.0     2.18812  0.01   
+  2  2    -4   -2   1272.5245  1431.8638  0.0     2.18799  0.00   
+  2  1    -5   1    3531.0165  4194.8986  180.0   2.18493  0.01   
+  2  2    -2   -3   1836.0978  1851.4932  0.0     2.15451  0.01   
+  2  1    5    -2   346.9346   312.7232   -180.0  2.15169  0.00   
+  2  3    1    -3   213.0550   204.6119   0.0     2.13824  0.00   
+  2  3    -3   -2   507.9092   512.1941   180.0   2.13724  0.00   
+  2  1    3    2    180.5985   174.4523   -180.0  2.13433  0.00   
+  2  0    0    3    485.7774   454.6548   -0.0    2.12929  0.00   
+  2  0    6    0    11395.4534 11042.6256 -0.0    2.12489  0.02   
+  2  1    3    -3   640.6103   674.2906   -180.0  2.11876  0.00   
+  2  1    5    1    4452.1473  4734.7647  180.0   2.11595  0.01   
+  2  3    3    0    1418.2327  1496.6439  -180.0  2.11318  0.00   
+  2  3    -3   0    109.5363   182.7827   -180.0  2.09956  0.00   
+  2  3    -1   -3   1307.9496  2416.5634  0.0     2.08973  0.00   
+  2  2    -4   1    7090.4797  8370.0925  180.0   2.07604  0.02   
+  2  0    2    -3   272.5174   286.8930   -180.0  2.05903  0.00   
+  2  0    6    -1   74.4241    83.9001    -0.0    2.05549  0.00   
+  2  2    4    1    1591.3879  2723.1302  180.0   2.03350  0.00   
+  2  4    0    -2   1234.0923  1673.8545  -0.0    2.01366  0.00   
+  2  1    -5   -2   786.1593   976.2191   -0.0    2.00557  0.00   
+  2  4    0    -1   3034.9590  3207.5402  -0.0    2.00025  0.01   
+  2  2    0    2    894.6601   914.6787   0.0     1.99827  0.00   
+  2  1    -3   -3   1824.8773  2006.9284  -0.0    1.99351  0.01   
+  2  0    2    3    1161.9305  1320.4879  0.0     1.98235  0.01   
+  2  0    6    1    4371.7988  4760.1395  0.0     1.97919  0.01   
+  2  3    -1   1    1527.2335  1778.1424  0.0     1.97162  0.00   
+  2  3    3    -3   589.4513   747.2487   -180.0  1.97003  0.00   
+  2  3    1    1    1135.4423  1049.8991  0.0     1.96352  0.00   
+  2  2    4    -3   228.5724   210.6125   -180.0  1.96339  0.00   
+  2  4    2    -2   1107.7087  1505.1300  0.0     1.94723  0.00   
+  2  2    -2   2    4246.7102  4434.5615  -0.0    1.92633  0.01   
+  2  4    2    -1   187.0874   195.3738   0.0     1.92397  0.00   
+  2  2    6    -1   23.6656    25.7092    -0.0    1.91781  0.00   
+  2  4    -2   -2   14873.2834 14612.2943 -0.0    1.89414  0.02   
+  2  4    -2   -1   85.0387    83.9894    180.0   1.89341  0.00   
+  2  3    5    -1   3189.5434  3253.1319  -180.0  1.88804  0.01   
+  2  2    2    2    11037.3030 11147.4650 -0.0    1.88782  0.03   
+  2  3    -3   -3   207.0590   242.1347   -0.0    1.86184  0.00   
+  2  3    5    -2   137.7655   151.7748   -180.0  1.86122  0.00   
+  2  4    0    -3   11478.0149 17227.6438 -180.0  1.84958  0.02   
+  2  2    -6   -1   652.8691   630.1904   -180.0  1.84310  0.00   
+  2  1    -5   2    35.0321    32.7906    -180.0  1.84286  0.00   
+  2  2    6    0    7959.0460  5973.8074  -0.0    1.84084  0.01   
+  2  2    6    -2   3844.7046  2234.4122  -180.0  1.83281  0.01   
+  2  1    -1   3    3674.0681  2403.8627  -180.0  1.82957  0.01   
+  2  2    -6   0    15315.5614 11170.3478 0.0     1.82883  0.02   
+  2  2    -4   -3   459.3325   351.5785   -0.0    1.82817  0.00   
+  2  0    4    -3   7430.2213  6600.1943  180.0   1.82454  0.02   
+  2  3    -5   -1   574.4002   547.0575   -180.0  1.82305  0.00   
+  2  0    6    -2   9834.3714  9376.7847  -180.0  1.82300  0.02   
+  2  4    0    0    16517.7909 16544.7345 -0.0    1.81888  0.03   
+  2  3    -3   1    1332.7013  1388.1619  -0.0    1.81269  0.00   
+  2  4    2    -3   1634.6228  1698.2109  -0.0    1.80678  0.00   
+  2  1    1    3    11028.9435 13204.6231 -180.0  1.80269  0.04   
+  2  3    3    1    433.2348   659.8672   -0.0    1.79396  0.00   
+  2  1    5    -3   26.2176    36.9138    180.0   1.79152  0.00   
+  2  1    7    -1   288.1544   370.2527   -180.0  1.78554  0.00   
+  2  2    0    -4   23499.8976 29304.7955 0.0     1.78457  0.07   
+  2  1    7    0    1666.1380  1186.7943  -0.0    1.76994  0.00   
+  2  3    5    0    543.7071   192.4714   -180.0  1.76391  0.00   
+  2  1    -7   0    5424.2417  1861.7091  0.0     1.76369  0.01   
+  2  1    5    2    5651.3574  1478.1411  -180.0  1.75728  0.01   
+  2  3    -5   -2   974.4470   292.8600   -180.0  1.75539  0.00   
+  2  2    2    -4   11657.1452 5374.4235  180.0   1.75260  0.03   
+  2  4    2    0    6996.6533  3240.2714  180.0   1.75255  0.01   
+  2  3    -5   0    1.2789     0.6787     -180.0  1.75073  0.00   
+  2  4    -2   -3   2343.4548  1498.9920  -180.0  1.74735  0.00   
+  2  4    -2   0    2212.8680  1478.3757  -180.0  1.74562  0.00   
+  2  4    4    -2   12135.7203 11156.5991 -180.0  1.74061  0.02   
+  2  3    1    -4   15.3201    11.6942    0.0     1.73791  0.00   
+  2  1    1    -4   1332.8395  931.5858   180.0   1.73044  0.00   
+  2  0    4    3    1734.0608  1649.4123  180.0   1.72108  0.00   
+  2  1    -7   -1   570.5367   544.5769   -0.0    1.72100  0.00   
+  2  2    -4   2    5287.4467  5111.9528  -180.0  1.72066  0.01   
+  2  0    6    2    4111.6571  4043.0244  180.0   1.71979  0.01   
+  2  2    -6   -2   5826.5371  5843.5104  180.0   1.71808  0.01   
+  2  1    -3   3    3869.5625  3889.7621  0.0     1.71755  0.01   
+  2  4    4    -1   3492.9789  3425.3612  -0.0    1.71605  0.00   
+  2  3    -1   -4   39.7616    26.3196    -0.0    1.70384  0.00   
+  2  3    5    -3   2522.9689  1781.5059  180.0   1.70048  0.00   
+  2  1    -1   -4   1640.1655  1087.2281  180.0   1.69839  0.01   
+  2  2    -2   -4   7119.0520  6607.2640  -0.0    1.68632  0.02   
+  2  2    -6   1    126.3669   111.8094   180.0   1.68403  0.00   
+  2  1    -7   1    1371.6243  1037.6002  0.0     1.67991  0.00   
+  2  1    7    -2   4279.8269  3014.1863  0.0     1.67337  0.01   
+  2  4    -4   -1   4399.4008  3113.5342  -0.0    1.67328  0.01   
+  2  1    -5   -3   363.7236   322.6770   -180.0  1.66739  0.00   
+  2  2    4    2    7687.5180  6980.1241  -180.0  1.66673  0.02   
+  2  4    -4   -2   3292.2727  2996.9232  -180.0  1.66656  0.00   
+  2  1    3    3    607.7874   605.4945   0.0     1.65314  0.00   
+  2  3    3    -4   491.2200   474.5918   180.0   1.65084  0.00   
+  2  2    6    1    15.6879    15.0623    180.0   1.64996  0.00   
+  2  4    4    -3   86.7576    81.5092    0.0     1.64497  0.00   
+  2  1    3    -4   1323.2953  1267.0308  -180.0  1.64299  0.00   
+  2  2    6    -3   385.3158   438.3802   0.0     1.63845  0.00   
+  2  1    7    1    862.6274   959.6711   0.0     1.63566  0.00   
+  2  5    1    -2   52.6144    62.3555    -180.0  1.62122  0.00   
+  2  2    4    -4   7.5658     6.6299     0.0     1.60885  0.00   
+  2  3    -1   2    268.2717   237.1891   -180.0  1.60779  0.00   
+  2  4    0    -4   28.8653    25.5451    0.0     1.60742  0.00   
+  2  5    -1   -2   122.5931   104.4782   -0.0    1.60481  0.00   
+  2  3    1    2    5.2627     3.3755     -180.0  1.59704  0.00   
+  2  0    0    4    2689.1823  1719.5025  -0.0    1.59697  0.01   
+  2  0    8    0    6784.0094  4104.7411  -0.0    1.59366  0.01   
+  2  3    -5   -3   7779.2131  7048.0684  -180.0  1.58673  0.01   
+  2  4    2    -4   5949.2017  5767.4424  -180.0  1.58523  0.01   
+  2  4    4    0    82.5773    80.5872    180.0   1.58489  0.00   
+  2  3    -5   1    3624.9969  3541.7994  0.0     1.57987  0.00   
+  2  1    -7   -2   123.9238   106.0592   180.0   1.57566  0.00   
+  2  4    -4   0    1116.1011  972.7791   180.0   1.57467  0.00   
+  2  4    0    1    1528.2845  1313.3627  0.0     1.57405  0.00   
+  2  0    2    -4   7882.8944  6835.8768  -180.0  1.57267  0.02   
+  2  5    1    -1   2086.3543  1838.8969  0.0     1.57223  0.00   
+  2  5    1    -3   4.7392     4.5305     0.0     1.57056  0.00   
+  2  0    8    -1   5072.2793  5105.5113  -180.0  1.56971  0.01   
+  2  3    -3   -4   206.3108   222.0271   -180.0  1.56739  0.00   
+  2  1    -3   -4   1107.9153  1168.3240  -180.0  1.56437  0.00   
+  2  5    -1   -1   3437.2388  3532.8589  -0.0    1.56314  0.00   
+  2  3    5    1    6106.3110  6630.5027  -0.0    1.55930  0.01   
+  2  2    0    3    1618.5273  1763.6711  -180.0  1.55911  0.00   
+  2  4    -4   -3   611.1001   668.2938   0.0     1.55805  0.00   
+  2  0    6    -3   51.0501    50.4752    180.0   1.55391  0.00   
+  2  5    -1   -3   3416.6073  3177.9812  180.0   1.54983  0.00   
+  2  5    3    -2   1815.6385  1684.3120  0.0     1.53962  0.00   
+  2  3    7    -1   366.5052   255.3064   -0.0    1.53554  0.00   
+  2  4    -2   -4   6897.0448  4566.3850  180.0   1.53333  0.01   
+  2  4    -2   1    555.3251   360.2122   -0.0    1.53138  0.00   
+  2  2    -2   3    5213.1945  3884.5431  0.0     1.52972  0.01   
+  2  1    -5   3    156.0408   114.2358   180.0   1.52775  0.00   
+  2  0    2    4    2635.1878  1999.2534  180.0   1.52655  0.01   
+  2  3    7    -2   1865.6482  1417.6951  180.0   1.52649  0.00   
+  2  4    2    1    74.8020    55.0425    -0.0    1.52494  0.00   
+  2  0    8    1    76.7777    53.4117    0.0     1.52385  0.00   
+  2  3    -3   2    1062.2291  713.5252   0.0     1.52351  0.00   
+  2  2    -6   -3   1471.4320  972.3599   180.0   1.52111  0.00   
+  2  1    -7   2    2828.4764  2092.8268  180.0   1.51406  0.00   
+  2  2    -4   -4   4183.2175  3475.0688  -180.0  1.51008  0.01   
+  2  2    8    -1   8880.1272  8932.7653  0.0     1.50687  0.01   
+  2  5    3    -3   11303.6354 11216.4371 -0.0    1.50125  0.01   
+  2  2    2    3    251.9261   261.4234   0.0     1.49966  0.00   
+  2  5    -3   -2   1246.0409  1283.3165  0.0     1.49852  0.00   
+  2  4    6    -2   1584.7864  1643.4734  -180.0  1.49804  0.00   
+  2  3    3    2    2649.9514  2828.3266  0.0     1.49651  0.00   
+  2  5    3    -1   1432.5529  1375.8687  180.0   1.49230  0.00   
+  2  1    7    -3   998.3490   963.7100   -0.0    1.49138  0.00   
+  2  3    5    -4   1003.3271  976.7543   0.0     1.48741  0.00   
+  2  3    -7   -1   4.4772     4.1505     -180.0  1.48641  0.00   
+  2  2    -6   2    2299.1588  2225.9899  -180.0  1.48209  0.00   
+  2  1    5    -4   547.7520   569.2303   -0.0    1.48061  0.00   
+  2  4    4    -4   1018.2803  936.8644   -0.0    1.47752  0.00   
+  2  4    6    -1   2690.0761  2425.3077  -0.0    1.47727  0.00   
+  2  2    8    -2   2619.6394  2036.6290  -0.0    1.46947  0.00   
+  2  5    -3   -1   2918.2114  2250.7625  180.0   1.46932  0.00   
+  2  0    4    -4   2243.9846  1799.2981  0.0     1.46530  0.00   
+  2  2    8    0    20520.2755 17372.8918 180.0   1.46378  0.02   
+  2  0    8    -2   3141.6761  2670.5014  0.0     1.46338  0.00   
+  2  3    7    0    1576.7859  1344.4772  -0.0    1.46164  0.00   
+  2  0    6    3    10269.0333 9727.2084  -180.0  1.45874  0.02   
+  2  2    -8   -1   303.3630   277.6153   0.0     1.45806  0.00   
+  2  2    -8   0    15975.5259 14971.6548 -180.0  1.45572  0.02   
+  2  1    5    3    87.5285    84.4701    0.0     1.45352  0.00   
+  2  3    -7   0    1805.1801  1874.7884  -0.0    1.45113  0.00   
+  2  5    -3   -3   3883.1925  3973.0050  -0.0    1.44873  0.00   
+  2  1    7    2    343.6355   339.6716   180.0   1.44736  0.00   
+  2  5    1    0    476.3633   468.7582   0.0     1.44694  0.00   
+  2  5    -1   0    282.9247   282.6566   0.0     1.44450  0.00   
+  2  3    -7   -2   410.3996   407.5222   -180.0  1.44435  0.00   
+  2  5    1    -4   378.8477   376.0669   -0.0    1.44434  0.00   
+  2  4    6    -3   5099.8858  4799.2632  180.0   1.44037  0.00   
+  2  3    7    -3   2321.3084  2066.9126  0.0     1.43858  0.00   
+  2  4    -6   -1   16301.5415 13974.0377 -0.0    1.43651  0.02   
+  2  1    -1   4    2141.1874  1747.7612  -0.0    1.43156  0.00   
+  2  2    6    2    16361.2346 14127.5120 -180.0  1.43067  0.03   
+  2  4    -6   -2   12390.8602 11494.7453 -180.0  1.42772  0.01   
+  2  3    1    -5   57.2510    54.5453    0.0     1.42498  0.00   
+  2  2    -4   3    9777.3889  9304.7725  -0.0    1.42492  0.01   
+  2  5    -1   -4   6660.8853  6191.0063  0.0     1.42367  0.01   
+  2  2    0    -5   568.4136   530.6717   -0.0    1.41970  0.00   
+  2  2    6    -4   4426.3625  4109.1661  -0.0    1.41942  0.01   
+  2  4    -4   1    2250.0101  2328.2327  -180.0  1.41643  0.00   
+  2  1    1    4    9636.7169  9765.5200  -0.0    1.41417  0.02   
+  2  2    2    -5   147.7943   102.1798   180.0   1.40774  0.00   
+  2  4    4    1    5517.5791  4251.1055  -180.0  1.40628  0.01   
+  2  1    9    -1   539.3824   313.3806   180.0   1.40427  0.00   
+  2  3    -1   -5   894.9104   559.2035   180.0   1.40173  0.00   
+  2  5    5    -2   177.0959   121.8591   180.0   1.39689  0.00   
+  2  4    -4   -4   481.8542   333.7965   -180.0  1.39638  0.00   
+  2  5    3    -4   11909.7857 10290.7248 -180.0  1.39407  0.01   
+  2  0    4    4    740.1695   603.2489   180.0   1.39300  0.00   
+  2  1    9    0    7525.7609  6061.3448  -180.0  1.39244  0.01   
+  2  0    8    2    930.2593   841.8614   -0.0    1.39135  0.00   
+  2  1    -7   -3   9.2506     8.6161     0.0     1.39082  0.00   
+  2  2    -8   -2   449.4119   389.1003   0.0     1.38958  0.00   
+  2  1    -9   0    5341.2445  5032.6219  -180.0  1.38852  0.00   
+  2  3    -5   -4   728.7941   712.8918   180.0   1.38828  0.00   
+  2  1    -5   -4   10.8938    12.2841    -0.0    1.38705  0.00   
+  2  4    6    0    6103.3672  6881.9956  0.0     1.38694  0.01   
+  2  2    -8   1    2132.0206  2583.5813  -0.0    1.38353  0.00   
+  2  3    -5   2    93.1746    107.7060   180.0   1.38139  0.00   
+  2  1    -3   4    9188.6018  11498.8556 180.0   1.38001  0.02   
+  2  3    3    -5   473.1903   601.2645   -0.0    1.37984  0.00   
+  2  5    3    0    1621.8316  2064.1961  180.0   1.37983  0.00   
+  2  2    4    3    5702.1855  7682.9819  -0.0    1.37735  0.01   
+  2  4    -6   0    2111.8483  2929.6322  0.0     1.37669  0.00   
+  2  5    -3   0    1290.4546  1846.9850  -180.0  1.37349  0.00   
+  2  4    0    -5   6922.6049  9852.1453  -0.0    1.37263  0.01   
+  2  5    5    -3   745.6649   1000.1841  -0.0    1.37203  0.00   
+  2  1    1    -5   63.2063    51.8333    180.0   1.36876  0.00   
+  2  2    8    -3   1373.3731  897.0709   0.0     1.36740  0.00   
+  2  2    -2   -5   1347.0783  890.9937   -180.0  1.36475  0.00   
+  2  1    -9   -1   3430.7986  2521.2414  180.0   1.36346  0.00   
+  2  4    2    -5   14136.0228 11335.5971 180.0   1.36264  0.02   
+  2  2    8    1    4224.4211  3611.9875  -180.0  1.35827  0.00   
+  2  5    5    -1   1053.4940  870.4892   -180.0  1.35737  0.00   
+  2  4    -6   -3   4373.8772  4126.3352  180.0   1.35385  0.00   
+  2  3    -7   1    623.9461   576.4772   0.0     1.35312  0.00   
+  2  1    9    -2   14529.6867 16147.0686 0.0     1.35152  0.01   
+  2  6    0    -2   14997.2011 16981.3924 180.0   1.35133  0.01   
+  2  1    -9   1    3338.9795  3741.5161  -0.0    1.35032  0.00   
+  2  1    -1   -5   9658.3435  10683.9602 -0.0    1.34891  0.02   
+  2  3    5    2    193.3569   209.3398   0.0     1.34817  0.00   
+  2  5    -5   -2   519.9820   568.7530   180.0   1.34647  0.00   
+  2  4    0    2    16506.9049 20266.7951 180.0   1.34356  0.02   
+  2  6    0    -3   384.4535   424.9852   0.0     1.34244  0.00   
+  2  3    -7   -3   916.9365   987.1236   180.0   1.34218  0.00   
+  2  5    -3   -4   18.6513    19.4544    -0.0    1.34037  0.00   
+  2  3    7    1    789.3033   545.2034   0.0     1.33504  0.00   
+  2  1    3    4    434.9781   303.9072   180.0   1.33473  0.00   
+  2  2    4    -5   2431.2064  2138.1647  -0.0    1.33359  0.00   
+  2  6    2    -2   7505.5497  7470.5514  0.0     1.33146  0.01   
+  2  3    -1   3    526.8931   551.6386   -0.0    1.32984  0.00   
+  2  5    -5   -1   2805.5805  3077.6343  -180.0  1.32879  0.00   
+  2  1    -7   3    750.3996   845.5145   -180.0  1.32789  0.00   
+  2  1    3    -5   11455.8474 12956.3684 180.0   1.32785  0.02   
+  2  4    6    -4   1038.3410  1219.1637  0.0     1.32754  0.00   
+  2  6    2    -3   5.1330     6.0091     -0.0    1.32656  0.00   
+  2  4    -2   -5   2829.8514  3146.4347  0.0     1.32203  0.00   
+  2  1    9    1    962.6676   1105.1306  -0.0    1.32057  0.00   
+  2  4    -2   2    1903.7006  2255.4357  0.0     1.32028  0.00   
+  2  3    1    3    2701.0331  3237.6008  0.0     1.32015  0.00   
+  2  2    -6   -4   93.1285    114.0134   0.0     1.31919  0.00   
+  2  3    -3   -5   1781.3581  2179.7868  180.0   1.31918  0.00   
+  2  0    6    -4   3034.6570  3685.3963  0.0     1.31717  0.00   
+  2  0    8    -3   3807.8551  4546.6333  -0.0    1.31636  0.00   
+  2  6    -2   -2   305.1190   330.6363   180.0   1.31265  0.00   
+  2  4    2    2    581.4175   505.4413   0.0     1.30914  0.00   
+  2  5    -5   -3   7043.6306  6208.9517  0.0     1.30653  0.01   
+  2  3    7    -4   15.4270    11.5530    -180.0  1.30602  0.00   
+  2  6    0    -1   1083.7063  635.2341   -0.0    1.30261  0.00   
+  2  6    -2   -3   7866.4996  4797.6968  0.0     1.30107  0.01   
+  2  1    7    -4   1374.0467  816.7390   180.0   1.30069  0.00   
+  2  4    4    -5   1380.2343  839.8412   -180.0  1.29576  0.00   
+  2  5    -1   1    941.8947   560.8179   -180.0  1.29287  0.00   
+  2  5    5    -4   162.7033   102.0732   -0.0    1.29210  0.00   
+  2  5    1    1    322.4145   213.0414   180.0   1.29128  0.00   
+  2  5    1    -5   1474.6531  1297.0866  -180.0  1.28850  0.00   
+  2  1    -9   -2   7676.5272  7594.2794  0.0     1.28440  0.01   
+  2  3    -3   3    3759.0297  3821.2749  180.0   1.28422  0.00   
+  2  2    -6   3    90.3300    97.9036    -0.0    1.28363  0.00   
+  2  3    5    -5   2851.3777  3037.5557  -0.0    1.28334  0.00   
+  2  6    2    -1   2480.1691  2446.8719  180.0   1.28151  0.00   
+  2  4    8    -2   15882.5509 16043.2073 -0.0    1.27998  0.01   
+  2  6    0    -4   4746.4607  4642.8182  0.0     1.27913  0.00   
+  2  1    -5   4    0.2808     0.2762     -0.0    1.27885  0.00   
+  2  0    0    5    1509.1878  1504.7953  0.0     1.27757  0.00   
+  2  2    -8   -3   1065.0823  969.8153   0.0     1.27578  0.00   
+  2  1    -3   -5   1809.7494  1649.0848  -180.0  1.27554  0.00   
+  2  0    10   0    6255.9573  5612.4673  -0.0    1.27493  0.01   
+  2  3    9    -1   703.6411   567.6734   180.0   1.27318  0.00   
+  2  3    9    -2   276.1022   209.3409   0.0     1.27118  0.00   
+  2  6    -2   -1   789.9871   604.9530   -180.0  1.27102  0.00   
+  2  5    -1   -5   3998.9177  3287.3648  -0.0    1.27057  0.00   
+  2  4    -6   1    2534.9507  2157.0193  180.0   1.27033  0.00   
+  2  2    0    4    5123.8636  5970.9564  -0.0    1.26862  0.01   
+  2  6    2    -4   2220.1810  2642.8907  -180.0  1.26852  0.00   
+  2  0    2    -5   3265.9525  4140.6925  180.0   1.26818  0.01   
+  2  2    -8   2    12072.1896 15669.9235 0.0     1.26800  0.01   
+  2  5    5    0    1176.9376  1539.1640  -0.0    1.26791  0.00   
+  2  0    10   -1   619.1467   722.1628   -180.0  1.26570  0.00   
+  2  4    8    -1   121.3910   116.1733   180.0   1.26381  0.00   
+  2  2    -4   -5   34.1349    34.2839    180.0   1.26302  0.00   
+  2  1    -9   2    406.0799   407.6104   0.0     1.26267  0.00   
+  2  6    4    -2   4272.9767  4060.9393  -0.0    1.26012  0.00   
+  2  1    7    3    1533.2638  1423.0605  -180.0  1.25993  0.00   
+  2  5    -5   0    1362.9484  1251.7915  -0.0    1.25974  0.00   
+  2  4    6    1    37.8273    35.4122    180.0   1.25938  0.00   
+  2  6    4    -3   6004.6300  5742.7030  -180.0  1.25904  0.00   
+  2  3    3    3    35.1147    34.1056    0.0     1.25855  0.00   
+  2  2    -2   4    2820.1382  2630.4316  180.0   1.25569  0.00   
+  2  5    3    -5   8490.4824  7849.9862  180.0   1.25548  0.01   
+  2  1    9    -3   500.4729   446.4585   -180.0  1.25310  0.00   
+  2  4    -4   2    3197.3930  2913.1494  0.0     1.24747  0.00   
+  2  4    8    -3   1611.8176  1591.0184  -180.0  1.24643  0.00   
+  2  5    -3   1    161.7634   154.1169   -180.0  1.24419  0.00   
+  2  4    -6   -4   4595.3782  4649.8078  0.0     1.24074  0.00   
+  2  1    5    -5   20.4717    20.8490    -0.0    1.24058  0.00   
+  2  6    -2   -4   113.8169   116.0421   -0.0    1.24022  0.00   
+  2  5    3    1    850.8972   865.0651   -180.0  1.23993  0.00   
+  2  0    6    4    4350.4515  4402.8269  -0.0    1.23960  0.01   
+  2  0    8    3    2539.8859  2523.8232  0.0     1.23892  0.00   
+  2  5    7    -2   47.3270    48.4702    -180.0  1.23815  0.00   
+  2  0    2    5    5.9269     6.1649     -0.0    1.23770  0.00   
+  2  3    -9   -1   1959.5731  1878.7146  -180.0  1.23697  0.00   
+  2  0    10   1    78.3571    69.0195    180.0   1.23540  0.00   
+  2  2    8    -4   0.7217     0.6712     -0.0    1.23509  0.00   
+  2  2    2    4    268.2740   202.3679   180.0   1.23305  0.00   
+  2  2    10   -1   828.4506   674.5837   -0.0    1.23266  0.00   
+  2  2    6    3    619.0189   591.5126   -0.0    1.23202  0.00   
+  2  4    -8   -1   1542.8697  1660.8265  180.0   1.22975  0.00   
+  2  4    4    2    6256.1503  7216.8110  -0.0    1.22886  0.01   
+  2  6    -4   -2   6378.6685  7429.0559  0.0     1.22874  0.00   
+  2  4    -4   -5   5099.9827  5935.8119  180.0   1.22833  0.01   
+  2  3    9    0    192.1309   207.1256   180.0   1.22722  0.00   
+  2  2    8    2    16694.6090 16367.8700 -0.0    1.22501  0.02   
+  2  3    -7   2    4.5360     4.4310     -180.0  1.22493  0.00   
+  2  5    7    -3   816.8430   701.3947   180.0   1.22357  0.00   
+  2  5    -5   -4   559.0196   527.2945   -180.0  1.22255  0.00   
+  2  2    6    -5   96.8221    93.3157    -0.0    1.22244  0.00   
+  2  3    9    -3   3837.4036  3989.5508  -0.0    1.22187  0.00   
+  2  4    -8   -2   14892.0157 15576.6760 0.0     1.22139  0.01   
+  2  1    5    4    2822.2926  2923.6151  -180.0  1.22003  0.00   
+  2  3    -9   0    63.5259    63.1939    -0.0    1.21922  0.00   
+  2  6    -4   -3   2.1064     1.6171     -180.0  1.21643  0.00   
+  2  6    4    -1   12.3782    10.2523    180.0   1.21473  0.00   
+  2  2    10   -2   3858.7846  3195.8904  -180.0  1.21471  0.00   
+  2  3    -7   -4   10.9976    9.5153     0.0     1.21279  0.00   
+  2  6    0    0    15108.2221 13100.2263 0.0     1.21259  0.01   
+  2  1    9    2    2017.8924  1749.7864  0.0     1.21259  0.00   
+  2  0    4    -5   59.2781    51.4047    -180.0  1.21258  0.00   
+  2  1    -7   -4   776.4372   673.8718   0.0     1.21254  0.00   
+  2  6    4    -4   222.1781   199.9465   0.0     1.21185  0.00   
+  2  0    10   -2   2669.4120  2393.1814  180.0   1.21068  0.00   
+  2  3    -9   -2   2.6770     2.4088     0.0     1.20966  0.00   
+  2  5    7    -1   1004.0305  919.5910   -0.0    1.20764  0.00   
+  2  5    -3   -5   1819.2091  1669.4106  -180.0  1.20756  0.00   
+  2  2    10   0    13.5604    11.8619    180.0   1.20601  0.00   
+  2  3    -5   -5   5758.4500  5223.5291  -0.0    1.20426  0.01   
+  2  4    8    0    2350.1538  2036.1638  -180.0  1.20314  0.00   
+  2  2    -10  0    1200.2991  1234.3417  180.0   1.20037  0.00   
+  2  2    -10  -1   1746.2988  1881.5821  0.0     1.19900  0.00   
+  2  2    -4   4    0.0038     0.0043     180.0   1.19841  0.00   
+  2  3    -5   3    4579.1833  5149.8089  -180.0  1.19827  0.00   
+  2  6    -4   -1   3471.2701  4013.4094  180.0   1.19705  0.00   
+  2  4    -8   0    1740.5693  1701.7086  -180.0  1.19422  0.00   
+  2  4    6    -5   5762.9090  5356.2972  -0.0    1.19366  0.01   
+  2  6    2    0    7991.9484  6359.8747  -180.0  1.19287  0.01   
+  2  3    1    -6   223.1199   172.0799   180.0   1.19278  0.00   
+  2  3    7    2    288.2946   210.6961   180.0   1.19262  0.00   
+  2  6    -2   0    2566.6814  1825.4606  -180.0  1.18959  0.00   
+  2  5    -7   -2   328.4722   235.2689   -180.0  1.18926  0.00   
+  2  5    5    -5   646.6713   652.0282   -0.0    1.18202  0.00   
+  2  6    0    -5   1883.5331  1859.8386  -0.0    1.18139  0.00   
+  2  5    -7   -1   1136.6432  1170.6276  -0.0    1.17956  0.00   
+  2  3    -1   -6   9439.6303  10651.6340 0.0     1.17652  0.01   
+  2  1    -9   -3   3002.0186  3479.3329  -0.0    1.17569  0.00   
+  2  4    0    -6   600.1953   694.8770   -180.0  1.17567  0.00   
+  2  6    2    -5   599.4071   690.4314   180.0   1.17553  0.00   
+  2  4    8    -4   4535.9469  5262.2410  180.0   1.17365  0.00   
+  2  1    -1   5    38.5355    44.3347    0.0     1.17349  0.00   
+  2  2    0    -6   3026.0804  3262.2227  -180.0  1.17258  0.01   
+  2  4    2    -6   722.7864   785.7923   0.0     1.17185  0.00   
+  2  4    -8   -3   466.3518   512.5086   -0.0    1.17167  0.00   
+  2  1    -5   -5   4893.3993  5414.4867  -180.0  1.17131  0.01   
+  2  3    3    -6   3291.1545  3178.6335  180.0   1.16840  0.00   
+  2  5    7    -4   6181.0861  5932.4007  0.0     1.16833  0.00   
+  2  2    2    -6   464.9924   444.4424   0.0     1.16828  0.00   
+  2  0    8    -4   6492.5768  6734.2463  -180.0  1.16544  0.01   
+  2  3    5    3    7837.3822  9033.3981  -180.0  1.16397  0.01   
+  2  6    -4   -4   1186.5544  1331.0105  -180.0  1.16381  0.00   
+  2  3    7    -5   1062.6968  1180.8749  180.0   1.16377  0.00   
+  2  3    -9   1    27.6779    24.5109    -0.0    1.16177  0.00   
+  2  1    1    5    2272.6272  1984.2370  0.0     1.16142  0.00   
+  2  2    -10  1    468.7988   408.7012   -180.0  1.16134  0.00   
+  2  0    4    5    4436.4687  3674.6390  -180.0  1.16082  0.01   
+  2  6    6    -3   741.7378   572.9928   0.0     1.16041  0.00   
+  2  5    -5   1    10.6604    8.2052     180.0   1.16017  0.00   
+  2  7    1    -3   417.1045   326.8856   180.0   1.15995  0.00   
+  2  2    4    4    424.8499   334.7388   180.0   1.15990  0.00   
+  2  0    10   2    2501.5691  1953.1670  -180.0  1.15916  0.00   
+  2  5    -7   -3   17.9682    13.9221    0.0     1.15905  0.00   
+  2  6    6    -2   1378.9679  1062.5954  180.0   1.15883  0.00   
+  2  2    -10  -2   1081.3257  927.1428   -180.0  1.15763  0.00   
+  2  2    10   -3   528.4451   456.9863   180.0   1.15752  0.00   
+  2  1    -7   4    8901.9560  7894.1741  -0.0    1.15699  0.01   
+  2  1    11   -1   181.4985   172.4013   -0.0    1.15488  0.00   
+  2  5    5    1    15.6363    14.5872    180.0   1.15443  0.00   
+  2  4    0    3    418.1234   372.8509   -0.0    1.15214  0.00   
+  2  7    -1   -3   211.1866   190.7937   -0.0    1.15103  0.00   
+  2  1    -9   3    432.3401   390.2848   -180.0  1.15086  0.00   
+  2  7    1    -2   513.2056   417.6649   180.0   1.14957  0.00   
+  2  6    -2   -5   3.5402     3.3422     180.0   1.14818  0.00   
+  2  2    -8   -4   1376.2944  1241.1393  -0.0    1.14713  0.00   
+  2  3    9    1    950.7162   840.9132   -180.0  1.14703  0.00   
+  2  1    -3   5    151.8280   131.0137   -0.0    1.14691  0.00   
+  2  4    -6   2    1088.3403  884.2580   -180.0  1.14653  0.00   
+  2  1    11   0    724.2876   673.8595   0.0     1.14593  0.00   
+  2  3    -9   -3   6191.9247  6842.7549  -0.0    1.14539  0.01   
+  2  1    -11  0    51.9631    56.5171    180.0   1.14326  0.00   
+  2  7    -1   -2   234.3334   258.5173   180.0   1.14319  0.00   
+  2  2    10   1    1816.0652  2221.3310  -180.0  1.14260  0.00   
+  2  2    -6   -5   6759.0852  8280.7099  -0.0    1.14253  0.01   
+  2  5    -1   2    0.2080     0.2523     -180.0  1.14237  0.00   
+  2  4    -2   -6   131.5406   159.9954   -0.0    1.14109  0.00   
+  2  5    7    0    1287.5413  1584.2307  0.0     1.14103  0.00   
+  2  3    9    -4   3181.0682  3452.1120  -180.0  1.13977  0.00   
+  2  4    -2   3    653.3735   675.3480   180.0   1.13965  0.00   
+  2  2    -8   3    951.3010   940.5804   180.0   1.13923  0.00   
+  2  5    1    2    142.1834   151.0052   180.0   1.13897  0.00   
+  2  2    -2   -6   397.0419   457.5743   180.0   1.13875  0.00   
+  2  5    1    -6   86.7901    92.8501    180.0   1.13644  0.00   
+  2  6    4    0    8621.3437  9886.1889  -180.0  1.13618  0.01   
+  2  1    9    -4   5247.9166  6387.1239  180.0   1.13575  0.00   
+  2  7    1    -4   88.5127    104.3489   0.0     1.13318  0.00   
+  2  5    -7   0    470.8872   561.3250   0.0     1.13270  0.00   
+  2  6    4    -5   2988.5689  3560.8356  -0.0    1.13225  0.00   
+  2  7    3    -3   1611.2767  1752.7599  180.0   1.13164  0.00   
+  2  1    7    -5   1759.3579  1876.4532  -0.0    1.13113  0.00   
+  2  4    4    -6   60.8384    74.0198    180.0   1.13073  0.00   
+  2  6    -4   0    6755.3548  8996.3605  -180.0  1.13052  0.01   
+  2  1    1    -6   9.2859     12.7255    180.0   1.13041  0.00   
+  2  4    2    3    21.7976    26.9687    0.0     1.12798  0.00   
+  2  1    11   -2   3282.4613  4054.5939  -180.0  1.12721  0.00   
+  2  2    4    -6   506.6028   617.9103   -180.0  1.12706  0.00   
+  2  1    -11  -1   65.9581    80.5660    180.0   1.12692  0.00   
+  2  0    6    -5   665.2204   825.3110   -0.0    1.12677  0.00   
+  2  0    10   -3   22.6508    25.1309    180.0   1.12560  0.00   
+  2  6    6    -4   1056.8877  1116.6065  -0.0    1.12535  0.00   
+  2  4    -8   1    1416.7681  1428.0735  -0.0    1.12500  0.00   
+  2  4    6    2    488.4370   491.6513   180.0   1.12497  0.00   
+  2  3    -3   -6   2639.0709  2679.1058  0.0     1.12421  0.00   
+  2  1    -11  1    528.4984   520.4388   180.0   1.12385  0.00   
+  2  3    -1   4    61.2739    62.3074    180.0   1.12290  0.00   
+  2  7    -1   -4   330.6752   340.7362   180.0   1.12266  0.00   
+  2  6    -6   -2   5.6882     5.8815     -0.0    1.12259  0.00   
+  2  5    -1   -6   3363.4938  3679.1020  -180.0  1.12188  0.00   
+  2  6    6    -1   22.4003    18.5196    -180.0  1.12105  0.00   
+  2  7    3    -2   427.6700   466.2613   -180.0  1.11981  0.00   
+  2  5    -5   -5   2861.4588  3254.1700  180.0   1.11710  0.00   
+  2  1    -1   -6   1419.4048  1573.1101  -180.0  1.11699  0.00   
+  2  4    -6   -5   12.9909    12.1624    -180.0  1.11621  0.00   
+  2  5    3    -6   4204.8458  3572.8767  0.0     1.11574  0.00   
+  2  3    1    4    671.4688   557.2568   180.0   1.11489  0.00   
+  2  4    8    1    3646.7294  3030.2470  -0.0    1.11486  0.00   
+  2  1    3    5    265.4056   208.8946   -180.0  1.11404  0.00   
+  2  2    -6   4    2381.5148  1626.0861  -0.0    1.11278  0.00   
+  2  6    -6   -3   12143.1838 9170.8262  180.0   1.11104  0.01   
+  2  5    -3   2    30.2197    23.9804    -180.0  1.11049  0.00   
+  2  3    5    -6   94.1108    75.3696    -0.0    1.11017  0.00   
+  2  1    3    -6   4376.7179  3749.4968  0.0     1.10915  0.01   
+  2  7    3    -4   987.2078   851.8273   -0.0    1.10885  0.00   
+  2  7    -3   -3   9.3055     8.0510     -0.0    1.10731  0.00   
+  2  7    1    -1   612.2508   540.2195   -180.0  1.10485  0.00   
+  2  6    0    1    3141.9409  2851.2916  180.0   1.10441  0.00   
+  2  1    11   1    381.7599   353.4958   0.0     1.10278  0.00   
+  2  7    -3   -2   8.0967     7.6618     -0.0    1.10240  0.00   
+  2  4    10   -2   318.9308   293.9448   -180.0  1.10139  0.00   
+  2  7    -1   -1   613.5236   560.8360   -180.0  1.10125  0.00   
+  2  5    3    2    101.5473   92.4856    -180.0  1.10119  0.00   
+  2  2    8    -5   4189.6011  3728.5603  180.0   1.10077  0.00   
+  2  6    -6   -1   6.8871     6.2337     0.0     1.10033  0.00   
+  2  5    -7   -4   144.2314   136.6182   0.0     1.09716  0.00   
+  2  3    -3   4    150.6037   143.6453   -0.0    1.09706  0.00   
+  2  1    7    4    56.7978    57.0295    -0.0    1.09661  0.00   
+  2  0    8    4    2875.0229  2959.2417  180.0   1.09406  0.00   
+  2  4    -8   -4   3565.3341  3685.4545  -180.0  1.09399  0.00   
+  2  4    -4   3    2120.0416  2186.7268  180.0   1.09385  0.00   
+  2  3    -7   3    1759.8358  1814.2931  0.0     1.09384  0.00   
+  2  1    9    3    299.3080   308.2223   180.0   1.09383  0.00   
+  2  2    -10  2    4.3520     3.3265     -0.0    1.09247  0.00   
+  2  2    8    3    483.8681   379.8198   0.0     1.09126  0.00   
+  2  5    9    -2   2351.5655  1582.6840  -0.0    1.09021  0.00   
+  2  4    10   -1   2.5041     1.7369     -180.0  1.08903  0.00   
+  2  6    -2   1    2.1966     1.5406     -180.0  1.08894  0.00   
+  2  1    -5   5    8011.6208  5646.2565  0.0     1.08884  0.01   
+  2  6    2    1    358.6465   245.3481   -0.0    1.08745  0.00   
+  2  2    -10  -3   899.8027   617.4947   180.0   1.08733  0.00   
+  2  5    7    -5   126.2835   91.0318    -180.0  1.08704  0.00   
+  2  6    -4   -5   466.0175   422.0173   180.0   1.08477  0.00   
+  2  3    -7   -5   2726.4398  3180.2930  0.0     1.08232  0.00   
+  2  5    9    -3   30.4607    37.0056    -180.0  1.08217  0.00   
+  2  4    10   -3   390.4136   496.5346   180.0   1.08176  0.00   
+  2  4    8    -5   367.3143   416.8216   0.0     1.08002  0.00   
+  2  7    -3   -4   419.2551   475.9937   -180.0  1.08002  0.00   
+  2  3    11   -2   985.1286   1209.7235  180.0   1.07973  0.00   
+  2  3    -9   2    892.2257   1162.0253  -0.0    1.07952  0.00   
+  2  1    -11  -2   377.0205   505.5742   -0.0    1.07909  0.00   
+  2  3    11   -1   1890.7155  2531.9784  -180.0  1.07901  0.00   
+  2  4    -4   -6   61.9086    79.4879    0.0     1.07725  0.00   
+  2  7    3    -1   318.5904   517.9063   0.0     1.07642  0.00   
+  2  7    1    -5   15.0558    25.2106    -0.0    1.07626  0.00   
+  2  5    -3   -6   804.4223   1371.1187  180.0   1.07586  0.00   
+  2  2    10   -4   1669.3471  2842.5457  0.0     1.07584  0.00   
+  2  2    -4   -6   112.1364   186.5753   0.0     1.07568  0.00   
+  2  3    3    4    362.8170   560.4316   180.0   1.07511  0.00   
+  2  1    -11  2    360.1701   558.2780   -180.0  1.07370  0.00   
+  2  7    5    -3   620.6600   928.6481   180.0   1.07351  0.00   
+  2  4    4    3    549.1710   818.8776   180.0   1.07348  0.00   
+  2  1    -3   -6   98.2039    135.6225   180.0   1.07233  0.00   
+  2  6    0    -6   2.8435     4.1780     -180.0  1.07161  0.00   
+  2  1    11   -3   393.8452   540.3856   180.0   1.07008  0.00   
+  2  6    2    -6   80.7781    107.8329   0.0     1.06912  0.00   
+  2  6    -6   -4   475.8559   552.9788   0.0     1.06862  0.00   
+  2  5    9    -1   800.5536   1026.4794  0.0     1.06732  0.00   
+  2  2    6    4    3313.3656  4143.5979  0.0     1.06716  0.01   
+  2  7    -3   -1   155.3972   173.9010   0.0     1.06652  0.00   
+  2  2    0    5    1650.3373  1937.9253  0.0     1.06580  0.00   
+  2  0    6    5    296.1133   358.8678   0.0     1.06561  0.00   
+  2  7    -1   -5   2684.2655  3288.8085  0.0     1.06535  0.00   
+  2  5    5    -6   375.9320   447.2840   -180.0  1.06509  0.00   
+  2  0    0    6    45.1420    53.4823    180.0   1.06464  0.00   
+  2  0    10   3    2761.8336  3276.3246  0.0     1.06463  0.00   
+  2  4    6    -6   29.4393    31.3322    -180.0  1.06282  0.00   
+  2  6    6    -5   410.2379   434.3157   -0.0    1.06260  0.00   
+  2  0    12   0    106.3979   112.6819   180.0   1.06244  0.00   
+  2  4    -10  -1   1054.9776  1132.6677  180.0   1.06171  0.00   
+  2  7    5    -2   4175.8964  4496.3914  -180.0  1.06153  0.00   
+  2  0    2    -6   681.2577   748.1993   0.0     1.06104  0.00   
+  2  5    -7   1    916.4291   969.1237   180.0   1.06052  0.00   
+  2  1    -9   -4   1637.1616  1706.8793  -180.0  1.06015  0.00   
+  2  2    -2   5    3087.3664  3313.4198  -180.0  1.05994  0.01   
+  2  3    -9   -4   12.6963    13.6703    -180.0  1.05993  0.00   
+  2  2    6    -6   247.6101   288.6216   -180.0  1.05938  0.00   
+  2  0    12   -1   1067.4219  1340.4500  -0.0    1.05892  0.00   
+  2  1    -7   -5   6.2929     7.5059     -180.0  1.05860  0.00   
+  2  1    5    -6   39.9127    47.4061    -180.0  1.05858  0.00   
+  2  2    10   2    1253.2663  1237.1699  -0.0    1.05797  0.00   
+  2  3    7    3    12.7311    12.9031    -180.0  1.05758  0.00   
+  2  7    3    -5   2083.0579  2239.1302  -180.0  1.05718  0.00   
+  2  6    6    0    433.2552   461.7745   -0.0    1.05659  0.00   
+  2  7    5    -4   2222.7751  2051.4003  0.0     1.05581  0.00   
+  2  4    -10  -2   3205.0577  3145.7849  0.0     1.05450  0.00   
+  2  5    7    1    38.1821    37.2884    180.0   1.05440  0.00   
+  2  6    8    -3   9795.7243  8866.7538  -0.0    1.05196  0.01   
+  2  3    -11  -1   287.3913   261.5320   -0.0    1.05193  0.00   
+  2  5    -5   2    5342.5696  5387.0808  -180.0  1.05131  0.01   
+  2  3    9    2    862.9496   862.2832   -0.0    1.05108  0.00   
+  2  3    11   -3   697.3870   673.7850   180.0   1.05082  0.00   
+  2  6    -6   0    518.5984   488.9045   -0.0    1.04978  0.00   
+  2  6    8    -2   353.4278   331.3808   0.0     1.04899  0.00   
+  2  3    11   0    439.2946   407.0557   -0.0    1.04881  0.00   
+  2  3    -5   -6   1341.4814  1235.7557  -180.0  1.04872  0.00   
+  2  4    10   0    66.9200    61.4161    -0.0    1.04771  0.00   
+  2  5    -9   -2   2409.4682  2208.3085  -0.0    1.04729  0.00   
+  2  5    9    -4   242.5564   228.7958   -180.0  1.04516  0.00   
+  2  6    -2   -6   1398.0926  1293.5044  -0.0    1.04487  0.00   
+  2  6    -4   1    3420.0068  3160.5795  -0.0    1.04485  0.00   
+  2  3    -5   4    2719.3288  2301.6767  -0.0    1.04377  0.00   
+  2  3    9    -5   2140.8719  1817.7670  180.0   1.04328  0.00   
+  2  1    5    5    1861.6781  1623.2967  -0.0    1.04294  0.00   
+  2  3    -11  0    1594.5279  1387.3612  0.0     1.04270  0.00   
+  2  2    2    5    303.9364   264.3036   0.0     1.04269  0.00   
+  2  5    -9   -1   73.5561    62.5557    0.0     1.04240  0.00   
+  2  6    4    1    1214.6882  1021.8291  -0.0    1.04223  0.00   
+  2  4    -10  0    610.2630   554.7785   -0.0    1.04034  0.00   
+  2  2    12   -1   4174.3018  3828.0670  -180.0  1.03971  0.00   
+  2  0    2    6    1599.4597  1492.8101  0.0     1.03949  0.00   
+  2  7    -5   -3   3745.5270  3517.5593  180.0   1.03943  0.00   
+  2  5    5    2    3980.1369  4324.4718  -180.0  1.03825  0.01   
+  2  4    -8   2    271.1930   298.1823   -0.0    1.03802  0.00   
+  2  6    4    -6   1136.6951  1251.2761  -180.0  1.03798  0.00   
+  2  0    12   1    294.6931   335.8693   -0.0    1.03750  0.00   
+  2  7    -5   -2   1230.9087  1492.9651  -180.0  1.03709  0.00   
+  2  7    1    0    952.8698   1264.8986  -0.0    1.03656  0.00   
+  2  1    -9   4    1.8565     2.8086     180.0   1.03594  0.00   
+  2  1    11   2    1095.5154  1702.3367  180.0   1.03580  0.00   
+  2  7    -1   0    1158.3636  1823.6465  -0.0    1.03529  0.00   
+  2  4    10   -4   5.7160     9.1218     0.0     1.03486  0.00   
+  2  3    -11  -2   814.0545   1522.0493  -180.0  1.03326  0.00   
+  3  1    1    0    1334.1960  1271.9616  -0.0    3.25118  0.03   
+  3  1    0    1    573.8927   492.3083   -0.0    2.48932  0.01   
+  3  2    0    0    293.4264   149.3026   -0.0    2.29893  0.00   
+  3  1    1    1    331.6865   374.9555   180.0   2.18908  0.01   
+  3  2    1    0    137.0637   152.7665   0.0     2.05623  0.00   
+  3  2    1    1    960.7703   880.2245   -0.0    1.68889  0.02   
+  3  2    2    0    956.8227   1142.9561  -0.0    1.62559  0.01   
+  3  0    0    2    1397.0015  1418.4370  -0.0    1.48040  0.00   
+  3  3    1    0    375.2406   356.7420   -0.0    1.45397  0.00   
+  3  2    2    1    29.8338    28.2349    180.0   1.42495  0.00   
+  3  3    0    1    1273.6201  1055.2044  -0.0    1.36108  0.01   
+  3  1    1    2    510.6420   541.7155   -0.0    1.34730  0.00   
+  3  3    1    1    47.0334    32.7482    0.0     1.30510  0.00   
+  3  3    2    0    16.6550    15.0214    180.0   1.27522  0.00   
+  3  2    0    2    151.0387   145.3475   -0.0    1.24466  0.00   
+  3  2    1    2    44.9276    42.1752    0.0     1.20142  0.00   
+  3  3    2    1    142.6309   154.4876   -0.0    1.17121  0.00   
+  3  4    0    0    513.4055   422.1172   -0.0    1.14947  0.00   
+  3  4    1    0    94.2206    78.6710    180.0   1.11515  0.00   
+  3  2    2    2    588.8972   562.7287   -0.0    1.09454  0.00   
+  3  3    3    0    557.2875   592.2106   -0.0    1.08373  0.00   
+  3  4    1    1    319.7452   271.7076   -0.0    1.04358  0.00   
+  3  3    1    2    189.2126   220.8531   -0.0    1.03733  0.00   
+  4  1    1    0    8901.7804  5230.9801  0.0     5.76584  0.01   
+  4  1    1    -1   2315.8541  1404.6704  0.0     5.75322  0.00   
+  4  0    0    2    11353.3689 6634.3195  0.0     5.70106  0.00   
+  4  2    0    0    1177.2941  777.5840   180.0   5.30365  0.00   
+  4  2    0    -2   15375.6028 11505.0663 0.0     5.26468  0.01   
+  4  1    1    1    5400.3099  5911.9602  -180.0  4.69678  0.00   
+  4  1    1    -2   415.8960   470.8719   -180.0  4.67639  0.00   
+  4  1    1    2    1479.7888  1807.6343  -180.0  3.62818  0.00   
+  4  1    1    -3   5874.3556  6211.2421  180.0   3.61251  0.00   
+  4  0    2    0    8582.1911  1738.6637  180.0   3.43465  0.00   
+  4  3    1    -1   2419.7228  1015.4506  -0.0    3.40613  0.00   
+  4  3    1    -2   6152.3886  3188.3766  180.0   3.39833  0.00   
+  4  0    2    1    4386.8050  5008.4817  -0.0    3.28869  0.00   
+  4  2    0    2    10310.5845 11585.3666 -0.0    3.21816  0.00   
+  4  2    0    -4   5047.4572  4995.9553  180.0   3.19207  0.00   
+  4  3    1    0    2378.7213  2137.7205  0.0     3.14376  0.00   
+  4  3    1    -3   2907.8642  2675.3550  180.0   3.12546  0.00   
+  4  4    0    -2   89183.5889 80910.5503 180.0   2.98152  0.01   
+  4  2    2    -1   86031.3825 75056.7102 -0.0    2.97625  0.02   
+  4  0    2    2    811.7833   793.0397   0.0     2.94199  0.00   
+  4  2    2    0    1049.8273  1809.9835  0.0     2.88292  0.00   
+  4  2    2    -2   354.5790   529.5161   -0.0    2.87661  0.00   
+  4  1    1    3    2084.3808  2484.3500  -0.0    2.86316  0.00   
+  4  1    1    -4   5034.4975  5797.7013  -0.0    2.85237  0.00   
+  4  0    0    4    8969.0157  10329.0263 -0.0    2.85053  0.00   
+  4  3    1    1    3533.1388  3753.2275  -180.0  2.75709  0.00   
+  4  3    1    -4   2801.6188  3262.1954  -0.0    2.73656  0.00   
+  4  4    0    0    75454.7838 71041.9911 0.0     2.65183  0.01   
+  4  2    2    1    147196.8728 133022.1773 0.0     2.64322  0.03   
+  4  2    2    -3   74514.0922 66277.1922 -180.0  2.63352  0.01   
+  4  4    0    -4   158893.4581 140508.8148 180.0   2.63234  0.01   
+  4  0    2    3    18236.6407 14181.7572 180.0   2.54828  0.00   
+  4  3    1    2    10014.4897 9772.1059  -180.0  2.37485  0.00   
+  4  3    1    -5   6204.5627  5858.2101  -0.0    2.35649  0.00   
+  4  2    2    2    161.6583   143.8182   -180.0  2.34839  0.00   
+  4  2    2    -4   1012.3875  881.4346   180.0   2.33820  0.00   
+  4  1    1    4    3638.5725  2963.5205  -0.0    2.33515  0.00   
+  4  1    1    -5   461.4799   299.5633   -0.0    2.32762  0.00   
+  4  4    2    -2   1693.9113  1408.0652  -0.0    2.25154  0.00   
+  4  5    1    -2   2468.8533  2123.3090  180.0   2.24419  0.00   
+  4  5    1    -3   601.5468   539.1542   180.0   2.24047  0.00   
+  4  1    3    0    57.2455    52.5027    0.0     2.23821  0.00   
+  4  1    3    -1   4533.0633  4186.2462  -0.0    2.23747  0.00   
+  4  4    2    -1   899.5071   918.5298   0.0     2.21174  0.00   
+  4  4    2    -3   12043.4937 13298.4938 -0.0    2.20604  0.00   
+  4  0    2    4    824.5510   966.9500   180.0   2.19350  0.00   
+  4  5    1    -1   10015.9840 11520.4080 -0.0    2.16535  0.00   
+  4  1    3    1    1007.7397  1032.3941  -0.0    2.15732  0.00   
+  4  1    3    -2   11109.3106 10975.5516 0.0     2.15533  0.00   
+  4  5    1    -4   718.0625   709.7605   -180.0  2.15536  0.00   
+  4  2    0    4    1698.6268  1630.7411  0.0     2.13639  0.00   
+  4  2    0    -6   7105.4566  7201.1177  0.0     2.12363  0.00   
+  4  4    2    0    491.4653   728.5144   -180.0  2.09901  0.00   
+  4  4    2    -4   366.4721   548.6325   -180.0  2.08931  0.00   
+  4  4    0    2    272101.4556 285741.4893 180.0   2.06969  0.01   
+  4  2    2    3    283593.4331 292787.7239 0.0     2.06326  0.03   
+  4  2    2    -5   261055.1180 297019.9126 0.0     2.05405  0.03   
+  4  4    0    -6   259643.2256 302016.1855 -180.0  2.05120  0.01   
+  4  3    1    3    906.9078   1081.1190  -180.0  2.04788  0.00   
+  4  3    1    -6   100.2043   154.6340   -0.0    2.03274  0.00   
+  4  5    1    0    487.7035   771.0005   180.0   2.02700  0.00   
+  4  1    3    2    9532.4932  14027.7789 -0.0    2.01823  0.00   
+  4  1    3    -3   877.5958   1239.3116  -0.0    2.01552  0.00   
+  4  5    1    -5   10294.4162 14151.2165 -0.0    2.01339  0.00   
+  4  3    3    -1   6270.5844  7028.4965  -0.0    1.97746  0.00   
+  4  3    3    -2   168.2668   188.2835   0.0     1.97593  0.00   
+  4  1    1    5    4704.0115  4612.1293  180.0   1.96050  0.00   
+  4  6    0    -2   988.5318   970.6743   180.0   1.96113  0.00   
+  4  1    1    -6   1454.7640  1560.3950  -0.0    1.95505  0.00   
+  4  6    0    -4   16159.2833 17257.5959 -180.0  1.95518  0.00   
+  4  4    2    1    16682.5780 20965.9734 -0.0    1.94293  0.00   
+  4  4    2    -5   65.1600    70.9153    180.0   1.93141  0.00   
+  4  3    3    0    9089.5197  9843.5896  180.0   1.92195  0.00   
+  4  3    3    -3   2526.4448  2771.1302  -0.0    1.91774  0.00   
+  4  0    0    6    1602.4146  1705.1365  -0.0    1.90035  0.00   
+  4  0    2    5    85.5763    90.1372    -180.0  1.89981  0.00   
+  4  5    1    1    2408.6767  2501.1033  -180.0  1.86056  0.00   
+  4  1    3    3    2945.3718  3425.4494  0.0     1.85210  0.00   
+  4  1    3    -4   422.3063   509.1035   -180.0  1.84917  0.00   
+  4  5    1    -6   2641.8126  2896.6648  -180.0  1.84586  0.00   
+  4  3    3    1    3691.9521  3298.1879  -0.0    1.82244  0.00   
+  4  3    3    -4   15622.5130 15083.2702 -180.0  1.81647  0.00   
+  4  2    2    4    2020.2816  2004.7601  180.0   1.81409  0.00   
+  4  2    2    -6   106.1499   110.8462   -0.0    1.80626  0.00   
+  4  3    1    4    1090.1152  1170.9069  -0.0    1.78183  0.00   
+  4  4    2    2    734.4924   570.0027   -0.0    1.77271  0.00   
+  4  3    1    -7   1145.4003  720.6469   -180.0  1.76963  0.00   
+  4  6    0    0    60810.7365 33117.2582 180.0   1.76788  0.00   
+  4  4    2    -6   3809.2767  1198.1600  -0.0    1.76106  0.00   
+  4  6    0    -6   5.6554     2.0510     0.0     1.75489  0.00   
+  4  6    2    -3   419846.4104 370038.4229 -180.0  1.72037  0.03   
+  4  0    4    0    389637.2899 349197.4003 -180.0  1.71733  0.01   
+  4  6    2    -2   572.2204   389.6517   -0.0    1.70307  0.00   
+  4  6    2    -4   2259.8535  1559.8102  180.0   1.69917  0.00   
+  4  0    4    1    4743.8186  3261.1281  -0.0    1.69817  0.00   
+  4  3    3    2    5243.3467  3601.8680  -0.0    1.69798  0.00   
+  4  3    3    -5   13582.3751 10536.8117 0.0     1.69123  0.00   
+  4  5    1    2    3266.2867  2567.1386  -180.0  1.69091  0.00   
+  4  1    1    6    877.6322   741.7350   -0.0    1.68468  0.00   
+  4  1    3    4    54.6404    44.9703    -0.0    1.68329  0.00   
+  4  1    1    -7   16038.6048 12420.3292 -180.0  1.68059  0.00   
+  4  1    3    -5   6063.4900  4681.6764  0.0     1.68046  0.00   
+  4  5    1    -7   368.1094   265.7581   -180.0  1.67673  0.00   
+  4  0    2    6    1077.5844  1003.5888  0.0     1.66280  0.00   
+  4  2    4    -1   2937.4525  2846.0747  180.0   1.65025  0.00   
+  4  6    2    -1   893.1706   865.8969   -180.0  1.65056  0.00   
+  4  7    1    -3   36.6213    35.4867    180.0   1.65033  0.00   
+  4  5    3    -2   347.8877   336.9162   -180.0  1.64825  0.00   
+  4  7    1    -4   575.6921   557.5403   -0.0    1.64826  0.00   
+  4  5    3    -3   1278.2257  1233.5025  -180.0  1.64677  0.00   
+  4  0    4    2    634.2501   612.1127   -180.0  1.64434  0.00   
+  4  6    2    -5   520.7166   505.2539   -180.0  1.64348  0.00   
+  4  2    4    0    700.9425   754.1348   -0.0    1.63381  0.00   
+  4  2    4    -2   4148.0449  4465.8494  180.0   1.63266  0.00   
+  4  7    1    -2   3283.4949  3571.4802  180.0   1.61877  0.00   
+  4  5    3    -1   927.4004   967.1505   0.0     1.61624  0.00   
+  4  7    1    -5   942.5880   916.8984   -0.0    1.61292  0.00   
+  4  5    3    -4   4032.7979  3836.8577  -180.0  1.61207  0.00   
+  4  4    0    4    71771.0133 64364.2002 180.0   1.60908  0.00   
+  4  4    2    3    31.1188    27.4398    180.0   1.60765  0.00   
+  4  2    2    5    43884.8411 37127.6016 -180.0  1.60496  0.00   
+  4  2    2    -7   94794.3405 66511.2896 0.0     1.59845  0.01   
+  4  4    2    -7   3860.7317  2580.8493  -0.0    1.59679  0.00   
+  4  4    0    -8   56267.4239 36927.3328 0.0     1.59604  0.00   
+  4  2    4    1    2223.6817  1926.4611  0.0     1.58623  0.00   
+  4  2    4    -3   2005.5685  1878.0675  0.0     1.58413  0.00   
+  4  2    0    6    32451.0384 28885.1715 -0.0    1.57490  0.00   
+  4  6    2    0    345.5868   317.4281   -0.0    1.57188  0.00   
+  4  2    0    -8   4913.3916  4971.2983  -180.0  1.56773  0.00   
+  4  3    1    5    1717.5987  1737.9254  180.0   1.56773  0.00   
+  4  3    3    3    473.6775   485.0009   0.0     1.56559  0.00   
+  4  0    4    3    2848.1001  2917.1059  -0.0    1.56499  0.00   
+  4  6    2    -6   1216.3660  1247.1099  -180.0  1.56273  0.00   
+  4  3    3    -6   1445.6006  1492.8885  -180.0  1.55880  0.00   
+  4  3    1    -8   1809.7244  1857.3102  0.0     1.55790  0.00   
+  4  7    1    -1   1976.6180  2042.4001  -0.0    1.55896  0.00   
+  4  5    3    0    3764.2581  3764.8648  180.0   1.55620  0.00   
+  4  7    1    -6   4128.4910  3784.2912  -180.0  1.55028  0.00   
+  4  5    3    -5   1534.7364  1407.6591  0.0     1.55002  0.00   
+  4  5    1    3    1120.2479  786.8987   0.0     1.53211  0.00   
+  4  1    3    5    10.1177    7.3898     -180.0  1.52550  0.00   
+  4  1    3    -6   1669.5493  1155.7827  0.0     1.52293  0.00   
+  4  5    1    -8   7.8343     5.3759     0.0     1.51922  0.00   
+  4  2    4    2    5831.1410  4259.2701  180.0   1.51510  0.00   
+  4  2    4    -4   3172.0352  2489.5300  -0.0    1.51235  0.00   
+  4  6    0    2    9313.4141  8929.2480  -180.0  1.50509  0.00   
+  4  6    0    -8   4563.8228  4381.9848  -180.0  1.49176  0.00   
+  4  8    0    -4   21170.0301 20096.2166 0.0     1.49076  0.00   
+  4  4    4    -2   21979.6561 20517.7233 -0.0    1.48812  0.00   
+  4  7    1    0    550.4952   522.1602   0.0     1.47975  0.00   
+  4  6    2    1    554.0119   505.4373   180.0   1.47800  0.00   
+  4  5    3    1    1663.1476  1470.7859  180.0   1.47697  0.00   
+  4  4    4    -1   207.2902   180.6208   180.0   1.47646  0.00   
+  4  1    1    7    10982.3968 9073.7519  -0.0    1.47458  0.00   
+  4  4    4    -3   2010.5814  1670.1267  180.0   1.47476  0.00   
+  4  1    1    -8   9496.5506  7391.2827  0.0     1.47142  0.00   
+  4  0    2    7    3191.6584  2499.6018  180.0   1.47175  0.00   
+  4  0    4    4    756.0358   585.1247   180.0   1.47100  0.00   
+  4  5    3    -6   0.2318     0.1795     -180.0  1.46958  0.00   
+  4  7    1    -7   299.0160   231.8398   -180.0  1.46938  0.00   
+  4  6    2    -7   1373.4839  1079.4025  180.0   1.46787  0.00   
+  4  4    2    4    338.2100   309.0628   -180.0  1.45711  0.00   
+  4  4    2    -8   307.7954   302.4845   -180.0  1.44740  0.00   
+  4  8    0    -2   53427.9027 52301.5540 0.0     1.44545  0.00   
+  4  4    4    0    42921.7105 40431.8829 -180.0  1.44146  0.00   
+  4  8    0    -6   43706.7771 39499.2643 -180.0  1.43911  0.00   
+  4  4    4    -4   60928.1627 54152.0299 0.0     1.43831  0.00   
+  4  3    3    4    5353.0591  4620.7657  -180.0  1.43665  0.00   
+  4  2    2    6    0.9690     0.8056     -180.0  1.43158  0.00   
+  4  3    3    -7   1716.8497  1448.7970  0.0     1.43023  0.00   
+  4  2    4    3    3187.6185  2700.7215  180.0   1.42973  0.00   
+  4  2    2    -8   1989.0658  1819.8832  -0.0    1.42619  0.00   
+  4  2    4    -5   1840.3395  1673.3904  180.0   1.42665  0.00   
+  4  0    0    8    289630.4012 266539.2379 -0.0    1.42526  0.01   
+  4  3    1    6    1178.9703  937.8761   180.0   1.39460  0.00   
+  4  5    1    4    846.0027   766.4026   0.0     1.38990  0.00   
+  4  7    1    1    56.0186    50.2105    -180.0  1.39036  0.00   
+  4  3    1    -9   682.7487   707.0497   -0.0    1.38661  0.00   
+  4  4    4    1    3668.2072  3625.7059  -0.0    1.38781  0.00   
+  4  5    3    2    445.8577   442.9769   -180.0  1.38770  0.00   
+  4  1    3    6    2862.5623  3149.1806  0.0     1.38425  0.00   
+  4  4    4    -5   1091.0110  1224.9425  0.0     1.38359  0.00   
+  4  1    3    -7   421.1838   485.7509   -180.0  1.38198  0.00   
+  4  5    3    -7   898.8470   1075.5006  180.0   1.37983  0.00   
+  4  7    1    -8   190.8088   231.2862   0.0     1.37932  0.00   
+  4  5    1    -9   2565.7551  3159.9602  -0.0    1.37851  0.00   
+  4  6    2    2    207.5878   255.5312   -180.0  1.37854  0.00   
+  4  0    4    5    323.2811   361.2702   -180.0  1.37183  0.00   
+  4  6    2    -8   3.5837     2.8619     0.0     1.36828  0.00   
+  4  8    2    -4   979.5381   738.9032   180.0   1.36751  0.00   
+  4  7    3    -3   4402.7365  3199.1281  -180.0  1.36501  0.00   
+  4  7    3    -4   614.0930   462.5993   -180.0  1.36383  0.00   
+  4  1    5    0    5492.0879  4377.5663  -180.0  1.36248  0.00   
+  4  1    5    -1   71.7019    57.4866    -0.0    1.36231  0.00   
+  4  8    2    -3   2287.8677  1922.5602  180.0   1.35910  0.00   
+  4  8    2    -5   16188.3504 14150.5569 180.0   1.35646  0.00   
+  4  7    3    -2   6700.4195  6974.2207  0.0     1.34698  0.00   
+  4  1    5    1    7073.1475  7447.5757  0.0     1.34359  0.00   
+  4  7    3    -5   2271.3569  2391.3241  180.0   1.34361  0.00   
+  4  1    5    -2   2666.5087  2805.7617  180.0   1.34311  0.00   
+  4  2    4    4    244.1891   204.8439   -180.0  1.33849  0.00   
+  4  2    4    -6   5315.8777  4277.5018  180.0   1.33534  0.00   
+  4  8    2    -2   209.6330   192.2543   0.0     1.33228  0.00   
+  4  8    2    -6   106.7389   116.6868   0.0     1.32731  0.00   
+  4  8    0    0    115156.4622 126661.5899 0.0     1.32591  0.00   
+  4  4    2    5    11589.4105 12808.5293 0.0     1.32400  0.00   
+  4  4    4    2    103063.5033 113941.9059 0.0     1.32161  0.00   
+  4  0    2    8    328.3465   368.2075   180.0   1.31642  0.00   
+  4  4    4    -6   107083.9061 120729.4823 0.0     1.31676  0.00   
+  4  3    3    5    1099.7247  1245.5389  -0.0    1.31715  0.00   
+  4  4    2    -9   5012.1830  5522.7067  180.0   1.31550  0.00   
+  4  8    0    -8   124620.7451 139112.4286 -0.0    1.31617  0.00   
+  4  3    3    -8   7374.0095  7098.7737  180.0   1.31130  0.00   
+  4  7    3    -1   1044.0315  1032.5927  180.0   1.31193  0.00   
+  4  1    1    8    173.2706   157.0013   180.0   1.30987  0.00   
+  4  1    1    -9   871.1902   714.9877   180.0   1.30735  0.00   
+  4  1    5    2    2098.0356  1741.0921  180.0   1.30791  0.00   
+  4  1    5    -3   8976.8069  7332.3806  -0.0    1.30718  0.00   
+  4  7    3    -6   9393.1460  7542.3359  -0.0    1.30675  0.00   
+  4  6    4    -3   3842.5896  2359.2813  -0.0    1.29949  0.00   
+  4  9    1    -4   1370.0050  840.7626   0.0     1.29967  0.00   
+  4  9    1    -5   411.5297   256.7371   0.0     1.29837  0.00   
+  4  7    1    2    6354.8197  3971.2947  -180.0  1.29827  0.00   
+  4  3    5    -1   986.2570   623.9480   0.0     1.29662  0.00   
+  4  3    5    -2   3456.8585  2195.2006  -0.0    1.29619  0.00   
+  4  5    3    3    525.9553   335.5374   180.0   1.29581  0.00   
+  4  6    4    -2   37.7622    25.6459    0.0     1.29198  0.00   
+  4  4    0    6    24495.8393 18445.1890 180.0   1.29041  0.00   
+  4  6    4    -4   9397.8591  7147.8738  -0.0    1.29028  0.00   
+  4  8    2    -1   11605.2924 8919.4141  180.0   1.29014  0.00   
+  4  5    3    -8   4023.8939  3485.2815  180.0   1.28798  0.00   
+  4  7    1    -9   150.4702   133.1816   180.0   1.28729  0.00   
+  4  2    2    7    18436.8806 16121.3989 -0.0    1.28772  0.00   
+  4  2    2    -9   20348.2776 19749.4871 0.0     1.28323  0.00   
+  4  8    2    -7   442.7558   429.3576   -180.0  1.28339  0.00   
+  4  9    1    -3   5801.1991  5505.8053  180.0   1.28437  0.00   
+  4  4    0    -10  21281.4361 20626.8832 -180.0  1.28142  0.00   
+  4  3    5    0    743.9925   723.0322   -0.0    1.28059  0.00   
+  4  9    1    -6   191.8088   186.4033   -0.0    1.28061  0.00   
+  4  6    2    3    0.3914     0.3803     180.0   1.28034  0.00   
+  4  3    5    -3   6264.3295  6057.1432  -0.0    1.27934  0.00   
+  4  0    4    6    137.1936   118.7790   180.0   1.27414  0.00   
+  4  6    2    -9   522.1614   464.9998   180.0   1.27048  0.00   
+  4  6    4    -1   464.9381   482.3156   -180.0  1.26861  0.00   
+  4  6    4    -5   544.6456   582.1506   -180.0  1.26538  0.00   
+  4  5    1    5    4323.3349  4608.9316  180.0   1.26524  0.00   
+  4  6    0    4    6781.5899  7257.1579  180.0   1.26546  0.00   
+  4  7    3    0    792.1173   802.9980   180.0   1.26367  0.00   
+  4  1    3    7    8566.8731  8422.3689  -0.0    1.26045  0.00   
+  4  1    5    3    37.0440    35.3555    180.0   1.25929  0.00   
+  4  1    3    -8   3285.5328  3096.4805  180.0   1.25847  0.00   
+  4  1    5    -4   3305.2546  3109.1160  180.0   1.25836  0.00   
+  4  7    3    -7   2629.3510  2422.5128  180.0   1.25719  0.00   
+  4  5    1    -10  7701.4415  7040.6080  -180.0  1.25533  0.00   
+  4  6    0    -10  130.0901   117.7995   180.0   1.25436  0.00   
+  4  3    1    7    1818.2242  1611.9052  -0.0    1.25310  0.00   
+  4  9    1    -2   400.6261   361.7381   0.0     1.25413  0.00   
+  4  3    5    1    10017.1110 8364.6882  0.0     1.24984  0.00   
+  4  4    4    3    19.5158    16.4610    0.0     1.24881  0.00   
+  4  9    1    -7   10158.8601 8727.7224  -180.0  1.24831  0.00   
+  4  3    5    -4   1249.7928  1094.9028  -0.0    1.24791  0.00   
+  4  3    1    -10  3199.8515  2986.1989  180.0   1.24653  0.00   
+  4  2    4    5    1291.1252  1152.6107  0.0     1.24755  0.00   
+  4  2    4    -7   828.1319   791.7891   0.0     1.24448  0.00   
+  4  4    4    -7   6817.9210  6546.9764  -0.0    1.24370  0.00   
+  4  2    0    8    28.5082    27.6681    -0.0    1.24151  0.00   
+  4  2    0    -10  2141.4729  2004.2607  180.0   1.23699  0.00   
+  4  8    2    0    784.1793   732.5347   180.0   1.23694  0.00   
+  4  6    4    0    15016.5044 14164.7168 -0.0    1.23182  0.00   
+  4  8    2    -8   599.2056   627.3611   180.0   1.22902  0.00   
+  4  6    4    -6   126.0499   129.7550   -180.0  1.22740  0.00   
+  4  9    1    -1   3093.1624  2737.0310  -0.0    1.21201  0.00   
+  4  3    3    6    945.7147   849.4249   0.0     1.20939  0.00   
+  4  4    2    6    457.4657   411.6959   -0.0    1.20797  0.00   
+  4  7    1    3    81.5159    73.2966    180.0   1.20853  0.00   
+  4  3    5    2    4172.4957  3752.2007  0.0     1.20744  0.00   
+  4  5    3    4    8461.7501  7534.7350  -180.0  1.20632  0.00   
+  4  7    3    1    3065.2228  2738.1132  180.0   1.20663  0.00   
+  4  3    5    -5   55.0455    48.9057    180.0   1.20500  0.00   
+  4  3    3    -9   1052.0110  945.1661   -0.0    1.20417  0.00   
+  4  9    1    -8   2600.7183  2320.3991  0.0     1.20467  0.00   
+  4  1    5    4    4288.7581  3946.6484  180.0   1.20212  0.00   
+  4  4    2    -10  168.9483   165.4794   -0.0    1.20059  0.00   
+  4  1    5    -5   686.9334   658.1130   0.0     1.20109  0.00   
+  4  7    3    -8   5.3040     5.4369     0.0     1.19939  0.00   
+  4  5    3    -9   288.9057   300.8548   180.0   1.19886  0.00   
+  4  7    1    -10  7804.4340  8291.7393  -180.0  1.19807  0.00   
+  4  0    2    9    341.0630   269.4602   -0.0    1.18862  0.00   
+  4  5    5    -2   3921.1970  3033.1047  -0.0    1.18916  0.00   
+  4  5    5    -3   0.1281     0.1013     -0.0    1.18860  0.00   
+  4  6    2    4    316.1101   267.9123   180.0   1.18743  0.00   
+  4  10   0    -4   7908.7935  6791.4438  0.0     1.18724  0.00   
+  4  10   0    -6   11645.4891 11083.9325 0.0     1.18504  0.00   
+  4  6    4    1    1388.7900  1321.5609  0.0     1.18505  0.00   
+  4  0    4    7    288.3496   286.3109   180.0   1.18182  0.00   
+  4  6    4    -7   1752.8757  1787.8415  0.0     1.17981  0.00   
+  4  6    2    -10  2.1270     2.2339     -0.0    1.17825  0.00   
+  4  1    1    9    115.4029   122.6215   -0.0    1.17757  0.00   
+  4  8    0    2    29628.1664 31208.9425 180.0   1.17807  0.00   
+  4  5    5    -1   6815.5795  7333.2479  -180.0  1.17697  0.00   
+  4  1    1    -10  691.5487   762.8322   180.0   1.17552  0.00   
+  4  8    2    1    5431.9286  5829.5691  -180.0  1.17708  0.00   
+  4  5    5    -4   5046.5579  5571.4326  -0.0    1.17536  0.00   
+  4  4    4    4    30603.4596 33801.2648 0.0     1.17420  0.00   
+  4  4    4    -8   28967.0942 28612.5301 -180.0  1.16910  0.00   
+  4  8    2    -9   8559.4840  8411.0748  180.0   1.16856  0.00   
+  4  8    0    -10  39027.0032 38238.0217 0.0     1.16784  0.00   
+  4  2    2    8    102.3545   100.3650   0.0     1.16757  0.00   
+  4  2    2    -10  559.6885   559.3630   -0.0    1.16381  0.00   
+  4  2    4    6    16187.5767 13793.8077 180.0   1.16072  0.00   
+  4  9    1    0    199.0621   175.9750   180.0   1.16162  0.00   
+  4  2    4    -8   2824.2114  2418.4289  0.0     1.15783  0.00   
+  4  3    5    3    3553.5113  3138.9165  0.0     1.15697  0.00   
+  4  5    1    6    57.0628    50.4393    0.0     1.15695  0.00   
+  4  3    5    -6   56.1601    51.9835    -0.0    1.15422  0.00   
+  4  9    1    -9   612.8339   565.3148   180.0   1.15332  0.00   
+  4  1    3    8    3008.7507  2761.9705  0.0     1.15288  0.00   
+  4  5    5    0    7249.3341  6677.8488  -0.0    1.15317  0.00   
+  4  1    3    -9   1.4814     1.3309     -0.0    1.15116  0.00   
+  4  5    5    -5   9562.4964  8524.5720  -180.0  1.15064  0.00   
+  4  5    1    -11  1672.5476  1512.6930  0.0     1.14836  0.00   
+  4  9    3    -4   440.7034   426.9046   0.0     1.14591  0.00   
+  4  0    6    0    2512.6088  2617.0231  -0.0    1.14488  0.00   
+  4  9    3    -5   62.6914    64.8810    -0.0    1.14502  0.00   
+  4  7    3    2    4718.3733  4899.9757  -0.0    1.14495  0.00   
+  4  0    0    10   372.6139   423.7872   -0.0    1.14021  0.00   
+  4  1    5    5    4404.1931  5052.6414  -0.0    1.14051  0.00   
+  4  10   0    -2   13883.0153 15977.0108 0.0     1.14083  0.00   
+  4  1    5    -6   4816.4067  5316.8792  180.0   1.13943  0.00   
+  4  0    6    1    1501.4347  1652.6802  180.0   1.13916  0.00   
+  4  7    3    -9   4265.2313  4662.3484  180.0   1.13739  0.00   
+  4  3    1    8    60.5148    68.5290    180.0   1.13600  0.00   
+  4  10   0    -8   1234.0975  1446.9812  0.0     1.13500  0.00   
+  4  9    3    -3   1226.1904  1425.8009  -180.0  1.13538  0.00   
+  4  9    3    -6   1601.7970  1854.9560  -0.0    1.13278  0.00   
+  4  3    1    -11  26.0510    30.9463    0.0     1.13052  0.00   
+  4  6    4    2    2466.0310  2828.6870  0.0     1.13190  0.00   
+  4  6    4    -8   1857.5445  2098.6789  -0.0    1.12620  0.00   
+  4  10   2    -5   5436.2243  6260.3145  0.0     1.12662  0.00   
+  4  8    4    -4   3779.2891  4163.4508  -180.0  1.12577  0.00   
+  4  2    6    -1   3482.1034  3576.1516  180.0   1.12435  0.00   
+  4  7    1    4    4830.6288  4923.6613  -0.0    1.12407  0.00   
+  4  0    6    2    1365.2966  1380.1016  -180.0  1.12247  0.00   
+  4  5    3    5    1957.1560  1969.9637  -180.0  1.12210  0.00   
+  4  10   2    -4   8.9927     9.0506     180.0   1.12210  0.00   
+  4  8    4    -3   3401.0442  3322.0045  -180.0  1.12107  0.00   
+  4  10   2    -6   172.8767   172.4285   180.0   1.12024  0.00   
+  4  5    5    1    707.4841   712.3459   0.0     1.11980  0.00   
+  4  8    4    -5   1023.6725  1031.7594  180.0   1.11958  0.00   
+  4  2    6    0    5287.4183  5323.9761  180.0   1.11911  0.00   
+  4  2    6    -2   984.9688   994.6994   180.0   1.11874  0.00   
+  4  5    5    -6   2608.4208  2507.7650  0.0     1.11656  0.00   
+  4  5    3    -10  1858.7907  1595.3866  -0.0    1.11517  0.00   
+  4  7    1    -11  2546.0356  2080.5242  180.0   1.11435  0.00   
+  4  3    3    7    9207.9764  7162.2968  0.0     1.11361  0.00   
+  4  9    3    -2   2473.7398  2019.0786  0.0     1.11433  0.00   
+  4  8    2    2    147.6833   120.6468   0.0     1.11435  0.00   
+  4  9    3    -7   2148.9615  1750.0554  -180.0  1.11024  0.00   
+  4  3    3    -10  310.0217   264.2393   -0.0    1.10899  0.00   
+  4  4    2    7    10566.5860 9262.0651  0.0     1.10733  0.00   
+  4  8    2    -10  40.6464    36.4788    0.0     1.10568  0.00   
+  4  10   2    -3   39907.6176 35134.6049 -180.0  1.10704  0.00   
+  4  9    1    1    4275.0763  3804.5571  -180.0  1.10646  0.00   
+  4  8    4    -2   32753.1084 29367.7986 -180.0  1.10587  0.00   
+  4  2    6    1    30154.8437 27657.2710 -180.0  1.10346  0.00   
+  4  10   2    -7   38105.7908 34945.5796 0.0     1.10347  0.00   
+  4  8    4    -6   32764.0487 30145.0352 0.0     1.10302  0.00   
+  4  2    6    -3   32468.4049 29932.7872 0.0     1.10275  0.00   
+  4  4    2    -11  2378.4464  2171.7260  -0.0    1.10093  0.00   
+  4  3    5    4    76.3996    70.5308    0.0     1.10191  0.00   
+  4  6    2    5    143295.7929 132118.4929 -180.0  1.10176  0.01   
+  4  4    4    5    2949.3019  2698.2919  180.0   1.10112  0.00   
+  4  3    5    -7   3235.7019  2940.6878  0.0     1.09901  0.00   
+  4  9    1    -10  302.9170   279.5570   0.0     1.09771  0.00   
+  4  0    4    8    141171.4401 133943.8055 -180.0  1.09675  0.01   
+  4  4    4    -9   140.1937   134.0820   0.0     1.09622  0.00   
+  4  0    6    3    3561.1558  3405.7446  -0.0    1.09623  0.00   
+  4  6    2    -11  169050.6587 149682.1479 -180.0  1.09337  0.01   
+  4  9    3    -1   1163.5215  1114.3484  0.0     1.08447  0.00   
+  4  0    2    10   120.0551   133.7299   0.0     1.08214  0.00   
+  4  10   2    -2   817.0129   879.0255   -0.0    1.08267  0.00   
+  4  7    3    3    5336.3436  5994.9982  180.0   1.08198  0.00   
+  4  8    4    -1   5.7194     6.5236     0.0     1.08141  0.00   
+  4  2    4    7    122.0853   143.6472   180.0   1.07999  0.00   
+  4  9    3    -8   13.8018    16.9908    180.0   1.07920  0.00   
+  4  5    5    2    4349.0567  5313.7515  0.0     1.07936  0.00   
+  4  2    6    2    383.4858   479.5437   0.0     1.07866  0.00   
+  4  2    4    -9   1001.4871  1303.4737  -180.0  1.07733  0.00   
+  4  1    5    6    5903.8848  7502.3719  180.0   1.07773  0.00   
+  4  2    6    -4   2480.6502  3161.5489  -0.0    1.07767  0.00   
+  4  10   2    -8   236.6520   301.4058   0.0     1.07768  0.00   
+  4  8    4    -7   685.1252   885.6925   -0.0    1.07743  0.00   
+  4  1    5    -7   8101.0029  11199.6750 0.0     1.07666  0.00   
+  4  5    5    -7   11.3717    16.4800    0.0     1.07564  0.00   
+  4  6    4    3    1048.5957  1519.6083  -180.0  1.07562  0.00   
+  4  7    3    -10  8612.0953  12260.3533 0.0     1.07445  0.00   
+  4  6    0    6    625.8370   878.8977   180.0   1.07272  0.00   
+  4  6    4    -9   617.0028   817.6472   -180.0  1.06975  0.00   
+  4  1    1    10   2020.0582  2598.9786  -180.0  1.06913  0.00   
+  4  11   1    -5   117.0977   156.8616   180.0   1.07020  0.00   
+  4  11   1    -6   4.3628     5.6711     -180.0  1.06931  0.00   
+  4  4    6    -2   1975.7405  2494.2659  -180.0  1.06880  0.00   
+  4  1    1    -11  34.4641    42.2046    0.0     1.06744  0.00   
+  4  7    5    -3   1065.2954  1332.0657  -180.0  1.06857  0.00   
+  4  4    0    8    18978.0990 23529.7854 -0.0    1.06820  0.00   
+  4  7    5    -4   136.3562   168.7354   180.0   1.06801  0.00   
+  4  2    2    9    20763.0563 24380.3803 -0.0    1.06635  0.00   
+  4  6    0    -12  2554.1421  2929.7469  -180.0  1.06402  0.00   
+  4  4    6    -1   1.7626     2.0438     -0.0    1.06445  0.00   
+  4  2    2    -11  18916.8430 21004.2825 -180.0  1.06316  0.00   
+  4  4    6    -3   2486.6507  2831.4970  180.0   1.06381  0.00   
+  4  4    0    -12  26000.5422 28258.1165 -180.0  1.06181  0.00   
+  4  5    1    7    2948.6836  3263.4211  0.0     1.06306  0.00   
+  4  0    6    4    1536.1092  1675.3512  0.0     1.06240  0.00   
+  4  11   1    -4   4701.9103  5109.6716  0.0     1.06176  0.00   
+  4  1    3    9    1462.3517  1610.8804  0.0     1.05959  0.00   
+  4  10   0    0    755.0686   818.6871   0.0     1.06073  0.00   
+  4  7    5    -2   1.5029     1.6444     -0.0    1.05986  0.00   
+  4  11   1    -7   59.5744    66.0173    -180.0  1.05916  0.00   
+  4  1    3    -10  2217.1023  2357.5321  0.0     1.05810  0.00   
+  4  7    5    -5   3633.3939  3887.5199  -180.0  1.05821  0.00   
+  4  5    1    -12  2148.1893  2093.0629  -180.0  1.05561  0.00   
+  4  10   0    -10  5001.8794  4647.5795  0.0     1.05294  0.00   
+  4  4    6    0    1670.3477  1594.2503  0.0     1.05111  0.00   
+  4  8    2    3    23814.1835 22550.5447 180.0   1.05162  0.00   
+  4  10   2    -1   60768.8328 57925.1992 0.0     1.05081  0.00   
+  4  4    6    -4   1240.6329  1172.5845  0.0     1.04988  0.00   
+  4  8    4    0    65941.0658 62159.8536 -180.0  1.04950  0.00   
+  4  9    1    2    140.5690   132.4732   -0.0    1.04947  0.00   
+  4  9    3    0    2543.3858  2356.5625  0.0     1.04792  0.00   
+  4  2    6    3    60346.0865 55953.1978 -180.0  1.04653  0.00   
+  4  7    1    5    1102.7280  1023.5807  0.0     1.04623  0.00   
+  4  2    6    -5   60844.8669 56260.1373 -180.0  1.04532  0.00   
+  4  3    5    5    3960.8946  3649.5277  -0.0    1.04514  0.00   
+  4  10   2    -9   73767.5668 67209.1538 0.0     1.04473  0.00   
+  4  8    4    -8   74328.3223 67545.8582 -180.0  1.04465  0.00   
+  4  5    3    6    1549.0514  1400.2751  -180.0  1.04449  0.00   
+  4  8    2    -11  5.5092     4.8524     0.0     1.04312  0.00   
+  4  11   1    -3   30.1242    27.3651    180.0   1.04464  0.00   
+  4  3    5    -8   435.1391   382.4968   -0.0    1.04221  0.00   
+  4  7    5    -1   5296.6754  4658.2850  -180.0  1.04253  0.00   
+  4  9    3    -9   559.1026   492.8769   -180.0  1.04182  0.00   
+  4  9    1    -11  5388.1953  4934.4777  180.0   1.04066  0.00   
+  4  11   1    -8   5788.4441  5328.4278  0.0     1.04053  0.00   
+  4  7    5    -6   21.7941    20.5779    180.0   1.03992  0.00   
+  4  5    3    -11  154.9534   166.7382   -0.0    1.03815  0.00   
+  4  7    1    -12  487.4535   563.7093   -180.0  1.03735  0.00   
+  4  3    1    9    893.5204   983.6862   -180.0  1.03788  0.00   
+_reflns_number_total  1184
+_reflns_d_resolution_low    6.388
+_reflns_d_resolution_high   1.033
+
+# POWDER DATA TABLE
+_pd_meas_2theta_range_min  10.01313
+_pd_meas_2theta_range_max  119.99238
+_pd_meas_2theta_range_inc  0.02626
+_pd_proc_2theta_range_min  9.98829
+_pd_proc_2theta_range_max  119.96754
+_pd_proc_2theta_range_inc  0.02626
+_pd_proc_number_of_points  4189
+
+loop_
+   _pd_meas_intensity_total
+   _pd_calc_intensity_total
+   _pd_proc_intensity_bkg_calc
+   _pd_proc_ls_weight
+  2703         0            0           0         
+  2678         0            0           0         
+  2659         0            0           0         
+  2758         0            0           0         
+  2748         0            0           0         
+  2641         0            0           0         
+  2689         0            0           0         
+  2578         0            0           0         
+  2670         0            0           0         
+  2692         0            0           0         
+  2616         0            0           0         
+  2558         0            0           0         
+  2644         0            0           0         
+  2644         0            0           0         
+  2656         0            0           0         
+  2709         0            0           0         
+  2677         0            0           0         
+  2614         0            0           0         
+  2500         0            0           0         
+  2625         0            0           0         
+  2618         0            0           0         
+  2558         0            0           0         
+  2609         0            0           0         
+  2630         0            0           0         
+  2577         0            0           0         
+  2660         0            0           0         
+  2521         0            0           0         
+  2533         0            0           0         
+  2591         0            0           0         
+  2539         0            0           0         
+  2563         0            0           0         
+  2462         0            0           0         
+  2552         0            0           0         
+  2614         0            0           0         
+  2441         0            0           0         
+  2494         0            0           0         
+  2462         0            0           0         
+  2503         0            0           0         
+  2546         0            0           0         
+  2478         0            0           0         
+  2449         0            0           0         
+  2462         0            0           0         
+  2498         0            0           0         
+  2391         0            0           0         
+  2400         0            0           0         
+  2430         0            0           0         
+  2445         0            0           0         
+  2350         0            0           0         
+  2429         0            0           0         
+  2382         0            0           0         
+  2327         0            0           0         
+  2476         0            0           0         
+  2374         0            0           0         
+  2393         0            0           0         
+  2393         0            0           0         
+  2320         0            0           0         
+  2400         0            0           0         
+  2377         0            0           0         
+  2281         0            0           0         
+  2312         0            0           0         
+  2414         0            0           0         
+  2357         0            0           0         
+  2365         0            0           0         
+  2276         0            0           0         
+  2361         0            0           0         
+  2276         0            0           0         
+  2328         0            0           0         
+  2372         0            0           0         
+  2252         0            0           0         
+  2194         0            0           0         
+  2339         0            0           0         
+  2264         0            0           0         
+  2225         0            0           0         
+  2164         0            0           0         
+  2288         0            0           0         
+  2258         0            0           0         
+  2341         0            0           0         
+  2290         0            0           0         
+  2253         0            0           0         
+  2154         0            0           0         
+  2249         0            0           0         
+  2239         0            0           0         
+  2214         0            0           0         
+  2222         0            0           0         
+  2236         0            0           0         
+  2179         0            0           0         
+  2106         0            0           0         
+  2181         0            0           0         
+  2173         0            0           0         
+  2153         0            0           0         
+  2164         0            0           0         
+  2071         0            0           0         
+  2114         0            0           0         
+  2179         0            0           0         
+  2113         0            0           0         
+  2142         0            0           0         
+  2067         0            0           0         
+  2247         0            0           0         
+  2147         0            0           0         
+  2190         0            0           0         
+  2130         0            0           0         
+  2144         0            0           0         
+  2092         0            0           0         
+  2121         0            0           0         
+  2007         0            0           0         
+  2081         0            0           0         
+  2099         0            0           0         
+  2057         0            0           0         
+  2034         0            0           0         
+  2022         0            0           0         
+  2002         0            0           0         
+  2056         0            0           0         
+  2079         0            0           0         
+  2072         0            0           0         
+  2025         0            0           0         
+  2094         0            0           0         
+  2030         0            0           0         
+  2034         0            0           0         
+  2054         0            0           0         
+  2061         0            0           0         
+  1988         0            0           0         
+  2009         0            0           0         
+  1954         0            0           0         
+  2032         0            0           0         
+  2027         0            0           0         
+  2012         0            0           0         
+  1953         0            0           0         
+  1962         0            0           0         
+  1955         0            0           0         
+  1969         0            0           0         
+  1989         0            0           0         
+  1944         0            0           0         
+  1907         0            0           0         
+  1874         0            0           0         
+  1949         0            0           0         
+  1893         0            0           0         
+  1947         0            0           0         
+  1967         0            0           0         
+  1959         0            0           0         
+  1915         0            0           0         
+  1884         0            0           0         
+  1960         0            0           0         
+  1896         0            0           0         
+  1908         0            0           0         
+  1966         0            0           0         
+  1887         0            0           0         
+  1851         0            0           0         
+  1801         0            0           0         
+  1879         0            0           0         
+  1928         0            0           0         
+  1831         0            0           0         
+  1854         0            0           0         
+  1783         0            0           0         
+  1779         0            0           0         
+  1837         0            0           0         
+  1923         0            0           0         
+  1907         0            0           0         
+  1753         0            0           0         
+  1828         0            0           0         
+  1814         0            0           0         
+  1798         0            0           0         
+  1744         0            0           0         
+  1870         0            0           0         
+  1792         0            0           0         
+  1810         0            0           0         
+  1860         0            0           0         
+  1780         0            0           0         
+  1751         0            0           0         
+  1818         0            0           0         
+  1804         0            0           0         
+  1789         0            0           0         
+  1814         0            0           0         
+  1767         0            0           0         
+  1817         0            0           0         
+  1804         0            0           0         
+  1736         0            0           0         
+  1727         0            0           0         
+  1746         0            0           0         
+  1675         0            0           0         
+  1723         1706.50316   1706.10301  0.000580383 
+  1770         1703.04545   1702.63351  0.000564972 
+  1708         1699.59524   1699.17087  0.00058548 
+  1737         1696.15257   1695.71509  0.000575705 
+  1705         1692.71748   1692.26615  0.00058651 
+  1690         1689.29001   1688.82405  0.000591716 
+  1746         1685.87024   1685.38876  0.000572738 
+  1716         1682.45822   1681.96029  0.000582751 
+  1714         1679.05403   1678.53862  0.000583431 
+  1739         1675.65775   1675.12373  0.000575043 
+  1724         1672.26948   1671.71562  0.000580046 
+  1651         1668.88943   1668.31428  0.000605694 
+  1691         1665.51752   1664.91969  0.000591366 
+  1725         1662.15401   1661.53184  0.00057971 
+  1714         1658.7991    1658.15072  0.000583431 
+  1669         1655.45288   1654.77633  0.000599161 
+  1614         1652.11564   1651.40864  0.000619579 
+  1647         1648.78763   1648.04765  0.000607165 
+  1630         1645.46916   1644.69335  0.000613497 
+  1612         1642.16057   1641.34573  0.000620347 
+  1725         1638.86228   1638.00477  0.00057971 
+  1642         1635.57492   1634.67046  0.000609013 
+  1720         1632.29882   1631.3428   0.000581395 
+  1705         1629.03482   1628.02177  0.00058651 
+  1628         1625.78421   1624.70736  0.000614251 
+  1681         1622.54715   1621.39956  0.000594884 
+  1646         1619.32554   1618.09836  0.000607533 
+  1552         1616.1206    1614.80374  0.00064433 
+  1640         1612.93452   1611.51571  0.000609756 
+  1644         1609.76983   1608.23424  0.000608273 
+  1637         1606.62985   1604.95932  0.000610874 
+  1660         1603.51891   1601.69095  0.00060241 
+  1640         1600.44288   1598.42911  0.000609756 
+  1653         1597.40989   1595.17379  0.000604961 
+  1582         1594.43157   1591.92498  0.000632111 
+  1630         1591.52536   1588.68268  0.000613497 
+  1592         1588.71908   1585.44686  0.000628141 
+  1665         1586.06195   1582.21752  0.000600601 
+  1578         1583.65488   1578.99465  0.000633714 
+  1539         1581.71245   1575.77824  0.000649773 
+  1543         1580.5722    1572.56827  0.000648088 
+  1698         1580.08924   1569.36474  0.000588928 
+  1662         1580.23641   1566.16763  0.000601685 
+  1629         1582.10842   1562.97694  0.000613874 
+  1652         1584.46685   1559.79265  0.000605327 
+  1632         1588.09374   1556.61475  0.000612745 
+  1608         1593.91392   1553.44323  0.000621891 
+  1630         1600.59962   1550.27809  0.000613497 
+  1648         1611.59563   1547.1193   0.000606796 
+  1721         1625.0089    1543.96687  0.000581058 
+  1679         1645.0231    1540.82077  0.000595593 
+  1737         1666.72471   1537.681    0.000575705 
+  1736         1674.70458   1534.54755  0.000576037 
+  1763         1653.22819   1531.4204   0.000567215 
+  1651         1617.60708   1528.29956  0.000605694 
+  1621         1588.62724   1525.18499  0.000616903 
+  1599         1572.07052   1522.07671  0.000625391 
+  1568         1561.23626   1518.97468  0.000637755 
+  1607         1551.19168   1515.87891  0.000622278 
+  1533         1543.63984   1512.78939  0.000652316 
+  1551         1538.69818   1509.70609  0.000644745 
+  1538         1532.25046   1506.62902  0.000650195 
+  1510         1522.75567   1503.55816  0.000662252 
+  1532         1513.33585   1500.49351  0.000652742 
+  1497         1506.14275   1497.43504  0.000668003 
+  1513         1500.87292   1494.38275  0.000660939 
+  1528         1496.56215   1491.33663  0.00065445 
+  1503         1492.71407   1488.29668  0.000665336 
+  1505         1489.11997   1485.26287  0.000664452 
+  1551         1485.68473   1482.2352   0.000644745 
+  1501         1482.35785   1479.21366  0.000666223 
+  1499         1479.10956   1476.19823  0.000667111 
+  1504         1475.92114   1473.18892  0.000664894 
+  1475         1472.78021   1470.1857   0.000677966 
+  1489         1469.67835   1467.18857  0.000671592 
+  1472         1466.60968   1464.19751  0.000679348 
+  1482         1463.57002   1461.21252  0.000674764 
+  1400         1460.55644   1458.23358  0.000714286 
+  1499         1457.56693   1455.2607   0.000667111 
+  1463         1454.60018   1452.29384  0.000683527 
+  1484         1451.65551   1449.33301  0.000673854 
+  1503         1448.7328    1446.3782   0.000665336 
+  1412         1445.83248   1443.42939  0.000708215 
+  1429         1442.95563   1440.48657  0.00069979 
+  1407         1440.10413   1437.54974  0.000710732 
+  1518         1437.28096   1434.61888  0.000658762 
+  1418         1434.49079   1431.69399  0.000705219 
+  1412         1431.74122   1428.77505  0.000708215 
+  1426         1429.04575   1425.86205  0.000701262 
+  1465         1426.43216   1422.95499  0.000682594 
+  1390         1423.96016   1420.05385  0.000719424 
+  1407         1421.71943   1417.15862  0.000710732 
+  1453         1419.64642   1414.26929  0.000688231 
+  1464         1417.68871   1411.38586  0.00068306 
+  1330         1416.26954   1408.50831  0.00075188 
+  1433         1415.04149   1405.63663  0.000697837 
+  1400         1413.93933   1402.77082  0.000714286 
+  1449         1413.76492   1399.91085  0.000690131 
+  1523         1413.68092   1397.05673  0.000656599 
+  1464         1415.00088   1394.20844  0.00068306 
+  1361         1416.92112   1391.36598  0.000734754 
+  1446         1419.57875   1388.52932  0.000691563 
+  1444         1417.90276   1385.69847  0.000692521 
+  1390         1410.24905   1382.87341  0.000719424 
+  1442         1401.26841   1380.05414  0.000693481 
+  1461         1394.50312   1377.24063  0.000684463 
+  1405         1390.75422   1374.43289  0.000711744 
+  1400         1388.87261   1371.6309   0.000714286 
+  1386         1388.20089   1368.83465  0.000721501 
+  1317         1388.48861   1366.04414  0.000759301 
+  1400         1389.53646   1363.25935  0.000714286 
+  1477         1391.0256    1360.48027  0.000677048 
+  1413         1392.65013   1357.7069   0.000707714 
+  1361         1394.43602   1354.93922  0.000734754 
+  1366         1396.79943   1352.17722  0.000732064 
+  1406         1400.12717   1349.4209   0.000711238 
+  1435         1404.0748    1346.67024  0.000696864 
+  1387         1407.16035   1343.92524  0.000720981 
+  1410         1407.41974   1341.18588  0.00070922 
+  1425         1403.84843   1338.45215  0.000701754 
+  1336         1397.13323   1335.72405  0.000748503 
+  1366         1389.10053   1333.00157  0.000732064 
+  1379         1381.55652   1330.28469  0.000725163 
+  1317         1375.43035   1327.5734   0.000759301 
+  1423         1370.49744   1324.86771  0.000702741 
+  1402         1365.64887   1322.16759  0.000713267 
+  1400         1359.76471   1319.47303  0.000714286 
+  1355         1352.61087   1316.78404  0.000738007 
+  1309         1344.84366   1314.10059  0.000763942 
+  1347         1337.35952   1311.42267  0.00074239 
+  1306         1330.79132   1308.75029  0.000765697 
+  1388         1325.306     1306.08343  0.000720461 
+  1286         1320.6807    1303.42207  0.000777605 
+  1356         1317.09619   1300.76621  0.000737463 
+  1326         1314.40639   1298.11585  0.000754148 
+  1324         1312.05093   1295.47096  0.000755287 
+  1307         1310.96946   1292.83155  0.000765111 
+  1306         1310.23786   1290.19759  0.000765697 
+  1356         1311.08656   1287.56909  0.000737463 
+  1309         1312.68527   1284.94603  0.000763942 
+  1330         1314.62425   1282.3284   0.00075188 
+  1346         1311.06182   1279.7162   0.000742942 
+  1285         1301.61659   1277.10941  0.00077821 
+  1252         1291.11471   1274.50803  0.000798722 
+  1288         1282.76593   1271.91204  0.000776398 
+  1229         1277.1645    1269.32143  0.00081367 
+  1320         1272.99852   1266.7362   0.000757576 
+  1328         1269.48504   1264.15634  0.000753012 
+  1290         1266.29703   1261.58184  0.000775194 
+  1332         1263.29751   1259.01268  0.000750751 
+  1233         1260.42012   1256.44886  0.00081103 
+  1293         1257.62854   1253.89037  0.000773395 
+  1203         1254.90143   1251.3372   0.000831255 
+  1248         1252.22564   1248.78934  0.000801282 
+  1251         1249.59288   1246.24679  0.000799361 
+  1249         1246.99795   1243.70952  0.000800641 
+  1215         1244.43769   1241.17754  0.000823045 
+  1209         1241.91049   1238.65083  0.00082713 
+  1263         1239.41601   1236.12938  0.000791766 
+  1247         1236.95496   1233.61319  0.000801925 
+  1263         1234.52919   1231.10225  0.000791766 
+  1237         1232.14172   1228.59654  0.000808407 
+  1225         1229.79699   1226.09606  0.000816327 
+  1292         1227.50117   1223.6008   0.000773994 
+  1204         1225.26271   1221.11074  0.000830565 
+  1252         1223.09298   1218.62589  0.000798722 
+  1236         1221.0073    1216.14623  0.000809061 
+  1186         1219.02601   1213.67174  0.00084317 
+  1227         1217.17558   1211.20243  0.000814996 
+  1158         1215.48877   1208.73828  0.000863558 
+  1167         1214.00288   1206.27929  0.000856898 
+  1186         1212.75853   1203.82544  0.00084317 
+  1262         1211.80697   1201.37673  0.000792393 
+  1181         1211.22651   1198.93314  0.00084674 
+  1141         1211.11709   1196.49467  0.000876424 
+  1147         1211.54085   1194.06131  0.00087184 
+  1204         1212.39312   1191.63305  0.000830565 
+  1201         1213.38014   1189.20988  0.000832639 
+  1152         1214.20244   1186.79179  0.000868056 
+  1248         1214.89525   1184.37878  0.000801282 
+  1227         1215.76149   1181.97082  0.000814996 
+  1091         1216.84767   1179.56793  0.00091659 
+  1258         1217.39137   1177.17007  0.000794913 
+  1114         1215.99197   1174.77726  0.000897666 
+  1165         1211.73951   1172.38947  0.000858369 
+  1228         1205.02439   1170.0067   0.000814332 
+  1171         1197.12377   1167.62894  0.000853971 
+  1190         1189.29992   1165.25618  0.000840336 
+  1175         1182.256     1162.88841  0.000851064 
+  1178         1176.16242   1160.52562  0.000848896 
+  1115         1170.92404   1158.16781  0.000896861 
+  1126         1166.36015   1155.81497  0.000888099 
+  1047         1162.31819   1153.46708  0.00095511 
+  1157         1158.65575   1151.12414  0.000864304 
+  1113         1155.27827   1148.78614  0.000898473 
+  1153         1152.11981   1146.45307  0.000867303 
+  1134         1149.13482   1144.12491  0.000881834 
+  1087         1146.26351   1141.80168  0.000919963 
+  1136         1143.49146   1139.48334  0.000880282 
+  1132         1140.80505   1137.1699   0.000883392 
+  1148         1138.17616   1134.86135  0.00087108 
+  1078         1135.5998    1132.55767  0.000927644 
+  1074         1133.06713   1130.25886  0.000931099 
+  1101         1130.57127   1127.96491  0.000908265 
+  1092         1128.10679   1125.67582  0.000915751 
+  1160         1125.66939   1123.39156  0.000862069 
+  1126         1123.25559   1121.11214  0.000888099 
+  1091         1120.86256   1118.83755  0.00091659 
+  1113         1118.48811   1116.56777  0.000898473 
+  1072         1116.13019   1114.3028   0.000932836 
+  1128         1113.7873    1112.04263  0.000886525 
+  1163         1111.45818   1109.78725  0.000859845 
+  1140         1109.14166   1107.53665  0.000877193 
+  1080         1106.83687   1105.29082  0.000925926 
+  1062         1104.54302   1103.04976  0.00094162 
+  1091         1102.25945   1100.81346  0.00091659 
+  1134         1099.98559   1098.5819   0.000881834 
+  1071         1097.72098   1096.35509  0.000933707 
+  1121         1095.46519   1094.133    0.000892061 
+  1050         1093.21787   1091.91564  0.000952381 
+  1091         1090.97872   1089.70298  0.00091659 
+  1126         1088.74748   1087.49504  0.000888099 
+  1083         1086.52394   1085.29179  0.000923361 
+  1112         1084.30791   1083.09323  0.000899281 
+  1071         1082.10331   1080.89935  0.000933707 
+  1099         1079.90188   1078.71014  0.000909918 
+  1058         1077.70961   1076.52559  0.00094518 
+  1040         1075.52236   1074.3457   0.000961538 
+  1044         1073.34209   1072.17045  0.000957854 
+  1067         1071.17155   1069.99984  0.000937207 
+  1045         1069.00517   1067.83386  0.000956938 
+  1037         1066.85417   1065.6725   0.00096432 
+  1059         1064.70175   1063.51575  0.000944287 
+  1037         1062.55634   1061.36361  0.00096432 
+  1074         1060.42154   1059.21606  0.000931099 
+  1046         1058.29041   1057.0731   0.000956023 
+  1044         1056.16672   1054.93472  0.000957854 
+  1026         1054.05033   1052.80091  0.000974659 
+  1005         1051.94158   1050.67166  0.000995025 
+  1012         1049.84081   1048.54697  0.000988142 
+  1059         1047.74804   1046.42682  0.000944287 
+  1064         1045.66373   1044.31121  0.00093985 
+  1073         1043.58827   1042.20012  0.000931966 
+  1048         1041.52207   1040.09356  0.000954198 
+  1030         1039.4657    1037.99151  0.000970874 
+  1006         1037.4198    1035.89397  0.000994036 
+  1033         1035.38533   1033.80092  0.000968054 
+  1049         1033.3628    1031.71236  0.000953289 
+  1071         1031.3535    1029.62829  0.000933707 
+  993          1029.35889   1027.54868  0.001007049 
+  1003         1027.38036   1025.47353  0.000997009 
+  1007         1025.4205    1023.40285  0.000993049 
+  1019         1023.48119   1021.3366   0.000981354 
+  1012         1021.56508   1019.2748   0.000988142 
+  972          1019.67667   1017.21743  0.001028807 
+  968          1017.82049   1015.16448  0.001033058 
+  1010         1016.00255   1013.11595  0.000990099 
+  996          1014.23106   1011.07182  0.001004016 
+  973          1012.51652   1009.0321   0.001027749 
+  985          1010.87296   1006.99676  0.001015228 
+  994          1009.31914   1004.9658   0.001006036 
+  1015         1007.88051   1002.93922  0.000985222 
+  1006         1006.59178   1000.91701  0.000994036 
+  958          1005.49963   998.89916   0.001043841 
+  1012         1004.66576   996.88565   0.000988142 
+  1009         1004.16677   994.87649   0.00099108 
+  950          1004.08344   992.87166   0.001052632 
+  912          1004.46807   990.87116   0.001096491 
+  1040         1005.28671   988.87498   0.000961538 
+  955          1006.3946    986.8831    0.00104712 
+  973          1007.64822   984.89554   0.001027749 
+  924          1009.03671   982.91226   0.001082251 
+  951          1010.52618   980.93327   0.001051525 
+  968          1011.68143   978.95856   0.001033058 
+  1017         1011.55738   976.98813   0.000983284 
+  1018         1009.31526   975.02195   0.000982318 
+  963          1004.96726   973.06003   0.001038422 
+  992          999.22996    971.10236   0.001008065 
+  917          993.06138    969.14893   0.001090513 
+  915          987.16147    967.19972   0.001092896 
+  922          981.83364    965.25475   0.001084599 
+  965          977.10979    963.31399   0.001036269 
+  966          972.79617    961.37743   0.001035197 
+  982          968.89141    959.44508   0.00101833 
+  908          965.37915    957.51692   0.001101322 
+  949          962.2246     955.59295   0.001053741 
+  901          959.37442    953.67315   0.001109878 
+  939          956.74127    951.75752   0.001064963 
+  980          954.2612     949.84605   0.001020408 
+  913          951.89549    947.93874   0.00109529 
+  920          949.61812    946.03557   0.001086957 
+  940          947.40941    944.13655   0.00106383 
+  943          945.25619    942.24165   0.001060445 
+  855          943.14821    940.35088   0.001169591 
+  905          941.07775    938.46422   0.001104972 
+  940          939.03883    936.58167   0.00106383 
+  903          937.02677    934.70321   0.00110742 
+  940          935.0379     932.82886   0.00106383 
+  944          933.06929    930.95858   0.001059322 
+  968          931.11854    929.09239   0.001033058 
+  919          929.18377    927.23026   0.001088139 
+  838          927.26368    925.3722    0.001193317 
+  893          925.35641    923.51819   0.001119821 
+  920          923.4612     921.66822   0.001086957 
+  894          921.57731    919.8223    0.001118568 
+  875          919.70372    917.98041   0.001142857 
+  903          917.83997    916.14254   0.00110742 
+  889          915.98558    914.30869   0.001124859 
+  941          914.14012    912.47884   0.001062699 
+  888          912.30326    910.653     0.001126126 
+  944          910.47473    908.83116   0.001059322 
+  909          908.65431    907.0133    0.00110011 
+  899          906.84211    905.19942   0.001112347 
+  878          905.03748    903.38951   0.001138952 
+  827          903.2406     901.58356   0.00120919 
+  905          901.45158    899.78158   0.001104972 
+  902          899.67015    897.98354   0.001108647 
+  884          897.89648    896.18944   0.001131222 
+  938          896.13066    894.39928   0.001066098 
+  913          894.3728     892.61304   0.00109529 
+  867          892.62305    890.83073   0.001153403 
+  880          890.88163    889.05233   0.001136364 
+  863          889.14879    887.27783   0.001158749 
+  871          887.42483    885.50723   0.001148106 
+  869          885.71014    883.74052   0.001150748 
+  848          884.01075    881.97769   0.001179245 
+  864          882.31609    880.21874   0.001157407 
+  888          880.63241    878.46366   0.001126126 
+  856          878.96016    876.71244   0.001168224 
+  877          877.29925    874.96507   0.001140251 
+  863          875.65495    873.22155   0.001158749 
+  796          874.03308    871.48187   0.001256281 
+  855          872.42295    869.74601   0.001169591 
+  855          870.83164    868.01399   0.001169591 
+  850          869.26545    866.28578   0.001176471 
+  830          867.72426    864.56138   0.001204819 
+  843          866.20578    862.84079   0.00118624 
+  820          864.70525    861.12399   0.001219512 
+  835          863.20929    859.41097   0.001197605 
+  837          861.74078    857.70174   0.001194743 
+  887          860.31279    855.99629   0.001127396 
+  833          858.94068    854.2946    0.00120048 
+  841          857.63539    852.59667   0.001189061 
+  804          856.40473    850.90249   0.001243781 
+  805          855.26243    849.21206   0.001242236 
+  843          854.22869    847.52537   0.00118624 
+  836          853.33163    845.84241   0.001196172 
+  787          852.61077    844.16317   0.001270648 
+  825          852.12244    842.48765   0.001212121 
+  806          851.94939    840.81584   0.001240695 
+  790          852.21884    839.14774   0.001265823 
+  823          853.13629    837.48333   0.001215067 
+  843          855.06177    835.8226    0.00118624 
+  842          858.72565    834.16556   0.001187648 
+  766          865.91609    832.5122    0.001305483 
+  905          880.61877    830.8625    0.001104972 
+  845          905.38907    829.21646   0.001183432 
+  947          935.17125    827.57408   0.001055966 
+  954          994.29535    825.93534   0.001048218 
+  1066         1054.53981   824.30024   0.000938086 
+  1132         1156.8372    822.66878   0.000883392 
+  1436         1283.70687   821.04094   0.000696379 
+  1649         1437.55232   819.41672   0.000606428 
+  1639         1456.0558    817.79611   0.000610128 
+  1401         1306.46152   816.17911   0.000713776 
+  1213         1162.86102   814.5657    0.000824402 
+  919          1005.0968    812.95589   0.001088139 
+  863          914.2557     811.34966   0.001158749 
+  797          872.99414    809.74701   0.001254705 
+  830          851.88728    808.14792   0.001204819 
+  809          839.03741    806.55241   0.001236094 
+  847          830.26527    804.96044   0.001180638 
+  779          823.79871    803.37203   0.001283697 
+  781          818.75066    801.78716   0.00128041 
+  811          814.63016    800.20583   0.001233046 
+  805          811.13281    798.62803   0.001242236 
+  802          808.07974    797.05375   0.001246883 
+  866          805.35124    795.48298   0.001154734 
+  764          802.86563    793.91573   0.001308901 
+  768          800.56845    792.35197   0.001302083 
+  849          798.41881    790.79172   0.001177856 
+  832          796.38865    789.23495   0.001201923 
+  830          794.45646    787.68166   0.001204819 
+  773          792.60665    786.13185   0.001293661 
+  830          790.82754    784.5855    0.001204819 
+  807          789.12742    783.04262   0.001239157 
+  804          787.46644    781.50319   0.001243781 
+  765          785.85697    779.96722   0.00130719 
+  786          784.30467    778.43468   0.001272265 
+  734          782.79133    776.90558   0.001362398 
+  727          781.32525    775.3799    0.001375516 
+  737          779.90758    773.85765   0.001356852 
+  735          778.5409     772.33881   0.001360544 
+  767          777.27263    770.82339   0.001303781 
+  768          776.02214    769.31136   0.001302083 
+  794          774.84054    767.80273   0.001259446 
+  740          773.77266    766.29748   0.001351351 
+  771          772.76517    764.79562   0.001297017 
+  797          771.87125    763.29714   0.001254705 
+  750          771.12345    761.80202   0.001333333 
+  757          770.54561    760.31026   0.001321004 
+  780          770.19452    758.82186   0.001282051 
+  758          770.14312    757.33681   0.001319261 
+  801          770.50679    755.85511   0.001248439 
+  775          771.43656    754.37674   0.001290323 
+  725          773.21053    752.90169   0.00137931 
+  785          776.30954    751.42997   0.001273885 
+  795          781.68409    749.96157   0.001257862 
+  830          791.41088    748.49648   0.001204819 
+  820          809.40433    747.03469   0.001219512 
+  807          838.01263    745.5762    0.001239157 
+  896          871.71685    744.121     0.001116071 
+  940          931.84558    742.66908   0.00106383 
+  1078         1012.06001   741.22044   0.000927644 
+  1178         1102.95403   739.77507   0.000848896 
+  1294         1236.27494   738.33297   0.000772798 
+  1231         1293.12742   736.89412   0.000812348 
+  1120         1222.69434   735.45853   0.000892857 
+  963          1106.46343   734.02618   0.001038422 
+  837          982.93756    732.59707   0.001194743 
+  800          875.83048    731.1712    0.00125   
+  789          817.11578    729.74855   0.001267427 
+  775          786.7002     728.32912   0.001290323 
+  737          769.26011    726.91291   0.001356852 
+  756          757.97279    725.4999    0.001322751 
+  718          749.99369    724.09009   0.001392758 
+  725          743.98873    722.68348   0.00137931 
+  769          739.24159    721.28006   0.00130039 
+  705          735.33752    719.87982   0.00141844 
+  727          732.0212     718.48276   0.001375516 
+  712          729.12839    717.08886   0.001404494 
+  699          726.54986    715.69813   0.001430615 
+  691          724.21057    714.31056   0.001447178 
+  684          722.05756    712.92613   0.001461988 
+  759          720.05292    711.54485   0.001317523 
+  750          718.16897    710.16671   0.001333333 
+  712          716.38522    708.79171   0.001404494 
+  683          714.68661    707.41982   0.001464129 
+  727          713.06206    706.05106   0.001375516 
+  715          711.50355    704.68541   0.001398601 
+  719          710.00568    703.32287   0.001390821 
+  720          708.56527    701.96343   0.001388889 
+  680          707.18116    700.60709   0.001470588 
+  731          705.85439    699.25383   0.001367989 
+  710          704.58835    697.90366   0.001408451 
+  707          703.38929    696.55657   0.001414427 
+  681          702.26739    695.21254   0.001468429 
+  670          701.23826    693.87158   0.001492537 
+  623          700.32563    692.53368   0.001605136 
+  733          699.56634    691.19883   0.001364256 
+  746          699.01947    689.86702   0.001340483 
+  693          698.78523    688.53826   0.001443001 
+  681          699.05292    687.21253   0.001468429 
+  665          700.22281    685.88983   0.001503759 
+  685          703.12339    684.57015   0.001459854 
+  693          708.93378    683.25349   0.001443001 
+  690          716.96214    681.93983   0.001449275 
+  765          729.25956    680.62918   0.00130719 
+  894          750.14382    679.32153   0.001118568 
+  872          772.14377    678.01687   0.001146789 
+  988          805.72       676.71519   0.001012146 
+  949          825.24149    675.4165    0.001053741 
+  843          809.9297     674.12078   0.00118624 
+  770          780.77459    672.82803   0.001298701 
+  721          750.81532    671.53823   0.001386963 
+  657          720.61018    670.2514    0.00152207 
+  715          702.75938    668.96751   0.001398601 
+  649          693.62995    667.68657   0.001540832 
+  684          688.741      666.40857   0.001461988 
+  666          686.00558    665.1335    0.001501502 
+  686          684.63164    663.86136   0.001457726 
+  714          684.37603    662.59213   0.00140056 
+  675          685.29409    661.32583   0.001481481 
+  714          687.74353    660.06243   0.00140056 
+  664          692.62223    658.80193   0.001506024 
+  675          701.95574    657.54433   0.001481481 
+  713          719.46206    656.28962   0.001402525 
+  731          746.65511    655.0378    0.001367989 
+  757          781.93542    653.78885   0.001321004 
+  831          845.30412    652.54278   0.001203369 
+  907          919.06621    651.29958   0.001102536 
+  1030         1019.24805   650.05924   0.000970874 
+  1324         1110.03798   648.82176   0.000755287 
+  1375         1090.35702   647.58713   0.000727273 
+  1117         1000.33199   646.35534   0.000895255 
+  945          911.62085    645.12639   0.001058201 
+  865          810.03487    643.90027   0.001156069 
+  696          740.99804    642.67698   0.001436782 
+  698          705.18153    641.45652   0.001432665 
+  647          685.97977    640.23887   0.001545595 
+  692          674.41102    639.02403   0.001445087 
+  626          666.68698    637.81199   0.001597444 
+  647          661.16718    636.60276   0.001545595 
+  633          657.04318    635.39631   0.001579779 
+  668          653.8579     634.19266   0.001497006 
+  605          651.36048    632.99178   0.001652893 
+  589          649.40774    631.79369   0.001697793 
+  617          647.91964    630.59836   0.001620746 
+  691          646.88227    629.4058    0.001447178 
+  652          646.32366    628.21599   0.001533742 
+  616          646.35543    627.02894   0.001623377 
+  630          647.22212    625.84464   0.001587302 
+  626          649.45472    624.66309   0.001597444 
+  613          654.12488    623.48426   0.001631321 
+  671          662.47926    622.30817   0.001490313 
+  682          673.83273    621.13481   0.001466276 
+  781          692.97997    619.96416   0.00128041 
+  734          720.36905    618.79623   0.001362398 
+  777          754.73173    617.63101   0.001287001 
+  943          797.22215    616.4685    0.001060445 
+  992          813.47323    615.30868   0.001008065 
+  1053         812.48374    614.15155   0.000949668 
+  1005         820.28132    612.99711   0.000995025 
+  1036         836.99634    611.84535   0.000965251 
+  1077         873.4324     610.69626   0.000928505 
+  1224         901.84268    609.54985   0.000816993 
+  1093         935.96513    608.4061    0.000914913 
+  932          929.8324     607.26501   0.001072961 
+  923          863.68871    606.12658   0.001083424 
+  721          802.75807    604.99079   0.001386963 
+  605          742.89807    603.85765   0.001652893 
+  597          692.50307    602.72714   0.001675042 
+  602          665.09843    601.59927   0.00166113 
+  593          651.29306    600.47402   0.001686341 
+  640          643.86707    599.3514    0.0015625 
+  610          639.59058    598.23138   0.001639344 
+  642          637.05402    597.11399   0.001557632 
+  580          635.30854    595.99919   0.001724138 
+  635          633.40379    594.887     0.001574803 
+  616          630.6027     593.77739   0.001623377 
+  630          626.74799    592.67038   0.001587302 
+  629          622.1328     591.56595   0.001589825 
+  575          617.21724    590.4641    0.00173913 
+  595          612.47941    589.36483   0.001680672 
+  627          608.23955    588.26812   0.001594896 
+  608          604.59293    587.17397   0.001644737 
+  647          601.49136    586.08238   0.001545595 
+  577          598.83743    584.99334   0.001733102 
+  580          596.53435    583.90685   0.001724138 
+  567          594.50264    582.8229    0.001763668 
+  610          592.68169    581.74148   0.001639344 
+  609          591.02733    580.6626    0.001642036 
+  597          589.50602    579.58624   0.001675042 
+  574          588.09524    578.5124    0.00174216 
+  562          586.78308    577.44107   0.001779359 
+  592          585.55049    576.37226   0.001689189 
+  600          584.39463    575.30595   0.001666667 
+  589          583.31516    574.24214   0.001697793 
+  570          582.30872    573.18082   0.001754386 
+  591          581.38227    572.12199   0.001692047 
+  581          580.54544    571.06564   0.00172117 
+  565          579.81437    570.01177   0.001769912 
+  604          579.21466    568.96038   0.001655629 
+  552          578.78655    567.91145   0.001811594 
+  613          578.59544    566.86499   0.001631321 
+  584          578.75125    565.82098   0.001712329 
+  608          579.45357    564.77943   0.001644737 
+  609          581.12251    563.74032   0.001642036 
+  594          584.68106    562.70366   0.001683502 
+  593          591.83726    561.66943   0.001686341 
+  644          603.32969    560.63764   0.001552795 
+  641          616.10345    559.60827   0.001560062 
+  601          640.52855    558.58132   0.001663894 
+  738          675.24556    557.55679   0.001355014 
+  777          700.57164    556.53467   0.001287001 
+  757          711.2441     555.51496   0.001321004 
+  720          682.57057    554.49765   0.001388889 
+  638          658.96643    553.48274   0.001567398 
+  623          631.90509    552.47022   0.001605136 
+  609          607.0317     551.46008   0.001642036 
+  596          597.02785    550.45233   0.001677852 
+  553          596.31621    549.44695   0.001808318 
+  617          596.89834    548.44394   0.001620746 
+  646          595.32705    547.4433    0.001547988 
+  595          586.51586    546.44502   0.001680672 
+  584          579.47232    545.4491    0.001712329 
+  597          571.63224    544.45553   0.001675042 
+  591          564.64862    543.4643    0.001692047 
+  561          560.4756     542.47542   0.001782531 
+  624          557.98493    541.48887   0.001602564 
+  605          556.34678    540.50466   0.001652893 
+  626          555.19265    539.52277   0.001597444 
+  615          554.37439    538.5432    0.001626016 
+  632          553.82441    537.56595   0.001582278 
+  629          553.4842     536.59102   0.001589825 
+  697          553.29339    535.61838   0.00143472 
+  699          553.1659     534.64806   0.001430615 
+  729          552.98536    533.68002   0.001371742 
+  685          552.74892    532.71428   0.001459854 
+  679          552.46946    531.75083   0.001472754 
+  677          552.31005    530.78966   0.001477105 
+  641          552.37971    529.83077   0.001560062 
+  624          552.77242    528.87415   0.001602564 
+  572          553.59326    527.9198    0.001748252 
+  584          554.87746    526.96771   0.001712329 
+  616          556.60642    526.01788   0.001623377 
+  600          558.69904    525.07031   0.001666667 
+  588          561.0204     524.12498   0.00170068 
+  582          563.38603    523.1819    0.001718213 
+  568          565.61345    522.24105   0.001760563 
+  608          567.73548    521.30244   0.001644737 
+  582          570.13808    520.36606   0.001718213 
+  590          573.51201    519.43191   0.001694915 
+  565          579.01095    518.49997   0.001769912 
+  606          588.6908     517.57025   0.001650165 
+  585          605.40273    516.64274   0.001709402 
+  611          627.84806    515.71744   0.001636661 
+  655          658.29828    514.79434   0.001526718 
+  683          711.80296    513.87343   0.001464129 
+  728          763.80789    512.95472   0.001373626 
+  747          804.91339    512.03819   0.001338688 
+  792          803.32814    511.12385   0.001262626 
+  799          799.47182    510.21168   0.001251564 
+  877          821.88491    509.30169   0.001140251 
+  902          877.37776    508.39386   0.001108647 
+  1071         1032.79356   507.4882    0.000933707 
+  1235         1285.73345   506.5847    0.000809717 
+  1657         1695.6685    505.68335   0.0006035 
+  2310         2370.74642   504.78415   0.0004329 
+  3803         3184.41508   503.8871    0.00026295 
+  5138         4012.43977   502.99218   0.000194628 
+  4420         3686.27995   502.09941   0.000226244 
+  3195         2948.63075   501.20876   0.000312989 
+  2793         2489.61312   500.32024   0.000358038 
+  1750         1730.38642   499.43384   0.000571429 
+  1028         1156.98293   498.54956   0.000972763 
+  763          890.24563    497.6674    0.001310616 
+  656          763.59093    496.78734   0.00152439 
+  612          692.33698    495.90938   0.001633987 
+  573          647.44894    495.03353   0.001745201 
+  625          617.43812    494.15977   0.0016    
+  573          596.43532    493.28809   0.001745201 
+  568          581.25554    492.41851   0.001760563 
+  578          570.09006    491.551     0.001730104 
+  482          561.8619     490.68558   0.002074689 
+  548          555.89041    489.82222   0.001824818 
+  524          551.67862    488.96093   0.001908397 
+  500          548.72719    488.10171   0.002     
+  544          546.41443    487.24454   0.001838235 
+  566          544.11032    486.38943   0.001766784 
+  506          541.49895    485.53636   0.001976285 
+  524          538.65725    484.68534   0.001908397 
+  519          535.83488    483.83637   0.001926782 
+  526          533.35873    482.98943   0.001901141 
+  536          531.59753    482.14452   0.001865672 
+  519          530.88632    481.30163   0.001926782 
+  553          531.55768    480.46078   0.001808318 
+  527          534.12109    479.62193   0.001897533 
+  564          539.57861    478.78511   0.00177305 
+  509          549.88588    477.95029   0.001964637 
+  534          568.17376    477.11748   0.001872659 
+  610          595.51484    476.28667   0.001639344 
+  591          623.78874    475.45786   0.001692047 
+  695          659.91322    474.63104   0.001438849 
+  827          711.85219    473.8062    0.00120919 
+  738          725.44938    472.98335   0.001355014 
+  676          693.77034    472.16248   0.00147929 
+  693          670.34716    471.34358   0.001443001 
+  672          639.44295    470.52666   0.001488095 
+  603          604.9227     469.7117    0.001658375 
+  559          585.65498    468.8987    0.001788909 
+  594          580.94852    468.08766   0.001683502 
+  563          588.05769    467.27858   0.001776199 
+  555          608.40928    466.47144   0.001801802 
+  594          648.26143    465.66624   0.001683502 
+  627          709.59019    464.86299   0.001594896 
+  689          786.98537    464.06167   0.001451379 
+  894          924.4786     463.26229   0.001118568 
+  1012         1073.04914   462.46483   0.000988142 
+  1032         1166.48486   461.6693    0.000968992 
+  907          1129.45517   460.87568   0.001102536 
+  971          1072.74049   460.08398   0.001029866 
+  918          1078.47339   459.29419   0.001089325 
+  935          1103.65575   458.50631   0.001069519 
+  1069         1199.57459   457.72033   0.000935454 
+  1398         1462.90091   456.93625   0.000715308 
+  1903         1862.50772   456.15406   0.000525486 
+  2555         2154.38207   455.37376   0.000391389 
+  2558         2183.9686    454.59534   0.00039093 
+  2350         1998.90021   453.81881   0.000425532 
+  1986         1848.68356   453.04416   0.000503525 
+  1458         1520.45671   452.27137   0.000685871 
+  1119         1202.88311   451.50046   0.000893655 
+  931          1027.96613   450.73141   0.001074114 
+  768          902.98073    449.96422   0.001302083 
+  815          861.24538    449.19889   0.001226994 
+  894          871.07794    448.43541   0.001118568 
+  951          876.78441    447.67377   0.001051525 
+  914          832.77504    446.91399   0.001094092 
+  972          784.08213    446.15604   0.001028807 
+  889          758.01863    445.39992   0.001124859 
+  884          728.0843     444.64564   0.001131222 
+  880          722.03614    443.89319   0.001136364 
+  867          757.18612    443.14256   0.001153403 
+  857          828.69571    442.39375   0.001166861 
+  865          894.71494    441.64675   0.001156069 
+  886          928.22833    440.90157   0.001128668 
+  984          956.1663     440.15819   0.00101626 
+  1109         1067.53924   439.41662   0.000901713 
+  1361         1321.12219   438.67685   0.000734754 
+  1791         1730.00241   437.93887   0.000558347 
+  2673         2478.32988   437.20268   0.000374111 
+  4375         3655.66385   436.46828   0.000228571 
+  6501         5229.7208    435.73566   0.000153822 
+  7461         5999.14327   435.00482   0.00013403 
+  5116         4568.76405   434.27576   0.000195465 
+  4259         3811.60068   433.54847   0.000234797 
+  3507         3197.19039   432.82294   0.000285144 
+  1905         1925.27207   432.09918   0.000524934 
+  1018         1193.35415   431.37718   0.000982318 
+  746          892.19419    430.65693   0.001340483 
+  678          749.2928     429.93844   0.001474926 
+  652          666.83114    429.22169   0.001533742 
+  585          613.82731    428.50669   0.001709402 
+  573          577.39789    427.79342   0.001745201 
+  552          551.09266    427.08189   0.001811594 
+  495          531.36208    426.3721    0.002020202 
+  546          516.09243    425.66403   0.001831502 
+  531          503.97322    424.95768   0.001883239 
+  523          494.15106    424.25306   0.001912046 
+  476          486.04139    423.55015   0.00210084 
+  506          479.24002    422.84895   0.001976285 
+  501          473.46143    422.14946   0.001996008 
+  467          468.48732    421.45168   0.002141328 
+  438          464.16225    420.7556    0.002283105 
+  466          460.36837    420.06121   0.002145923 
+  487          457.00967    419.36852   0.002053388 
+  458          454.01578    418.67752   0.002183406 
+  466          451.33018    417.9882    0.002145923 
+  515          448.90779    417.30056   0.001941748 
+  449          446.71233    416.6146    0.002227171 
+  461          444.71541    415.93032   0.002169197 
+  450          442.89235    415.2477    0.002222222 
+  427          441.22457    414.56675   0.00234192 
+  406          439.69711    413.88747   0.002463054 
+  430          438.29708    413.20984   0.002325581 
+  404          437.01497    412.53387   0.002475248 
+  411          435.84342    411.85955   0.00243309 
+  446          434.77692    411.18688   0.002242152 
+  420          433.8118     410.51585   0.002380952 
+  422          432.94626    409.84646   0.002369668 
+  452          432.18014    409.1787    0.002212389 
+  433          431.51499    408.51258   0.002309469 
+  412          430.95434    407.84809   0.002427184 
+  449          430.50373    407.18522   0.002227171 
+  414          430.16698    406.52398   0.002415459 
+  416          429.96284    405.86435   0.002403846 
+  426          429.89924    405.20634   0.002347418 
+  467          429.99854    404.54993   0.002141328 
+  402          430.28123    403.89514   0.002487562 
+  425          430.77693    403.24194   0.002352941 
+  398          431.52378    402.59035   0.002512563 
+  450          432.57034    401.94035   0.002222222 
+  417          433.98032    401.29194   0.002398082 
+  395          435.83697    400.64512   0.002531646 
+  473          438.25076    399.99989   0.002114165 
+  430          441.36977    399.35623   0.002325581 
+  437          445.39388    398.71416   0.00228833 
+  412          450.59515    398.07365   0.002427184 
+  417          457.34468    397.43472   0.002398082 
+  489          466.13772    396.79735   0.00204499 
+  472          477.62692    396.16155   0.002118644 
+  500          492.612      395.52731   0.002     
+  575          511.92066    394.89462   0.00173913 
+  520          536.04825    394.26348   0.001923077 
+  596          564.42822    393.6339    0.001677852 
+  573          594.67859    393.00585   0.001745201 
+  584          622.7901     392.37935   0.001712329 
+  695          644.31184    391.75439   0.001438849 
+  736          655.21104    391.13096   0.001358696 
+  774          654.19796    390.50906   0.00129199 
+  748          645.25892    389.88869   0.001336898 
+  768          635.85871    389.26984   0.001302083 
+  757          630.55767    388.65252   0.001321004 
+  817          636.06126    388.03671   0.00122399 
+  731          662.64311    387.42241   0.001367989 
+  685          684.23511    386.80962   0.001459854 
+  619          671.84281    386.19834   0.001615509 
+  611          643.58805    385.58856   0.001636661 
+  596          640.90238    384.98028   0.001677852 
+  568          631.25777    384.3735    0.001760563 
+  555          594.81969    383.7682    0.001801802 
+  515          549.40385    383.1644    0.001941748 
+  544          521.14788    382.56208   0.001838235 
+  514          499.3586     381.96125   0.001945525 
+  408          473.36888    381.36189   0.00245098 
+  505          457.55107    380.76401   0.001980198 
+  461          453.51079    380.16759   0.002169197 
+  451          460.0222     379.57265   0.002217295 
+  529          476.28275    378.97917   0.001890359 
+  584          506.20155    378.38715   0.001712329 
+  603          550.5951     377.79659   0.001658375 
+  640          592.69285    377.20749   0.0015625 
+  676          610.07911    376.61983   0.00147929 
+  627          603.33956    376.03363   0.001594896 
+  563          572.78321    375.44886   0.001776199 
+  503          532.45731    374.86554   0.001988072 
+  457          496.34493    374.28366   0.002188184 
+  405          460.91963    373.70321   0.002469136 
+  392          432.74989    373.12419   0.00255102 
+  394          416.75188    372.5466    0.002538071 
+  370          407.75133    371.97043   0.002702703 
+  389          402.14984    371.39568   0.002570694 
+  367          398.32273    370.82235   0.002724796 
+  362          395.53289    370.25044   0.002762431 
+  375          393.42057    369.67993   0.002666667 
+  372          391.80011    369.11083   0.002688172 
+  399          390.55434    368.54314   0.002506266 
+  370          389.64038    367.97685   0.002702703 
+  388          389.0045     367.41195   0.00257732 
+  385          388.64665    366.84845   0.002597403 
+  369          388.55417    366.28634   0.002710027 
+  351          388.70195    365.72562   0.002849003 
+  375          388.97595    365.16628   0.002666667 
+  370          389.29889    364.60832   0.002702703 
+  381          389.66087    364.05174   0.002624672 
+  352          390.14078    363.49654   0.002840909 
+  356          390.90246    362.94271   0.002808989 
+  383          392.16191    362.39024   0.002610966 
+  398          394.38197    361.83914   0.002512563 
+  415          398.40285    361.2894    0.002409639 
+  383          405.80219    360.74102   0.002610966 
+  401          419.08098    360.194     0.002493766 
+  449          438.52204    359.64833   0.002227171 
+  445          467.18844    359.104     0.002247191 
+  478          505.87052    358.56103   0.00209205 
+  534          529.22577    358.01939   0.001872659 
+  510          514.18461    357.47909   0.001960784 
+  507          493.12855    356.94013   0.001972387 
+  453          480.87062    356.40251   0.002207506 
+  478          458.45444    355.86621   0.00209205 
+  410          432.3949     355.33124   0.002439024 
+  393          416.66056    354.79759   0.002544529 
+  383          408.65014    354.26526   0.002610966 
+  415          405.62498    353.73425   0.002409639 
+  402          404.87115    353.20456   0.002487562 
+  442          406.33326    352.67617   0.002262443 
+  364          411.40484    352.14909   0.002747253 
+  400          406.67034    351.62332   0.0025    
+  409          397.40036    351.09885   0.002444988 
+  406          393.65411    350.57568   0.002463054 
+  383          388.36841    350.0538    0.002610966 
+  328          381.12119    349.53321   0.00304878 
+  347          376.43672    349.01392   0.002881844 
+  359          373.75071    348.49591   0.002785515 
+  348          372.08879    347.97918   0.002873563 
+  386          370.95265    347.46373   0.002590674 
+  398          370.12593    346.94956   0.002512563 
+  354          369.50864    346.43667   0.002824859 
+  379          369.04732    345.92504   0.002638522 
+  363          368.7111     345.41468   0.002754821 
+  375          368.4779     344.90559   0.002666667 
+  375          368.87628    344.39776   0.002666667 
+  370          368.84379    343.89118   0.002702703 
+  352          368.90789    343.38587   0.002840909 
+  339          369.08513    342.8818    0.002949853 
+  357          369.67259    342.37899   0.00280112 
+  381          370.21126    341.87742   0.002624672 
+  401          371.05773    341.37709   0.002493766 
+  356          372.13673    340.87801   0.002808989 
+  334          373.57993    340.38016   0.002994012 
+  378          375.66804    339.88355   0.002645503 
+  376          377.27345    339.38816   0.002659574 
+  402          378.89924    338.89401   0.002487562 
+  361          381.91327    338.40108   0.002770083 
+  387          384.40604    337.90938   0.002583979 
+  395          385.40335    337.4189    0.002531646 
+  363          385.73173    336.92963   0.002754821 
+  389          385.04973    336.44157   0.002570694 
+  388          384.63502    335.95473   0.00257732 
+  372          384.86758    335.4691    0.002688172 
+  369          384.95068    334.98467   0.002710027 
+  387          385.8111     334.50144   0.002583979 
+  371          387.60628    334.01941   0.002695418 
+  380          390.06267    333.53858   0.002631579 
+  382          393.07896    333.05894   0.002617801 
+  402          396.62386    332.58049   0.002487562 
+  383          400.65061    332.10323   0.002610966 
+  414          405.03697    331.62716   0.002415459 
+  399          409.61173    331.15226   0.002506266 
+  435          414.30268    330.67855   0.002298851 
+  422          419.23465    330.20601   0.002369668 
+  400          424.62333    329.73464   0.0025    
+  451          430.68648    329.26445   0.002217295 
+  459          437.68116    328.79542   0.002178649 
+  441          445.91944    328.32756   0.002267574 
+  447          455.71829    327.86086   0.002237136 
+  393          467.38686    327.39532   0.002544529 
+  430          481.23526    326.93093   0.002325581 
+  456          497.59179    326.4677    0.002192982 
+  453          516.84308    326.00562   0.002207506 
+  493          539.62482    325.54469   0.002028398 
+  522          567.0142     325.0849    0.001915709 
+  528          600.59774    324.62625   0.001893939 
+  547          642.59542    324.16875   0.001828154 
+  586          696.22088    323.71238   0.001706485 
+  718          766.32196    323.25714   0.001392758 
+  807          860.49756    322.80304   0.001239157 
+  985          991.3065     322.35006   0.001015228 
+  1260         1181.03371   321.89821   0.000793651 
+  1639         1473.72806   321.44748   0.000610128 
+  2202         1975.84534   320.99787   0.000454133 
+  3241         2982.21841   320.54938   0.000308547 
+  4986         5090.496     320.10201   0.000200562 
+  8373         8202.81393   319.65574   0.000119432 
+  15312        13689.19332  319.21059   0.000065308 
+  25287        20776.06237  318.76654   0.000039546 
+  26562        22667.96229  318.32359   0.000037648 
+  16314        15754.3688   317.88175   0.000061297 
+  13615        13520.66014  317.441     0.000073448 
+  13800        12864.03992  317.00135   0.000072464 
+  8215         8258.73694   316.56279   0.000121729 
+  3436         4229.15143   316.12533   0.000291036 
+  1846         2505.48342   315.68895   0.000541712 
+  1540         1752.46293   315.25365   0.000649351 
+  1186         1348.38316   314.81944   0.00084317 
+  997          1099.73281   314.3863    0.001003009 
+  957          934.67144    313.95425   0.001044932 
+  888          819.16084    313.52326   0.001126126 
+  771          735.20866    313.09335   0.001297017 
+  635          671.72545    312.66451   0.001574803 
+  636          622.45685    312.23673   0.001572327 
+  582          584.03232    311.81002   0.001718213 
+  542          553.5235     311.38436   0.001845018 
+  543          528.81025    310.95977   0.001841621 
+  521          508.95139    310.53623   0.001919386 
+  520          493.09473    310.11375   0.001923077 
+  481          480.55853    309.69231   0.002079002 
+  466          470.91028    309.27192   0.002145923 
+  443          463.9401     308.85258   0.002257336 
+  434          459.63629    308.43428   0.002304147 
+  403          457.82204    308.01702   0.00248139 
+  453          458.73607    307.6008    0.002207506 
+  436          462.79278    307.18561   0.002293578 
+  479          468.66787    306.77145   0.002087683 
+  428          477.18624    306.35833   0.002336449 
+  471          490.33842    305.94623   0.002123142 
+  471          507.50676    305.53515   0.002123142 
+  559          527.15911    305.1251    0.001788909 
+  614          549.38258    304.71607   0.001628664 
+  589          574.676      304.30805   0.001697793 
+  641          603.88962    303.90105   0.001560062 
+  654          636.22108    303.49506   0.001529052 
+  784          668.29489    303.09008   0.00127551 
+  723          697.25935    302.68611   0.001383126 
+  876          724.65629    302.28314   0.001141553 
+  809          749.39248    301.88117   0.001236094 
+  841          778.03873    301.4802    0.001189061 
+  755          798.91735    301.08023   0.001324503 
+  790          774.47457    300.68125   0.001265823 
+  762          742.43042    300.28327   0.001312336 
+  721          717.03466    299.88627   0.001386963 
+  725          673.2631     299.49026   0.00137931 
+  639          619.17089    299.09524   0.001564945 
+  631          571.20187    298.7012    0.001584786 
+  581          528.98544    298.30813   0.00172117 
+  593          492.06561    297.91604   0.001686341 
+  536          460.89776    297.52493   0.001865672 
+  476          435.5497     297.13479   0.00210084 
+  448          415.34293    296.74562   0.002232143 
+  401          399.19769    296.35742   0.002493766 
+  412          386.22463    295.97018   0.002427184 
+  357          375.7305     295.5839    0.00280112 
+  368          367.12782    295.19858   0.002717391 
+  338          359.97776    294.81422   0.00295858 
+  398          353.9571     294.43082   0.002512563 
+  357          348.82644    294.04837   0.00280112 
+  347          344.36445    293.66687   0.002881844 
+  348          340.51893    293.28631   0.002873563 
+  348          337.11226    292.9067    0.002873563 
+  325          334.12947    292.52804   0.003076923 
+  326          331.47514    292.15031   0.003067485 
+  354          329.09388    291.77353   0.002824859 
+  353          326.95832    291.39768   0.002832861 
+  312          325.03127    291.02276   0.003205128 
+  322          323.28799    290.64877   0.00310559 
+  331          321.70879    290.27572   0.003021148 
+  313          320.27119    289.90358   0.003194888 
+  320          318.97848    289.53238   0.003125  
+  315          317.812      289.16209   0.003174603 
+  337          316.77497    288.79273   0.002967359 
+  341          315.86344    288.42428   0.002932551 
+  346          315.08166    288.05675   0.002890173 
+  309          314.43965    287.69012   0.003236246 
+  327          313.95927    287.32441   0.003058104 
+  318          313.65489    286.95961   0.003144654 
+  310          313.59049    286.59571   0.003225806 
+  314          313.83711    286.23272   0.003184713 
+  369          314.52229    285.87062   0.002710027 
+  340          315.87864    285.50943   0.002941176 
+  317          318.3606     285.14913   0.003154574 
+  343          322.97316    284.78972   0.002915452 
+  360          331.90271    284.43121   0.002777778 
+  376          348.76823    284.07359   0.002659574 
+  417          372.77405    283.71685   0.002398082 
+  418          399.50396    283.361     0.002392344 
+  486          430.10154    283.00603   0.002057613 
+  432          419.71709    282.65194   0.002314815 
+  397          394.40936    282.29873   0.002518892 
+  434          387.77268    281.9464    0.002304147 
+  391          382.49629    281.59494   0.002557545 
+  367          360.71126    281.24435   0.002724796 
+  351          344.25347    280.89463   0.002849003 
+  350          335.33762    280.54577   0.002857143 
+  336          329.88862    280.19778   0.00297619 
+  329          325.85766    279.85066   0.003039514 
+  352          322.6412     279.50439   0.002840909 
+  341          320.34617    279.15899   0.002932551 
+  317          319.53587    278.81443   0.003154574 
+  350          319.88508    278.47074   0.002857143 
+  327          321.40915    278.12789   0.003058104 
+  348          322.43127    277.78589   0.002873563 
+  315          317.31921    277.44474   0.003174603 
+  279          312.47826    277.10444   0.003584229 
+  352          310.61265    276.76498   0.002840909 
+  316          307.79141    276.42636   0.003164557 
+  323          303.38733    276.08857   0.003095975 
+  360          300.39777    275.75163   0.002777778 
+  312          298.67784    275.41551   0.003205128 
+  287          297.6548     275.08023   0.003484321 
+  275          297.02923    274.74578   0.003636364 
+  310          296.69238    274.41216   0.003225806 
+  336          297.11757    274.07936   0.00297619 
+  349          297.47107    273.74739   0.00286533 
+  309          298.49523    273.41624   0.003236246 
+  353          300.51404    273.0859    0.002832861 
+  342          303.27896    272.75639   0.002923977 
+  302          306.45238    272.42769   0.003311258 
+  343          308.09078    272.0998    0.002915452 
+  338          305.85877    271.77272   0.00295858 
+  339          304.49089    271.44645   0.002949853 
+  371          304.95582    271.12099   0.002695418 
+  308          304.48347    270.79633   0.003246753 
+  317          303.67812    270.47248   0.003154574 
+  297          304.61347    270.14942   0.003367003 
+  336          307.73071    269.82717   0.00297619 
+  339          313.5527     269.5057    0.002949853 
+  331          321.72385    269.18504   0.003021148 
+  370          333.50254    268.86516   0.002702703 
+  381          346.80503    268.54608   0.002624672 
+  339          358.88383    268.22778   0.002949853 
+  362          374.52534    267.91027   0.002762431 
+  400          392.5601     267.59354   0.0025    
+  382          392.62484    267.2776    0.002617801 
+  404          375.82568    266.96243   0.002475248 
+  397          364.64227    266.64805   0.002518892 
+  371          359.36812    266.33443   0.002695418 
+  381          348.04455    266.0216    0.002624672 
+  335          335.50582    265.70953   0.002985075 
+  331          326.99329    265.39823   0.003021148 
+  339          321.63117    265.0877    0.002949853 
+  334          319.36323    264.77794   0.002994012 
+  352          319.17326    264.46894   0.002840909 
+  340          319.5263     264.1607    0.002941176 
+  300          320.72077    263.85322   0.003333333 
+  322          323.31264    263.5465    0.00310559 
+  346          327.37734    263.24054   0.002890173 
+  321          333.05229    262.93533   0.003115265 
+  370          341.06598    262.63087   0.002702703 
+  388          352.42466    262.32716   0.00257732 
+  374          371.934      262.02419   0.002673797 
+  439          410.38938    261.72198   0.002277904 
+  505          475.33274    261.4205    0.001980198 
+  580          545.27892    261.11977   0.001724138 
+  692          640.60073    260.81978   0.001445087 
+  680          621.55846    260.52053   0.001470588 
+  625          548.61476    260.22202   0.0016    
+  546          532.91024    259.92423   0.001831502 
+  619          549.74431    259.62718   0.001615509 
+  542          504.91144    259.33086   0.001845018 
+  547          468.10528    259.03527   0.001828154 
+  523          466.30817    258.74041   0.001912046 
+  516          488.46121    258.44627   0.001937984 
+  583          523.02856    258.15285   0.001715266 
+  630          568.04018    257.86015   0.001587302 
+  575          600.52894    257.56818   0.00173913 
+  624          616.09949    257.27692   0.001602564 
+  636          652.22109    256.98637   0.001572327 
+  736          715.11231    256.69654   0.001358696 
+  827          790.20982    256.40742   0.00120919 
+  1038         895.23617    256.11901   0.000963391 
+  1097         1065.26882   255.8313    0.000911577 
+  1441         1340.17615   255.5443    0.000693963 
+  2017         1814.76259   255.25801   0.000495786 
+  3200         2755.31816   254.97242   0.0003125 
+  5248         4755.97908   254.68752   0.000190549 
+  9251         8167.96268   254.40333   0.000108096 
+  16489        13867.674    254.11983   0.000060646 
+  23059        18864.39016  253.83703   0.000043367 
+  18152        15827.83202  253.55492   0.00005509 
+  11154        10643.27736  253.2735    0.000089654 
+  10891        10420.52507  252.99277   0.000091819 
+  11360        10599.35986  252.71273   0.000088028 
+  7099         6848.70818   252.43337   0.000140865 
+  3116         3524.85552   252.1547    0.000320924 
+  1732         2084.78213   251.8767    0.000577367 
+  1165         1455.10298   251.59939   0.000858369 
+  979          1120.9884    251.32276   0.00102145 
+  872          919.94757    251.0468    0.001146789 
+  744          790.56532    250.77152   0.001344086 
+  611          703.9757     250.49691   0.001636661 
+  625          637.39789    250.22297   0.0016    
+  537          578.20169    249.9497    0.001862197 
+  542          535.22202    249.6771    0.001845018 
+  448          506.26316    249.40516   0.002232143 
+  459          477.45396    249.13389   0.002178649 
+  426          444.25406    248.86328   0.002347418 
+  397          418.94297    248.59333   0.002518892 
+  417          401.49857    248.32404   0.002398082 
+  378          386.65544    248.0554    0.002645503 
+  379          373.27893    247.78743   0.002638522 
+  385          364.63132    247.5201    0.002597403 
+  389          360.23882    247.25342   0.002570694 
+  346          359.31943    246.9874    0.002890173 
+  369          358.0245     246.72202   0.002710027 
+  374          352.90794    246.45729   0.002673797 
+  381          347.92705    246.19321   0.002624672 
+  369          342.14246    245.92977   0.002710027 
+  384          338.60844    245.66697   0.002604167 
+  379          336.60354    245.40481   0.002638522 
+  368          335.77055    245.14328   0.002717391 
+  338          330.84991    244.8824    0.00295858 
+  308          322.33916    244.62214   0.003246753 
+  314          316.57738    244.36252   0.003184713 
+  324          313.18138    244.10353   0.00308642 
+  301          308.01424    243.84517   0.003322259 
+  307          301.14928    243.58744   0.003257329 
+  299          295.61351    243.33034   0.003344482 
+  278          291.27505    243.07385   0.003597122 
+  287          287.70915    242.818     0.003484321 
+  266          284.76518    242.56276   0.003759398 
+  243          282.39469    242.30814   0.004115226 
+  267          280.5584     242.05414   0.003745318 
+  259          279.20183    241.80075   0.003861004 
+  247          278.24087    241.54798   0.004048583 
+  259          277.52547    241.29582   0.003861004 
+  293          276.82081    241.04428   0.003412969 
+  258          275.8979     240.79334   0.003875969 
+  290          274.69169    240.54301   0.003448276 
+  279          272.67072    240.29328   0.003584229 
+  311          271.20853    240.04416   0.003215434 
+  268          269.69461    239.79565   0.003731343 
+  288          267.82935    239.54773   0.003472222 
+  290          266.33483    239.30042   0.003448276 
+  244          265.01768    239.0537    0.004098361 
+  282          263.92665    238.80758   0.003546099 
+  250          263.05747    238.56205   0.004     
+  254          262.42315    238.31712   0.003937008 
+  243          262.05055    238.07278   0.004115226 
+  271          261.95626    237.82902   0.003690037 
+  266          262.16648    237.58586   0.003759398 
+  266          262.64546    237.34328   0.003759398 
+  271          263.26461    237.10129   0.003690037 
+  243          263.86379    236.85988   0.004115226 
+  250          264.16078    236.61906   0.004     
+  263          265.08486    236.37881   0.003802281 
+  289          266.57072    236.13915   0.003460208 
+  262          268.14856    235.90006   0.003816794 
+  298          267.01486    235.66154   0.003355705 
+  281          264.60146    235.4236    0.003558719 
+  282          263.77966    235.18624   0.003546099 
+  312          264.38071    234.94944   0.003205128 
+  271          264.88205    234.71322   0.003690037 
+  281          266.58634    234.47756   0.003558719 
+  320          272.41219    234.24247   0.003125  
+  338          284.92879    234.00794   0.00295858 
+  362          303.02854    233.77398   0.002762431 
+  399          323.45186    233.54058   0.002506266 
+  429          331.70415    233.30774   0.002331002 
+  441          316.41398    233.07545   0.002267574 
+  391          305.50261    232.84373   0.002557545 
+  421          301.79083    232.61256   0.002375297 
+  353          296.01123    232.38195   0.002832861 
+  337          281.03935    232.15188   0.002967359 
+  295          269.27459    231.92237   0.003389831 
+  303          261.70164    231.69341   0.00330033 
+  275          257.58251    231.465     0.003636364 
+  264          255.60023    231.23714   0.003787879 
+  271          254.9991     231.00982   0.003690037 
+  265          255.65287    230.78304   0.003773585 
+  311          257.75644    230.55681   0.003215434 
+  282          260.77464    230.33111   0.003546099 
+  286          261.56937    230.10596   0.003496503 
+  313          259.57021    229.88134   0.003194888 
+  305          258.3929     229.65726   0.003278689 
+  288          258.79069    229.43372   0.003472222 
+  295          258.8873     229.21071   0.003389831 
+  284          258.15184    228.98823   0.003521127 
+  293          258.26673    228.76628   0.003412969 
+  260          259.89209    228.54486   0.003846154 
+  284          263.35263    228.32397   0.003521127 
+  273          269.57369    228.10361   0.003663004 
+  274          281.19013    227.88377   0.003649635 
+  312          305.04158    227.66445   0.003205128 
+  335          353.52149    227.44566   0.002985075 
+  386          421.28147    227.22739   0.002590674 
+  536          500.79196    227.00963   0.001865672 
+  558          512.83564    226.79239   0.001792115 
+  524          441.42385    226.57567   0.001908397 
+  407          420.31163    226.35947   0.002457002 
+  445          435.18836    226.14378   0.002247191 
+  457          414.09338    225.9286    0.002188184 
+  396          348.80269    225.71393   0.002525253 
+  296          311.53971    225.49977   0.003378378 
+  292          294.93182    225.28612   0.003424658 
+  240          280.61882    225.07297   0.004166667 
+  276          269.62548    224.86033   0.003623188 
+  277          263.30558    224.64819   0.003610108 
+  260          259.83031    224.43656   0.003846154 
+  261          257.92334    224.22543   0.003831418 
+  252          256.98883    224.01479   0.003968254 
+  247          256.7669     223.80466   0.004048583 
+  279          257.01831    223.59502   0.003584229 
+  250          257.5393     223.38588   0.004     
+  273          257.78158    223.17723   0.003663004 
+  241          258.12882    222.96907   0.004149378 
+  268          258.97447    222.76141   0.003731343 
+  273          260.20893    222.55423   0.003663004 
+  292          261.50592    222.34755   0.003424658 
+  274          263.00064    222.14135   0.003649635 
+  258          264.93686    221.93564   0.003875969 
+  268          267.3502     221.73041   0.003731343 
+  280          270.39809    221.52567   0.003571429 
+  291          274.48274    221.32141   0.003436426 
+  352          280.38322    221.11762   0.002840909 
+  304          288.36523    220.91432   0.003289474 
+  291          297.38569    220.7115    0.003436426 
+  321          304.7359     220.50915   0.003115265 
+  338          306.90206    220.30728   0.00295858 
+  335          312.59183    220.10588   0.002985075 
+  308          326.35427    219.90496   0.003246753 
+  407          351.59102    219.70451   0.002457002 
+  373          385.67067    219.50453   0.002680965 
+  449          424.32788    219.30501   0.002227171 
+  421          440.11323    219.10597   0.002375297 
+  412          407.52069    218.90739   0.002427184 
+  405          397.81035    218.70927   0.002469136 
+  404          409.91889    218.51162   0.002475248 
+  436          422.3756     218.31444   0.002293578 
+  433          410.61292    218.11771   0.002309469 
+  402          409.30541    217.92144   0.002487562 
+  383          423.46263    217.72564   0.002610966 
+  467          448.59506    217.53029   0.002141328 
+  478          483.10869    217.33539   0.00209205 
+  513          526.67554    217.14095   0.001949318 
+  609          582.80106    216.94697   0.001642036 
+  748          661.28429    216.75343   0.001336898 
+  813          773.36602    216.56035   0.001230012 
+  904          938.04597    216.36772   0.001106195 
+  1162         1194.6111    216.17554   0.000860585 
+  1665         1637.97115   215.9838    0.000600601 
+  2670         2533.31152   215.79251   0.000374532 
+  4433         4565.3321    215.60167   0.000225581 
+  8163         8391.59924   215.41127   0.000122504 
+  14358        12840.7159   215.22131   0.000069648 
+  18172        16188.25663  215.03179   0.00005503 
+  11693        10856.13443  214.84272   0.000085521 
+  7374         7793.64198   214.65408   0.000135612 
+  7940         7921.74402   214.46588   0.000125945 
+  9172         9091.93885   214.27812   0.000109027 
+  6176         6060.26904   214.09079   0.000161917 
+  2774         3116.86094   213.9039    0.00036049 
+  1433         1825.54427   213.71743   0.000697837 
+  991          1264.13139   213.5314    0.001009082 
+  766          967.16742    213.3458    0.001305483 
+  603          785.49361    213.16064   0.001658375 
+  539          665.06435    212.97589   0.001855288 
+  440          580.97643    212.79158   0.002272727 
+  431          520.15253    212.60769   0.002320186 
+  381          475.26347    212.42422   0.002624672 
+  407          442.12576    212.24118   0.002457002 
+  339          418.69682    212.05856   0.002949853 
+  389          404.81092    211.87637   0.002570694 
+  372          401.85929    211.69459   0.002688172 
+  385          408.73435    211.51323   0.002597403 
+  393          411.24592    211.33229   0.002544529 
+  400          403.06283    211.15176   0.0025    
+  418          390.76464    210.97165   0.002392344 
+  370          380.03531    210.79195   0.002702703 
+  362          374.31373    210.61267   0.002762431 
+  316          357.48609    210.4338    0.003164557 
+  296          335.1057     210.25534   0.003378378 
+  277          315.53972    210.07729   0.003610108 
+  288          302.97083    209.89964   0.003472222 
+  264          291.96244    209.72241   0.003787879 
+  269          280.18503    209.54558   0.003717472 
+  281          271.61145    209.36915   0.003558719 
+  237          265.82127    209.19313   0.004219409 
+  258          261.70009    209.01751   0.003875969 
+  224          258.62464    208.84229   0.004464286 
+  266          256.31192    208.66748   0.003759398 
+  227          254.63999    208.49306   0.004405286 
+  264          253.54952    208.31904   0.003787879 
+  256          252.98248    208.14542   0.00390625 
+  263          252.81105    207.9722    0.003802281 
+  235          252.77661    207.79937   0.004255319 
+  243          252.55009    207.62693   0.004115226 
+  255          251.9361     207.45489   0.003921569 
+  213          251.05343    207.28323   0.004694836 
+  232          250.18552    207.11197   0.004310345 
+  240          249.52122    206.9411    0.004166667 
+  233          249.16505    206.77062   0.004291845 
+  247          249.31489    206.60052   0.004048583 
+  256          250.36602    206.43081   0.00390625 
+  255          252.91853    206.26148   0.003921569 
+  294          257.28612    206.09254   0.003401361 
+  252          262.09683    205.92399   0.003968254 
+  237          264.54467    205.75581   0.004219409 
+  215          259.85686    205.58802   0.004651163 
+  275          255.17151    205.4206    0.003636364 
+  269          252.97087    205.25357   0.003717472 
+  234          248.299      205.08691   0.004273504 
+  278          241.75389    204.92063   0.003597122 
+  256          237.14229    204.75472   0.00390625 
+  235          233.81193    204.58919   0.004255319 
+  268          231.48798    204.42403   0.003731343 
+  235          230.01659    204.25925   0.004255319 
+  232          229.1705     204.09483   0.004310345 
+  226          228.86852    203.93079   0.004424779 
+  234          229.19323    203.76712   0.004273504 
+  248          230.40737    203.60381   0.004032258 
+  237          232.61286    203.44087   0.004219409 
+  226          234.64248    203.2783    0.004424779 
+  215          235.34663    203.1161    0.004651163 
+  242          236.76724    202.95426   0.004132231 
+  249          239.57068    202.79278   0.004016064 
+  223          244.14578    202.63166   0.004484305 
+  280          251.69388    202.47091   0.003571429 
+  262          267.42339    202.31051   0.003816794 
+  330          300.69611    202.15048   0.003030303 
+  344          353.84691    201.9908    0.002906977 
+  441          412.44858    201.83148   0.002267574 
+  476          434.40908    201.67252   0.00210084 
+  415          401.16338    201.51391   0.002409639 
+  419          394.30271    201.35566   0.002386635 
+  401          381.49479    201.19776   0.002493766 
+  335          370.73091    201.04021   0.002985075 
+  344          335.6928     200.88302   0.002906977 
+  315          311.43532    200.72617   0.003174603 
+  305          293.1091     200.56967   0.003278689 
+  273          277.25805    200.41353   0.003663004 
+  234          272.70617    200.25773   0.004273504 
+  268          279.34384    200.10227   0.003731343 
+  267          277.5421     199.94717   0.003745318 
+  293          265.9615     199.7924    0.003412969 
+  236          260.07082    199.63798   0.004237288 
+  290          257.14437    199.48391   0.003448276 
+  264          253.53641    199.33017   0.003787879 
+  232          243.9907     199.17678   0.004310345 
+  222          236.57484    199.02372   0.004504505 
+  206          231.47197    198.87101   0.004854369 
+  259          226.61409    198.71863   0.003861004 
+  219          223.44914    198.56659   0.00456621 
+  196          221.68826    198.41488   0.005102041 
+  222          220.74625    198.26352   0.004504505 
+  202          220.30851    198.11248   0.004950495 
+  223          220.25978    197.96178   0.004484305 
+  200          220.59088    197.81141   0.005     
+  208          221.19394    197.66137   0.004807692 
+  196          221.48593    197.51166   0.005102041 
+  219          221.56739    197.36229   0.00456621 
+  202          222.00237    197.21324   0.004950495 
+  220          222.88416    197.06452   0.004545455 
+  241          224.06692    196.91612   0.004149378 
+  216          225.51245    196.76806   0.00462963 
+  203          227.94594    196.62031   0.004926108 
+  217          232.42469    196.47289   0.004608295 
+  219          240.05181    196.3258    0.00456621 
+  224          247.39136    196.17903   0.004464286 
+  194          245.40166    196.03257   0.005154639 
+  206          241.531      195.88644   0.004854369 
+  234          241.98382    195.74063   0.004273504 
+  241          245.9163     195.59514   0.004149378 
+  213          248.08068    195.44997   0.004694836 
+  201          247.35389    195.30511   0.004975124 
+  248          248.38696    195.16057   0.004032258 
+  249          251.85214    195.01634   0.004016064 
+  269          257.56179    194.87243   0.003717472 
+  281          266.02836    194.72883   0.003558719 
+  278          279.00987    194.58555   0.003597122 
+  295          299.95859    194.44257   0.003389831 
+  279          330.72725    194.29991   0.003584229 
+  324          352.66499    194.15756   0.00308642 
+  325          352.2588     194.01552   0.003076923 
+  320          358.814      193.87378   0.003125  
+  332          381.16182    193.73236   0.003012048 
+  389          412.42358    193.59124   0.002570694 
+  385          434.35771    193.45042   0.002597403 
+  468          449.39194    193.30991   0.002136752 
+  464          465.87431    193.16971   0.002155172 
+  566          484.93696    193.02981   0.001766784 
+  530          508.13332    192.89021   0.001886792 
+  586          535.42678    192.75091   0.001706485 
+  622          563.13137    192.61191   0.001607717 
+  603          584.9358     192.47322   0.001658375 
+  672          595.69437    192.33482   0.001488095 
+  582          595.98781    192.19672   0.001718213 
+  599          592.11362    192.05892   0.001669449 
+  636          590.48613    191.92141   0.001572327 
+  609          593.00907    191.7842    0.001642036 
+  563          599.05451    191.64729   0.001776199 
+  570          611.0742     191.51067   0.001754386 
+  602          627.31369    191.37434   0.00166113 
+  573          641.64978    191.23831   0.001745201 
+  599          651.47101    191.10257   0.001669449 
+  588          654.10446    190.96712   0.00170068 
+  582          648.20109    190.83196   0.001718213 
+  542          631.79886    190.69709   0.001845018 
+  572          604.92511    190.5625    0.001748252 
+  534          570.38735    190.42821   0.001872659 
+  460          531.06801    190.2942    0.002173913 
+  454          490.11152    190.16048   0.002202643 
+  418          449.90062    190.02704   0.002392344 
+  376          412.07403    189.89389   0.002659574 
+  366          378.12722    189.76102   0.00273224 
+  328          349.09992    189.62844   0.00304878 
+  300          325.15264    189.49614   0.003333333 
+  256          305.79662    189.36412   0.00390625 
+  272          290.28793    189.23238   0.003676471 
+  295          277.91271    189.10092   0.003389831 
+  238          268.10026    188.96974   0.004201681 
+  263          260.49564    188.83884   0.003802281 
+  229          255.07041    188.70821   0.004366812 
+  223          252.34905    188.57786   0.004484305 
+  208          253.47628    188.44779   0.004807692 
+  240          257.67891    188.318     0.004166667 
+  217          254.8016     188.18848   0.004608295 
+  215          244.6692     188.05923   0.004651163 
+  234          238.04846    187.93026   0.004273504 
+  210          236.31467    187.80155   0.004761905 
+  199          236.19186    187.67312   0.005025126 
+  229          231.55387    187.54497   0.004366812 
+  201          225.79155    187.41708   0.004975124 
+  198          222.04108    187.28946   0.005050505 
+  202          219.84047    187.16211   0.004950495 
+  222          218.57288    187.03503   0.004504505 
+  192          217.95576    186.90821   0.005208333 
+  217          217.88573    186.78166   0.004608295 
+  209          218.32819    186.65538   0.004784689 
+  195          219.2425     186.52936   0.005128205 
+  191          220.4962     186.40361   0.005235602 
+  224          221.87229    186.27812   0.004464286 
+  207          223.11308    186.15289   0.004830918 
+  195          224.30088    186.02793   0.005128205 
+  207          225.89097    185.90323   0.004830918 
+  225          228.50104    185.77878   0.004444444 
+  239          231.90067    185.6546    0.0041841 
+  220          232.01295    185.53068   0.004545455 
+  210          227.71762    185.40701   0.004761905 
+  221          223.94877    185.28361   0.004524887 
+  196          222.01935    185.16046   0.005102041 
+  202          221.14921    185.03757   0.004950495 
+  213          218.8651     184.91493   0.004694836 
+  210          216.25266    184.79255   0.004761905 
+  216          215.53898    184.67042   0.00462963 
+  201          216.24767    184.54855   0.004975124 
+  200          214.65042    184.42693   0.005     
+  171          211.87595    184.30556   0.005847953 
+  218          211.49563    184.18445   0.004587156 
+  227          214.54479    184.06358   0.004405286 
+  232          220.96206    183.94297   0.004310345 
+  220          226.46759    183.8226    0.004545455 
+  230          224.85873    183.70249   0.004347826 
+  233          222.13045    183.58262   0.004291845 
+  227          219.63829    183.463     0.004405286 
+  212          219.02572    183.34363   0.004716981 
+  168          221.1738     183.2245    0.005952381 
+  226          224.16246    183.10562   0.004424779 
+  243          229.88667    182.98699   0.004115226 
+  217          227.78809    182.86859   0.004608295 
+  229          218.22762    182.75045   0.004366812 
+  212          212.66546    182.63254   0.004716981 
+  205          212.39562    182.51488   0.004878049 
+  210          214.61532    182.39746   0.004761905 
+  213          213.011      182.28028   0.004694836 
+  209          209.66352    182.16334   0.004784689 
+  184          208.67015    182.04664   0.005434783 
+  190          210.25213    181.93018   0.005263158 
+  191          214.69826    181.81396   0.005235602 
+  224          223.58948    181.69798   0.004464286 
+  249          240.06958    181.58223   0.004016064 
+  258          266.27579    181.46672   0.003875969 
+  295          309.40511    181.35145   0.003389831 
+  334          368.36721    181.23641   0.002994012 
+  347          356.92148    181.12161   0.002881844 
+  303          310.17497    181.00704   0.00330033 
+  276          284.34928    180.8927    0.003623188 
+  246          287.67095    180.7786    0.004065041 
+  284          301.41152    180.66473   0.003521127 
+  291          278.91422    180.55109   0.003436426 
+  263          249.48506    180.43768   0.003802281 
+  243          232.37925    180.3245    0.004115226 
+  236          226.70294    180.21155   0.004237288 
+  208          224.86405    180.09883   0.004807692 
+  210          219.96426    179.98634   0.004761905 
+  190          215.01764    179.87408   0.005263158 
+  192          210.97053    179.76205   0.005208333 
+  204          210.20474    179.65024   0.004901961 
+  219          210.01916    179.53865   0.00456621 
+  201          208.57751    179.4273    0.004975124 
+  205          207.72926    179.31616   0.004878049 
+  203          208.84722    179.20526   0.004926108 
+  229          210.80126    179.09457   0.004366812 
+  207          209.20811    178.98411   0.004830918 
+  210          206.81265    178.87387   0.004761905 
+  201          206.3269     178.76386   0.004975124 
+  206          207.51197    178.65406   0.004854369 
+  229          208.73814    178.54449   0.004366812 
+  208          208.04523    178.43513   0.004807692 
+  217          207.29484    178.326     0.004608295 
+  235          207.3125     178.21708   0.004255319 
+  207          207.64414    178.10838   0.004830918 
+  218          207.87864    177.99991   0.004587156 
+  194          207.91197    177.89164   0.005154639 
+  205          207.89494    177.7836    0.004878049 
+  199          208.0144     177.67577   0.005025126 
+  210          208.36632    177.56816   0.004761905 
+  164          209.0262     177.46076   0.006097561 
+  209          210.23749    177.35357   0.004784689 
+  205          212.51891    177.2466    0.004878049 
+  200          216.2239     177.13985   0.005     
+  213          219.12392    177.0333    0.004694836 
+  213          219.04196    176.92697   0.004694836 
+  200          219.55653    176.82085   0.005     
+  197          221.82937    176.71494   0.005076142 
+  197          225.10931    176.60925   0.005076142 
+  217          227.23985    176.50376   0.004608295 
+  219          227.1786     176.39848   0.00456621 
+  230          226.90633    176.29341   0.004347826 
+  190          227.12742    176.18855   0.005263158 
+  211          227.76418    176.0839    0.004739336 
+  237          228.6181     175.97945   0.004219409 
+  215          229.6228     175.87521   0.004651163 
+  226          230.91516    175.77118   0.004424779 
+  220          232.71987    175.66735   0.004545455 
+  234          235.21777    175.56373   0.004273504 
+  229          238.52845    175.46031   0.004366812 
+  238          242.75056    175.3571    0.004201681 
+  219          248.00747    175.25409   0.00456621 
+  260          254.47926    175.15128   0.003846154 
+  262          262.45831    175.04868   0.003816794 
+  245          272.446      174.94628   0.004081633 
+  286          285.3905     174.84408   0.003496503 
+  332          303.0904     174.74208   0.003012048 
+  332          328.1634     174.64028   0.003012048 
+  331          359.07482    174.53868   0.003021148 
+  391          380.97467    174.43728   0.002557545 
+  418          399.55727    174.33608   0.002392344 
+  465          431.82791    174.23508   0.002150538 
+  485          482.26386    174.13427   0.002061856 
+  492          553.45398    174.03367   0.00203252 
+  565          646.46764    173.93326   0.001769912 
+  657          782.36471    173.83304   0.00152207 
+  908          1005.44529   173.73303   0.001101322 
+  1302         1406.37772   173.63321   0.000768049 
+  2179         2241.43905   173.53358   0.000458926 
+  3966         4158.63981   173.43415   0.000252143 
+  7317         7680.63237   173.33491   0.000136668 
+  10482        11136.9385   173.23586   0.000095402 
+  8779         9299.25205   173.13701   0.000113908 
+  4869         5332.88453   173.03835   0.000205381 
+  3711         4148.93118   172.93988   0.000269469 
+  4493         5020.99053   172.84161   0.000222568 
+  5492         6261.43079   172.74352   0.000182083 
+  4412         4918.73479   172.64563   0.000226655 
+  2320         2615.69288   172.54792   0.000431034 
+  1199         1480.84121   172.45041   0.000834028 
+  820          991.1027     172.35308   0.001219512 
+  639          745.66718    172.25595   0.001564945 
+  499          600.79625    172.159     0.002004008 
+  435          506.79776    172.06223   0.002298851 
+  365          441.98787    171.96566   0.002739726 
+  345          395.28088    171.86927   0.002898551 
+  292          360.46154    171.77307   0.003424658 
+  278          333.83081    171.67706   0.003597122 
+  282          313.07753    171.58123   0.003546099 
+  294          296.69952    171.48558   0.003401361 
+  265          283.72026    171.39012   0.003773585 
+  271          273.54941    171.29484   0.003690037 
+  289          265.94982    171.19975   0.003460208 
+  238          261.12566    171.10484   0.004201681 
+  272          260.11525    171.01011   0.003676471 
+  277          265.50726    170.91557   0.003610108 
+  296          281.26545    170.8212    0.003378378 
+  314          302.68678    170.72702   0.003184713 
+  311          297.66918    170.63302   0.003215434 
+  286          273.74746    170.5392    0.003496503 
+  287          261.32736    170.44556   0.003484321 
+  249          264.56028    170.3521    0.004016064 
+  278          280.09178    170.25881   0.003597122 
+  258          294.74665    170.16571   0.003875969 
+  285          315.36706    170.07278   0.003508772 
+  326          340.10507    169.98003   0.003067485 
+  316          317.35231    169.88746   0.003164557 
+  304          276.78873    169.79507   0.003289474 
+  261          257.1499     169.70285   0.003831418 
+  242          258.69314    169.61081   0.004132231 
+  281          268.28096    169.51894   0.003558719 
+  274          255.56642    169.42725   0.003649635 
+  240          231.01716    169.33573   0.004166667 
+  231          214.51499    169.24439   0.004329004 
+  184          205.19225    169.15322   0.005434783 
+  206          199.67233    169.06223   0.004854369 
+  197          196.03665    168.97141   0.005076142 
+  171          193.40389    168.88076   0.005847953 
+  203          191.37649    168.79028   0.004926108 
+  195          189.74447    168.69998   0.005128205 
+  168          188.38846    168.60984   0.005952381 
+  188          187.23495    168.51988   0.005319149 
+  192          186.23646    168.43009   0.005208333 
+  173          185.36312    168.34046   0.005780347 
+  154          184.58823    168.25101   0.006493506 
+  185          183.89842    168.16173   0.005405405 
+  183          183.28244    168.07261   0.005464481 
+  186          182.73249    167.98367   0.005376344 
+  196          182.24291    167.89489   0.005102041 
+  182          181.81218    167.80628   0.005494505 
+  181          181.44046    167.71784   0.005524862 
+  181          181.128      167.62956   0.005524862 
+  159          180.88215    167.54145   0.006289308 
+  199          180.71461    167.45351   0.005025126 
+  173          180.64987    167.36573   0.005780347 
+  189          180.73539    167.27812   0.005291005 
+  190          181.06299    167.19067   0.005263158 
+  155          181.73669    167.10339   0.006451613 
+  161          182.49908    167.01627   0.00621118 
+  190          182.49667    166.92931   0.005263158 
+  172          181.97576    166.84252   0.005813953 
+  198          181.68297    166.75589   0.005050505 
+  174          181.79975    166.66943   0.005747126 
+  177          182.21275    166.58312   0.005649718 
+  187          182.49367    166.49698   0.005347594 
+  171          182.67039    166.411     0.005847953 
+  203          183.18625    166.32518   0.004926108 
+  193          184.25857    166.23952   0.005181347 
+  185          186.07215    166.15403   0.005405405 
+  173          189.01827    166.06869   0.005780347 
+  189          194.01014    165.98351   0.005291005 
+  187          203.21092    165.89849   0.005347594 
+  233          220.86028    165.81363   0.004291845 
+  231          250.48048    165.72893   0.004329004 
+  224          272.02776    165.64439   0.004464286 
+  193          252.97645    165.56      0.005181347 
+  191          228.49231    165.47577   0.005235602 
+  219          219.50789    165.3917    0.00456621 
+  194          224.67688    165.30778   0.005154639 
+  179          233.70725    165.22403   0.005586592 
+  200          225.21914    165.14042   0.005     
+  180          210.42327    165.05698   0.005555556 
+  160          202.97481    164.97369   0.00625   
+  190          201.59429    164.89055   0.005263158 
+  216          205.62103    164.80757   0.00462963 
+  209          213.59592    164.72474   0.004784689 
+  244          212.18861    164.64207   0.004098361 
+  253          202.31738    164.55955   0.003952569 
+  237          196.12082    164.47718   0.004219409 
+  217          194.90908    164.39496   0.004608295 
+  189          197.7523     164.3129    0.005291005 
+  197          198.4418     164.23099   0.005076142 
+  222          193.85942    164.14924   0.004504505 
+  206          190.79237    164.06763   0.004854369 
+  209          191.18669    163.98617   0.004784689 
+  184          194.83661    163.90487   0.005434783 
+  246          199.71418    163.82372   0.004065041 
+  264          202.19483    163.74271   0.003787879 
+  298          207.24456    163.66186   0.003355705 
+  324          220.90026    163.58115   0.00308642 
+  309          244.66006    163.5006    0.003236246 
+  269          265.00879    163.42019   0.003717472 
+  259          259.79102    163.33993   0.003861004 
+  255          242.52543    163.25982   0.003921569 
+  316          238.09483    163.17986   0.003164557 
+  307          251.01083    163.10005   0.003257329 
+  283          277.0605     163.02038   0.003533569 
+  302          299.20506    162.94086   0.003311258 
+  280          300.78388    162.86148   0.003571429 
+  303          300.75546    162.78226   0.00330033 
+  292          296.14214    162.70317   0.003424658 
+  293          299.30971    162.62424   0.003412969 
+  379          330.87053    162.54545   0.002638522 
+  457          400.74229    162.4668    0.002188184 
+  510          542.6182     162.3883    0.001960784 
+  580          755.04672    162.30994   0.001724138 
+  703          793.44963    162.23173   0.001422475 
+  602          577.00374    162.15366   0.00166113 
+  578          437.11308    162.07573   0.001730104 
+  470          414.62911    161.99795   0.00212766 
+  450          477.55279    161.92031   0.002222222 
+  404          529.07365    161.84281   0.002475248 
+  418          431.22647    161.76545   0.002392344 
+  326          327.70651    161.68824   0.003067485 
+  275          272.77442    161.61117   0.003636364 
+  228          245.54886    161.53424   0.004385965 
+  217          233.07131    161.45745   0.004608295 
+  245          229.92197    161.3808    0.004081633 
+  252          235.57188    161.30429   0.003968254 
+  217          254.33101    161.22792   0.004608295 
+  286          304.25274    161.15169   0.003496503 
+  376          410.00182    161.0756    0.002659574 
+  449          463.06063    160.99965   0.002227171 
+  434          363.58421    160.92384   0.002304147 
+  333          306.53861    160.84816   0.003003003 
+  355          318.39981    160.77263   0.002816901 
+  378          392.57396    160.69723   0.002645503 
+  420          472.93056    160.62197   0.002380952 
+  373          409.10364    160.54685   0.002680965 
+  307          314.27669    160.47187   0.003257329 
+  262          267.85354    160.39702   0.003816794 
+  233          259.52077    160.32231   0.004291845 
+  219          269.28146    160.24773   0.00456621 
+  225          260.49832    160.17329   0.004444444 
+  176          232.17622    160.09899   0.005681818 
+  186          209.44851    160.02482   0.005376344 
+  168          196.78964    159.95079   0.005952381 
+  150          190.42684    159.87689   0.006666667 
+  186          187.61791    159.80313   0.005376344 
+  167          186.3748     159.7295    0.005988024 
+  182          184.38147    159.65601   0.005494505 
+  201          182.5047     159.58265   0.004975124 
+  180          181.91732    159.50942   0.005555556 
+  168          182.57864    159.43633   0.005952381 
+  157          184.33791    159.36337   0.006369427 
+  169          186.62491    159.29054   0.00591716 
+  158          189.70517    159.21785   0.006329114 
+  211          195.34373    159.14528   0.004739336 
+  188          205.59601    159.07285   0.005319149 
+  201          224.73727    159.00055   0.004975124 
+  225          261.87935    158.92839   0.004444444 
+  284          329.6103     158.85635   0.003521127 
+  359          411.41872    158.78444   0.002785515 
+  318          403.95369    158.71267   0.003144654 
+  312          327.705      158.64102   0.003205128 
+  277          280.67988    158.56951   0.003610108 
+  246          274.15333    158.49812   0.004065041 
+  244          297.9103     158.42687   0.004098361 
+  244          310.08604    158.35574   0.004098361 
+  261          270.99078    158.28475   0.003831418 
+  244          229.49113    158.21388   0.004098361 
+  210          205.13416    158.14314   0.004761905 
+  183          192.02779    158.07253   0.005464481 
+  186          184.62578    158.00205   0.005376344 
+  165          180.07985    157.93169   0.006060606 
+  174          177.11765    157.86147   0.005747126 
+  165          175.14989    157.79137   0.006060606 
+  166          173.87453    157.7214    0.006024096 
+  172          173.13772    157.65155   0.005813953 
+  173          172.87644    157.58183   0.005780347 
+  180          174.12216    157.51224   0.005555556 
+  185          175.0885     157.44277   0.005405405 
+  171          177.01297    157.37343   0.005847953 
+  188          179.42252    157.30422   0.005319149 
+  175          179.99053    157.23513   0.005714286 
+  175          179.23884    157.16617   0.005714286 
+  180          178.90726    157.09733   0.005555556 
+  185          179.53723    157.02861   0.005405405 
+  187          180.0506     156.96003   0.005347594 
+  218          180.42134    156.89156   0.004587156 
+  205          180.30497    156.82322   0.004878049 
+  196          181.21823    156.755     0.005102041 
+  197          182.87473    156.68691   0.005076142 
+  192          181.56929    156.61894   0.005208333 
+  222          178.07397    156.55109   0.004504505 
+  244          175.7361     156.48337   0.004098361 
+  219          175.00292    156.41577   0.00456621 
+  231          175.63102    156.34829   0.004329004 
+  268          176.43534    156.28093   0.003731343 
+  263          176.21279    156.2137    0.003802281 
+  303          177.06515    156.14658   0.00330033 
+  282          180.01761    156.07959   0.003546099 
+  256          181.99534    156.01272   0.00390625 
+  280          180.44385    155.94597   0.003571429 
+  266          179.90149    155.87935   0.003759398 
+  293          182.23082    155.81284   0.003412969 
+  279          188.67748    155.74645   0.003584229 
+  286          201.65759    155.68018   0.003496503 
+  275          219.15396    155.61404   0.003636364 
+  268          224.25469    155.54801   0.003731343 
+  274          208.60262    155.4821    0.003649635 
+  246          194.93847    155.41632   0.004065041 
+  200          190.31756    155.35065   0.005     
+  209          193.66042    155.2851    0.004784689 
+  227          200.56766    155.21967   0.004405286 
+  249          199.1145     155.15436   0.004016064 
+  211          192.50076    155.08916   0.004739336 
+  191          187.32947    155.02409   0.005235602 
+  227          183.98253    154.95913   0.004405286 
+  220          182.81509    154.89429   0.004545455 
+  184          181.02656    154.82957   0.005434783 
+  192          180.21042    154.76496   0.005208333 
+  170          181.39228    154.70048   0.005882353 
+  195          183.65159    154.63611   0.005128205 
+  182          189.04662    154.57185   0.005494505 
+  208          199.45882    154.50771   0.004807692 
+  189          213.15934    154.44369   0.005291005 
+  201          214.83104    154.37979   0.004975124 
+  202          201.45279    154.316     0.004950495 
+  200          191.58657    154.25233   0.005     
+  206          189.02214    154.18877   0.004854369 
+  207          192.48336    154.12532   0.004830918 
+  194          197.58741    154.062     0.005154639 
+  186          194.35947    153.99879   0.005376344 
+  159          187.19362    153.93569   0.006289308 
+  211          182.8914     153.8727    0.004739336 
+  204          181.23208    153.80984   0.004901961 
+  209          181.13177    153.74708   0.004784689 
+  203          182.04812    153.68444   0.004926108 
+  158          183.91451    153.62191   0.006329114 
+  197          186.99285    153.5595    0.005076142 
+  213          191.52822    153.4972    0.004694836 
+  208          195.48248    153.43501   0.004807692 
+  228          196.75452    153.37294   0.004385965 
+  231          198.04073    153.31098   0.004329004 
+  234          201.31441    153.24913   0.004273504 
+  228          206.6888     153.1874    0.004385965 
+  227          213.86761    153.12577   0.004405286 
+  266          221.91448    153.06426   0.003759398 
+  273          230.42716    153.00286   0.003663004 
+  263          241.63948    152.94158   0.003802281 
+  302          256.69804    152.8804    0.003311258 
+  348          276.40959    152.81934   0.002873563 
+  325          301.90569    152.75839   0.003076923 
+  325          334.69664    152.69754   0.003076923 
+  446          376.15596    152.63681   0.002242152 
+  424          423.87178    152.57619   0.002358491 
+  444          462.52528    152.51568   0.002252252 
+  466          480.09168    152.45528   0.002145923 
+  474          484.3982     152.39499   0.002109705 
+  477          490.7461     152.33481   0.002096436 
+  464          503.9745     152.27475   0.002155172 
+  451          504.54606    152.21479   0.002217295 
+  424          484.9309     152.15494   0.002358491 
+  444          455.80138    152.0952    0.002252252 
+  406          420.75409    152.03556   0.002463054 
+  360          390.22062    151.97604   0.002777778 
+  369          365.664      151.91663   0.002710027 
+  339          337.96829    151.85732   0.002949853 
+  306          309.91279    151.79813   0.003267974 
+  273          285.71796    151.73904   0.003663004 
+  270          263.62516    151.68006   0.003703704 
+  255          245.29558    151.62118   0.003921569 
+  260          231.10677    151.56242   0.003846154 
+  241          220.11875    151.50376   0.004149378 
+  233          211.49117    151.44521   0.004291845 
+  239          204.62657    151.38677   0.0041841 
+  223          199.1096     151.32844   0.004484305 
+  231          194.64453    151.27021   0.004329004 
+  213          191.01882    151.21209   0.004694836 
+  216          188.07852    151.15408   0.00462963 
+  230          185.72003    151.09617   0.004347826 
+  207          183.87707    151.03837   0.004830918 
+  177          182.49236    150.98067   0.005649718 
+  218          181.50548    150.92308   0.004587156 
+  198          181.03409    150.8656    0.005050505 
+  204          181.36844    150.80822   0.004901961 
+  198          182.91434    150.75095   0.005050505 
+  202          185.63408    150.69378   0.004950495 
+  196          187.14388    150.63672   0.005102041 
+  196          187.13451    150.57977   0.005102041 
+  204          188.83847    150.52292   0.004901961 
+  204          190.53778    150.46617   0.004901961 
+  191          188.89079    150.40953   0.005235602 
+  195          187.16372    150.35299   0.005128205 
+  193          185.9551     150.29656   0.005181347 
+  212          185.37482    150.24023   0.004716981 
+  220          186.46573    150.18401   0.004545455 
+  252          187.68917    150.12789   0.003968254 
+  244          187.79395    150.07187   0.004098361 
+  193          188.86345    150.01596   0.005181347 
+  219          191.87046    149.96015   0.00456621 
+  227          197.22756    149.90445   0.004405286 
+  231          205.96489    149.84884   0.004329004 
+  251          220.29235    149.79334   0.003984064 
+  243          243.67538    149.73795   0.004115226 
+  264          277.13674    149.68265   0.003787879 
+  274          304.19305    149.62746   0.003649635 
+  295          297.91156    149.57237   0.003389831 
+  305          277.70368    149.51739   0.003278689 
+  258          272.85557    149.4625    0.003875969 
+  267          283.94083    149.40772   0.003745318 
+  287          287.10116    149.35304   0.003484321 
+  271          276.38188    149.29847   0.003690037 
+  250          255.16634    149.24399   0.004     
+  234          235.00429    149.18961   0.004273504 
+  244          225.51056    149.13534   0.004098361 
+  243          222.78559    149.08117   0.004115226 
+  222          214.42727    149.0271    0.004504505 
+  211          203.71449    148.97313   0.004739336 
+  185          197.3585     148.91926   0.005405405 
+  205          194.4919     148.86549   0.004878049 
+  194          192.3828     148.81182   0.005154639 
+  216          189.6162     148.75825   0.00462963 
+  181          187.61163    148.70479   0.005524862 
+  241          186.86682    148.65142   0.004149378 
+  201          187.26507    148.59815   0.004975124 
+  215          188.6854     148.54499   0.004651163 
+  209          190.71082    148.49192   0.004784689 
+  226          193.77925    148.43895   0.004424779 
+  215          200.25461    148.38608   0.004651163 
+  280          213.40709    148.33332   0.003571429 
+  259          237.54296    148.28065   0.003861004 
+  314          274.87324    148.22808   0.003184713 
+  371          328.69621    148.17561   0.002695418 
+  403          341.14732    148.12323   0.00248139 
+  406          284.51994    148.07096   0.002463054 
+  340          246.7523     148.01879   0.002941176 
+  283          238.36155    147.96671   0.003533569 
+  285          248.96887    147.91473   0.003508772 
+  327          274.28992    147.86285   0.003058104 
+  323          282.87703    147.81107   0.003095975 
+  275          264.93055    147.75939   0.003636364 
+  275          260.05814    147.7078    0.003636364 
+  238          251.09119    147.65632   0.004201681 
+  239          229.38951    147.60493   0.0041841 
+  215          214.03296    147.55363   0.004651163 
+  207          208.62259    147.50244   0.004830918 
+  212          211.25042    147.45134   0.004716981 
+  195          218.37539    147.40034   0.005128205 
+  239          218.88668    147.34944   0.0041841 
+  224          211.27683    147.29863   0.004464286 
+  221          206.90198    147.24792   0.004524887 
+  231          209.30725    147.19731   0.004329004 
+  217          221.05032    147.14679   0.004608295 
+  214          245.65507    147.09638   0.004672897 
+  276          264.42745    147.04605   0.003623188 
+  237          244.81769    146.99583   0.004219409 
+  223          223.93933    146.94569   0.004484305 
+  199          216.20504    146.89566   0.005025126 
+  212          218.60366    146.84572   0.004716981 
+  229          229.82177    146.79588   0.004366812 
+  220          239.87341    146.74613   0.004545455 
+  219          231.3262     146.69648   0.00456621 
+  220          222.05725    146.64692   0.004545455 
+  213          219.60203    146.59746   0.004694836 
+  215          221.16181    146.5481    0.004651163 
+  224          222.98567    146.49883   0.004464286 
+  231          224.7231     146.44965   0.004329004 
+  228          227.97647    146.40057   0.004385965 
+  245          232.6221     146.35158   0.004081633 
+  250          237.57676    146.30269   0.004     
+  251          242.85217    146.2539    0.003984064 
+  234          248.25954    146.20519   0.004273504 
+  276          254.02466    146.15659   0.003623188 
+  257          261.13244    146.10807   0.003891051 
+  243          269.66242    146.05965   0.004115226 
+  262          279.17052    146.01133   0.003816794 
+  334          289.86721    145.9631    0.002994012 
+  308          302.42498    145.91496   0.003246753 
+  319          317.29073    145.86692   0.003134796 
+  328          334.93785    145.81897   0.00304878 
+  356          356.24574    145.77111   0.002808989 
+  382          382.01829    145.72335   0.002617801 
+  474          410.85892    145.67568   0.002109705 
+  474          442.3331     145.6281    0.002109705 
+  571          481.22895    145.58062   0.001751313 
+  681          530.99712    145.53323   0.001468429 
+  657          594.90834    145.48593   0.00152207 
+  701          677.77211    145.43872   0.001426534 
+  714          786.12619    145.39161   0.00140056 
+  743          930.81856    145.34459   0.001345895 
+  892          1132.78394   145.29767   0.001121076 
+  1134         1427.95606   145.25083   0.000881834 
+  1423         1884.2188    145.20409   0.000702741 
+  2159         2644.63209   145.15744   0.000463177 
+  3580         4081.3022    145.11088   0.00027933 
+  6505         7261.86298   145.06442   0.000153728 
+  12065        14454.2594   145.01804   0.000082884 
+  19753        24992.38003  144.97176   0.000050625 
+  21318        22109.30292  144.92557   0.000046909 
+  13113        12155.0458   144.87947   0.00007626 
+  7589         7282.64924   144.83346   0.00013177 
+  5977         6285.68208   144.78755   0.000167308 
+  7081         8326.39999   144.74172   0.000141223 
+  9957         13015.91753  144.69599   0.000100432 
+  11162        12620.70683  144.65035   0.00008959 
+  7388         7089.57448   144.6048    0.000135355 
+  3879         3798.30403   144.55934   0.000257798 
+  2118         2331.48788   144.51397   0.000472144 
+  1328         1631.08209   144.46869   0.000753012 
+  1076         1239.15238   144.4235    0.000929368 
+  840          995.80639    144.3784    0.001190476 
+  745          836.0789     144.3334    0.001342282 
+  627          723.1817     144.28848   0.001594896 
+  575          631.5714     144.24365   0.00173913 
+  483          555.46809    144.19892   0.002070393 
+  411          496.47089    144.15427   0.00243309 
+  327          452.17596    144.10972   0.003058104 
+  372          419.2463     144.06525   0.002688172 
+  347          393.32364    144.02088   0.002881844 
+  304          368.20999    143.97659   0.003289474 
+  275          343.23428    143.93239   0.003636364 
+  285          321.69693    143.88829   0.003508772 
+  269          304.16557    143.84427   0.003717472 
+  250          289.81235    143.80034   0.004     
+  254          277.80213    143.7565    0.003937008 
+  255          267.5441     143.71275   0.003921569 
+  263          258.65188    143.66909   0.003802281 
+  260          250.8579     143.62552   0.003846154 
+  253          244.02632    143.58204   0.003952569 
+  235          238.05828    143.53865   0.004255319 
+  216          232.84552    143.49534   0.00462963 
+  207          228.29926    143.45213   0.004830918 
+  186          224.37258    143.409     0.005376344 
+  198          221.04104    143.36596   0.005050505 
+  225          218.28356    143.32301   0.004444444 
+  191          216.07677    143.28015   0.005235602 
+  235          214.40183    143.23737   0.004255319 
+  235          213.55618    143.19469   0.004255319 
+  192          213.06349    143.15209   0.005208333 
+  207          213.33166    143.10958   0.004830918 
+  240          214.60255    143.06716   0.004166667 
+  241          217.26456    143.02483   0.004149378 
+  244          220.61673    142.98258   0.004098361 
+  239          219.66479    142.94042   0.0041841 
+  207          215.94407    142.89835   0.004830918 
+  233          213.24305    142.85637   0.004291845 
+  211          212.17568    142.81447   0.004739336 
+  211          212.70039    142.77267   0.004739336 
+  206          214.26684    142.73094   0.004854369 
+  225          214.31463    142.68931   0.004444444 
+  220          211.42053    142.64776   0.004545455 
+  228          208.06445    142.6063    0.004385965 
+  227          205.21877    142.56493   0.004405286 
+  194          203.27467    142.52365   0.005154639 
+  219          202.26647    142.48245   0.00456621 
+  208          202.04564    142.44134   0.004807692 
+  219          202.41044    142.40031   0.00456621 
+  236          203.28137    142.35937   0.004237288 
+  210          204.78435    142.31852   0.004761905 
+  217          206.93033    142.27775   0.004608295 
+  227          209.45609    142.23707   0.004405286 
+  230          212.05894    142.19648   0.004347826 
+  254          214.87416    142.15597   0.003937008 
+  252          218.36448    142.11555   0.003968254 
+  261          220.12843    142.07522   0.003831418 
+  271          216.15499    142.03497   0.003690037 
+  247          211.0556     141.9948    0.004048583 
+  292          208.01066    141.95473   0.003424658 
+  275          207.32084    141.91473   0.003636364 
+  264          209.26151    141.87483   0.003787879 
+  242          210.94297    141.83501   0.004132231 
+  221          204.94647    141.79527   0.004524887 
+  237          195.56309    141.75562   0.004219409 
+  241          188.79053    141.71606   0.004149378 
+  239          184.88675    141.67658   0.0041841 
+  236          183.31411    141.63718   0.004237288 
+  223          183.23317    141.59787   0.004484305 
+  203          181.95465    141.55865   0.004926108 
+  205          179.41679    141.51951   0.004878049 
+  192          178.39386    141.48046   0.005208333 
+  205          179.92955    141.44149   0.004878049 
+  193          184.98564    141.4026    0.005181347 
+  227          194.47336    141.3638    0.004405286 
+  192          203.54186    141.32509   0.005208333 
+  195          203.04187    141.28646   0.005128205 
+  223          201.60627    141.24791   0.004484305 
+  188          200.96496    141.20945   0.005319149 
+  226          194.73038    141.17107   0.004424779 
+  183          190.29394    141.13278   0.005464481 
+  168          190.63583    141.09457   0.005952381 
+  193          189.83647    141.05644   0.005181347 
+  177          187.23143    141.0184    0.005649718 
+  170          186.70888    140.98044   0.005882353 
+  177          184.71683    140.94257   0.005649718 
+  162          182.18894    140.90478   0.00617284 
+  197          182.76679    140.86707   0.005076142 
+  185          184.05884    140.82945   0.005405405 
+  168          181.36179    140.79191   0.005952381 
+  178          178.0288     140.75446   0.005617978 
+  172          176.81356    140.71709   0.005813953 
+  174          177.63644    140.6798    0.005747126 
+  195          180.2941     140.64259   0.005128205 
+  190          184.28113    140.60547   0.005263158 
+  192          187.39245    140.56843   0.005208333 
+  213          189.74785    140.53147   0.004694836 
+  190          193.91951    140.4946    0.005263158 
+  195          200.41198    140.45781   0.005128205 
+  219          208.65209    140.42111   0.00456621 
+  265          219.89843    140.38448   0.003773585 
+  266          236.57915    140.34794   0.003759398 
+  280          247.36095    140.31148   0.003571429 
+  265          241.27638    140.2751    0.003773585 
+  268          234.71658    140.23881   0.003731343 
+  260          236.61445    140.2026    0.003846154 
+  266          246.95377    140.16647   0.003759398 
+  247          264.76349    140.13042   0.004048583 
+  297          282.94132    140.09446   0.003367003 
+  282          293.90643    140.05858   0.003546099 
+  278          307.52356    140.02278   0.003597122 
+  291          336.50054    139.98706   0.003436426 
+  356          388.87264    139.95142   0.002808989 
+  443          478.61097    139.91587   0.002257336 
+  549          641.78131    139.8804    0.001821494 
+  934          983.62319    139.84501   0.001070664 
+  1631         1759.34311   139.8097    0.000613121 
+  2619         3144.56632   139.77447   0.000381825 
+  3180         3478.00923   139.73933   0.000314465 
+  2247         2135.63153   139.70426   0.000445038 
+  1327         1260.77048   139.66928   0.00075358 
+  923          949.78327    139.63438   0.001083424 
+  1043         999.64085    139.59956   0.000958773 
+  1290         1425.71085   139.56482   0.000775194 
+  1649         2007.40396   139.53017   0.000606428 
+  1500         1620.41684   139.49559   0.000666667 
+  1047         955.07208    139.46109   0.00095511 
+  613          616.24634    139.42668   0.001631321 
+  406          461.90491    139.39235   0.002463054 
+  331          371.61714    139.35809   0.003021148 
+  281          313.55167    139.32392   0.003558719 
+  269          276.77686    139.28983   0.003717472 
+  246          253.92094    139.25582   0.004065041 
+  219          241.17523    139.22189   0.00456621 
+  211          234.20891    139.18804   0.004739336 
+  216          224.29498    139.15428   0.00462963 
+  221          211.07607    139.12059   0.004524887 
+  171          200.34973    139.08698   0.005847953 
+  187          192.47231    139.05345   0.005347594 
+  206          186.72475    139.02001   0.004854369 
+  165          182.50263    138.98664   0.006060606 
+  180          179.40402    138.95335   0.005555556 
+  208          177.22343    138.92014   0.004807692 
+  207          175.95822    138.88702   0.004830918 
+  166          175.81999    138.85397   0.006024096 
+  180          177.10943    138.821     0.005555556 
+  156          179.08198    138.78812   0.006410256 
+  184          178.07839    138.75531   0.005434783 
+  179          174.42125    138.72258   0.005586592 
+  187          171.76278    138.68993   0.005347594 
+  178          170.74656    138.65736   0.005617978 
+  157          171.18199    138.62487   0.006369427 
+  208          172.96799    138.59246   0.004807692 
+  172          175.22213    138.56013   0.005813953 
+  195          176.74373    138.52788   0.005128205 
+  171          178.36256    138.49571   0.005847953 
+  190          182.4385     138.46361   0.005263158 
+  167          190.23354    138.4316    0.005988024 
+  210          204.35819    138.39966   0.004761905 
+  210          231.61981    138.36781   0.004761905 
+  305          288.08992    138.33603   0.003278689 
+  348          399.11332    138.30433   0.002873563 
+  407          533.16339    138.27271   0.002457002 
+  393          491.43446    138.24117   0.002544529 
+  369          357.52396    138.20971   0.002710027 
+  297          281.31672    138.17832   0.003367003 
+  254          257.71557    138.14702   0.003937008 
+  269          272.36299    138.11579   0.003717472 
+  298          323.22339    138.08464   0.003355705 
+  330          365.31262    138.05357   0.003030303 
+  258          310.55142    138.02258   0.003875969 
+  245          243.28463    137.99167   0.004081633 
+  216          206.54403    137.96083   0.00462963 
+  213          189.00503    137.93007   0.004694836 
+  176          179.86452    137.89939   0.005681818 
+  202          174.10832    137.86879   0.004950495 
+  183          170.71328    137.83827   0.005464481 
+  185          169.74076    137.80782   0.005405405 
+  179          171.6825     137.77745   0.005586592 
+  197          176.11981    137.74716   0.005076142 
+  216          177.6246     137.71695   0.00462963 
+  186          172.86127    137.68681   0.005376344 
+  206          168.49172    137.65676   0.004854369 
+  174          167.06659    137.62677   0.005747126 
+  204          168.3821     137.59687   0.004901961 
+  194          172.77366    137.56705   0.005154639 
+  209          180.56934    137.5373    0.004784689 
+  190          185.56082    137.50763   0.005263158 
+  185          180.28597    137.47803   0.005405405 
+  202          172.5822     137.44851   0.004950495 
+  182          168.88596    137.41907   0.005494505 
+  194          169.25946    137.38971   0.005154639 
+  192          173.56253    137.36042   0.005208333 
+  171          181.40256    137.33122   0.005847953 
+  184          184.82169    137.30208   0.005434783 
+  170          177.58612    137.27303   0.005882353 
+  181          169.72678    137.24405   0.005524862 
+  167          165.74266    137.21514   0.005988024 
+  153          165.00201    137.18632   0.006535948 
+  189          166.81919    137.15757   0.005291005 
+  210          169.65186    137.1289    0.004761905 
+  192          169.16961    137.1003    0.005208333 
+  177          165.81733    137.07178   0.005649718 
+  177          163.73043    137.04333   0.005649718 
+  222          163.5896     137.01496   0.004504505 
+  163          164.10409    136.98667   0.006134969 
+  147          163.67649    136.95846   0.006802721 
+  166          162.90278    136.93032   0.006024096 
+  175          162.25393    136.90225   0.005714286 
+  188          162.17701    136.87426   0.005319149 
+  172          162.80771    136.84635   0.005813953 
+  194          164.0337     136.81851   0.005154639 
+  188          165.24565    136.79075   0.005319149 
+  173          165.9248     136.76307   0.005780347 
+  207          166.7597     136.73545   0.004830918 
+  179          168.12792    136.70792   0.005586592 
+  201          170.04032    136.68046   0.004975124 
+  183          172.57853    136.65308   0.005464481 
+  190          175.9777     136.62577   0.005263158 
+  189          180.25282    136.59853   0.005291005 
+  204          183.72066    136.57138   0.004901961 
+  204          185.10804    136.54429   0.004901961 
+  200          186.8152     136.51728   0.005     
+  191          190.00197    136.49035   0.005235602 
+  239          194.79731    136.46349   0.0041841 
+  199          201.57121    136.43671   0.005025126 
+  245          210.97917    136.41      0.004081633 
+  269          222.87341    136.38337   0.003717472 
+  280          234.83399    136.35681   0.003571429 
+  269          241.84875    136.33032   0.003717472 
+  276          247.82362    136.30391   0.003623188 
+  303          259.12157    136.27758   0.00330033 
+  305          277.58074    136.25132   0.003278689 
+  304          305.08599    136.22513   0.003289474 
+  307          344.20968    136.19902   0.003257329 
+  382          392.43599    136.17298   0.002617801 
+  389          443.76998    136.14701   0.002570694 
+  468          516.5084     136.12112   0.002136752 
+  577          638.96       136.09531   0.001733102 
+  867          853.96108    136.06957   0.001153403 
+  1277         1273.08596   136.0439    0.000783085 
+  2178         2192.55752   136.0183    0.000459137 
+  3922         4130.84578   135.99278   0.000254972 
+  5851         6416.34182   135.96734   0.000170911 
+  5322         5202.12375   135.94196   0.000187899 
+  3124         2932.68308   135.91666   0.000320102 
+  2048         1817.14474   135.89144   0.000488281 
+  1587         1483.72104   135.86628   0.00063012 
+  1631         1673.95441   135.84121   0.000613121 
+  2344         2488.75781   135.8162    0.000426621 
+  3006         3502.40625   135.79127   0.000332668 
+  2704         2771.68252   135.76641   0.000369822 
+  1669         1575.37579   135.74162   0.000599161 
+  972          947.55083    135.71691   0.001028807 
+  670          660.46996    135.69227   0.001492537 
+  464          509.36239    135.6677    0.002155172 
+  408          418.97783    135.64321   0.00245098 
+  321          362.46353    135.61879   0.003115265 
+  304          321.57273    135.59444   0.003289474 
+  263          289.11631    135.57017   0.003802281 
+  253          265.41524    135.54596   0.003952569 
+  233          247.55938    135.52183   0.004291845 
+  239          234.04027    135.49777   0.0041841 
+  212          224.37146    135.47379   0.004716981 
+  205          217.94747    135.44988   0.004878049 
+  212          211.99866    135.42604   0.004716981 
+  201          206.04639    135.40227   0.004975124 
+  204          200.90354    135.37857   0.004901961 
+  195          196.19709    135.35495   0.005128205 
+  195          191.94684    135.3314    0.005128205 
+  186          187.8591     135.30792   0.005376344 
+  187          184.71507    135.28451   0.005347594 
+  184          182.72411    135.26117   0.005434783 
+  190          181.69714    135.23791   0.005263158 
+  205          180.92148    135.21472   0.004878049 
+  189          179.95969    135.1916    0.005291005 
+  172          178.96437    135.16855   0.005813953 
+  173          177.54409    135.14557   0.005780347 
+  176          175.0638     135.12267   0.005681818 
+  162          172.01609    135.09983   0.00617284 
+  175          169.52649    135.07707   0.005714286 
+  186          167.7388     135.05438   0.005376344 
+  170          166.51234    135.03176   0.005882353 
+  178          165.73897    135.00921   0.005617978 
+  148          165.25563    134.98673   0.006756757 
+  164          164.58382    134.96432   0.006097561 
+  173          163.96389    134.94199   0.005780347 
+  163          164.32832    134.91972   0.006134969 
+  181          166.1569     134.89753   0.005524862 
+  162          168.70512    134.87541   0.00617284 
+  182          169.90125    134.85335   0.005494505 
+  180          171.45963    134.83137   0.005555556 
+  151          174.91686    134.80946   0.006622517 
+  167          176.7445     134.78762   0.005988024 
+  178          173.9884     134.76585   0.005617978 
+  166          170.34505    134.74415   0.006024096 
+  158          168.6481     134.72252   0.006329114 
+  164          168.28435    134.70096   0.006097561 
+  175          169.73097    134.67947   0.005714286 
+  178          173.5208     134.65806   0.005617978 
+  159          175.56659    134.63671   0.006289308 
+  171          171.90151    134.61543   0.005847953 
+  174          166.73556    134.59422   0.005747126 
+  200          163.39295    134.57308   0.005     
+  138          161.92511    134.55201   0.007246377 
+  169          161.86494    134.53101   0.00591716 
+  159          162.76074    134.51008   0.006289308 
+  171          163.38851    134.48922   0.005847953 
+  197          162.39581    134.46843   0.005076142 
+  167          160.98485    134.44771   0.005988024 
+  166          160.23248    134.42706   0.006024096 
+  146          160.10182    134.40648   0.006849315 
+  146          160.33761    134.38596   0.006849315 
+  180          160.78409    134.36552   0.005555556 
+  191          161.46355    134.34515   0.005235602 
+  189          162.67352    134.32484   0.005291005 
+  188          164.95278    134.3046    0.005319149 
+  148          168.37697    134.28444   0.006756757 
+  175          170.22007    134.26434   0.005714286 
+  200          168.09804    134.24431   0.005     
+  190          165.50887    134.22435   0.005263158 
+  177          164.39998    134.20446   0.005649718 
+  191          164.71284    134.18463   0.005235602 
+  170          166.42576    134.16488   0.005882353 
+  186          169.67959    134.14519   0.005376344 
+  158          173.87923    134.12557   0.006329114 
+  170          177.91422    134.10602   0.005882353 
+  217          182.7829     134.08654   0.004608295 
+  211          188.59244    134.06713   0.004739336 
+  216          198.94643    134.04778   0.00462963 
+  208          215.32324    134.0285    0.004807692 
+  241          223.14569    134.00929   0.004149378 
+  214          212.51879    133.99015   0.004672897 
+  219          200.23085    133.97108   0.00456621 
+  228          195.07436    133.95207   0.004385965 
+  210          195.33493    133.93313   0.004761905 
+  216          198.93889    133.91426   0.00462963 
+  233          206.29253    133.89546   0.004291845 
+  221          213.74417    133.87672   0.004524887 
+  234          214.19161    133.85806   0.004273504 
+  225          214.9606     133.83946   0.004444444 
+  220          223.87186    133.82092   0.004545455 
+  211          237.08735    133.80246   0.004739336 
+  218          237.69582    133.78406   0.004587156 
+  245          228.13205    133.76572   0.004081633 
+  257          223.15404    133.74746   0.003891051 
+  223          226.03056    133.72926   0.004484305 
+  258          237.09562    133.71113   0.003875969 
+  265          257.49161    133.69306   0.003773585 
+  304          283.29032    133.67507   0.003289474 
+  302          295.04348    133.65714   0.003311258 
+  311          292.72177    133.63927   0.003215434 
+  323          298.12028    133.62147   0.003095975 
+  372          317.60566    133.60374   0.002688172 
+  393          351.04022    133.58608   0.002544529 
+  397          396.69597    133.56848   0.002518892 
+  431          427.17664    133.55094   0.002320186 
+  411          439.00253    133.53348   0.00243309 
+  427          465.61573    133.51608   0.00234192 
+  471          522.66782    133.49874   0.002123142 
+  565          619.22617    133.48147   0.001769912 
+  694          771.40952    133.46427   0.001440922 
+  953          1021.38013   133.44713   0.001049318 
+  1447         1465.72942   133.43006   0.000691085 
+  2450         2371.59399   133.41305   0.000408163 
+  4363         4344.26013   133.39611   0.0002292 
+  6722         7602.24685   133.37924   0.000148765 
+  7416         8111.40092   133.36243   0.000134844 
+  5028         4951.27484   133.34569   0.000198886 
+  3027         2830.47593   133.32901   0.00033036 
+  2027         1961.94042   133.31239   0.00049334 
+  1940         1809.85283   133.29584   0.000515464 
+  2229         2280.46104   133.27936   0.000448632 
+  3280         3557.02089   133.26294   0.000304878 
+  3817         4627.89248   133.24659   0.000261986 
+  3093         3333.74866   133.2303    0.000323311 
+  1907         1880.32615   133.21407   0.000524384 
+  1231         1137.07599   133.19792   0.000812348 
+  836          787.15011    133.18182   0.001196172 
+  602          604.69951    133.16579   0.00166113 
+  500          496.6832     133.14982   0.002     
+  393          427.30202    133.13392   0.002544529 
+  373          380.45848    133.11808   0.002680965 
+  334          347.86633    133.10231   0.002994012 
+  320          324.8183     133.0866    0.003125  
+  317          308.50917    133.07096   0.003154574 
+  304          294.79524    133.05538   0.003289474 
+  281          280.72866    133.03986   0.003558719 
+  287          269.54551    133.02441   0.003484321 
+  252          262.45063    133.00902   0.003968254 
+  281          257.46551    132.99369   0.003558719 
+  265          252.41404    132.97843   0.003773585 
+  287          249.00759    132.96323   0.003484321 
+  259          249.16135    132.94809   0.003861004 
+  253          251.90306    132.93302   0.003952569 
+  228          252.21011    132.91801   0.004385965 
+  292          241.26307    132.90307   0.003424658 
+  212          226.81916    132.88818   0.004716981 
+  229          215.89821    132.87337   0.004366812 
+  251          208.28236    132.85861   0.003984064 
+  213          204.03975    132.84392   0.004694836 
+  219          203.30582    132.82928   0.00456621 
+  229          205.04245    132.81472   0.004366812 
+  236          203.82345    132.80021   0.004237288 
+  227          198.84136    132.78577   0.004405286 
+  217          196.74308    132.77139   0.004608295 
+  228          200.2999     132.75707   0.004385965 
+  219          209.17309    132.74282   0.00456621 
+  225          221.55836    132.72862   0.004444444 
+  216          233.13047    132.71449   0.00462963 
+  252          227.40731    132.70042   0.003968254 
+  236          211.01973    132.68642   0.004237288 
+  250          200.65345    132.67247   0.004     
+  233          198.79081    132.65859   0.004291845 
+  266          204.69573    132.64477   0.003759398 
+  247          217.55729    132.63101   0.004048583 
+  203          234.39454    132.61731   0.004926108 
+  218          240.27851    132.60367   0.004587156 
+  246          229.00265    132.5901    0.004065041 
+  217          219.0459     132.57658   0.004608295 
+  220          217.41592    132.56313   0.004545455 
+  225          223.22465    132.54974   0.004444444 
+  227          235.53344    132.53641   0.004405286 
+  256          250.29081    132.52314   0.00390625 
+  258          253.1235     132.50993   0.003875969 
+  240          241.87129    132.49679   0.004166667 
+  240          231.08562    132.4837    0.004166667 
+  223          221.28723    132.47067   0.004484305 
+  206          211.39078    132.45771   0.004854369 
+  210          206.02875    132.4448    0.004761905 
+  208          205.41576    132.43196   0.004807692 
+  206          204.92574    132.41918   0.004854369 
+  190          199.13842    132.40645   0.005263158 
+  219          192.91277    132.39379   0.00456621 
+  208          189.35125    132.38119   0.004807692 
+  191          186.50703    132.36865   0.005235602 
+  176          186.20189    132.35616   0.005681818 
+  209          188.08234    132.34374   0.004784689 
+  197          188.38187    132.33138   0.005076142 
+  187          183.54774    132.31907   0.005347594 
+  189          173.58795    132.30683   0.005291005 
+  177          166.91204    132.29465   0.005649718 
+  171          164.87228    132.28252   0.005847953 
+  150          166.75574    132.27046   0.006666667 
+  172          171.44748    132.25845   0.005813953 
+  163          175.15216    132.2465    0.006134969 
+  167          176.42043    132.23462   0.005988024 
+  198          176.58481    132.22279   0.005050505 
+  175          180.50879    132.21102   0.005714286 
+  186          192.80228    132.19931   0.005376344 
+  203          206.17841    132.18766   0.004926108 
+  189          201.06138    132.17606   0.005291005 
+  155          184.24591    132.16453   0.006451613 
+  185          171.02261    132.15305   0.005405405 
+  168          163.59081    132.14164   0.005952381 
+  162          161.32752    132.13028   0.00617284 
+  142          163.75584    132.11898   0.007042254 
+  161          170.12281    132.10773   0.00621118 
+  174          173.8666     132.09655   0.005747126 
+  158          167.24026    132.08542   0.006329114 
+  167          158.00349    132.07435   0.005988024 
+  151          151.7749     132.06334   0.006622517 
+  165          148.1707     132.05239   0.006060606 
+  185          146.14907    132.0415    0.005405405 
+  162          145.05845    132.03066   0.00617284 
+  156          144.62536    132.01988   0.006410256 
+  124          144.78439    132.00915   0.008064516 
+  156          145.56825    131.99849   0.006410256 
+  154          147.36006    131.98788   0.006493506 
+  158          150.6976     131.97733   0.006329114 
+  126          154.10839    131.96684   0.007936508 
+  131          153.00674    131.9564    0.007633588 
+  148          148.87573    131.94602   0.006756757 
+  154          145.84545    131.9357    0.006493506 
+  179          144.4554     131.92543   0.005586592 
+  133          144.21518    131.91522   0.007518797 
+  168          144.77052    131.90507   0.005952381 
+  145          146.11557    131.89497   0.006896552 
+  169          147.19825    131.88493   0.00591716 
+  175          146.01735    131.87494   0.005714286 
+  143          144.19361    131.86502   0.006993007 
+  141          143.33651    131.85514   0.007092199 
+  157          142.96349    131.84533   0.006369427 
+  149          142.08565    131.83557   0.006711409 
+  154          141.02298    131.82586   0.006493506 
+  162          140.26303    131.81621   0.00617284 
+  144          139.86705    131.80662   0.006944444 
+  134          139.76468    131.79708   0.007462687 
+  143          139.92079    131.7876    0.006993007 
+  125          140.28368    131.77817   0.008     
+  142          140.53655    131.7688    0.007042254 
+  149          140.44394    131.75949   0.006711409 
+  152          140.41065    131.75023   0.006578947 
+  147          140.68125    131.74102   0.006802721 
+  147          141.28533    131.73187   0.006802721 
+  150          142.14654    131.72277   0.006666667 
+  150          143.07767    131.71373   0.006666667 
+  156          144.09207    131.70474   0.006410256 
+  158          145.85822    131.69581   0.006329114 
+  140          149.21668    131.68693   0.007142857 
+  170          155.16912    131.67811   0.005882353 
+  163          163.95062    131.66934   0.006134969 
+  168          170.26527    131.66062   0.005952381 
+  164          168.01122    131.65196   0.006097561 
+  174          164.65087    131.64335   0.005747126 
+  173          164.82096    131.6348    0.005780347 
+  187          166.1619     131.6263    0.005347594 
+  165          164.59104    131.61785   0.006060606 
+  179          162.79925    131.60946   0.005586592 
+  151          163.88587    131.60112   0.006622517 
+  173          164.09174    131.59284   0.005780347 
+  152          161.02259    131.58461   0.006578947 
+  168          159.13087    131.57643   0.005952381 
+  174          160.15011    131.5683    0.005747126 
+  182          162.42405    131.56023   0.005494505 
+  179          164.12158    131.55221   0.005586592 
+  184          166.51485    131.54424   0.005434783 
+  151          167.43332    131.53633   0.006622517 
+  164          165.60202    131.52847   0.006097561 
+  159          165.64395    131.52066   0.006289308 
+  152          169.35038    131.5129    0.006578947 
+  171          171.34603    131.5052    0.005847953 
+  160          168.24977    131.49754   0.00625   
+  167          165.8341     131.48994   0.005988024 
+  164          166.52941    131.4824    0.006097561 
+  179          168.24681    131.4749    0.005586592 
+  190          170.46744    131.46746   0.005263158 
+  160          176.1209     131.46006   0.00625   
+  159          186.87334    131.45272   0.006289308 
+  196          202.72905    131.44544   0.005102041 
+  188          227.3194     131.4382    0.005319149 
+  246          274.43753    131.43101   0.004065041 
+  284          353.75364    131.42388   0.003521127 
+  305          397.49877    131.4168    0.003278689 
+  294          332.97043    131.40976   0.003401361 
+  251          264.9394     131.40278   0.003984064 
+  257          233.38506    131.39585   0.003891051 
+  215          229.65246    131.38897   0.004651163 
+  238          247.45729    131.38214   0.004201681 
+  247          281.72305    131.37537   0.004048583 
+  277          316.89739    131.36864   0.003610108 
+  240          321.56888    131.36196   0.004166667 
+  207          276.08035    131.35534   0.004830918 
+  223          236.24275    131.34876   0.004484305 
+  193          220.70217    131.34223   0.005181347 
+  256          224.29946    131.33576   0.00390625 
+  207          240.15728    131.32933   0.004830918 
+  210          252.98803    131.32295   0.004761905 
+  223          253.85505    131.31663   0.004484305 
+  239          257.75097    131.31035   0.0041841 
+  225          287.12607    131.30412   0.004444444 
+  289          360.26467    131.29794   0.003460208 
+  279          455.52215    131.29182   0.003584229 
+  319          443.91872    131.28574   0.003134796 
+  238          354.52759    131.27971   0.004201681 
+  235          295.42659    131.27372   0.004255319 
+  199          272.31124    131.26779   0.005025126 
+  231          280.28214    131.26191   0.004329004 
+  266          324.22122    131.25607   0.003759398 
+  290          414.75328    131.25029   0.003448276 
+  326          508.50773    131.24455   0.003067485 
+  294          465.89593    131.23886   0.003401361 
+  261          346.63829    131.23322   0.003831418 
+  231          267.67395    131.22763   0.004329004 
+  198          229.79308    131.22208   0.005050505 
+  204          216.74068    131.21659   0.004901961 
+  199          221.29773    131.21114   0.005025126 
+  199          242.38995    131.20574   0.005025126 
+  180          264.25608    131.20039   0.005555556 
+  195          246.48561    131.19508   0.005128205 
+  199          208.83552    131.18982   0.005025126 
+  200          183.63263    131.18461   0.005     
+  177          170.18791    131.17945   0.005649718 
+  195          163.17234    131.17434   0.005128205 
+  167          158.89742    131.16927   0.005988024 
+  172          155.68326    131.16425   0.005813953 
+  197          153.56565    131.15927   0.005076142 
+  160          152.5317     131.15435   0.00625   
+  152          152.47048    131.14946   0.006578947 
+  187          153.403      131.14463   0.005347594 
+  182          155.43601    131.13984   0.005494505 
+  184          157.9606     131.1351    0.005434783 
+  181          159.94946    131.13041   0.005524862 
+  192          162.88365    131.12576   0.005208333 
+  185          168.73463    131.12116   0.005405405 
+  194          177.38396    131.1166    0.005154639 
+  196          188.35613    131.11209   0.005102041 
+  222          196.15769    131.10762   0.004504505 
+  191          194.1335     131.1032    0.005235602 
+  183          192.30124    131.09883   0.005464481 
+  195          196.23615    131.0945    0.005128205 
+  212          201.33265    131.09022   0.004716981 
+  217          199.66178    131.08598   0.004608295 
+  225          193.18419    131.08179   0.004444444 
+  208          189.0273     131.07764   0.004807692 
+  201          187.59234    131.07354   0.004975124 
+  192          184.15642    131.06948   0.005208333 
+  197          182.07549    131.06547   0.005076142 
+  199          185.20846    131.0615    0.005025126 
+  194          190.2319     131.05758   0.005154639 
+  184          189.55556    131.0537    0.005434783 
+  211          184.47264    131.04987   0.004739336 
+  214          181.01854    131.04608   0.004672897 
+  194          181.45768    131.04233   0.005154639 
+  192          187.40509    131.03863   0.005208333 
+  212          202.10384    131.03497   0.004716981 
+  248          234.2776     131.03136   0.004032258 
+  332          302.15953    131.02779   0.003012048 
+  414          416.68951    131.02426   0.002415459 
+  448          465.21328    131.02078   0.002232143 
+  382          362.01911    131.01734   0.002617801 
+  306          275.26281    131.01394   0.003267974 
+  250          234.3333     131.01059   0.004     
+  241          218.3948     131.00728   0.004149378 
+  245          220.56       131.00401   0.004081633 
+  313          245.14933    131.00078   0.003194888 
+  325          302.13952    130.9976    0.003076923 
+  330          361.16865    130.99446   0.003030303 
+  317          341.19979    130.99137   0.003154574 
+  225          292.67285    130.98831   0.004444444 
+  234          249.83583    130.9853    0.004273504 
+  195          222.35333    130.98233   0.005128205 
+  194          208.82517    130.97941   0.005154639 
+  215          205.45305    130.97652   0.004651163 
+  209          214.00932    130.97368   0.004784689 
+  222          233.42849    130.97088   0.004504505 
+  226          247.56162    130.96812   0.004424779 
+  185          240.15548    130.9654    0.005405405 
+  210          221.56747    130.96272   0.004761905 
+  177          207.79365    130.96009   0.005649718 
+  202          201.34351    130.95749   0.004950495 
+  189          195.92077    130.95494   0.005291005 
+  181          191.75403    130.95243   0.005524862 
+  191          192.35609    130.94996   0.005235602 
+  180          193.7086     130.94753   0.005555556 
+  192          188.09239    130.94514   0.005208333 
+  195          181.258      130.94279   0.005128205 
+  204          179.86519    130.94048   0.004901961 
+  203          184.66572    130.93821   0.004926108 
+  211          194.85025    130.93599   0.004739336 
+  198          210.00665    130.9338    0.005050505 
+  178          221.91678    130.93165   0.005617978 
+  175          212.22601    130.92955   0.005714286 
+  162          191.79453    130.92748   0.00617284 
+  195          177.19026    130.92545   0.005128205 
+  152          169.26193    130.92346   0.006578947 
+  168          165.44048    130.92152   0.005952381 
+  172          165.55315    130.91961   0.005813953 
+  142          170.14272    130.91774   0.007042254 
+  148          177.4651     130.91591   0.006756757 
+  141          177.41354    130.91412   0.007092199 
+  167          167.80767    130.91237   0.005988024 
+  148          158.56849    130.91065   0.006756757 
+  149          152.71285    130.90898   0.006711409 
+  154          148.878      130.90734   0.006493506 
+  143          146.06258    130.90575   0.006993007 
+  148          144.00209    130.90419   0.006756757 
+  165          142.72267    130.90267   0.006060606 
+  150          141.89568    130.90119   0.006666667 
+  137          141.3792     130.89974   0.00729927 
+  149          141.09352    130.89834   0.006711409 
+  142          141.03309    130.89697   0.007042254 
+  138          141.15699    130.89564   0.007246377 
+  129          141.51732    130.89435   0.007751938 
+  158          142.18538    130.8931    0.006329114 
+  155          143.23799    130.89188   0.006451613 
+  155          144.50339    130.8907    0.006451613 
+  160          145.42645    130.88956   0.00625   
+  162          146.15378    130.88846   0.00617284 
+  165          147.62202    130.88739   0.006060606 
+  141          149.57797    130.88636   0.007092199 
+  145          149.88184    130.88536   0.006896552 
+  146          148.91715    130.88441   0.006849315 
+  160          149.00339    130.88349   0.00625   
+  154          150.97269    130.8826    0.006493506 
+  176          154.89613    130.88176   0.005681818 
+  164          159.91226    130.88094   0.006097561 
+  153          162.24389    130.88017   0.006535948 
+  145          160.28842    130.87943   0.006896552 
+  153          158.02879    130.87873   0.006535948 
+  162          156.81801    130.87806   0.00617284 
+  165          157.42808    130.87743   0.006060606 
+  165          160.00943    130.87684   0.006060606 
+  158          165.09979    130.87628   0.006329114 
+  152          173.939      130.87575   0.006578947 
+  198          185.56134    130.87526   0.005050505 
+  181          198.51921    130.87481   0.005524862 
+  222          211.7281     130.87439   0.004504505 
+  203          211.98282    130.87401   0.004926108 
+  154          198.52322    130.87366   0.006493506 
+  175          186.76587    130.87335   0.005714286 
+  178          181.04439    130.87307   0.005617978 
+  169          180.13478    130.87282   0.00591716 
+  174          182.47082    130.87261   0.005747126 
+  192          186.84023    130.87244   0.005208333 
+  184          193.37996    130.87229   0.005434783 
+  208          198.26733    130.87219   0.004807692 
+  177          194.46712    130.87211   0.005649718 
+  172          187.14983    130.87208   0.005813953 
+  158          182.52496    130.87207   0.006329114 
+  186          181.08023    130.8721    0.005376344 
+  167          181.91882    130.87216   0.005988024 
+  162          184.45814    130.87226   0.00617284 
+  193          188.53803    130.87238   0.005181347 
+  179          193.88913    130.87255   0.005586592 
+  192          198.39882    130.87274   0.005208333 
+  213          199.25891    130.87297   0.004694836 
+  204          198.70841    130.87323   0.004901961 
+  220          199.65146    130.87353   0.004545455 
+  197          203.13296    130.87385   0.005076142 
+  184          207.90707    130.87421   0.005434783 
+  185          209.5127     130.8746    0.005405405 
+  198          207.77097    130.87503   0.005050505 
+  181          207.82696    130.87549   0.005524862 
+  197          208.16704    130.87597   0.005076142 
+  189          206.57809    130.8765    0.005291005 
+  185          206.68277    130.87705   0.005405405 
+  187          210.60325    130.87763   0.005347594 
+  215          218.51417    130.87825   0.004651163 
+  218          228.55826    130.8789    0.004587156 
+  198          235.76649    130.87958   0.005050505 
+  211          238.95382    130.88029   0.004739336 
+  186          241.89245    130.88103   0.005376344 
+  225          243.30938    130.88181   0.004444444 
+  264          246.01858    130.88261   0.003787879 
+  250          259.44746    130.88345   0.004     
+  275          296.96876    130.88432   0.003636364 
+  314          378.18797    130.88521   0.003184713 
+  432          483.67672    130.88614   0.002314815 
+  398          458.73797    130.8871    0.002512563 
+  310          348.07962    130.88809   0.003225806 
+  256          277.05553    130.88911   0.00390625 
+  233          241.49543    130.89016   0.004291845 
+  211          225.26522    130.89124   0.004739336 
+  192          223.03589    130.89235   0.005208333 
+  219          238.1124     130.89349   0.00456621 
+  257          278.19503    130.89466   0.003891051 
+  295          317.17322    130.89586   0.003389831 
+  252          280.65089    130.89709   0.003968254 
+  215          225.03561    130.89835   0.004651163 
+  181          192.62629    130.89964   0.005524862 
+  174          176.12826    130.90095   0.005747126 
+  177          167.29247    130.9023    0.005649718 
+  162          162.09488    130.90368   0.00617284 
+  147          158.82711    130.90508   0.006802721 
+  154          156.45164    130.90651   0.006493506 
+  188          154.41124    130.90798   0.005319149 
+  169          152.95606    130.90947   0.00591716 
+  143          152.22577    130.91099   0.006993007 
+  172          152.25369    130.91254   0.005813953 
+  156          153.21805    130.91411   0.006410256 
+  136          155.45943    130.91572   0.007352941 
+  149          158.82315    130.91735   0.006711409 
+  137          160.47539    130.91901   0.00729927 
+  170          157.57614    130.9207    0.005882353 
+  167          153.45751    130.92241   0.005988024 
+  174          150.75331    130.92416   0.005747126 
+  160          149.33248    130.92593   0.00625   
+  151          148.43008    130.92773   0.006622517 
+  151          147.91997    130.92955   0.006622517 
+  147          148.23064    130.93141   0.006802721 
+  157          149.26839    130.93329   0.006369427 
+  142          149.46385    130.9352    0.007042254 
+  151          147.78487    130.93713   0.006622517 
+  158          146.18006    130.93909   0.006329114 
+  167          145.45354    130.94108   0.005988024 
+  161          145.11957    130.9431    0.00621118 
+  147          145.1161     130.94514   0.006802721 
+  162          146.04422    130.94721   0.00617284 
+  152          148.26646    130.9493    0.006578947 
+  172          150.42067    130.95142   0.005813953 
+  140          149.66963    130.95357   0.007142857 
+  161          146.90804    130.95574   0.00621118 
+  186          144.44474    130.95794   0.005376344 
+  141          143.00104    130.96016   0.007092199 
+  144          142.24032    130.96241   0.006944444 
+  155          142.05514    130.96469   0.006451613 
+  167          142.57302    130.96699   0.005988024 
+  152          143.76409    130.96932   0.006578947 
+  146          144.77726    130.97167   0.006849315 
+  150          144.23112    130.97404   0.006666667 
+  141          142.72412    130.97645   0.007092199 
+  166          141.41837    130.97887   0.006024096 
+  146          140.6616     130.98132   0.006849315 
+  141          140.38018    130.9838    0.007092199 
+  151          140.47868    130.9863    0.006622517 
+  153          140.8776     130.98883   0.006535948 
+  155          141.19351    130.99138   0.006451613 
+  132          140.84732    130.99395   0.007575758 
+  139          140.19811    130.99655   0.007194245 
+  138          139.7524     130.99917   0.007246377 
+  159          139.58113    131.00182   0.006289308 
+  134          139.65409    131.00449   0.007462687 
+  151          139.97119    131.00719   0.006622517 
+  137          140.58131    131.0099    0.00729927 
+  147          141.52059    131.01265   0.006802721 
+  163          142.51831    131.01541   0.006134969 
+  161          142.93705    131.0182    0.00621118 
+  154          143.00859    131.02101   0.006493506 
+  161          143.35686    131.02385   0.00621118 
+  148          144.09999    131.02671   0.006756757 
+  147          145.21362    131.02959   0.006802721 
+  180          146.54259    131.03249   0.005555556 
+  155          148.01465    131.03542   0.006451613 
+  177          149.77129    131.03837   0.005649718 
+  127          151.87208    131.04134   0.007874016 
+  171          154.35759    131.04434   0.005847953 
+  154          157.78302    131.04736   0.006493506 
+  164          163.48834    131.0504    0.006097561 
+  171          173.82049    131.05346   0.005847953 
+  211          192.61092    131.05654   0.004739336 
+  215          222.65725    131.05965   0.004651163 
+  268          248.44259    131.06278   0.003731343 
+  203          233.4655     131.06593   0.004926108 
+  198          202.12191    131.0691    0.005050505 
+  168          181.83444    131.07229   0.005952381 
+  189          171.90867    131.07551   0.005291005 
+  165          168.50444    131.07874   0.006060606 
+  202          170.15785    131.082     0.004950495 
+  193          177.63791    131.08528   0.005181347 
+  207          192.32235    131.08858   0.004830918 
+  230          208.23911    131.0919    0.004347826 
+  193          207.14002    131.09524   0.005181347 
+  200          198.72561    131.09861   0.005     
+  212          195.3268     131.10199   0.004716981 
+  179          189.85298    131.1054    0.005586592 
+  164          181.44142    131.10882   0.006097561 
+  141          175.43067    131.11227   0.007092199 
+  170          171.1171     131.11573   0.005882353 
+  174          167.05435    131.11922   0.005747126 
+  157          164.93327    131.12272   0.006369427 
+  170          165.74094    131.12625   0.005882353 
+  188          169.65334    131.1298    0.005319149 
+  178          175.16796    131.13336   0.005617978 
+  172          177.47837    131.13695   0.005813953 
+  177          176.12498    131.14055   0.005649718 
+  167          176.69957    131.14418   0.005988024 
+  184          181.28713    131.14783   0.005434783 
+  200          188.45401    131.15149   0.005     
+  168          192.21766    131.15517   0.005952381 
+  192          188.59214    131.15888   0.005208333 
+  187          185.0676     131.1626    0.005347594 
+  188          184.21897    131.16634   0.005319149 
+  184          185.70637    131.1701    0.005434783 
+  182          193.76262    131.17388   0.005494505 
+  208          216.23411    131.17768   0.004807692 
+  251          263.84694    131.18149   0.003984064 
+  336          329.08151    131.18533   0.00297619 
+  286          328.85581    131.18918   0.003496503 
+  265          265.0096     131.19305   0.003773585 
+  230          218.84897    131.19694   0.004347826 
+  224          196.73643    131.20085   0.004464286 
+  179          188.22627    131.20478   0.005586592 
+  190          188.386      131.20872   0.005263158 
+  214          195.56952    131.21268   0.004672897 
+  233          212.74221    131.21667   0.004291845 
+  238          239.98026    131.22066   0.004201681 
+  211          244.38659    131.22468   0.004739336 
+  188          210.33813    131.22871   0.005319149 
+  178          181.82509    131.23276   0.005617978 
+  195          167.21249    131.23683   0.005128205 
+  162          160.90071    131.24092   0.00617284 
+  172          158.52779    131.24502   0.005813953 
+  147          157.28348    131.24914   0.006802721 
+  148          156.10223    131.25328   0.006756757 
+  155          154.90968    131.25743   0.006451613 
+  164          153.16755    131.2616    0.006097561 
+  176          152.10241    131.26579   0.005681818 
+  165          152.85911    131.27      0.006060606 
+  199          155.39552    131.27422   0.005025126 
+  168          158.77362    131.27846   0.005952381 
+  167          160.51174    131.28271   0.005988024 
+  193          159.71984    131.28698   0.005181347 
+  153          159.33882    131.29127   0.006535948 
+  180          162.23953    131.29557   0.005555556 
+  179          169.92788    131.29989   0.005586592 
+  161          183.54549    131.30423   0.00621118 
+  187          200.61189    131.30858   0.005347594 
+  193          213.30317    131.31295   0.005181347 
+  190          216.57864    131.31733   0.005263158 
+  152          205.56743    131.32173   0.006578947 
+  161          187.42604    131.32614   0.00621118 
+  150          173.32679    131.33057   0.006666667 
+  159          165.80123    131.33502   0.006289308 
+  159          163.76702    131.33948   0.006289308 
+  158          166.48895    131.34396   0.006329114 
+  181          172.80851    131.34845   0.005524862 
+  155          178.70751    131.35295   0.006451613 
+  156          180.46419    131.35748   0.006410256 
+  150          175.77568    131.36201   0.006666667 
+  175          166.11286    131.36656   0.005714286 
+  147          157.56788    131.37113   0.006802721 
+  140          152.05991    131.37571   0.007142857 
+  149          148.83103    131.38031   0.006711409 
+  160          146.98892    131.38492   0.00625   
+  172          146.00053    131.38954   0.005813953 
+  133          145.59407    131.39418   0.007518797 
+  140          145.39391    131.39884   0.007142857 
+  124          145.0763     131.40351   0.008064516 
+  173          144.74149    131.40819   0.005780347 
+  138          144.68624    131.41289   0.007246377 
+  129          145.04726    131.4176    0.007751938 
+  136          145.90123    131.42232   0.007352941 
+  158          147.38431    131.42706   0.006329114 
+  122          149.79592    131.43181   0.008196721 
+  164          153.54666    131.43658   0.006097561 
+  147          158.39963    131.44136   0.006802721 
+  163          161.94549    131.44615   0.006134969 
+  192          162.45082    131.45096   0.005208333 
+  149          162.28532    131.45578   0.006711409 
+  164          162.84657    131.46061   0.006097561 
+  169          161.93469    131.46546   0.00591716 
+  150          160.05995    131.47032   0.006666667 
+  159          159.79712    131.4752    0.006289308 
+  156          162.0574     131.48008   0.006410256 
+  177          167.23731    131.48498   0.005649718 
+  185          175.69027    131.48989   0.005405405 
+  215          188.54193    131.49482   0.004651163 
+  233          210.84056    131.49976   0.004291845 
+  263          248.64154    131.50471   0.003802281 
+  276          285.24405    131.50968   0.003623188 
+  277          275.00015    131.51465   0.003610108 
+  224          241.51668    131.51964   0.004464286 
+  230          215.09489    131.52464   0.004347826 
+  230          194.94079    131.52966   0.004347826 
+  183          182.08394    131.53468   0.005464481 
+  164          176.87201    131.53972   0.006097561 
+  199          179.08092    131.54478   0.005025126 
+  202          190.03517    131.54984   0.004950495 
+  218          208.81963    131.55491   0.004587156 
+  189          217.28829    131.56      0.005291005 
+  227          203.34607    131.5651    0.004405286 
+  183          187.3844     131.57021   0.005464481 
+  167          174.82361    131.57534   0.005988024 
+  165          165.08275    131.58047   0.006060606 
+  153          158.68089    131.58562   0.006535948 
+  175          154.8558     131.59078   0.005714286 
+  145          152.65814    131.59595   0.006896552 
+  148          151.48231    131.60113   0.006756757 
+  148          150.99098    131.60632   0.006756757 
+  166          150.97534    131.61153   0.006024096 
+  150          151.22568    131.61674   0.006666667 
+  164          151.58126    131.62197   0.006097561 
+  165          152.08682    131.62721   0.006060606 
+  155          152.80581    131.63246   0.006451613 
+  160          153.76646    131.63772   0.00625   
+  190          155.01564    131.64299   0.005263158 
+  188          156.63277    131.64828   0.005319149 
+  152          158.7511     131.65357   0.006578947 
+  169          161.58149    131.65887   0.00591716 
+  188          165.31402    131.66419   0.005319149 
+  173          169.44103    131.66952   0.005780347 
+  161          172.36026    131.67485   0.00621118 
+  184          174.48438    131.6802    0.005434783 
+  162          177.78407    131.68556   0.00617284 
+  182          182.64407    131.69093   0.005494505 
+  187          188.67391    131.69631   0.005347594 
+  183          196.74395    131.7017    0.005464481 
+  220          208.46956    131.7071    0.004545455 
+  216          225.61333    131.71251   0.00462963 
+  240          250.77026    131.71793   0.004166667 
+  289          288.0233     131.72337   0.003460208 
+  361          346.35089    131.72881   0.002770083 
+  467          450.60649    131.73426   0.002141328 
+  731          655.9085     131.73972   0.001367989 
+  1108         1047.27453   131.7452    0.000902527 
+  1481         1562.6167    131.75068   0.000675219 
+  1415         1546.85951   131.75617   0.000706714 
+  958          1034.78427   131.76167   0.001043841 
+  692          663.96277    131.76719   0.001445087 
+  520          479.02552    131.77271   0.001923077 
+  417          398.41762    131.77824   0.002398082 
+  420          376.37341    131.78378   0.002380952 
+  417          404.75732    131.78933   0.002398082 
+  597          505.60854    131.79489   0.001675042 
+  729          714.70824    131.80046   0.001371742 
+  833          936.98454    131.80605   0.00120048 
+  721          825.96843    131.81164   0.001386963 
+  576          562.95023    131.81723   0.001736111 
+  393          397.01966    131.82284   0.002544529 
+  329          311.68415    131.82846   0.003039514 
+  251          263.93047    131.83409   0.003984064 
+  251          234.18819    131.83973   0.003984064 
+  198          214.31095    131.84537   0.005050505 
+  201          200.09364    131.85103   0.004975124 
+  180          190.5855     131.85669   0.005555556 
+  179          183.76451    131.86237   0.005586592 
+  171          178.37059    131.86805   0.005847953 
+  181          175.27813    131.87374   0.005524862 
+  158          174.18601    131.87945   0.006329114 
+  172          172.4229     131.88516   0.005813953 
+  156          168.28244    131.89088   0.006410256 
+  169          163.85951    131.89661   0.00591716 
+  162          159.84129    131.90234   0.00617284 
+  175          156.28468    131.90809   0.005714286 
+  164          153.62339    131.91385   0.006097561 
+  129          151.81048    131.91961   0.007751938 
+  140          150.63891    131.92538   0.007142857 
+  153          150.00735    131.93116   0.006535948 
+  148          149.72559    131.93696   0.006756757 
+  158          149.33196    131.94276   0.006329114 
+  154          148.72799    131.94856   0.006493506 
+  164          148.36865    131.95438   0.006097561 
+  164          148.46516    131.96021   0.006097561 
+  166          148.94573    131.96604   0.006024096 
+  170          149.54354    131.97188   0.005882353 
+  149          150.04567    131.97773   0.006711409 
+  160          150.46894    131.98359   0.00625   
+  149          150.85034    131.98946   0.006711409 
+  142          150.87896    131.99534   0.007042254 
+  158          150.8133     132.00123   0.006329114 
+  131          151.12626    132.00712   0.007633588 
+  164          152.03561    132.01302   0.006097561 
+  153          153.73944    132.01893   0.006535948 
+  163          156.51772    132.02485   0.006134969 
+  159          160.78535    132.03078   0.006289308 
+  156          167.22673    132.03672   0.006410256 
+  188          176.94274    132.04266   0.005319149 
+  190          192.67049    132.04862   0.005263158 
+  210          218.00419    132.05458   0.004761905 
+  203          246.91291    132.06055   0.004926108 
+  191          251.17627    132.06652   0.005235602 
+  210          227.0592     132.07251   0.004761905 
+  187          201.17526    132.0785    0.005347594 
+  177          183.47915    132.08451   0.005649718 
+  175          174.09771    132.09052   0.005714286 
+  151          170.73434    132.09654   0.006622517 
+  158          171.81166    132.10257   0.006329114 
+  181          177.67537    132.1086    0.005524862 
+  195          189.86085    132.11464   0.005128205 
+  193          205.33633    132.1207    0.005181347 
+  188          210.36584    132.12676   0.005319149 
+  192          203.84297    132.13283   0.005208333 
+  193          199.8594     132.1389    0.005181347 
+  187          200.94104    132.14499   0.005347594 
+  182          197.2323     132.15108   0.005494505 
+  176          184.71237    132.15718   0.005681818 
+  185          172.52487    132.16329   0.005405405 
+  185          164.75984    132.16941   0.005405405 
+  168          160.7929     132.17553   0.005952381 
+  170          159.41358    132.18167   0.005882353 
+  181          159.91555    132.18781   0.005524862 
+  179          162.64216    132.19396   0.005586592 
+  179          168.31128    132.20012   0.005586592 
+  193          176.07958    132.20628   0.005181347 
+  170          181.45043    132.21246   0.005882353 
+  189          182.92729    132.21864   0.005291005 
+  185          184.63448    132.22483   0.005405405 
+  174          186.60117    132.23103   0.005747126 
+  181          183.60744    132.23723   0.005524862 
+  183          175.65527    132.24345   0.005464481 
+  153          169.25595    132.24967   0.006535948 
+  152          166.7955     132.2559    0.006578947 
+  178          167.36384    132.26214   0.005617978 
+  167          167.84166    132.26839   0.005988024 
+  152          166.62304    132.27465   0.006578947 
+  136          166.21042    132.28091   0.007352941 
+  161          167.56535    132.28718   0.00621118 
+  162          169.40046    132.29346   0.00617284 
+  161          168.96769    132.29975   0.00621118 
+  168          165.64628    132.30605   0.005952381 
+  163          162.78974    132.31235   0.006134969 
+  189          161.92035    132.31867   0.005291005 
+  151          162.67016    132.32499   0.006622517 
+  139          163.56762    132.33132   0.007194245 
+  190          163.45837    132.33766   0.005263158 
+  185          163.34475    132.344     0.005405405 
+  187          164.08298    132.35036   0.005347594 
+  180          165.73266    132.35672   0.005555556 
+  177          168.23717    132.36309   0.005649718 
+  204          171.63909    132.36947   0.004901961 
+  181          176.10256    132.37586   0.005524862 
+  192          181.92294    132.38226   0.005208333 
+  189          189.43463    132.38866   0.005291005 
+  216          198.52328    132.39508   0.00462963 
+  240          208.46454    132.4015    0.004166667 
+  257          220.2919     132.40793   0.003891051 
+  258          236.72247    132.41437   0.003875969 
+  276          260.4673     132.42082   0.003623188 
+  346          295.42988    132.42728   0.002890173 
+  365          348.69449    132.43374   0.002739726 
+  476          434.13271    132.44022   0.00210084 
+  685          580.12815    132.4467    0.001459854 
+  962          844.68457    132.45319   0.001039501 
+  1651         1333.7449    132.45969   0.000605694 
+  2289         2054.20011   132.4662    0.000436872 
+  2269         2270.26903   132.47272   0.000440723 
+  1639         1614.05096   132.47924   0.000610128 
+  1061         1014.18488   132.48578   0.000942507 
+  780          690.98412    132.49233   0.001282051 
+  610          539.21467    132.49888   0.001639344 
+  512          479.14264    132.50544   0.001953125 
+  514          481.22183    132.51201   0.001945525 
+  641          551.38112    132.51859   0.001560062 
+  876          727.17724    132.52518   0.001141553 
+  1129         1046.11      132.53178   0.00088574 
+  1261         1277.32218   132.53839   0.000793021 
+  991          1024.55703   132.54501   0.001009082 
+  696          673.29758    132.55164   0.001436782 
+  549          461.79       132.55827   0.001821494 
+  372          351.4057     132.56492   0.002688172 
+  329          292.02617    132.57157   0.003039514 
+  254          256.74967    132.57824   0.003937008 
+  218          232.96954    132.58491   0.004587156 
+  213          215.30855    132.5916    0.004694836 
+  199          202.23335    132.59829   0.005025126 
+  207          192.67001    132.60499   0.004830918 
+  216          185.59135    132.61171   0.00462963 
+  197          180.28415    132.61843   0.005076142 
+  166          176.33344    132.62516   0.006024096 
+  182          173.55957    132.63191   0.005494505 
+  186          171.9608     132.63866   0.005376344 
+  167          171.56315    132.64542   0.005988024 
+  185          172.11083    132.65219   0.005405405 
+  175          173.44291    132.65898   0.005714286 
+  191          175.58307    132.66577   0.005235602 
+  171          175.99805    132.67257   0.005847953 
+  179          172.53469    132.67939   0.005586592 
+  157          168.33977    132.68621   0.006369427 
+  155          165.78627    132.69304   0.006451613 
+  172          164.58214    132.69989   0.005813953 
+  193          163.47873    132.70675   0.005181347 
+  178          162.46508    132.71361   0.005617978 
+  175          162.46735    132.72049   0.005714286 
+  176          163.94163    132.72738   0.005681818 
+  172          166.98395    132.73427   0.005813953 
+  165          170.81712    132.74118   0.006060606 
+  176          173.79028    132.7481    0.005681818 
+  184          176.892      132.75504   0.005434783 
+  190          183.62892    132.76198   0.005263158 
+  215          197.89473    132.76893   0.004651163 
+  209          223.88458    132.7759    0.004784689 
+  246          260.59445    132.78287   0.004065041 
+  257          278.89345    132.78986   0.003891051 
+  243          252.44833    132.79686   0.004115226 
+  233          219.13254    132.80387   0.004291845 
+  172          200.10805    132.81089   0.005813953 
+  202          193.25429    132.81793   0.004950495 
+  212          194.7773     132.82497   0.004716981 
+  206          204.07136    132.83203   0.004854369 
+  217          218.88736    132.8391    0.004608295 
+  221          228.00004    132.84618   0.004524887 
+  221          230.97196    132.85328   0.004524887 
+  203          236.28857    132.86039   0.004926108 
+  216          227.71201    132.8675    0.00462963 
+  203          206.34737    132.87464   0.004926108 
+  194          188.77405    132.88178   0.005154639 
+  170          178.1224     132.88894   0.005882353 
+  152          173.17525    132.8961    0.006578947 
+  150          172.67598    132.90329   0.006666667 
+  165          175.91716    132.91048   0.006060606 
+  147          178.85169    132.91769   0.006802721 
+  168          174.92154    132.92491   0.005952381 
+  159          168.14062    132.93214   0.006289308 
+  150          164.06968    132.93939   0.006666667 
+  169          162.99064    132.94665   0.00591716 
+  153          163.48932    132.95393   0.006535948 
+  155          164.38771    132.96121   0.006451613 
+  142          165.79527    132.96852   0.007042254 
+  181          167.24174    132.97583   0.005524862 
+  152          167.18673    132.98316   0.006578947 
+  154          167.00857    132.9905    0.006493506 
+  153          167.44866    132.99786   0.006535948 
+  178          165.84974    133.00523   0.005617978 
+  197          162.1955     133.01262   0.005076142 
+  192          159.17459    133.02002   0.005208333 
+  174          157.77665    133.02743   0.005747126 
+  149          157.7679     133.03486   0.006711409 
+  171          158.63023    133.04231   0.005847953 
+  191          160.00903    133.04977   0.005235602 
+  158          161.15487    133.05724   0.006329114 
+  181          161.65579    133.06473   0.005524862 
+  176          162.55014    133.07224   0.005681818 
+  166          163.61392    133.07976   0.006024096 
+  190          163.64033    133.08729   0.005263158 
+  187          163.30603    133.09484   0.005347594 
+  165          163.24315    133.10241   0.006060606 
+  203          162.95667    133.10999   0.004926108 
+  173          162.65996    133.11759   0.005780347 
+  197          162.83079    133.1252    0.005076142 
+  173          163.58011    133.13284   0.005780347 
+  163          164.75445    133.14048   0.006134969 
+  199          166.48643    133.14815   0.005025126 
+  200          168.67524    133.15583   0.005     
+  190          171.36347    133.16352   0.005263158 
+  190          174.62097    133.17124   0.005263158 
+  188          178.45431    133.17897   0.005319149 
+  174          182.62954    133.18672   0.005747126 
+  197          187.04457    133.19448   0.005076142 
+  188          192.17638    133.20227   0.005319149 
+  188          198.54192    133.21007   0.005319149 
+  206          206.55349    133.21788   0.004854369 
+  219          216.65543    133.22572   0.00456621 
+  235          229.6936     133.23358   0.004255319 
+  259          246.89058    133.24145   0.003861004 
+  277          270.495      133.24934   0.003610108 
+  303          304.46136    133.25725   0.00330033 
+  339          354.90678    133.26517   0.002949853 
+  407          426.17205    133.27312   0.002457002 
+  446          502.59586    133.28109   0.002242152 
+  546          568.85759    133.28907   0.001831502 
+  712          677.66598    133.29707   0.001404494 
+  950          904.53779    133.3051    0.001052632 
+  1529         1359.00154   133.31314   0.000654022 
+  2393         2195.74711   133.3212    0.000417885 
+  3062         3262.96524   133.32928   0.000326584 
+  2855         3300.05226   133.33738   0.000350263 
+  2098         2264.52777   133.34551   0.000476644 
+  1350         1441.45909   133.35365   0.000740741 
+  1019         1009.34992   133.36181   0.000981354 
+  886          801.81232    133.36999   0.001128668 
+  686          703.66381    133.3782    0.001457726 
+  791          691.85704    133.38642   0.001264223 
+  817          783.74306    133.39467   0.00122399 
+  1063         1019.90337   133.40294   0.000940734 
+  1467         1435.20648   133.41123   0.000681663 
+  1662         1896.57851   133.41954   0.000601685 
+  1586         1779.2551    133.42787   0.000630517 
+  1103         1212.09058   133.43622   0.000906618 
+  797          790.82113    133.4446    0.001254705 
+  572          558.8968     133.453     0.001748252 
+  438          435.34193    133.46142   0.002283105 
+  382          367.13531    133.46986   0.002617801 
+  309          329.51047    133.47833   0.003236246 
+  306          312.75586    133.48682   0.003267974 
+  304          307.76489    133.49533   0.003289474 
+  280          293.74202    133.50387   0.003571429 
+  257          267.40087    133.51243   0.003891051 
+  257          246.25951    133.52101   0.003891051 
+  259          234.87348    133.52962   0.003861004 
+  215          231.4749     133.53826   0.004651163 
+  226          232.78962    133.54691   0.004424779 
+  230          231.39689    133.55559   0.004347826 
+  201          222.62018    133.5643    0.004975124 
+  179          212.8554     133.57303   0.005586592 
+  200          206.06713    133.58179   0.005     
+  189          200.1362     133.59057   0.005291005 
+  182          194.06232    133.59937   0.005494505 
+  183          189.50629    133.60821   0.005464481 
+  177          187.28626    133.61707   0.005649718 
+  183          187.48394    133.62595   0.005464481 
+  174          190.1827     133.63486   0.005747126 
+  181          194.77866    133.6438    0.005524862 
+  195          198.06718    133.65276   0.005128205 
+  180          196.98914    133.66176   0.005555556 
+  184          193.11643    133.67077   0.005434783 
+  170          189.30665    133.67982   0.005882353 
+  188          186.8833     133.68889   0.005319149 
+  181          185.86229    133.698     0.005524862 
+  180          185.26431    133.70713   0.005555556 
+  191          183.47421    133.71628   0.005235602 
+  177          182.2889     133.72547   0.005649718 
+  177          183.82538    133.73468   0.005649718 
+  186          188.11837    133.74393   0.005376344 
+  172          193.44137    133.7532    0.005813953 
+  169          194.76393    133.7625    0.00591716 
+  188          189.33279    133.77184   0.005319149 
+  186          181.84081    133.7812    0.005376344 
+  162          176.53859    133.79059   0.00617284 
+  174          174.13834    133.80001   0.005747126 
+  174          173.40107    133.80947   0.005747126 
+  162          172.77354    133.81895   0.00617284 
+  186          172.74234    133.82847   0.005376344 
+  169          174.44836    133.83801   0.00591716 
+  175          178.14412    133.84759   0.005714286 
+  184          183.42959    133.8572    0.005434783 
+  177          188.39627    133.86684   0.005649718 
+  167          190.5444     133.87651   0.005988024 
+  210          188.02381    133.88622   0.004761905 
+  189          181.09307    133.89596   0.005291005 
+  180          173.93211    133.90573   0.005555556 
+  194          168.78911    133.91553   0.005154639 
+  166          165.5485     133.92537   0.006024096 
+  152          163.69208    133.93524   0.006578947 
+  189          162.89092    133.94515   0.005291005 
+  179          163.05461    133.95509   0.005586592 
+  161          164.3182     133.96507   0.00621118 
+  175          166.97354    133.97507   0.005714286 
+  167          170.97836    133.98512   0.005988024 
+  179          174.88157    133.9952    0.005586592 
+  201          176.75597    134.00531   0.004975124 
+  167          175.72492    134.01546   0.005988024 
+  142          172.18195    134.02565   0.007042254 
+  148          169.21642    134.03587   0.006756757 
+  163          168.90192    134.04613   0.006134969 
+  161          171.83693    134.05643   0.00621118 
+  163          177.83123    134.06676   0.006134969 
+  150          183.81191    134.07713   0.006666667 
+  160          183.61783    134.08754   0.00625   
+  163          177.65658    134.09799   0.006134969 
+  183          171.90911    134.10848   0.005464481 
+  167          168.86004    134.119     0.005988024 
+  181          167.37107    134.12956   0.005524862 
+  175          165.75676    134.14016   0.005714286 
+  180          164.65345    134.1508    0.005555556 
+  147          165.29892    134.16148   0.006802721 
+  180          168.28027    134.1722    0.005555556 
+  168          173.91004    134.18296   0.005952381 
+  177          181.22235    134.19376   0.005649718 
+  200          186.13554    134.20461   0.005     
+  162          186.28541    134.21549   0.00617284 
+  165          184.73394    134.22641   0.006060606 
+  183          181.91276    134.23738   0.005464481 
+  211          177.5581     134.24839   0.004739336 
+  212          173.98251    134.25944   0.004716981 
+  199          172.24199    134.27053   0.005025126 
+  178          172.08696    134.28167   0.005617978 
+  176          173.26073    134.29284   0.005681818 
+  167          175.97498    134.30407   0.005988024 
+  219          179.91942    134.31533   0.00456621 
+  214          183.91777    134.32664   0.004672897 
+  217          187.3202     134.338     0.004608295 
+  217          190.81507    134.3494    0.004608295 
+  231          195.12494    134.36084   0.004329004 
+  226          199.80014    134.37233   0.004424779 
+  230          206.2427     134.38387   0.004347826 
+  222          215.9884     134.39545   0.004504505 
+  260          229.81096    134.40708   0.003846154 
+  249          248.66084    134.41875   0.004016064 
+  292          272.73593    134.43047   0.003424658 
+  321          302.85763    134.44224   0.003115265 
+  384          347.60817    134.45406   0.002604167 
+  455          424.5896     134.46592   0.002197802 
+  652          566.16049    134.47784   0.001533742 
+  1014         831.3695     134.4898    0.000986193 
+  1350         1283.33138   134.50181   0.000740741 
+  1667         1743.3762    134.51387   0.00059988 
+  1421         1603.48208   134.52598   0.00070373 
+  1057         1096.17626   134.53814   0.000946074 
+  748          731.98252    134.55035   0.001336898 
+  592          536.97764    134.56261   0.001689189 
+  467          440.34564    134.57492   0.002141328 
+  435          397.98902    134.58728   0.002298851 
+  384          394.78861    134.5997    0.002604167 
+  459          433.87301    134.61217   0.002178649 
+  597          532.3021     134.62469   0.001675042 
+  726          708.93224    134.63726   0.00137741 
+  860          943.62628    134.64988   0.001162791 
+  929          1027.92866   134.66256   0.001076426 
+  784          798.56803    134.6753    0.00127551 
+  603          549.00614    134.68808   0.001658375 
+  386          397.75546    134.70092   0.002590674 
+  317          315.28489    134.71382   0.003154574 
+  285          269.56131    134.72677   0.003508772 
+  268          243.55806    134.73978   0.003731343 
+  252          229.94617    134.75285   0.003968254 
+  208          225.86578    134.76597   0.004807692 
+  248          227.45715    134.77914   0.004032258 
+  217          222.9128     134.79238   0.004608295 
+  208          207.81718    134.80567   0.004807692 
+  202          193.31185    134.81902   0.004950495 
+  211          183.67334    134.83243   0.004739336 
+  189          177.89885    134.8459    0.005291005 
+  191          174.38975    134.85942   0.005235602 
+  179          171.5009     134.87301   0.005586592 
+  192          168.19348    134.88665   0.005208333 
+  172          164.74662    134.90036   0.005813953 
+  145          161.81494    134.91413   0.006896552 
+  182          159.60267    134.92796   0.005494505 
+  149          157.97579    134.94184   0.006711409 
+  163          156.77352    134.9558    0.006134969 
+  157          156.01601    134.96981   0.006369427 
+  150          155.83384    134.98389   0.006666667 
+  157          156.36351    134.99803   0.006369427 
+  164          157.60861    135.01223   0.006097561 
+  160          158.94014    135.0265    0.00625   
+  163          159.09923    135.04083   0.006134969 
+  165          158.0296     135.05522   0.006060606 
+  188          156.80004    135.06968   0.005319149 
+  177          156.00763    135.08421   0.005649718 
+  176          156.07519    135.0988    0.005681818 
+  144          157.24017    135.11346   0.006944444 
+  152          159.4105     135.12819   0.006578947 
+  143          161.63676    135.14298   0.006993007 
+  157          161.53902    135.15784   0.006369427 
+  151          159.06804    135.17277   0.006622517 
+  154          156.6569     135.18777   0.006493506 
+  148          155.08723    135.20284   0.006756757 
+  156          153.93891    135.21797   0.006410256 
+  156          153.20533    135.23318   0.006410256 
+  147          153.08514    135.24846   0.006802721 
+  157          153.69049    135.2638    0.006369427 
+  155          155.33934    135.27922   0.006451613 
+  174          158.39005    135.29471   0.005747126 
+  157          163.16983    135.31027   0.006369427 
+  177          169.4989     135.32591   0.005649718 
+  174          175.8757     135.34161   0.005747126 
+  149          178.9475     135.3574    0.006711409 
+  162          175.23488    135.37325   0.00617284 
+  171          168.03758    135.38918   0.005847953 
+  162          162.29489    135.40518   0.00617284 
+  141          159.24757    135.42126   0.007092199 
+  144          158.66807    135.43742   0.006944444 
+  182          160.33773    135.45365   0.005494505 
+  161          163.85377    135.46996   0.00621118 
+  160          167.36453    135.48634   0.00625   
+  147          168.0462     135.5028    0.006802721 
+  148          167.60531    135.51934   0.006756757 
+  147          168.93692    135.53596   0.006802721 
+  151          170.47564    135.55266   0.006622517 
+  159          169.40534    135.56944   0.006289308 
+  161          166.08699    135.5863    0.00621118 
+  179          162.3049     135.60323   0.005586592 
+  162          159.50016    135.62025   0.00617284 
+  176          157.95494    135.63735   0.005681818 
+  138          157.54248    135.65453   0.007246377 
+  139          157.84321    135.6718    0.007194245 
+  151          157.79004    135.68915   0.006622517 
+  151          156.20591    135.70658   0.006622517 
+  169          154.15151    135.72409   0.00591716 
+  146          153.08685    135.74169   0.006849315 
+  125          153.17963    135.75938   0.008     
+  155          154.00729    135.77715   0.006451613 
+  176          154.89092    135.795     0.005681818 
+  165          155.90318    135.81294   0.006060606 
+  172          157.93146    135.83097   0.005813953 
+  187          161.58941    135.84909   0.005347594 
+  139          166.61546    135.86729   0.007194245 
+  174          170.47736    135.88559   0.005747126 
+  149          170.4353     135.90397   0.006711409 
+  167          167.39631    135.92244   0.005988024 
+  149          162.41613    135.941     0.006711409 
+  161          157.20583    135.95965   0.00621118 
+  133          153.35802    135.97839   0.007518797 
+  142          151.00987    135.99723   0.007042254 
+  147          149.82831    136.01616   0.006802721 
+  157          149.59431    136.03517   0.006369427 
+  133          150.29052    136.05429   0.007518797 
+  144          152.01882    136.07349   0.006944444 
+  162          154.61403    136.09279   0.00617284 
+  144          156.86125    136.11219   0.006944444 
+  157          157.35987    136.13168   0.006369427 
+  152          156.48537    136.15127   0.006578947 
+  131          154.79837    136.17095   0.007633588 
+  175          153.1972     136.19073   0.005714286 
+  154          152.56469    136.21061   0.006493506 
+  148          152.90909    136.23059   0.006756757 
+  136          153.64743    136.25066   0.007352941 
+  153          153.73226    136.27083   0.006535948 
+  148          153.24062    136.29111   0.006756757 
+  174          153.12442    136.31148   0.005747126 
+  135          153.49743    136.33196   0.007407407 
+  166          154.40031    136.35253   0.006024096 
+  157          155.89013    136.37321   0.006369427 
+  165          157.58702    136.394     0.006060606 
+  155          159.96653    136.41488   0.006451613 
+  135          161.29785    136.43587   0.007407407 
+  138          159.55785    136.45696   0.007246377 
+  146          156.38819    136.47816   0.006849315 
+  159          153.88528    136.49946   0.006289308 
+  156          152.05601    136.52087   0.006410256 
+  137          150.60586    136.54239   0.00729927 
+  154          149.76867    136.56402   0.006493506 
+  125          149.48333    136.58575   0.008     
+  152          149.6416     136.60759   0.006578947 
+  155          150.24947    136.62954   0.006451613 
+  166          151.08299    136.6516    0.006024096 
+  146          152.4045     136.67377   0.006849315 
+  150          153.60743    136.69605   0.006666667 
+  138          153.58715    136.71844   0.007246377 
+  156          152.96856    136.74095   0.006410256 
+  142          153.15162    136.76356   0.007042254 
+  137          154.1928     136.78629   0.00729927 
+  154          154.78753    136.80914   0.006493506 
+  160          154.00567    136.8321    0.00625   
+  140          152.46887    136.85517   0.007142857 
+  138          150.8788     136.87836   0.007246377 
+  137          149.69381    136.90167   0.00729927 
+  157          149.11308    136.9251    0.006369427 
+  145          149.1258     136.94864   0.006896552 
+  143          149.71952    136.9723    0.006993007 
+  152          150.89748    136.99608   0.006578947 
+  151          152.55176    137.01998   0.006622517 
+  159          154.4393     137.044     0.006289308 
+  160          156.25904    137.06814   0.00625   
+  153          157.51545    137.0924    0.006535948 
+  167          158.2837     137.11679   0.005988024 
+  164          158.96077    137.14129   0.006097561 
+  173          158.77373    137.16593   0.005780347 
+  140          156.89801    137.19068   0.007142857 
+  164          154.44289    137.21556   0.006097561 
+  157          152.50118    137.24057   0.006369427 
+  130          151.38302    137.2657    0.007692308 
+  157          151.0699     137.29096   0.006369427 
+  142          151.40676    137.31635   0.007042254 
+  154          152.14358    137.34186   0.006493506 
+  159          153.07715    137.36751   0.006289308 
+  147          154.20099    137.39328   0.006802721 
+  168          155.916      137.41919   0.005952381 
+  142          158.21244    137.44522   0.007042254 
+  149          159.39211    137.47139   0.006711409 
+  139          157.82802    137.49769   0.007194245 
+  133          154.88379    137.52412   0.007518797 
+  164          152.31565    137.55069   0.006097561 
+  180          150.56077    137.57739   0.005555556 
+  169          149.51167    137.60422   0.00591716 
+  133          148.99643    137.63119   0.007518797 
+  152          148.88433    137.6583    0.006578947 
+  144          149.09482    137.68555   0.006944444 
+  144          149.59987    137.71293   0.006944444 
+  155          150.41018    137.74045   0.006451613 
+  155          151.39881    137.76811   0.006451613 
+  132          152.10723    137.79591   0.007575758 
+  158          151.93133    137.82385   0.006329114 
+  151          151.15015    137.85194   0.006622517 
+  162          150.52646    137.88016   0.00617284 
+  161          150.31657    137.90853   0.00621118 
+  153          150.33504    137.93705   0.006535948 
+  138          150.32656    137.9657    0.007246377 
+  147          150.481      137.9945    0.006802721 
+  146          151.07386    138.02345   0.006849315 
+  158          152.27082    138.05255   0.006329114 
+  133          154.24516    138.08179   0.007518797 
+  148          157.07675    138.11118   0.006756757 
+  141          160.22005    138.14072   0.007092199 
+  161          161.91776    138.17041   0.00621118 
+  159          161.03663    138.20024   0.006289308 
+  160          159.17568    138.23023   0.00625   
+  152          158.12391    138.26038   0.006578947 
+  150          158.38096    138.29067   0.006666667 
+  171          159.80585    138.32112   0.005847953 
+  168          161.94901    138.35172   0.005952381 
+  156          163.80951    138.38248   0.006410256 
+  165          165.01709    138.41339   0.006060606 
+  161          166.96468    138.44446   0.00621118 
+  185          170.67474    138.47569   0.005405405 
+  172          175.45129    138.50707   0.005813953 
+  171          178.07251    138.53861   0.005847953 
+  175          175.42268    138.57032   0.005714286 
+  174          170.17124    138.60218   0.005747126 
+  158          166.01473    138.6342    0.006329114 
+  173          163.6688     138.66639   0.005780347 
+  148          162.75913    138.69874   0.006756757 
+  178          163.00158    138.73125   0.005617978 
+  210          163.96506    138.76393   0.004761905 
+  184          165.00676    138.79677   0.005434783 
+  179          166.18801    138.82978   0.005586592 
+  184          167.87091    138.86295   0.005434783 
+  202          169.65463    138.8963    0.004950495 
+  199          170.95477    138.92981   0.005025126 
+  184          170.87753    138.96349   0.005434783 
+  175          169.43874    138.99734   0.005714286 
+  176          168.48365    139.03136   0.005681818 
+  179          168.98819    139.06555   0.005586592 
+  203          171.01118    139.09991   0.004926108 
+  201          174.65962    139.13445   0.004975124 
+  196          178.46969    139.16917   0.005102041 
+  206          180.29476    139.20405   0.004854369 
+  183          179.52705    139.23912   0.005464481 
+  178          178.45634    139.27436   0.005617978 
+  193          178.34939    139.30977   0.005181347 
+  206          179.11953    139.34537   0.004854369 
+  198          180.80985    139.38115   0.005050505 
+  190          183.73247    139.4171    0.005263158 
+  194          188.17533    139.45324   0.005154639 
+  201          194.33492    139.48955   0.004975124 
+  201          201.80638    139.52606   0.004975124 
+  217          208.98301    139.56274   0.004608295 
+  243          215.03535    139.59961   0.004115226 
+  230          221.1049     139.63666   0.004347826 
+  246          227.76186    139.6739    0.004065041 
+  258          236.17154    139.71133   0.003875969 
+  257          247.996      139.74894   0.003891051 
+  279          264.9067     139.78675   0.003584229 
+  306          288.59426    139.82474   0.003267974 
+  359          321.86555    139.86292   0.002785515 
+  373          369.81698    139.9013    0.002680965 
+  500          442.17114    139.93987   0.002     
+  642          558.397      139.97863   0.001557632 
+  897          756.93345    140.01758   0.001114827 
+  1324         1104.6198    140.05673   0.000755287 
+  1940         1670.16733   140.09608   0.000515464 
+  2230         2272.70884   140.13562   0.00044843 
+  2026         2218.18825   140.17536   0.000493583 
+  1498         1594.40871   140.2153    0.000667557 
+  1124         1066.77103   140.25544   0.00088968 
+  763          755.79842    140.29578   0.001310616 
+  655          587.39348    140.33632   0.001526718 
+  612          499.2627     140.37706   0.001633987 
+  537          458.75378    140.41801   0.001862197 
+  545          453.03804    140.45916   0.001834862 
+  560          483.20739    140.50051   0.001785714 
+  658          564.19513    140.54208   0.001519757 
+  852          726.97377    140.58384   0.001173709 
+  1096         1002.58188   140.62582   0.000912409 
+  1189         1286.22261   140.66801   0.000841043 
+  1174         1228.59405   140.7104    0.000851789 
+  897          906.05785    140.75301   0.001114827 
+  709          641.3975     140.79582   0.001410437 
+  522          483.44187    140.83886   0.001915709 
+  440          393.63137    140.8821    0.002272727 
+  370          340.80505    140.92556   0.002702703 
+  320          307.63456    140.96923   0.003125  
+  293          285.55948    141.01312   0.003412969 
+  282          270.27456    141.05723   0.003546099 
+  253          259.22524    141.10156   0.003952569 
+  225          250.51663    141.14611   0.004444444 
+  223          243.18412    141.19087   0.004484305 
+  259          237.05583    141.23586   0.003861004 
+  239          231.96001    141.28107   0.0041841 
+  236          227.63564    141.32651   0.004237288 
+  226          223.93076    141.37217   0.004424779 
+  232          220.42531    141.41805   0.004310345 
+  223          216.13476    141.46416   0.004484305 
+  223          211.09264    141.5105    0.004484305 
+  205          206.35324    141.55707   0.004878049 
+  211          202.43128    141.60386   0.004739336 
+  182          199.32404    141.65089   0.005494505 
+  206          196.85766    141.69815   0.004854369 
+  199          194.83609    141.74564   0.005025126 
+  198          193.10674    141.79337   0.005050505 
+  212          191.59021    141.84133   0.004716981 
+  194          190.26073    141.88952   0.005154639 
+  174          189.13332    141.93795   0.005747126 
+  205          188.2682     141.98662   0.004878049 
+  207          187.61219    142.03553   0.004830918 
+  222          186.7618     142.08468   0.004504505 
+  190          185.68451    142.13406   0.005263158 
+  174          184.94618    142.1837    0.005747126 
+  225          184.86448    142.23357   0.004444444 
+  178          185.4161     142.28369   0.005617978 
+  168          186.44845    142.33405   0.005952381 
+  219          187.72263    142.38466   0.00456621 
+  181          188.9063     142.43551   0.005524862 
+  197          189.69094    142.48662   0.005076142 
+  188          189.94939    142.53797   0.005319149 
+  203          189.67525    142.58957   0.004926108 
+  177          188.9825     142.64143   0.005649718 
+  179          188.11493    142.69353   0.005586592 
+  200          187.35594    142.7459    0.005     
+  179          186.96984    142.79851   0.005586592 
+  181          187.1879     142.85138   0.005524862 
+  193          188.22099    142.90451   0.005181347 
+  189          190.27619    142.9579    0.005291005 
+  187          193.56105    143.01154   0.005347594 
+  203          198.17887    143.06545   0.004926108 
+  208          203.83454    143.11962   0.004807692 
+  219          209.52972    143.17405   0.00456621 
+  201          214.26621    143.22874   0.004975124 
+  213          218.14604    143.2837    0.004694836 
+  178          220.73377    143.33892   0.005617978 
+  158          219.91888    143.39441   0.006329114 
+  209          215.41669    143.45017   0.004784689 
+  195          209.64918    143.5062    0.005128205 
+  208          204.53009    143.56249   0.004807692 
+  204          200.39427    143.61906   0.004901961 
+  217          197.07276    143.67591   0.004608295 
+  193          194.50868    143.73302   0.005181347 
+  208          192.79145    143.79041   0.004807692 
+  216          191.97283    143.84808   0.00462963 
+  219          191.80631    143.90602   0.00456621 
+  211          191.79183    143.96424   0.004739336 
+  204          191.81443    144.02274   0.004901961 
+  181          191.92533    144.08153   0.005524862 
+  218          191.21632    144.14059   0.004587156 
+  186          188.8469     144.19994   0.005376344 
+  155          185.43894    144.25957   0.006451613 
+  207          182.04267    144.31948   0.004830918 
+  178          179.13739    144.37969   0.005617978 
+  182          176.76677    144.44018   0.005494505 
+  180          174.8614     144.50096   0.005555556 
+  182          173.30791    144.56203   0.005494505 
+  182          171.81971    144.62339   0.005494505 
+  174          170.17624    144.68504   0.005747126 
+  196          168.67468    144.74699   0.005102041 
+  202          167.74074    144.80923   0.004950495 
+  197          167.62081    144.87177   0.005076142 
+  191          168.5018     144.9346    0.005235602 
+  165          170.45996    144.99774   0.006060606 
+  181          172.85412    145.06117   0.005524862 
+  187          173.62165    145.12491   0.005347594 
+  200          171.42306    145.18894   0.005     
+  176          168.00099    145.25328   0.005681818 
+  177          165.20284    145.31793   0.005649718 
+  181          163.44193    145.38288   0.005524862 
+  173          162.48208    145.44814   0.005780347 
+  187          161.95317    145.5137    0.005347594 
+  161          161.68319    145.57958   0.00621118 
+  170          161.6565     145.64577   0.005882353 
+  180          161.76303    145.71227   0.005555556 
+  186          162.0547     145.77908   0.005376344 
+  172          162.80724    145.8462    0.005813953 
+  165          164.10772    145.91365   0.006060606 
+  162          165.40693    145.98141   0.00617284 
+  150          165.60796    146.04949   0.006666667 
+  165          164.69465    146.11789   0.006060606 
+  165          163.7614     146.1866    0.006060606 
+  182          163.42119    146.25565   0.005494505 
+  164          163.76231    146.32501   0.006097561 
+  176          164.7738     146.3947    0.005681818 
+  170          166.50294    146.46472   0.005882353 
+  161          169.07509    146.53506   0.00621118 
+  189          172.70312    146.60574   0.005291005 
+  206          177.83538    146.67674   0.004854369 
+  200          185.56679    146.74807   0.005     
+  184          198.22932    146.81974   0.005434783 
+  238          219.91402    146.89174   0.004201681 
+  257          255.50364    146.96408   0.003891051 
+  273          300.05556    147.03675   0.003663004 
+  268          315.08214    147.10976   0.003731343 
+  250          281.74122    147.18311   0.004     
+  241          242.57295    147.2568    0.004149378 
+  209          217.21339    147.33084   0.004784689 
+  189          203.75977    147.40521   0.005291005 
+  231          198.23559    147.47993   0.004329004 
+  204          198.41374    147.555     0.004901961 
+  196          203.7813     147.63042   0.005102041 
+  217          215.05775    147.70618   0.004608295 
+  212          233.86646    147.78229   0.004716981 
+  225          263.18894    147.85876   0.004444444 
+  235          303.7223     147.93558   0.004255319 
+  264          338.42726    148.01275   0.003787879 
+  270          341.37108    148.09027   0.003703704 
+  286          310.3184     148.16816   0.003496503 
+  216          265.43382    148.2464    0.00462963 
+  250          230.68391    148.32501   0.004     
+  212          209.2271     148.40397   0.004716981 
+  187          196.92391    148.4833    0.005347594 
+  187          190.39771    148.56299   0.005347594 
+  194          187.85058    148.64304   0.005154639 
+  182          188.63405    148.72346   0.005494505 
+  209          192.72032    148.80425   0.004784689 
+  182          200.31906    148.88542   0.005494505 
+  195          212.00422    148.96695   0.005128205 
+  186          226.02171    149.04885   0.005376344 
+  170          231.2399     149.13113   0.005882353 
+  197          219.96457    149.21378   0.005076142 
+  186          203.91182    149.29681   0.005376344 
+  199          191.41784    149.38022   0.005025126 
+  175          182.6503     149.464     0.005714286 
+  171          176.68728    149.54817   0.005847953 
+  164          172.80852    149.63272   0.006097561 
+  160          170.37187    149.71766   0.00625   
+  166          168.91728    149.80298   0.006024096 
+  186          168.15657    149.88868   0.005376344 
+  167          167.87994    149.97478   0.005988024 
+  167          167.87947    150.06126   0.005988024 
+  181          167.99086    150.14814   0.005524862 
+  164          168.10355    150.23541   0.006097561 
+  170          168.16837    150.32307   0.005882353 
+  143          168.30042    150.41113   0.006993007 
+  166          168.59811    150.49959   0.006024096 
+  155          168.88131    150.58844   0.006451613 
+  163          169.06169    150.6777    0.006134969 
+  147          169.41702    150.76735   0.006802721 
+  166          170.24008    150.85741   0.006024096 
+  165          171.37557    150.94787   0.006060606 
+  158          171.85603    151.03875   0.006329114 
+  149          170.98409    151.13002   0.006711409 
+  179          169.5199     151.22171   0.005586592 
+  148          168.36655    151.31381   0.006756757 
+  162          167.63781    151.40632   0.00617284 
+  160          167.02129    151.49924   0.00625   
+  154          166.41768    151.59258   0.006493506 
+  172          165.98702    151.68634   0.005813953 
+  164          165.82864    151.78051   0.006097561 
+  166          165.962      151.87511   0.006024096 
+  160          166.39778    151.97012   0.00625   
+  165          167.16691    152.06556   0.006060606 
+  153          168.31383    152.16143   0.006535948 
+  159          169.62324    152.25772   0.006289308 
+  151          170.25001    152.35443   0.006622517 
+  165          169.44769    152.45158   0.006060606 
+  167          167.80325    152.54916   0.005988024 
+  142          166.31826    152.64717   0.007042254 
+  176          165.30133    152.74561   0.005681818 
+  156          164.59533    152.84449   0.006410256 
+  152          164.0643     152.94381   0.006578947 
+  158          163.68299    153.04357   0.006329114 
+  170          163.39288    153.14376   0.005882353 
+  169          163.179      153.2444    0.00591716 
+  148          163.09368    153.34549   0.006756757 
+  150          163.17521    153.44701   0.006666667 
+  152          163.429      153.54899   0.006578947 
+  161          163.79111    153.65141   0.00621118 
+  177          164.07271    153.75428   0.005649718 
+  171          164.06069    153.85761   0.005847953 
+  163          163.81633    153.96139   0.006134969 
+  153          163.60648    154.06562   0.006535948 
+  152          163.57853    154.17031   0.006578947 
+  150          163.75102    154.27546   0.006666667 
+  153          164.08387    154.38107   0.006535948 
+  171          164.46158    154.48714   0.005847953 
+  172          164.73232    154.59367   0.005813953 
+  153          164.90938    154.70067   0.006535948 
+  167          165.13447    154.80813   0.005988024 
+  154          165.48458    154.91607   0.006493506 
+  153          165.9653     155.02447   0.006535948 
+  155          166.55277    155.13334   0.006451613 
+  181          167.21874    155.24269   0.005524862 
+  157          167.95531    155.35252   0.006369427 
+  157          168.71532    155.46282   0.006369427 
+  191          169.40437    155.57359   0.005235602 
+  149          170.06       155.68485   0.006711409 
+  169          170.85205    155.79659   0.00591716 
+  173          171.92765    155.90882   0.005780347 
+  160          173.40512    156.02153   0.00625   
+  182          175.41226    156.13472   0.005494505 
+  154          178.10787    156.24841   0.006493506 
+  170          181.40735    156.36258   0.005882353 
+  186          184.30213    156.47725   0.005376344 
+  171          185.13325    156.59241   0.005847953 
+  177          183.90102    156.70807   0.005649718 
+  188          182.33738    156.82422   0.005319149 
+  173          181.51913    156.94087   0.005780347 
+  177          181.58215    157.05803   0.005649718 
+  215          182.41038    157.17568   0.004651163 
+  193          183.96859    157.29384   0.005181347 
+  181          186.18128    157.41251   0.005524862 
+  181          188.50696    157.53169   0.005524862 
+  180          190.27157    157.65137   0.005555556 
+  182          191.68345    157.77157   0.005494505 
+  162          193.16519    157.89228   0.00617284 
+  181          194.85346    158.0135    0.005524862 
+  211          197.10426    158.13524   0.004739336 
+  187          199.83386    158.2575    0.005347594 
+  207          202.57577    158.38028   0.004830918 
+  195          205.49646    158.50359   0.005128205 
+  165          209.69238    158.62741   0.006060606 
+  215          215.81351    158.75176   0.004651163 
+  212          220.91868    158.87664   0.004716981 
+  184          222.04353    159.00205   0.005434783 
+  198          223.33101    159.128     0.005050505 
+  219          229.66927    159.25447   0.00456621 
+  244          243.87737    159.38148   0.004098361 
+  233          270.05193    159.50902   0.004291845 
+  316          314.11543    159.63711   0.003164557 
+  378          372.96386    159.76573   0.002645503 
+  369          404.21164    159.8949    0.002710027 
+  368          367.53137    160.02461   0.002717391 
+  315          310.07968    160.15487   0.003174603 
+  256          269.26387    160.28568   0.00390625 
+  255          245.87096    160.41703   0.003921569 
+  230          234.13978    160.54894   0.004347826 
+  208          229.27517    160.6814    0.004807692 
+  239          226.4165     160.81442   0.0041841 
+  232          223.22534    160.94799   0.004310345 
+  227          220.9943     161.08213   0.004405286 
+  208          221.68605    161.21682   0.004807692 
+  246          227.51697    161.35208   0.004065041 
+  253          241.04406    161.4879    0.003952569 
+  248          264.73984    161.62429   0.004032258 
+  311          292.6828     161.76125   0.003215434 
+  299          297.7784     161.89878   0.003344482 
+  265          273.24415    162.03688   0.003773585 
+  260          247.10985    162.17556   0.003846154 
+  234          229.72208    162.31481   0.004273504 
+  202          218.17308    162.45464   0.004950495 
+  215          209.6656     162.59506   0.004651163 
+  178          203.63871    162.73605   0.005617978 
+  193          199.71218    162.87763   0.005181347 
+  209          196.85235    163.0198    0.004784689 
+  179          194.5609     163.16255   0.005586592 
+  178          192.61025    163.30589   0.005617978 
+  159          190.97114    163.44983   0.006289308 
+  174          189.61287    163.59436   0.005747126 
+  191          188.74242    163.73949   0.005235602 
+  172          188.57149    163.88521   0.005813953 
+  187          189.08156    164.03153   0.005347594 
+  197          190.01166    164.17846   0.005076142 
+  203          190.85102    164.32599   0.004926108 
+  213          191.07372    164.47413   0.004694836 
+  176          190.49983    164.62288   0.005681818 
+  181          189.52809    164.77223   0.005524862 
+  191          188.70082    164.9222    0.005235602 
+  178          187.86514    165.07278   0.005617978 
+  191          186.96624    165.22398   0.005235602 
+  194          186.2286     165.3758    0.005154639 
+  173          185.79733    165.52823   0.005780347 
+  171          185.5166     165.68129   0.005847953 
+  196          185.3848     165.83498   0.005102041 
+  175          185.58537    165.98929   0.005714286 
+  201          186.19219    166.14423   0.004975124 
+  189          187.01017    166.2998    0.005291005 
+  194          187.54551    166.456     0.005154639 
+  199          187.51429    166.61284   0.005025126 
+  178          187.27666    166.77031   0.005617978 
+  193          187.30586    166.92843   0.005181347 
+  201          187.78446    167.08718   0.004975124 
+  183          188.65268    167.24658   0.005464481 
+  178          189.70293    167.40662   0.005617978 
+  165          190.78012    167.56731   0.006060606 
+  195          191.66834    167.72865   0.005128205 
+  200          191.92054    167.89064   0.005     
+  192          191.58639    168.05328   0.005208333 
+  177          191.24662    168.21658   0.005649718 
+  192          191.28177    168.38054   0.005208333 
+  195          191.74828    168.54516   0.005128205 
+  183          192.51482    168.71044   0.005464481 
+  187          193.34679    168.87639   0.005347594 
+  203          194.14808    169.043     0.004926108 
+  218          195.08461    169.21028   0.004587156 
+  223          196.33313    169.37823   0.004484305 
+  217          197.99717    169.54685   0.004608295 
+  191          200.18088    169.71615   0.005235602 
+  187          203.02908    169.88613   0.005347594 
+  229          206.69037    170.05678   0.004366812 
+  235          211.13969    170.22812   0.004255319 
+  230          215.91574    170.40014   0.004347826 
+  240          219.96035    170.57285   0.004166667 
+  244          222.17034    170.74625   0.004098361 
+  220          223.14417    170.92033   0.004545455 
+  209          224.46352    171.09511   0.004784689 
+  219          226.36673    171.27058   0.00456621 
+  200          227.67932    171.44676   0.005     
+  231          227.7217     171.62363   0.004329004 
+  198          227.1574     171.8012    0.005050505 
+  249          226.71648    171.97947   0.004016064 
+  209          226.68216    172.15845   0.004784689 
+  246          227.1792     172.33814   0.004065041 
+  255          228.30528    172.51854   0.003921569 
+  200          230.13085    172.69966   0.005     
+  242          232.702      172.88148   0.004132231 
+  235          235.91703    173.06403   0.004255319 
+  253          239.23273    173.24729   0.003952569 
+  246          241.79996    173.43128   0.004065041 
+  229          243.62175    173.61599   0.004366812 
+  223          245.61587    173.80143   0.004484305 
+  265          248.27464    173.98759   0.003773585 
+  247          251.26007    174.17449   0.004048583 
+  259          254.10974    174.36212   0.003861004 
+  254          256.95128    174.55048   0.003937008 
+  285          260.38958    174.73959   0.003508772 
+  283          265.66557    174.92943   0.003533569 
+  293          274.45149    175.12002   0.003412969 
+  315          288.15295    175.31135   0.003174603 
+  351          305.58504    175.50342   0.002849003 
+  351          317.87087    175.69625   0.002849003 
+  327          315.07426    175.88983   0.003058104 
+  292          304.1488     176.08416   0.003424658 
+  349          295.51271    176.27925   0.00286533 
+  308          291.31285    176.4751    0.003246753 
+  293          290.40767    176.67171   0.003412969 
+  316          291.92678    176.86909   0.003164557 
+  312          295.47618    177.06723   0.003205128 
+  297          300.73841    177.26613   0.003367003 
+  334          307.42966    177.46581   0.002994012 
+  337          315.42895    177.66626   0.002967359 
+  328          325.08864    177.86749   0.00304878 
+  351          337.26123    178.0695    0.002849003 
+  352          352.94163    178.27228   0.002840909 
+  335          372.62222    178.47585   0.002985075 
+  358          394.12949    178.6802    0.002793296 
+  394          411.85693    178.88534   0.002538071 
+  417          425.75574    179.09128   0.002398082 
+  434          442.38576    179.298     0.002304147 
+  456          465.31542    179.50552   0.002192982 
+  486          495.03983    179.71383   0.002057613 
+  549          531.80254    179.92295   0.001821494 
+  581          577.61695    180.13287   0.00172117 
+  692          636.98193    180.34359   0.001445087 
+  800          716.04035    180.55512   0.00125   
+  830          821.79567    180.76746   0.001204819 
+  1042         960.71814    180.98061   0.000959693 
+  1297         1144.17375   181.19457   0.00077101 
+  1688         1407.97423   181.40936   0.000592417 
+  2249         1820.04282   181.62496   0.000444642 
+  3170         2491.97025   181.84138   0.000315457 
+  4733         3598.16189   182.05863   0.000211282 
+  6899         5312.27054   182.27671   0.000144949 
+  8292         7317.69955   182.49561   0.000120598 
+  8081         7979.75696   182.71535   0.000123747 
+  6470         6468.50326   182.93592   0.00015456 
+  4979         4497.08177   183.15733   0.000200844 
+  3575         3086.56922   183.37958   0.00027972 
+  2724         2222.638     183.60267   0.000367107 
+  2123         1712.31522   183.8266    0.000471032 
+  1739         1413.47602   184.05139   0.000575043 
+  1562         1244.4845    184.27702   0.000640205 
+  1423         1161.95004   184.5035    0.000702741 
+  1409         1148.76896   184.73084   0.000709723 
+  1521         1212.75725   184.95904   0.000657462 
+  1732         1383.87431   185.1881    0.000577367 
+  2279         1720.51971   185.41802   0.000438789 
+  2971         2313.69186   185.6488    0.000336587 
+  3801         3219.85243   185.88045   0.000263089 
+  4262         4111.64435   186.11298   0.000234632 
+  3899         4076.44766   186.34637   0.000256476 
+  3195         3129.86047   186.58065   0.000312989 
+  2493         2180.43292   186.8158    0.000401123 
+  1744         1538.72171   187.05183   0.000573394 
+  1455         1143.02801   187.28874   0.000687285 
+  1088         898.7046     187.52654   0.000919118 
+  902          742.09552    187.76523   0.001108647 
+  717          636.25005    188.00482   0.0013947 
+  618          560.4074     188.24529   0.001618123 
+  562          502.90533    188.48666   0.001779359 
+  536          457.62754    188.72893   0.001865672 
+  469          421.81221    188.97211   0.002132196 
+  405          393.67252    189.21619   0.002469136 
+  371          371.65964    189.46117   0.002695418 
+  366          354.54735    189.70707   0.00273224 
+  327          341.4049     189.95388   0.003058104 
+  338          331.28031    190.2016    0.00295858 
+  304          322.822      190.45024   0.003289474 
+  296          314.73599    190.69981   0.003378378 
+  342          307.0071     190.95029   0.002923977 
+  299          300.40553    191.20171   0.003344482 
+  323          295.52145    191.45405   0.003095975 
+  265          292.2654     191.70732   0.003773585 
+  290          289.61117    191.96153   0.003448276 
+  282          286.13151    192.21668   0.003546099 
+  278          281.06371    192.47276   0.003597122 
+  259          274.93214    192.72979   0.003861004 
+  251          269.01875    192.98776   0.003984064 
+  259          264.2282     193.24669   0.003861004 
+  244          260.68864    193.50656   0.004098361 
+  253          258.16489    193.76739   0.003952569 
+  244          256.6237     194.02917   0.004098361 
+  241          256.10423    194.29191   0.004149378 
+  248          256.25768    194.55562   0.004032258 
+  231          256.52131    194.82029   0.004329004 
+  215          256.7991     195.08593   0.004651163 
+  234          257.63728    195.35253   0.004273504 
+  254          260.02931    195.62012   0.003937008 
+  250          264.82766    195.88867   0.004     
+  266          272.62506    196.15821   0.003759398 
+  233          284.15467    196.42873   0.004291845 
+  294          298.63481    196.70023   0.003401361 
+  295          308.44224    196.97273   0.003389831 
+  237          302.69292    197.24621   0.004219409 
+  231          285.91049    197.52068   0.004329004 
+  260          269.8905     197.79615   0.003846154 
+  226          258.62787    198.07262   0.004424779 
+  219          251.58394    198.3501    0.00456621 
+  230          247.69826    198.62857   0.004347826 
+  221          246.21025    198.90806   0.004524887 
+  227          246.65462    199.18855   0.004405286 
+  196          248.77647    199.47006   0.005102041 
+  236          252.63932    199.75258   0.004237288 
+  210          258.75407    200.03613   0.004761905 
+  219          268.13266    200.3207    0.00456621 
+  251          282.75302    200.60629   0.003984064 
+#--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--#
+
+# start Validation Reply Form
+_vrf_PLAT741_NEW2minmill_phase_1 # for all atoms in 1_quartz
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT741_NEW2minmill_phase_3 # for all atoms in 3_pyrrhotite
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT741_NEW2minmill_phase_4 # for all atoms in 4_rutile
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT741_NEW2minmill_phase_2 # for all atoms in 2_albite
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT155_NEW2minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT141_NEW2minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT142_NEW2minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT143_2_minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT144_NEW2minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT145_NEW2minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT146_NEW2minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT151_NEW2minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+# end Validation Reply Form

--- a/data/hamish/vb5042sup7.cif
+++ b/data/hamish/vb5042sup7.cif
@@ -1,0 +1,6669 @@
+
+data_NEW3minmill_publ
+_audit_creation_method  "created in GSAS-II"
+_audit_creation_date  2021-08-04T18:35
+_audit_author_name  "McDougall, Hamish"
+_audit_update_record
+   "2021-08-04T18:35  Initial software-generated CIF"
+_pd_block_id  2021-08-04T18:35|NEW3minmill|McDougallHamish|Overall
+# GSAS-II edited template follows Publication_Template
+#=============================================================================
+# this information describes the project, paper etc. for the CIF             #
+# Acta Cryst. Section C papers and editorial correspondence is generated     #
+# from the information in this section                                       #
+#                                                                            #
+#   (from)   CIF submission form for Rietveld refinements (Acta Cryst. C)    #
+#                                                 Version 14 December 1998   #
+#=============================================================================
+# 1. SUBMISSION DETAILS
+
+_publ_contact_author_name            "Suzanne Neville; Vanessa Peterson; Christophe Didier"   # Name of author for correspondence
+_publ_contact_author_address             # Address of author for correspondence
+; ?
+;
+_publ_contact_author_email           "s.neville@unsw.edu.au; vanessa.peterson@ansto.gov.au; drchristophedidier@gmail.com"
+_publ_contact_author_fax             ?
+_publ_contact_author_phone           ?
+
+_publ_contact_letter
+; ?
+;
+   
+_publ_requested_journal              ?
+_publ_requested_coeditor_name        ?
+_publ_requested_category             ?   # Acta C: one of CI/CM/CO/FI/FM/FO
+
+#==============================================================================
+
+# 2. PROCESSING SUMMARY (IUCr Office Use Only)
+
+_journal_data_validation_number      ?
+
+_journal_date_recd_electronic        ?
+_journal_date_to_coeditor            ?
+_journal_date_from_coeditor          ?
+_journal_date_accepted               ?
+_journal_date_printers_first         ?
+_journal_date_printers_final         ?
+_journal_date_proofs_out             ?
+_journal_date_proofs_in              ?
+_journal_coeditor_name               ?
+_journal_coeditor_code               ?
+_journal_coeditor_notes
+; ?
+;
+_journal_techeditor_code             ?
+_journal_techeditor_notes
+; ?
+;
+_journal_coden_ASTM                  ?
+_journal_name_full                   ?
+_journal_year                        ?
+_journal_volume                      ?
+_journal_issue                       ?
+_journal_page_first                  ?
+_journal_page_last                   ?
+_journal_paper_category              ?
+_journal_suppl_publ_number           ?
+_journal_suppl_publ_pages            ?
+
+#==============================================================================
+
+# 3. TITLE AND AUTHOR LIST
+
+_publ_section_title
+; ?
+;
+_publ_section_title_footnote
+; ?
+;         
+ 
+# The loop structure below should contain the names and addresses of all 
+# authors, in the required order of publication. Repeat as necessary.
+
+loop_
+	_publ_author_name
+        _publ_author_footnote
+	_publ_author_address
+ ?                                   #<--'Last name, first name' 
+; ?
+;
+; ?
+;
+
+#==============================================================================
+
+# 4. TEXT
+
+_publ_section_synopsis
+;  ?
+;
+_publ_section_abstract                         
+; ?
+;          
+_publ_section_comment                          
+; ?
+;
+_publ_section_exptl_prep      # Details of the preparation of the sample(s)
+                              # should be given here. 
+; ?
+;
+_publ_section_exptl_refinement                  
+; ?
+;
+_publ_section_references
+; ?
+;
+_publ_section_figure_captions
+; ?
+;
+_publ_section_acknowledgements
+; ?
+;
+
+#=============================================================================
+# 5. OVERALL REFINEMENT & COMPUTING DETAILS
+
+_refine_special_details
+; ?
+;
+_pd_proc_ls_special_details
+; ?
+;
+
+# The following items are used to identify the programs used.
+_computing_molecular_graphics     ?
+_computing_publication_material   ?
+
+_refine_ls_weighting_scheme       ?        
+_refine_ls_weighting_details      ?
+_refine_ls_hydrogen_treatment     ?        
+_refine_ls_extinction_method      ?        
+_refine_ls_extinction_coef        ?         
+_refine_ls_number_constraints     ?        
+
+_refine_ls_restrained_S_all       ?        
+_refine_ls_restrained_S_obs       ?
+
+#==============================================================================
+# 6. SAMPLE PREPARATION DATA
+
+# (In the unusual case where multiple samples are used in a single
+#  Rietveld study, this information should be moved into the phase
+#  blocks)
+
+# The following three fields describe the preparation of the material.
+# The cooling rate is in K/min.  The pressure at which the sample was  
+# prepared is in kPa.  The temperature of preparation is in K.
+               
+_pd_prep_cool_rate                N/A        
+_pd_prep_pressure                 101.3        
+_pd_prep_temperature              298          
+
+_pd_char_colour                   ?       # use ICDD colour descriptions
+
+data_NEW3minmill_overall
+_pd_proc_info_datetime  2021-08-04T18:35
+_pd_calc_method  "Rietveld Refinement"
+_computing_structure_refinement
+   "GSAS-II (Toby & Von Dreele, J. Appl. Cryst. 46, 544-549, 2013)"
+_refine_ls_number_parameters  27
+_refine_ls_goodness_of_fit_all  2.636
+_refine_ls_shift/su_max  0.7872
+
+# OVERALL WEIGHTED R-FACTOR
+_refine_ls_wR_factor_obs  0.10301
+_refine_ls_matrix_type  full
+# POINTERS TO PHASE AND HISTOGRAM BLOCKS
+loop_   _pd_phase_block_id
+  2021-08-04T18:35|NEW3minmill|phase_0|McDougallHamish
+  2021-08-04T18:35|NEW3minmill|phase_2|McDougallHamish
+  2021-08-04T18:35|NEW3minmill|phase_4|McDougallHamish
+  2021-08-04T18:35|NEW3minmill|phase_1|McDougallHamish
+  2021-08-04T18:35|NEW3minmill|phase_3|McDougallHamish
+_pd_block_diffractogram_id
+;
+2021-08-04T18:35|NEW3minmill|McDougallHamish|PANalytical,Co-EmpyreanII_hist_0
+;
+
+data_NEW3minmill_phase_0
+# Information for phase 0
+_pd_block_id  2021-08-04T18:35|NEW3minmill|phase_0|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for FeS2 follows
+_pd_phase_name  FeS2
+_cell_length_a  5.419481(29)
+_cell_length_b  5.419481(29)
+_cell_length_c  5.419481(29)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  90
+_cell_volume  159.1744(26)
+_exptl_crystal_density_diffrn  5.0061
+_symmetry_cell_setting  cubic
+_symmetry_space_group_name_H-M  "P a -3"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  z,x,y
+     3  y,z,x
+     4  1/2+x,y,1/2-z
+     5  1/2-z,1/2+x,y
+     6  y,1/2-z,1/2+x
+     7  -z,1/2+x,1/2-y
+     8  1/2-y,-z,1/2+x
+     9  1/2+y,1/2-z,-x
+    10  -x,1/2+y,1/2-z
+    11  1/2-z,-x,1/2+y
+    12  1/2+x,1/2-y,-z
+    13  -x,-y,-z
+    14  -z,-x,-y
+    15  -y,-z,-x
+    16  1/2-x,-y,1/2+z
+    17  1/2+z,1/2-x,-y
+    18  -y,1/2+z,1/2-x
+    19  z,1/2-x,1/2+y
+    20  1/2+y,z,1/2-x
+    21  1/2-y,1/2+z,x
+    22  x,1/2-y,1/2+z
+    23  1/2+z,x,1/2-y
+    24  1/2-x,1/2+y,z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Fe1    Fe   0.00000     0.00000     0.00000     1.000      Uiso 0.010      4   
+S2     S    0.38680     0.38680     0.38680     1.000      Uiso 0.010      8   
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Fe   4      11.7695    7.3573     3.5222     2.3045     4.7611     0.3072     15.3535    76.8805    1.0369     0.945
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S    8      6.9053     5.2034     1.4379     1.5863     1.4679     22.2151    0.2536     56.172     0.8669     0.2847
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Fe S2"
+_chemical_formula_weight  119.97
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Fe1    S2     2.2687       1_555    4_455 yes
+  Fe1    S2     2.2687       1_555    5_545 yes
+  Fe1    S2     2.2687       1_555    6_554 yes
+  Fe1    S2     2.2687       1_555    7_545 yes
+  Fe1    S2     2.2687       1_555    8_554 yes
+  Fe1    S2     2.2687       1_555    9_455 yes
+  S2     Fe1    2.2687       1_555    4_555 yes
+  S2     Fe1    2.2687       1_555    5_555 yes
+  S2     Fe1    2.2687       1_555    6_555 yes
+  S2     S2     2.12518      1_555   13_666 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.2508(19), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW3minmill_phase_2
+# Information for phase 2
+_pd_block_id  2021-08-04T18:35|NEW3minmill|phase_2|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for NaAlSi3O8 follows
+_pd_phase_name  NaAlSi3O8
+_cell_length_a  8.137
+_cell_length_b  12.785
+_cell_length_c  7.1583
+_cell_angle_alpha  94.26
+_cell_angle_beta   116.6
+_cell_angle_gamma  87.71
+_cell_volume  664.008
+_exptl_crystal_density_diffrn  2.6230
+_symmetry_cell_setting  triclinic
+_symmetry_space_group_name_H-M  "C -1"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -x,-y,-z
+     3  1/2+x,1/2+y,z
+     4  1/2-x,1/2-y,-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Al1    Al3+ 0.00887     0.16846     0.20805     1.000      Uani 0.007      4   
+Si1    Si4+ 0.00375     0.82051     0.23737     1.000      Uani 0.006      4   
+Si2    Si4+ 0.69162     0.11021     0.31466     1.000      Uani 0.006      4   
+Si3    Si4+ 0.68129     0.88190     0.36076     1.000      Uani 0.006      4   
+Na1    Na1+ 0.26799     0.98865     0.14650     1.000      Uani 0.031      4   
+O1     O2-  0.00490     0.13103     0.96660     1.000      Uani 0.012      4   
+O2     O2-  0.59176     0.99756     0.28040     1.000      Uani 0.008      4   
+O3     O2-  0.81230     0.10966     0.19010     1.000      Uani 0.014      4   
+O4     O2-  0.82000     0.85101     0.25870     1.000      Uani 0.018      4   
+O5     O2-  0.01288     0.30238     0.27060     1.000      Uani 0.011      4   
+O6     O2-  0.02329     0.69368     0.22910     1.000      Uani 0.011      4   
+O7     O2-  0.20780     0.10896     0.38900     1.000      Uani 0.011      4   
+O8     O2-  0.18400     0.86817     0.43620     1.000      Uani 0.012      4   
+
+loop_
+   _atom_site_aniso_label
+   _atom_site_aniso_U_11
+   _atom_site_aniso_U_22
+   _atom_site_aniso_U_33
+   _atom_site_aniso_U_12
+   _atom_site_aniso_U_13
+   _atom_site_aniso_U_23
+Al1    0.0074      0.0068      0.0061      -0.0009     0.0031      0.0004      
+Si1    0.0068      0.0065      0.0055      0.0011      0.0030      0.0008      
+Si2    0.0061      0.0055      0.0073      -0.0002     0.0025      0.0004      
+Si3    0.0060      0.0055      0.0074      0.0006      0.0028      0.0009      
+Na1    0.0136      0.0471      0.0315      -0.0050     0.0084      -0.0219     
+O1     0.0164      0.0122      0.0074      -0.0002     0.0067      0.0014      
+O2     0.0074      0.0056      0.0119      0.0003      0.0033      0.0020      
+O3     0.0117      0.0130      0.0162      -0.0040     0.0093      -0.0017     
+O4     0.0134      0.0179      0.0216      0.0046      0.0129      0.0020      
+O5     0.0103      0.0076      0.0150      -0.0020     0.0052      -0.0009     
+O6     0.0101      0.0071      0.0145      0.0022      0.0034      0.0012      
+O7     0.0120      0.0129      0.0080      0.0024      0.0013      0.0015      
+O8     0.0140      0.0140      0.0084      -0.0026     -0.0002     -0.0006     
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Al   4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Na   4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  O    32     ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si   12     ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Al Na O8 Si3"
+_chemical_formula_weight  262.22
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Al1    O1     1.74519      1_555    1_554 yes
+  Al1    O3     1.7429       1_555    1_455 yes
+  Al1    O5     1.73509      1_555    1_555 yes
+  Al1    O7     1.74556      1_555    1_555 yes
+  Si1    O1     1.59985      1_555    2_566 yes
+  Si1    O4     1.59997      1_555    1_455 yes
+  Si1    O6     1.62225      1_555    1_555 yes
+  Si1    O8     1.61907      1_555    1_555 yes
+  Si2    O2     1.63011      1_555    1_545 yes
+  Si2    O3     1.59435      1_555    1_555 yes
+  Si2    O6     1.61836      1_555    3_545 yes
+  Si2    O8     1.6168       1_555    2_666 yes
+  Si3    O2     1.64718      1_555    1_555 yes
+  Si3    O4     1.61975      1_555    1_555 yes
+  Si3    O5     1.59682      1_555    3_555 yes
+  Si3    O7     1.60203      1_555    2_666 yes
+  Na1    O1     2.66887      1_555    1_564 yes
+  Na1    O1     2.53079      1_555    2_566 yes
+  Na1    O2     2.3704       1_555    1_555 yes
+  Na1    O3     2.45321      1_555    2_665 yes
+  Na1    O7     2.43384      1_555    1_565 yes
+  O1     Al1    1.74519      1_555    1_556 yes
+  O1     Si1    1.59985      1_555    2_566 yes
+  O1     Na1    2.66887      1_555    1_546 yes
+  O1     Na1    2.53079      1_555    2_566 yes
+  O2     Si2    1.63011      1_555    1_565 yes
+  O2     Si3    1.64718      1_555    1_555 yes
+  O2     Na1    2.3704       1_555    1_555 yes
+  O3     Al1    1.7429       1_555    1_655 yes
+  O3     Si2    1.59435      1_555    1_555 yes
+  O3     Na1    2.45321      1_555    2_665 yes
+  O4     Si1    1.59997      1_555    1_655 yes
+  O4     Si3    1.61975      1_555    1_555 yes
+  O5     Al1    1.73509      1_555    1_555 yes
+  O5     Si3    1.59682      1_555    3_445 yes
+  O6     Si1    1.62225      1_555    1_555 yes
+  O6     Si2    1.61836      1_555    3_455 yes
+  O7     Al1    1.74556      1_555    1_555 yes
+  O7     Si3    1.60203      1_555    2_666 yes
+  O7     Na1    2.43384      1_555    1_545 yes
+  O8     Si1    1.61907      1_555    1_555 yes
+  O8     Si2    1.6168       1_555    2_666 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Al1    O3     102.836       1_554  1_555    1_455 yes
+  O1     Al1    O5     116.047       1_554  1_555    1_555 yes
+  O3     Al1    O5     112.215       1_455  1_555    1_555 yes
+  O1     Al1    O7     104.004       1_554  1_555    1_555 yes
+  O3     Al1    O7     111.151       1_455  1_555    1_555 yes
+  O5     Al1    O7     110.14        1_555  1_555    1_555 yes
+  O1     Si1    O4     109.433       2_566  1_555    1_455 yes
+  O1     Si1    O6     112.47        2_566  1_555    1_555 yes
+  O4     Si1    O6     108.187       1_455  1_555    1_555 yes
+  O1     Si1    O8     107.176       2_566  1_555    1_555 yes
+  O4     Si1    O8     111.446       1_455  1_555    1_555 yes
+  O6     Si1    O8     108.16        1_555  1_555    1_555 yes
+  O2     Si2    O3     111.144       1_545  1_555    1_555 yes
+  O2     Si2    O6     104.24        1_545  1_555    3_545 yes
+  O3     Si2    O6     112.114       1_555  1_555    3_545 yes
+  O2     Si2    O8     106.97        1_545  1_555    2_666 yes
+  O3     Si2    O8     111.591       1_555  1_555    2_666 yes
+  O6     Si2    O8     110.422       3_545  1_555    2_666 yes
+  O2     Si3    O4     107.269       1_555  1_555    1_555 yes
+  O2     Si3    O5     105.914       1_555  1_555    3_555 yes
+  O4     Si3    O5     110.224       1_555  1_555    3_555 yes
+  O2     Si3    O7     108.565       1_555  1_555    2_666 yes
+  O4     Si3    O7     110.208       1_555  1_555    2_666 yes
+  O5     Si3    O7     114.328       3_555  1_555    2_666 yes
+  Al1    O1     Si1    141.397       1_556  1_555    2_566 yes
+  Si2    O2     Si3    130.019       1_565  1_555    1_555 yes
+  Si2    O2     Na1    120.351       1_565  1_555    1_555 yes
+  Si3    O2     Na1    108.811       1_555  1_555    1_555 yes
+  Al1    O3     Si2    139.461       1_655  1_555    1_555 yes
+  Si1    O4     Si3    161.151       1_655  1_555    1_555 yes
+  Al1    O5     Si3    129.689       1_555  1_555    3_445 yes
+  Si1    O6     Si2    135.676       1_555  1_555    3_455 yes
+  Al1    O7     Si3    133.943       1_555  1_555    2_666 yes
+  Si1    O8     Si2    151.747       1_555  1_555    2_666 yes
+_pd_proc_ls_pref_orient_corr  none
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.143(10), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW3minmill_phase_4
+# Information for phase 4
+_pd_block_id  2021-08-04T18:35|NEW3minmill|phase_4|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Pyrrhotite 4M follows
+_pd_phase_name  "Pyrrhotite 4M"
+_cell_length_a  11.933(22)
+_cell_length_b  6.868(3)
+_cell_length_c  12.827(25)
+_cell_angle_alpha  90
+_cell_angle_beta   117.23(4)
+_cell_angle_gamma  90
+_cell_volume  934.8(4)
+_exptl_crystal_density_diffrn  4.6003
+_symmetry_cell_setting  monoclinic
+_symmetry_space_group_name_H-M  "C 2/c"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -x,y,1/2-z
+     3  -x,-y,-z
+     4  x,-y,1/2+z
+     5  1/2+x,1/2+y,z
+     6  1/2-x,1/2+y,1/2-z
+     7  1/2-x,1/2-y,-z
+     8  1/2+x,1/2-y,1/2+z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+S1     S    0.01800     0.38330     0.11960     1.000      Uiso 0.010      8   
+S2     S    0.02910     0.11420     0.63900     1.000      Uiso 0.010      8   
+Fe3    Fe   0.10860     0.10250     0.49980     1.000      Uiso 0.010      8   
+S4     S    0.23410     0.13550     0.38260     1.000      Uiso 0.010      8   
+Fe5    Fe   0.24180     0.36600     0.24680     1.000      Uiso 0.010      8   
+S6     S    0.26790     0.13400     0.12360     1.000      Uiso 0.010      8   
+Fe7    Fe   0.38720     0.15000     0.01260     1.000      Uiso 0.010      8   
+Fe8    Fe   0.00000     0.14720     0.25000     1.000      Uiso 0.010      4   
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Fe   28     11.7695    7.3573     3.5222     2.3045     4.7611     0.3072     15.3535    76.8805    1.0369     0.945
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S    32     6.9053     5.2034     1.4379     1.5863     1.4679     22.2151    0.2536     56.172     0.8669     0.2847
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Fe7 S8"
+_chemical_formula_weight  647.41
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  S1     Fe3    2.49598      1_555    2_555 yes
+  S1     Fe5    2.4127       1_555    1_555 yes
+  S1     Fe7    2.39055      1_555    5_455 yes
+  S1     Fe7    2.44193      1_555    7_555 yes
+  S1     Fe8    2.40875      1_555    1_555 yes
+  S2     Fe3    2.37585      1_555    1_555 yes
+  S2     Fe3    2.32549      1_555    3_556 yes
+  S2     Fe5    2.4441       1_555    7_556 yes
+  S2     Fe7    2.3678       1_555    8_456 yes
+  S2     Fe8    2.41316      1_555    3_556 yes
+  Fe3    S1     2.49598      1_555    2_555 yes
+  Fe3    S2     2.37585      1_555    1_555 yes
+  Fe3    S2     2.32549      1_555    3_556 yes
+  Fe3    S6     2.45179      1_555    4_556 yes
+  S4     Fe5    2.3865       1_555    1_555 yes
+  Fe5    S1     2.4127       1_555    1_555 yes
+  Fe5    S2     2.4441       1_555    7_556 yes
+  Fe5    S4     2.3865       1_555    1_555 yes
+  Fe5    S6     2.36297      1_555    1_555 yes
+  S6     Fe3    2.45179      1_555    4_555 yes
+  S6     Fe5    2.36297      1_555    1_555 yes
+  S6     Fe7    2.43326      1_555    1_555 yes
+  S6     Fe7    2.39158      1_555    7_555 yes
+  Fe7    S1     2.39055      1_555    5_545 yes
+  Fe7    S1     2.44193      1_555    7_555 yes
+  Fe7    S2     2.3678       1_555    8_555 yes
+  Fe7    S6     2.43326      1_555    1_555 yes
+  Fe7    S6     2.39158      1_555    7_555 yes
+  Fe8    S1     2.40875      1_555    1_555 yes
+  Fe8    S1     2.40875      1_555    2_555 yes
+  Fe8    S2     2.41316      1_555    3_556 yes
+  Fe8    S2     2.41316      1_555    4_555 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.040(3), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW3minmill_phase_1
+# Information for phase 1
+_pd_block_id  2021-08-04T18:35|NEW3minmill|phase_1|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for SiO2 follows
+_pd_phase_name  SiO2
+_cell_length_a  4.9151(4)
+_cell_length_b  4.9151(4)
+_cell_length_c  5.4055(3)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  120
+_cell_volume  113.092(9)
+_exptl_crystal_density_diffrn  2.6467
+_symmetry_cell_setting  trigonal
+_symmetry_space_group_name_H-M  "P 32 2 1"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -y,x-y,2/3+z
+     3  y-x,-x,1/3+z
+     4  y,x,-z
+     5  -x,y-x,2/3-z
+     6  x-y,-y,1/3-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Si1    Si4+ 0.47000     0.00000     0.66670     1.000      Uani 0.006      3   
+O1     O2-  0.41460     0.26780     0.78543     1.000      Uani 0.011      6   
+
+loop_
+   _atom_site_aniso_label
+   _atom_site_aniso_U_11
+   _atom_site_aniso_U_22
+   _atom_site_aniso_U_33
+   _atom_site_aniso_U_12
+   _atom_site_aniso_U_13
+   _atom_site_aniso_U_23
+Si1    0.0073      0.0059      0.0053      0.0029      0.0003      0.0006      
+O1     0.0120      0.0105      0.0118      0.0065      -0.0029     -0.0040     
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  O    6      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si   3      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  3
+_chemical_formula_sum  "O2 Si"
+_chemical_formula_weight  60.08
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Si1    O1     1.60531      1_555    1_555 yes
+  Si1    O1     1.61161      1_555    2_654 yes
+  Si1    O1     1.61135      1_555    5_656 yes
+  Si1    O1     1.60545      1_555    6_556 yes
+  O1     Si1    1.60531      1_555    1_555 yes
+  O1     Si1    1.61161      1_555    3_665 yes
+  O1     Si1    1.61135      1_555    5_666 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Si1    O1     110.254       1_555  1_555    2_654 yes
+  O1     Si1    O1     108.749       1_555  1_555    5_656 yes
+  O1     Si1    O1     109.682       2_654  1_555    5_656 yes
+  O1     Si1    O1     109.16        1_555  1_555    6_556 yes
+  O1     Si1    O1     108.729       2_654  1_555    6_556 yes
+  O1     Si1    O1     110.26        5_656  1_555    6_556 yes
+  Si1    O1     Si1    143.831       1_555  1_555    3_665 yes
+  Si1    O1     Si1    143.835       1_555  1_555    5_666 yes
+  Si1    O1     Si1    0.009         3_665  1_555    5_666 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.205(11), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW3minmill_phase_3
+# Information for phase 3
+_pd_block_id  2021-08-04T18:35|NEW3minmill|phase_3|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for TiO2 follows
+_pd_phase_name  TiO2
+_cell_length_a  4.5969(7)
+_cell_length_b  4.5969(7)
+_cell_length_c  2.9612(7)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  90
+_cell_volume  62.575(16)
+_exptl_crystal_density_diffrn  4.2405
+_symmetry_cell_setting  tetragonal
+_symmetry_space_group_name_H-M  "P 42/m n m"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  1/2-y,1/2+x,1/2+z
+     3  -x,-y,z
+     4  1/2+y,1/2-x,1/2+z
+     5  1/2-x,1/2+y,1/2+z
+     6  -y,-x,z
+     7  1/2+x,1/2-y,1/2+z
+     8  y,x,z
+     9  -x,-y,-z
+    10  1/2+y,1/2-x,1/2-z
+    11  x,y,-z
+    12  1/2-y,1/2+x,1/2-z
+    13  1/2+x,1/2-y,1/2-z
+    14  y,x,-z
+    15  1/2-x,1/2+y,1/2-z
+    16  -y,-x,-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Ti1    Ti4+ 0.00000     0.00000     0.00000     1.000      Uani 0.006      2   
+O1     O2-  0.30493     0.30493     0.00000     1.000      Uani 0.006      4   
+
+loop_
+   _atom_site_aniso_label
+   _atom_site_aniso_U_11
+   _atom_site_aniso_U_22
+   _atom_site_aniso_U_33
+   _atom_site_aniso_U_12
+   _atom_site_aniso_U_13
+   _atom_site_aniso_U_23
+Ti1    0.0070      0.0070      0.0047      -0.0002     0.0000      0.0000      
+O1     0.0060      0.0060      0.0045      -0.0019     0.0000      0.0000      
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  O    4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Ti   2      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  2
+_chemical_formula_sum  "O2 Ti"
+_chemical_formula_weight  79.9
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Ti1    O1     1.98237      1_555    1_555 yes
+  Ti1    O1     1.94945      1_555    2_544 yes
+  Ti1    O1     1.94945      1_555    2_545 yes
+  Ti1    O1     1.98237      1_555    3_555 yes
+  Ti1    O1     1.94945      1_555    4_454 yes
+  Ti1    O1     1.94945      1_555    4_455 yes
+  O1     Ti1    1.98237      1_555    1_555 yes
+  O1     Ti1    1.94945      1_555    2_554 yes
+  O1     Ti1    1.94945      1_555    2_555 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Ti1    O1     90            1_555  1_555    2_544 yes
+  O1     Ti1    O1     90            1_555  1_555    2_545 yes
+  O1     Ti1    O1     98.838        2_544  1_555    2_545 yes
+  O1     Ti1    O1     180           1_555  1_555    3_555 yes
+  O1     Ti1    O1     90            2_544  1_555    3_555 yes
+  O1     Ti1    O1     90            2_545  1_555    3_555 yes
+  O1     Ti1    O1     90            1_555  1_555    4_454 yes
+  O1     Ti1    O1     81.162        2_544  1_555    4_454 yes
+  O1     Ti1    O1     180           2_545  1_555    4_454 yes
+  O1     Ti1    O1     90            3_555  1_555    4_454 yes
+  O1     Ti1    O1     90            1_555  1_555    4_455 yes
+  O1     Ti1    O1     180           2_544  1_555    4_455 yes
+  O1     Ti1    O1     81.162        2_545  1_555    4_455 yes
+  O1     Ti1    O1     90            3_555  1_555    4_455 yes
+  O1     Ti1    O1     98.838        4_454  1_555    4_455 yes
+  Ti1    O1     Ti1    130.581       1_555  1_555    2_554 yes
+  Ti1    O1     Ti1    130.581       1_555  1_555    2_555 yes
+  Ti1    O1     Ti1    98.838        2_554  1_555    2_555 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.200, 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW3minmill_pwd_0
+_pd_proc_ls_profile_function
+;
+Finger-Cox-Jephcoat function parameters U, V, W, X, Y, SH/L:
+  peak variance(Gauss) = Utan(Th)^2^+Vtan(Th)+W:
+  peak HW(Lorentz) = X/cos(Th)+Ytan(Th); SH/L = S/L+H/L
+  U, V, W in (centideg)^2^, X & Y in centideg
+    0.000, 0.000, 1.089, 0.882, 1.689, 0.058, 
+;
+# Information for histogram 0: PWDR BAT3_3min_milla_30mm_MonicaHamish_Ruoming_step size 0_3_min_mill_a.xrdml Scan 1
+_pd_block_id
+;
+2021-08-04T18:35|NEW3minmill|McDougallHamish|PANalytical,Co-EmpyreanII_hist_0
+;
+# GSAS-II edited template follows Instrument_Template
+#==============================================================================
+# 9. INSTRUMENT CHARACTERIZATION
+
+_exptl_special_details
+; ?
+;
+
+# if regions of the data are excluded, the reason(s) are supplied here:
+_pd_proc_info_excluded_regions
+; ?
+;
+
+# The following item is used to identify the equipment used to record 
+# the powder pattern when the diffractogram was measured at a laboratory 
+# other than the authors' home institution, e.g. when neutron or synchrotron
+# radiation is used.
+
+_pd_instr_location
+; ?
+;
+_pd_calibration_special_details           # description of the method used
+                                          # to calibrate the instrument
+; ?
+;
+
+_diffrn_source                    Co-Ka       
+_diffrn_source_target             Co
+_diffrn_source_type               Graded_Flat
+_diffrn_measurement_device_type   Panalytical_Reflection_Transmission       
+_diffrn_detector                  PIXcel1D       
+_diffrn_detector_type             Empyrean_II       # make or model of detector
+
+_pd_meas_scan_method              ?       # options are 'step', 'cont',
+                                          # 'tof', 'fixed' or
+                                          # 'disp' (= dispersive)
+_pd_meas_special_details
+;  ?
+;
+
+# The following two items identify the program(s) used (if appropriate).
+_computing_data_collection        ?        
+_computing_data_reduction         ?                   
+
+# Describe any processing performed on the data, prior to refinement.
+# For example: a manual Lp correction or a precomputed absorption correction
+_pd_proc_info_data_reduction      ?
+
+# The following item is used for angular dispersive measurements only.
+
+_diffrn_radiation_monochromator   ?        
+
+# The following items are used to define the size of the instrument.
+# Not all distances are appropriate for all instrument types.
+
+_pd_instr_dist_src/mono           ?
+_pd_instr_dist_mono/spec          ?
+_pd_instr_dist_src/spec           ?
+_pd_instr_dist_spec/anal          ?
+_pd_instr_dist_anal/detc          ?
+_pd_instr_dist_spec/detc          ?
+
+# 10. Specimen size and mounting information
+
+# The next three fields give the specimen dimensions in mm.  The equatorial 
+# plane contains the incident and diffracted beam.
+
+_pd_spec_size_axial               ?       # perpendicular to 
+                                          # equatorial plane
+
+_pd_spec_size_equat               ?       # parallel to 
+                                          # scattering vector 
+                                          # in transmission
+
+_pd_spec_size_thick               ?       # parallel to 
+                                          # scattering vector 
+                                          # in reflection
+
+_pd_spec_mounting                         # This field should be
+                                          # used to give details of the 
+                                          # container.
+; ?
+;
+
+_pd_spec_mount_mode               ?       # options are 'reflection' 
+                                          # or 'transmission'
+    
+_pd_spec_shape                    ?       # options are 'cylinder' 
+                                          # 'flat_sheet' or 'irregular'
+
+
+loop_
+     _atom_type_symbol
+     _atom_type_scat_dispersion_real
+     _atom_type_scat_dispersion_imag
+     _atom_type_scat_dispersion_source
+  Al        0.255   0.328   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Fe       -3.332   0.490   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Na        0.167   0.167   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  O         0.063   0.044   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S         0.371   0.733   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si        0.298   0.438   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Ti       -0.063   2.321   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+_diffrn_radiation_type  K\a~1,2~
+loop_
+   _diffrn_radiation_wavelength
+   _diffrn_radiation_wavelength_wt
+   _diffrn_radiation_wavelength_id
+  1.78892         1.0             1     
+  1.79278         0.5000          2     
+
+# PHASE TABLE
+loop_
+   _pd_phase_id
+   _pd_phase_block_id
+   _pd_phase_mass_%
+  0  2021-08-04T18:35|NEW3minmill|phase_0|McDougallHamish  0.7917(27)
+  2  2021-08-04T18:35|NEW3minmill|phase_2|McDougallHamish  0.0992(24)
+  4  2021-08-04T18:35|NEW3minmill|phase_4|McDougallHamish  0.0419(13)
+  1  2021-08-04T18:35|NEW3minmill|phase_1|McDougallHamish  0.0594(9)
+  3  2021-08-04T18:35|NEW3minmill|phase_3|McDougallHamish  0.0079(5)
+loop_
+   _gsas_proc_phase_R_F_factor
+   _gsas_proc_phase_R_Fsqd_factor
+   _gsas_proc_phase_id
+   _gsas_proc_phase_block_id
+    0.04890  0.08090  0  2021-08-04T18:35|NEW3minmill|phase_0|McDougallHamish
+    0.07803  0.17816  2  2021-08-04T18:35|NEW3minmill|phase_2|McDougallHamish
+    0.06155  0.07652  4  2021-08-04T18:35|NEW3minmill|phase_4|McDougallHamish
+    0.05724  0.12959  1  2021-08-04T18:35|NEW3minmill|phase_1|McDougallHamish
+    0.09604  0.26511  3  2021-08-04T18:35|NEW3minmill|phase_3|McDougallHamish
+_pd_proc_ls_prof_R_factor     0.07864
+_pd_proc_ls_prof_wR_factor    0.10301
+_gsas_proc_ls_prof_R_B_factor   0.09823
+_gsas_proc_ls_prof_wR_B_factor  0.12387
+_pd_proc_ls_prof_wR_expected  0.03921
+_diffrn_radiation_probe  x-ray
+_diffrn_radiation_polarisn_ratio  0.7000
+_pd_proc_ls_background_function
+;
+Background function: "chebyschev-1" function with 7 terms:
+    449.5(16), -519.0(25), 386.7(24), -191.6(21), 100.5(20), 
+    -31.9(15), 14.9(14), 
+;
+_diffrn_ambient_temperature  300
+_diffrn_ambient_pressure  100
+
+# STRUCTURE FACTOR TABLE
+loop_
+   _pd_refln_phase_id
+   _refln_index_h
+   _refln_index_k
+   _refln_index_l
+   _refln_F_squared_meas
+   _refln_F_squared_calc
+   _refln_phase_calc
+   _refln_d_spacing
+   _gsas_i100_meas
+  0  1    1    1    951.9285   782.7112   0.0     3.12894  25.49  
+  0  2    0    0    6736.0912  6547.9992  -0.0    2.70974  100.00 
+  0  2    1    0    3629.5032  3206.1761  0.0     2.42367  85.12  
+  0  2    1    1    1731.2821  1663.0482  -180.0  2.21249  66.93  
+  0  2    2    0    2925.7300  3284.9049  -0.0    1.91608  41.75  
+  0  2    2    1    44.9286    49.7153    -0.0    1.80649  1.13   
+  0  3    1    1    4588.9307  4960.9514  -0.0    1.63404  94.68  
+  0  2    2    2    2084.6901  2257.2851  0.0     1.56447  13.19  
+  0  3    0    2    2834.5771  3034.3018  -0.0    1.50309  24.99  
+  0  3    1    2    472.7347   490.9171   0.0     1.44842  7.81   
+  0  3    2    1    1598.4301  1659.9093  180.0   1.44842  26.42  
+  0  4    0    0    365.4323   329.8038   -180.0  1.35487  1.36   
+  0  3    2    2    43.3298    55.5070    -0.0    1.31442  0.62   
+  0  4    1    0    103.2726   132.2957   -0.0    1.31442  0.74   
+  0  4    1    1    58.7608    73.0023    180.0   1.27738  0.81   
+  0  3    3    1    530.0764   591.7270   -0.0    1.24331  7.14   
+  0  4    0    2    885.4471   761.5114   0.0     1.21183  5.85   
+  0  4    2    0    885.4471   761.5114   0.0     1.21183  5.85   
+  0  4    1    2    2.5536     2.4873     -0.0    1.18263  0.03   
+  0  4    2    1    1225.5436  1193.7099  -180.0  1.18263  16.00  
+  0  3    3    2    682.4533   602.5946   0.0     1.15544  8.86   
+  0  4    2    2    1003.0557  918.9398   0.0     1.10625  13.14  
+  0  4    3    0    130.6112   167.0559   -0.0    1.08390  0.87   
+  0  4    1    3    75.2723    92.8043    -180.0  1.06285  1.02   
+  0  4    3    1    22.2617    27.4468    0.0     1.06285  0.30   
+  0  5    1    1    3457.2414  3062.3683  -0.0    1.04298  48.47  
+  0  3    3    3    1499.6348  1328.3521  -0.0    1.04298  7.01   
+  1  1    0    0    270.5106   242.5062   -180.0  4.25660  0.58   
+  1  1    0    1    701.0564   634.4377   120.0   3.34421  0.91   
+  1  1    0    -1   1667.7655  1509.2841  -120.0  3.34421  2.16   
+  1  1    1    0    371.2282   343.7933   -155.6  2.45755  0.25   
+  1  1    0    2    281.5448   298.8427   -120.0  2.28166  0.16   
+  1  1    0    -2   81.1534    86.1394    -60.0   2.28166  0.05   
+  1  1    1    1    93.7278    96.0404    82.9    2.23719  0.10   
+  1  2    0    0    304.2401   308.9271   0.0     2.12830  0.15   
+  1  2    0    -1   77.1268    77.2058    60.0    1.98033  0.03   
+  1  2    0    1    184.7769   184.9662   -60.0   1.98033  0.08   
+  1  1    1    2    533.2100   602.7589   9.8     1.81827  0.38   
+  1  0    0    3    93.1370    94.4758    0.0     1.80183  0.01   
+  1  2    0    2    88.2847    82.0680    60.0    1.67210  0.03   
+  1  2    0    -2   391.7218   364.1379   120.0   1.67210  0.12   
+  1  1    0    -3   199.6986   203.8151   180.0   1.65929  0.06   
+  1  1    0    3    2.5294     2.5815     0.0     1.65929  0.00   
+  1  2    1    0    15.9829    14.6360    -38.9   1.60884  0.01   
+  1  2    1    -1   373.6375   356.2772   95.9    1.54199  0.19   
+  1  2    1    1    321.6431   306.6986   -109.6  1.54199  0.17   
+  1  1    1    3    138.9825   142.5487   117.5   1.45311  0.06   
+  1  3    0    0    83.3352    76.3414    -180.0  1.41887  0.02   
+  1  2    1    -2   397.9721   413.7432   -123.3  1.38245  0.17   
+  1  2    1    2    123.5531   128.4493   143.4   1.38245  0.05   
+  1  2    0    -3   246.9166   292.6410   -0.0    1.37519  0.05   
+  1  2    0    3    869.2357   1030.2021  0.0     1.37519  0.19   
+  1  3    0    -1   686.1960   815.7068   -120.0  1.37238  0.15   
+  1  3    0    1    0.8527     1.0136     -60.0   1.37238  0.00   
+  1  1    0    -4   96.4260    120.2766   -120.0  1.28802  0.02   
+  1  1    0    4    317.7597   396.3564   120.0   1.28802  0.06   
+  1  3    0    -2   188.4026   208.2678   120.0   1.25628  0.04   
+  1  3    0    2    429.5599   474.8527   -120.0  1.25628  0.08   
+  1  2    2    0    275.2944   370.9996   -16.5   1.22877  0.05   
+  1  2    1    -3   68.8129    70.9918    179.1   1.20008  0.03   
+  1  2    1    3    292.0815   301.3302   -134.8  1.20008  0.11   
+  1  2    2    1    93.4680    105.5681   88.6    1.19821  0.03   
+  1  1    1    4    351.4539   334.0963   -14.4   1.18415  0.13   
+  1  3    1    0    371.8672   361.4751   121.4   1.18057  0.14   
+  1  3    1    -1   224.2378   189.8720   -18.5   1.15338  0.08   
+  1  3    1    1    74.8696    63.3954    16.4    1.15338  0.03   
+  1  2    0    4    78.3332    70.6602    120.0   1.14083  0.01   
+  1  2    0    -4   1.6319     1.4720     -120.0  1.14083  0.00   
+  1  2    2    2    2.5014     3.3490     -9.8    1.11860  0.00   
+  1  3    0    -3   7.2410     6.6828     -0.0    1.11474  0.00   
+  1  3    0    3    67.9469    62.7087    -180.0  1.11474  0.01   
+  1  3    1    -2   233.8808   304.2779   -8.9    1.08186  0.09   
+  1  3    1    2    95.5579    124.3204   59.1    1.08186  0.04   
+  1  4    0    0    132.2682   168.1572   -0.0    1.06415  0.03   
+  1  1    0    -5   390.6058   346.1824   120.0   1.04783  0.08   
+  1  1    0    5    146.5596   129.8915   -120.0  1.04783  0.03   
+  1  4    0    -1   37.1078    31.3997    60.0    1.04411  0.01   
+  1  4    0    1    342.2726   289.6232   120.0   1.04411  0.07   
+  1  2    1    -4   7.6184     10.8607    51.2    1.03477  0.00   
+  1  2    1    4    168.9357   240.8341   -129.5  1.03477  0.07   
+  2  0    0    1    2208.6215  685.7541   180.0   6.38786  0.09   
+  2  0    2    0    1202.7419  396.3962   180.0   6.37466  0.02   
+  2  1    1    0    646.5094   238.2363   -0.0    6.33955  0.01   
+  2  1    -1   0    735.6956   287.4879   -0.0    6.29869  0.01   
+  2  1    1    -1   862.1738   406.2352   180.0   5.91009  0.01   
+  2  1    -1   -1   507.9976   415.6378   -180.0  5.58552  0.01   
+  2  0    2    -1   4.9647     16.5792    0.0     4.66174  0.00   
+  2  0    2    1    1.0538     1.8371     180.0   4.37623  0.00   
+  2  2    0    -1   20221.9887 21037.4763 -0.0    4.02732  0.13   
+  2  1    -1   1    4799.2653  3767.3897  -0.0    3.85265  0.05   
+  2  1    1    1    10804.9168 10390.3834 0.0     3.77565  0.12   
+  2  1    3    0    7338.7389  5886.9121  180.0   3.68167  0.04   
+  2  1    3    -1   5589.1170  4505.3267  0.0     3.66562  0.03   
+  2  1    -3   0    12279.8835 11675.3013 180.0   3.65766  0.06   
+  2  2    0    0    1.4215     2.5781     0.0     3.63776  0.00   
+  2  1    1    -2   5776.7095  4328.5159  0.0     3.50520  0.05   
+  2  2    2    -1   2968.8541  1650.0035  180.0   3.48122  0.01   
+  2  1    -3   -1   62.6040    12.1276    0.0     3.43616  0.00   
+  2  1    -1   -2   6496.3829  5251.4578  0.0     3.37264  0.06   
+  2  2    -2   -1   341.0325   364.8637   0.0     3.33313  0.00   
+  2  2    0    -2   27264.8367 26655.4799 -180.0  3.21484  0.15   
+  2  0    0    2    38871.0538 37071.8044 -180.0  3.19393  0.40   
+  2  0    4    0    25340.6197 25362.8195 180.0   3.18733  0.10   
+  2  2    2    0    14370.3614 13873.6743 180.0   3.16977  0.07   
+  2  2    -2   0    16786.1259 14946.6082 -180.0  3.14934  0.07   
+  2  1    -3   1    12182.5407 11175.2497 -180.0  2.96418  0.05   
+  2  2    2    -2   6818.3191  7187.5067  0.0     2.95504  0.03   
+  2  0    2    -2   6154.2768  5310.5610  0.0     2.93060  0.04   
+  2  0    4    -1   9249.8826  8585.7945  0.0     2.92677  0.03   
+  2  1    3    1    6335.1513  6897.0276  180.0   2.86133  0.03   
+  2  1    3    -2   1429.2721  1923.0466  -0.0    2.83885  0.01   
+  2  2    -2   -2   139.7816   183.4547   -0.0    2.79276  0.00   
+  2  0    2    2    156.8508   191.6414   0.0     2.78600  0.00   
+  2  0    4    1    311.4777   387.5360   -0.0    2.78271  0.00   
+  2  2    0    1    107.8810   109.5836   -0.0    2.68712  0.00   
+  2  3    1    -1   416.5005   431.0071   -180.0  2.66293  0.00   
+  2  1    -3   -2   6989.8388  6171.6319  -0.0    2.63839  0.03   
+  2  3    -1   -1   39.8753    33.5476    -180.0  2.62530  0.00   
+  2  2    4    -1   14310.9248 12550.4891 -180.0  2.55995  0.04   
+  2  3    1    -2   2142.0134  1812.0722  180.0   2.53704  0.01   
+  2  1    -1   2    1020.5273  667.2869   180.0   2.51139  0.00   
+  2  2    -2   1    2245.2701  1686.7859  -180.0  2.49495  0.01   
+  2  3    -1   -2   683.8159   451.5613   180.0   2.48043  0.00   
+  2  1    1    2    127.1711   110.2849   180.0   2.46610  0.00   
+  2  2    2    1    1489.2105  1367.0046  -180.0  2.45771  0.01   
+  2  2    -4   -1   11746.7915 10453.7459 -180.0  2.44277  0.03   
+  2  1    5    -1   4744.4729  4093.1663  -0.0    2.42941  0.01   
+  2  1    5    0    61.2791    64.0884    180.0   2.41202  0.00   
+  2  2    4    0    3924.1883  3944.1458  -0.0    2.40628  0.01   
+  2  1    -5   0    2247.6751  2230.8323  180.0   2.40074  0.00   
+  2  2    -4   0    2226.3396  2079.3222  -0.0    2.38844  0.00   
+  2  3    1    0    1680.4293  1565.2946  -0.0    2.38575  0.00   
+  2  3    -1   0    2243.2393  2090.0863  -0.0    2.37918  0.01   
+  2  2    0    -3   7.3452     7.3701     180.0   2.35133  0.00   
+  2  2    4    -2   2.9437     2.9331     0.0     2.34729  0.00   
+  2  1    1    -3   130.1463   110.8373   -0.0    2.33656  0.00   
+  2  0    4    -2   1294.9209  884.3144   -180.0  2.33087  0.00   
+  2  3    3    -1   20851.5070 9809.7794  180.0   2.31766  0.04   
+  2  1    -5   -1   2286.3640  1044.9800  0.0     2.31526  0.01   
+  2  1    -1   -3   2114.1417  2291.2470  -0.0    2.27750  0.01   
+  2  2    2    -3   182.6011   155.6865   -0.0    2.26146  0.00   
+  2  3    3    -2   18.9776    15.9172    0.0     2.25070  0.00   
+  2  3    -3   -1   2867.6980  2703.2457  -180.0  2.24518  0.01   
+  2  1    -3   2    862.2371   824.7896   -0.0    2.22556  0.00   
+  2  0    4    2    1733.8097  2085.0250  0.0     2.18812  0.01   
+  2  2    -4   -2   1190.7373  1431.8638  0.0     2.18799  0.00   
+  2  1    -5   1    3475.2255  4194.8986  180.0   2.18493  0.01   
+  2  2    -2   -3   961.8479   1851.4932  0.0     2.15451  0.00   
+  2  1    5    -2   151.8819   312.7232   -180.0  2.15169  0.00   
+  2  3    1    -3   163.8289   204.6119   0.0     2.13824  0.00   
+  2  3    -3   -2   428.5483   512.1941   180.0   2.13724  0.00   
+  2  1    3    2    146.0927   174.4523   -180.0  2.13433  0.00   
+  2  0    0    3    425.5574   454.6548   -0.0    2.12929  0.00   
+  2  0    6    0    10517.9332 11042.6256 -0.0    2.12489  0.02   
+  2  1    3    -3   647.4780   674.2906   -180.0  2.11876  0.00   
+  2  1    5    1    4414.3889  4734.7647  180.0   2.11595  0.01   
+  2  3    3    0    1299.0212  1496.6439  -180.0  2.11318  0.00   
+  2  3    -3   0    136.6508   182.7827   -180.0  2.09956  0.00   
+  2  3    -1   -3   1437.6235  2416.5634  0.0     2.08973  0.00   
+  2  2    -4   1    7199.9440  8370.0925  180.0   2.07604  0.01   
+  2  0    2    -3   278.2752   286.8930   -180.0  2.05903  0.00   
+  2  0    6    -1   76.2357    83.9001    -0.0    2.05549  0.00   
+  2  2    4    1    2497.3133  2723.1302  180.0   2.03350  0.01   
+  2  4    0    -2   1276.8523  1673.8545  -0.0    2.01366  0.00   
+  2  1    -5   -2   788.0327   976.2191   -0.0    2.00557  0.00   
+  2  4    0    -1   2878.1571  3207.5402  -0.0    2.00025  0.00   
+  2  2    0    2    821.9683   914.6787   0.0     1.99827  0.00   
+  2  1    -3   -3   1743.7547  2006.9284  -0.0    1.99351  0.01   
+  2  0    2    3    1241.5073  1320.4879  0.0     1.98235  0.00   
+  2  0    6    1    4985.7074  4760.1395  0.0     1.97919  0.01   
+  2  3    -1   1    1723.8536  1778.1424  0.0     1.97162  0.00   
+  2  3    3    -3   741.2621   747.2487   -180.0  1.97003  0.00   
+  2  3    1    1    1135.4473  1049.8991  0.0     1.96352  0.00   
+  2  2    4    -3   226.3944   210.6125   -180.0  1.96339  0.00   
+  2  4    2    -2   1244.5618  1505.1300  0.0     1.94723  0.00   
+  2  2    -2   2    4127.2928  4434.5615  -0.0    1.92633  0.01   
+  2  4    2    -1   180.3803   195.3738   0.0     1.92397  0.00   
+  2  2    6    -1   23.1703    25.7092    -0.0    1.91781  0.00   
+  2  4    -2   -2   12969.6562 14612.2943 -0.0    1.89414  0.02   
+  2  4    -2   -1   72.8875    83.9894    180.0   1.89341  0.00   
+  2  3    5    -1   2923.1695  3253.1319  -180.0  1.88804  0.00   
+  2  2    2    2    10093.9919 11147.4650 -0.0    1.88782  0.03   
+  2  3    -3   -3   281.3605   242.1347   -0.0    1.86184  0.00   
+  2  3    5    -2   169.2791   151.7748   -180.0  1.86122  0.00   
+  2  4    0    -3   14387.7888 17227.6438 -180.0  1.84958  0.02   
+  2  2    -6   -1   564.0997   630.1904   -180.0  1.84310  0.00   
+  2  1    -5   2    29.8311    32.7906    -180.0  1.84286  0.00   
+  2  2    6    0    6494.6296  5973.8074  -0.0    1.84084  0.01   
+  2  2    6    -2   2832.8387  2234.4122  -180.0  1.83281  0.00   
+  2  1    -1   3    2622.8699  2403.8627  -180.0  1.82957  0.01   
+  2  2    -6   0    11504.2956 11170.3478 0.0     1.82883  0.01   
+  2  2    -4   -3   354.0224   351.5785   -0.0    1.82817  0.00   
+  2  0    4    -3   6480.9071  6600.1943  180.0   1.82454  0.01   
+  2  3    -5   -1   522.1012   547.0575   -180.0  1.82305  0.00   
+  2  0    6    -2   8944.7488  9376.7847  -180.0  1.82300  0.01   
+  2  4    0    0    14955.9387 16544.7345 -0.0    1.81888  0.02   
+  2  3    -3   1    1233.4497  1388.1619  -0.0    1.81269  0.00   
+  2  4    2    -3   1544.9477  1698.2109  -0.0    1.80678  0.00   
+  2  1    1    3    12920.4897 13204.6231 -180.0  1.80269  0.04   
+  2  3    3    1    598.6252   659.8672   -0.0    1.79396  0.00   
+  2  1    5    -3   32.2795    36.9138    180.0   1.79152  0.00   
+  2  1    7    -1   288.4321   370.2527   -180.0  1.78554  0.00   
+  2  2    0    -4   23450.2066 29304.7955 0.0     1.78457  0.06   
+  2  1    7    0    1666.6594  1186.7943  -0.0    1.76994  0.00   
+  2  3    5    0    556.0992   192.4714   -180.0  1.76391  0.00   
+  2  1    -7   0    5515.6112  1861.7091  0.0     1.76369  0.01   
+  2  1    5    2    5567.1767  1478.1411  -180.0  1.75728  0.01   
+  2  3    -5   -2   928.0740   292.8600   -180.0  1.75539  0.00   
+  2  2    2    -4   11587.3873 5374.4235  180.0   1.75260  0.02   
+  2  4    2    0    6953.7656  3240.2714  180.0   1.75255  0.01   
+  2  3    -5   0    1.3416     0.6787     -180.0  1.75073  0.00   
+  2  4    -2   -3   2581.5965  1498.9920  -180.0  1.74735  0.00   
+  2  4    -2   0    2382.3394  1478.3757  -180.0  1.74562  0.00   
+  2  4    4    -2   14241.3470 11156.5991 -180.0  1.74061  0.02   
+  2  3    1    -4   14.6668    11.6942    0.0     1.73791  0.00   
+  2  1    1    -4   1090.2557  931.5858   180.0   1.73044  0.00   
+  2  0    4    3    1564.5479  1649.4123  180.0   1.72108  0.00   
+  2  1    -7   -1   515.8402   544.5769   -0.0    1.72100  0.00   
+  2  2    -4   2    4818.4880  5111.9528  -180.0  1.72066  0.01   
+  2  0    6    2    3771.7848  4043.0244  180.0   1.71979  0.01   
+  2  2    -6   -2   5332.2607  5843.5104  180.0   1.71808  0.01   
+  2  1    -3   3    3545.9084  3889.7621  0.0     1.71755  0.01   
+  2  4    4    -1   3205.9050  3425.3612  -0.0    1.71605  0.00   
+  2  3    -1   -4   37.1273    26.3196    -0.0    1.70384  0.00   
+  2  3    5    -3   2710.2623  1781.5059  180.0   1.70048  0.00   
+  2  1    -1   -4   1747.3585  1087.2281  180.0   1.69839  0.00   
+  2  2    -2   -4   7190.5430  6607.2640  -0.0    1.68632  0.02   
+  2  2    -6   1    132.4830   111.8094   180.0   1.68403  0.00   
+  2  1    -7   1    1392.7460  1037.6002  0.0     1.67991  0.00   
+  2  1    7    -2   3490.9849  3014.1863  0.0     1.67337  0.00   
+  2  4    -4   -1   3580.0486  3113.5342  -0.0    1.67328  0.00   
+  2  1    -5   -3   327.6954   322.6770   -180.0  1.66739  0.00   
+  2  2    4    2    7078.7568  6980.1241  -180.0  1.66673  0.01   
+  2  4    -4   -2   3044.2358  2996.9232  -180.0  1.66656  0.00   
+  2  1    3    3    608.5262   605.4945   0.0     1.65314  0.00   
+  2  3    3    -4   493.6974   474.5918   180.0   1.65084  0.00   
+  2  2    6    1    15.5850    15.0623    180.0   1.64996  0.00   
+  2  4    4    -3   86.5064    81.5092    0.0     1.64497  0.00   
+  2  1    3    -4   1345.9506  1267.0308  -180.0  1.64299  0.00   
+  2  2    6    -3   398.7997   438.3802   0.0     1.63845  0.00   
+  2  1    7    1    884.8436   959.6711   0.0     1.63566  0.00   
+  2  5    1    -2   60.0864    62.3555    -180.0  1.62122  0.00   
+  2  2    4    -4   7.2474     6.6299     0.0     1.60885  0.00   
+  2  3    -1   2    251.6169   237.1891   -180.0  1.60779  0.00   
+  2  4    0    -4   27.0644    25.5451    0.0     1.60742  0.00   
+  2  5    -1   -2   110.2936   104.4782   -0.0    1.60481  0.00   
+  2  3    1    2    5.3228     3.3755     -180.0  1.59704  0.00   
+  2  0    0    4    2720.7781  1719.5025  -0.0    1.59697  0.01   
+  2  0    8    0    7071.1915  4104.7411  -0.0    1.59366  0.01   
+  2  3    -5   -3   8469.1807  7048.0684  -180.0  1.58673  0.01   
+  2  4    2    -4   6831.6014  5767.4424  -180.0  1.58523  0.01   
+  2  4    4    0    95.6690    80.5872    180.0   1.58489  0.00   
+  2  3    -5   1    4004.0452  3541.7994  0.0     1.57987  0.00   
+  2  1    -7   -2   103.7896   106.0592   180.0   1.57566  0.00   
+  2  4    -4   0    984.1853   972.7791   180.0   1.57467  0.00   
+  2  4    0    1    1333.2907  1313.3627  0.0     1.57405  0.00   
+  2  0    2    -4   6995.1432  6835.8768  -180.0  1.57267  0.01   
+  2  5    1    -1   1882.2711  1838.8969  0.0     1.57223  0.00   
+  2  5    1    -3   4.6364     4.5305     0.0     1.57056  0.00   
+  2  0    8    -1   5075.1381  5105.5113  -180.0  1.56971  0.00   
+  2  3    -3   -4   211.0597   222.0271   -180.0  1.56739  0.00   
+  2  1    -3   -4   1102.7658  1168.3240  -180.0  1.56437  0.00   
+  2  5    -1   -1   3430.4154  3532.8589  -0.0    1.56314  0.00   
+  2  3    5    1    6600.9758  6630.5027  -0.0    1.55930  0.01   
+  2  2    0    3    1758.7910  1763.6711  -180.0  1.55911  0.00   
+  2  4    -4   -3   680.0758   668.2938   0.0     1.55805  0.00   
+  2  0    6    -3   55.7641    50.4752    180.0   1.55391  0.00   
+  2  5    -1   -3   3553.1600  3177.9812  180.0   1.54983  0.00   
+  2  5    3    -2   2108.7417  1684.3120  0.0     1.53962  0.00   
+  2  3    7    -1   393.8420   255.3064   -0.0    1.53554  0.00   
+  2  4    -2   -4   6563.5523  4566.3850  180.0   1.53333  0.01   
+  2  4    -2   1    531.4210   360.2122   -0.0    1.53138  0.00   
+  2  2    -2   3    5153.0729  3884.5431  0.0     1.52972  0.01   
+  2  1    -5   3    148.5598   114.2358   180.0   1.52775  0.00   
+  2  0    2    4    2549.3399  1999.2534  180.0   1.52655  0.01   
+  2  3    7    -2   1808.8948  1417.6951  180.0   1.52649  0.00   
+  2  4    2    1    72.5895    55.0425    -0.0    1.52494  0.00   
+  2  0    8    1    73.2661    53.4117    0.0     1.52385  0.00   
+  2  3    -3   2    997.6576   713.5252   0.0     1.52351  0.00   
+  2  2    -6   -3   1515.9944  972.3599   180.0   1.52111  0.00   
+  2  1    -7   2    2658.5588  2092.8268  180.0   1.51406  0.00   
+  2  2    -4   -4   3887.1756  3475.0688  -180.0  1.51008  0.01   
+  2  2    8    -1   8609.7091  8932.7653  0.0     1.50687  0.01   
+  2  5    3    -3   10740.5827 11216.4371 -0.0    1.50125  0.01   
+  2  2    2    3    245.0774   261.4234   0.0     1.49966  0.00   
+  2  5    -3   -2   1204.2906  1283.3165  0.0     1.49852  0.00   
+  2  4    6    -2   1540.6206  1643.4734  -180.0  1.49804  0.00   
+  2  3    3    2    2662.6306  2828.3266  0.0     1.49651  0.00   
+  2  5    3    -1   1352.4707  1375.8687  180.0   1.49230  0.00   
+  2  1    7    -3   984.5418   963.7100   -0.0    1.49138  0.00   
+  2  3    5    -4   1232.4396  976.7543   0.0     1.48741  0.00   
+  2  3    -7   -1   5.3928     4.1505     -180.0  1.48641  0.00   
+  2  2    -6   2    3189.9341  2225.9899  -180.0  1.48209  0.00   
+  2  1    5    -4   852.4287   569.2303   -0.0    1.48061  0.00   
+  2  4    4    -4   1372.4194  936.8644   -0.0    1.47752  0.00   
+  2  4    6    -1   3603.1611  2425.3077  -0.0    1.47727  0.00   
+  2  2    8    -2   2926.2485  2036.6290  -0.0    1.46947  0.00   
+  2  5    -3   -1   3228.1648  2250.7625  180.0   1.46932  0.00   
+  2  0    4    -4   2241.7650  1799.2981  0.0     1.46530  0.00   
+  2  2    8    0    20112.9925 17372.8918 180.0   1.46378  0.02   
+  2  0    8    -2   3053.1508  2670.5014  0.0     1.46338  0.00   
+  2  3    7    0    1582.2958  1344.4772  -0.0    1.46164  0.00   
+  2  0    6    3    10929.0880 9727.2084  -180.0  1.45874  0.02   
+  2  2    -8   -1   313.7054   277.6153   0.0     1.45806  0.00   
+  2  2    -8   0    16049.6902 14971.6548 -180.0  1.45572  0.01   
+  2  1    5    3    84.5619    84.4701    0.0     1.45352  0.00   
+  2  3    -7   0    1808.1500  1874.7884  -0.0    1.45113  0.00   
+  2  5    -3   -3   3877.3016  3973.0050  -0.0    1.44873  0.00   
+  2  1    7    2    337.3835   339.6716   180.0   1.44736  0.00   
+  2  5    1    0    465.4865   468.7582   0.0     1.44694  0.00   
+  2  5    -1   0    270.9314   282.6566   0.0     1.44450  0.00   
+  2  3    -7   -2   390.7335   407.5222   -180.0  1.44435  0.00   
+  2  5    1    -4   360.5796   376.0669   -0.0    1.44434  0.00   
+  2  4    6    -3   4786.2702  4799.2632  180.0   1.44037  0.00   
+  2  3    7    -3   2276.5626  2066.9126  0.0     1.43858  0.00   
+  2  4    -6   -1   16293.1935 13974.0377 -0.0    1.43651  0.01   
+  2  1    -1   4    2204.5236  1747.7612  -0.0    1.43156  0.00   
+  2  2    6    2    17029.4262 14127.5120 -180.0  1.43067  0.02   
+  2  4    -6   -2   11646.6498 11494.7453 -180.0  1.42772  0.01   
+  2  3    1    -5   50.5729    54.5453    0.0     1.42498  0.00   
+  2  2    -4   3    8630.6587  9304.7725  -0.0    1.42492  0.01   
+  2  5    -1   -4   5977.3242  6191.0063  0.0     1.42367  0.01   
+  2  2    0    -5   553.8396   530.6717   -0.0    1.41970  0.00   
+  2  2    6    -4   4312.9751  4109.1661  -0.0    1.41942  0.00   
+  2  4    -4   1    2281.2613  2328.2327  -180.0  1.41643  0.00   
+  2  1    1    4    9452.3707  9765.5200  -0.0    1.41417  0.02   
+  2  2    2    -5   142.0814   102.1798   180.0   1.40774  0.00   
+  2  4    4    1    4558.0931  4251.1055  -180.0  1.40628  0.00   
+  2  1    9    -1   417.3748   313.3806   180.0   1.40427  0.00   
+  2  3    -1   -5   677.8213   559.2035   180.0   1.40173  0.00   
+  2  5    5    -2   203.0635   121.8591   180.0   1.39689  0.00   
+  2  4    -4   -4   535.4056   333.7965   -180.0  1.39638  0.00   
+  2  5    3    -4   13258.0389 10290.7248 -180.0  1.39407  0.01   
+  2  0    4    4    768.3836   603.2489   180.0   1.39300  0.00   
+  2  1    9    0    7594.9685  6061.3448  -180.0  1.39244  0.01   
+  2  0    8    2    954.3958   841.8614   -0.0    1.39135  0.00   
+  2  1    -7   -3   9.9752     8.6161     0.0     1.39082  0.00   
+  2  2    -8   -2   447.7001   389.1003   0.0     1.38958  0.00   
+  2  1    -9   0    5177.7812  5032.6219  -180.0  1.38852  0.00   
+  2  3    -5   -4   731.1608   712.8918   180.0   1.38828  0.00   
+  2  1    -5   -4   12.5202    12.2841    -0.0    1.38705  0.00   
+  2  4    6    0    6956.4639  6881.9956  0.0     1.38694  0.01   
+  2  2    -8   1    2491.3610  2583.5813  -0.0    1.38353  0.00   
+  2  3    -5   2    111.5387   107.7060   180.0   1.38139  0.00   
+  2  1    -3   4    10833.8710 11498.8556 180.0   1.38001  0.02   
+  2  3    3    -5   561.4461   601.2645   -0.0    1.37984  0.00   
+  2  5    3    0    1925.8815  2064.1961  180.0   1.37983  0.00   
+  2  2    4    3    7067.0475  7682.9819  -0.0    1.37735  0.01   
+  2  4    -6   0    2651.7381  2929.6322  0.0     1.37669  0.00   
+  2  5    -3   0    1633.3982  1846.9850  -180.0  1.37349  0.00   
+  2  4    0    -5   8540.4517  9852.1453  -0.0    1.37263  0.01   
+  2  5    5    -3   893.0132   1000.1841  -0.0    1.37203  0.00   
+  2  1    1    -5   65.3153    51.8333    180.0   1.36876  0.00   
+  2  2    8    -3   1277.3373  897.0709   0.0     1.36740  0.00   
+  2  2    -2   -5   1167.1423  890.9937   -180.0  1.36475  0.00   
+  2  1    -9   -1   2745.4317  2521.2414  180.0   1.36346  0.00   
+  2  4    2    -5   11562.6227 11335.5971 180.0   1.36264  0.01   
+  2  2    8    1    3412.7204  3611.9875  -180.0  1.35827  0.00   
+  2  5    5    -1   889.6336   870.4892   -180.0  1.35737  0.00   
+  2  4    -6   -3   4468.2741  4126.3352  180.0   1.35385  0.00   
+  2  3    -7   1    621.7437   576.4772   0.0     1.35312  0.00   
+  2  1    9    -2   14770.0833 16147.0686 0.0     1.35152  0.01   
+  2  6    0    -2   15282.7153 16981.3924 180.0   1.35133  0.01   
+  2  1    -9   1    3205.1524  3741.5161  -0.0    1.35032  0.00   
+  2  1    -1   -5   8675.2637  10683.9602 -0.0    1.34891  0.02   
+  2  3    5    2    163.1386   209.3398   0.0     1.34817  0.00   
+  2  5    -5   -2   452.4398   568.7530   180.0   1.34647  0.00   
+  2  4    0    2    17087.1954 20266.7951 180.0   1.34356  0.02   
+  2  6    0    -3   414.5552   424.9852   0.0     1.34244  0.00   
+  2  3    -7   -3   1016.2144  987.1236   180.0   1.34218  0.00   
+  2  5    -3   -4   24.2000    19.4544    -0.0    1.34037  0.00   
+  2  3    7    1    807.6586   545.2034   0.0     1.33504  0.00   
+  2  1    3    4    440.8804   303.9072   180.0   1.33473  0.00   
+  2  2    4    -5   2633.4464  2138.1647  -0.0    1.33359  0.00   
+  2  6    2    -2   7542.8993  7470.5514  0.0     1.33146  0.01   
+  2  3    -1   3    514.6388   551.6386   -0.0    1.32984  0.00   
+  2  5    -5   -1   2722.4075  3077.6343  -180.0  1.32879  0.00   
+  2  1    -7   3    709.6764   845.5145   -180.0  1.32789  0.00   
+  2  1    3    -5   10864.4185 12956.3684 180.0   1.32785  0.01   
+  2  4    6    -4   1019.2188  1219.1637  0.0     1.32754  0.00   
+  2  6    2    -3   5.4082     6.0091     -0.0    1.32656  0.00   
+  2  4    -2   -5   2977.4294  3146.4347  0.0     1.32203  0.00   
+  2  1    9    1    972.4129   1105.1306  -0.0    1.32057  0.00   
+  2  4    -2   2    1919.3249  2255.4357  0.0     1.32028  0.00   
+  2  3    1    3    2716.7202  3237.6008  0.0     1.32015  0.00   
+  2  2    -6   -4   93.0619    114.0134   0.0     1.31919  0.00   
+  2  3    -3   -5   1779.2674  2179.7868  180.0   1.31918  0.00   
+  2  0    6    -4   2887.5269  3685.3963  0.0     1.31717  0.00   
+  2  0    8    -3   3558.2650  4546.6333  -0.0    1.31636  0.00   
+  2  6    -2   -2   309.3130   330.6363   180.0   1.31265  0.00   
+  2  4    2    2    653.5713   505.4413   0.0     1.30914  0.00   
+  2  5    -5   -3   9335.7288  6208.9517  0.0     1.30653  0.01   
+  2  3    7    -4   18.2112    11.5530    -180.0  1.30602  0.00   
+  2  6    0    -1   1005.1324  635.2341   -0.0    1.30261  0.00   
+  2  6    -2   -3   5779.6274  4797.6968  0.0     1.30107  0.00   
+  2  1    7    -4   952.2546   816.7390   180.0   1.30069  0.00   
+  2  4    4    -5   973.1466   839.8412   -180.0  1.29576  0.00   
+  2  5    -1   1    675.1013   560.8179   -180.0  1.29287  0.00   
+  2  5    5    -4   120.9988   102.0732   -0.0    1.29210  0.00   
+  2  5    1    1    240.8796   213.0414   180.0   1.29128  0.00   
+  2  5    1    -5   1112.6046  1297.0866  -180.0  1.28850  0.00   
+  2  1    -9   -2   6474.6986  7594.2794  0.0     1.28440  0.01   
+  2  3    -3   3    3280.6940  3821.2749  180.0   1.28422  0.00   
+  2  2    -6   3    88.3462    97.9036    -0.0    1.28363  0.00   
+  2  3    5    -5   2804.2867  3037.5557  -0.0    1.28334  0.00   
+  2  6    2    -1   2015.6369  2446.8719  180.0   1.28151  0.00   
+  2  4    8    -2   13204.0170 16043.2073 -0.0    1.27998  0.01   
+  2  6    0    -4   3858.8604  4642.8182  0.0     1.27913  0.00   
+  2  1    -5   4    0.2297     0.2762     -0.0    1.27885  0.00   
+  2  0    0    5    1241.8045  1504.7953  0.0     1.27757  0.00   
+  2  2    -8   -3   859.2502   969.8153   0.0     1.27578  0.00   
+  2  1    -3   -5   1439.1232  1649.0848  -180.0  1.27554  0.00   
+  2  0    10   0    4678.0959  5612.4673  -0.0    1.27493  0.00   
+  2  3    9    -1   522.5074   567.6734   180.0   1.27318  0.00   
+  2  3    9    -2   166.8493   209.3409   0.0     1.27118  0.00   
+  2  6    -2   -1   485.5023   604.9530   -180.0  1.27102  0.00   
+  2  5    -1   -5   2657.5653  3287.3648  -0.0    1.27057  0.00   
+  2  4    -6   1    1741.7618  2157.0193  180.0   1.27033  0.00   
+  2  2    0    4    4668.2232  5970.9564  -0.0    1.26862  0.01   
+  2  6    2    -4   2035.2237  2642.8907  -180.0  1.26852  0.00   
+  2  0    2    -5   3052.0787  4140.6925  180.0   1.26818  0.00   
+  2  2    -8   2    11347.6417 15669.9235 0.0     1.26800  0.01   
+  2  5    5    0    1106.2284  1539.1640  -0.0    1.26791  0.00   
+  2  0    10   -1   609.7398   722.1628   -180.0  1.26570  0.00   
+  2  4    8    -1   113.4013   116.1733   180.0   1.26381  0.00   
+  2  2    -4   -5   35.6047    34.2839    180.0   1.26302  0.00   
+  2  1    -9   2    415.4875   407.6104   0.0     1.26267  0.00   
+  2  6    4    -2   3446.9678  4060.9393  -0.0    1.26012  0.00   
+  2  1    7    3    1185.7548  1423.0605  -180.0  1.25993  0.00   
+  2  5    -5   0    1029.0679  1251.7915  -0.0    1.25974  0.00   
+  2  4    6    1    28.3040    35.4122    180.0   1.25938  0.00   
+  2  6    4    -3   4441.0151  5742.7030  -180.0  1.25904  0.00   
+  2  3    3    3    26.4392    34.1056    0.0     1.25855  0.00   
+  2  2    -2   4    2449.5812  2630.4316  180.0   1.25569  0.00   
+  2  5    3    -5   7423.0677  7849.9862  180.0   1.25548  0.01   
+  2  1    9    -3   479.8840   446.4585   -180.0  1.25310  0.00   
+  2  4    -4   2    3006.5457  2913.1494  0.0     1.24747  0.00   
+  2  4    8    -3   1564.5047  1591.0184  -180.0  1.24643  0.00   
+  2  5    -3   1    147.2570   154.1169   -180.0  1.24419  0.00   
+  2  4    -6   -4   4297.5470  4649.8078  0.0     1.24074  0.00   
+  2  1    5    -5   19.2289    20.8490    -0.0    1.24058  0.00   
+  2  6    -2   -4   107.5398   116.0421   -0.0    1.24022  0.00   
+  2  5    3    1    808.3957   865.0651   -180.0  1.23993  0.00   
+  2  0    6    4    4131.0947  4402.8269  -0.0    1.23960  0.01   
+  2  0    8    3    2305.5874  2523.8232  0.0     1.23892  0.00   
+  2  5    7    -2   46.3529    48.4702    -180.0  1.23815  0.00   
+  2  0    2    5    6.2571     6.1649     -0.0    1.23770  0.00   
+  2  3    -9   -1   2105.5184  1878.7146  -180.0  1.23697  0.00   
+  2  0    10   1    77.9482    69.0195    180.0   1.23540  0.00   
+  2  2    8    -4   0.7993     0.6712     -0.0    1.23509  0.00   
+  2  2    2    4    280.1421   202.3679   180.0   1.23305  0.00   
+  2  2    10   -1   908.4587   674.5837   -0.0    1.23266  0.00   
+  2  2    6    3    776.7644   591.5126   -0.0    1.23202  0.00   
+  2  4    -8   -1   1583.4102  1660.8265  180.0   1.22975  0.00   
+  2  4    4    2    5674.6586  7216.8110  -0.0    1.22886  0.01   
+  2  6    -4   -2   5779.6530  7429.0559  0.0     1.22874  0.00   
+  2  4    -4   -5   4544.8944  5935.8119  180.0   1.22833  0.00   
+  2  3    9    0    175.5992   207.1256   180.0   1.22722  0.00   
+  2  2    8    2    16107.1218 16367.8700 -0.0    1.22501  0.02   
+  2  3    -7   2    4.4027     4.4310     -180.0  1.22493  0.00   
+  2  5    7    -3   875.9329   701.3947   180.0   1.22357  0.00   
+  2  5    -5   -4   598.7639   527.2945   -180.0  1.22255  0.00   
+  2  2    6    -5   104.2186   93.3157    -0.0    1.22244  0.00   
+  2  3    9    -3   4331.8871  3989.5508  -0.0    1.22187  0.00   
+  2  4    -8   -2   17493.7362 15576.6760 0.0     1.22139  0.01   
+  2  1    5    4    3685.8636  2923.6151  -180.0  1.22003  0.01   
+  2  3    -9   0    81.5922    63.1939    -0.0    1.21922  0.00   
+  2  6    -4   -3   2.4782     1.6171     -180.0  1.21643  0.00   
+  2  6    4    -1   13.3468    10.2523    180.0   1.21473  0.00   
+  2  2    10   -2   4150.8609  3195.8904  -180.0  1.21471  0.00   
+  2  3    -7   -4   11.8062    9.5153     0.0     1.21279  0.00   
+  2  6    0    0    16190.0341 13100.2263 0.0     1.21259  0.01   
+  2  1    9    2    2162.3168  1749.7864  0.0     1.21259  0.00   
+  2  0    4    -5   63.5185    51.4047    -180.0  1.21258  0.00   
+  2  1    -7   -4   831.5463   673.8718   0.0     1.21254  0.00   
+  2  6    4    -4   236.9247   199.9465   0.0     1.21185  0.00   
+  2  0    10   -2   2896.2810  2393.1814  180.0   1.21068  0.00   
+  2  3    -9   -2   2.9108     2.4088     0.0     1.20966  0.00   
+  2  5    7    -1   1110.2154  919.5910   -0.0    1.20764  0.00   
+  2  5    -3   -5   2019.5595  1669.4106  -180.0  1.20756  0.00   
+  2  2    10   0    14.8285    11.8619    180.0   1.20601  0.00   
+  2  3    -5   -5   6304.7294  5223.5291  -0.0    1.20426  0.01   
+  2  4    8    0    2405.5662  2036.1638  -180.0  1.20314  0.00   
+  2  2    -10  0    1224.9461  1234.3417  180.0   1.20037  0.00   
+  2  2    -10  -1   1804.1427  1881.5821  0.0     1.19900  0.00   
+  2  2    -4   4    0.0039     0.0043     180.0   1.19841  0.00   
+  2  3    -5   3    4682.7586  5149.8089  -180.0  1.19827  0.00   
+  2  6    -4   -1   3951.9377  4013.4094  180.0   1.19705  0.00   
+  2  4    -8   0    1863.3338  1701.7086  -180.0  1.19422  0.00   
+  2  4    6    -5   6330.2243  5356.2972  -0.0    1.19366  0.00   
+  2  6    2    0    7534.0488  6359.8747  -180.0  1.19287  0.01   
+  2  3    1    -6   204.8531   172.0799   180.0   1.19278  0.00   
+  2  3    7    2    253.8880   210.6961   180.0   1.19262  0.00   
+  2  6    -2   0    2656.7599  1825.4606  -180.0  1.18959  0.00   
+  2  5    -7   -2   346.1118   235.2689   -180.0  1.18926  0.00   
+  2  5    5    -5   676.5005   652.0282   -0.0    1.18202  0.00   
+  2  6    0    -5   1959.2525  1859.8386  -0.0    1.18139  0.00   
+  2  5    -7   -1   1162.6264  1170.6276  -0.0    1.17956  0.00   
+  2  3    -1   -6   9065.6887  10651.6340 0.0     1.17652  0.01   
+  2  1    -9   -3   2783.9447  3479.3329  -0.0    1.17569  0.00   
+  2  4    0    -6   556.0294   694.8770   -180.0  1.17567  0.00   
+  2  6    2    -5   555.0350   690.4314   180.0   1.17553  0.00   
+  2  4    8    -4   4317.0355  5262.2410  180.0   1.17365  0.00   
+  2  1    -1   5    36.2112    44.3347    0.0     1.17349  0.00   
+  2  2    0    -6   2773.3358  3262.2227  -180.0  1.17258  0.00   
+  2  4    2    -6   682.0746   785.7923   0.0     1.17185  0.00   
+  2  4    -8   -3   442.4039   512.5086   -0.0    1.17167  0.00   
+  2  1    -5   -5   4690.2978  5414.4867  -180.0  1.17131  0.01   
+  2  3    3    -6   3025.9524  3178.6335  180.0   1.16840  0.00   
+  2  5    7    -4   5662.3741  5932.4007  0.0     1.16833  0.00   
+  2  2    2    -6   425.2877   444.4424   0.0     1.16828  0.00   
+  2  0    8    -4   6290.5931  6734.2463  -180.0  1.16544  0.00   
+  2  3    5    3    8644.5672  9033.3981  -180.0  1.16397  0.01   
+  2  6    -4   -4   1249.5573  1331.0105  -180.0  1.16381  0.00   
+  2  3    7    -5   1103.5341  1180.8749  180.0   1.16377  0.00   
+  2  3    -9   1    29.2168    24.5109    -0.0    1.16177  0.00   
+  2  1    1    5    2376.9700  1984.2370  0.0     1.16142  0.00   
+  2  2    -10  1    489.9378   408.7012   -180.0  1.16134  0.00   
+  2  0    4    5    4431.9590  3674.6390  -180.0  1.16082  0.01   
+  2  6    6    -3   692.3545   572.9928   0.0     1.16041  0.00   
+  2  5    -5   1    9.8611     8.2052     180.0   1.16017  0.00   
+  2  7    1    -3   392.3611   326.8856   180.0   1.15995  0.00   
+  2  2    4    4    402.0167   334.7388   180.0   1.15990  0.00   
+  2  0    10   2    2448.4025  1953.1670  -180.0  1.15916  0.00   
+  2  5    -7   -3   17.5856    13.9221    0.0     1.15905  0.00   
+  2  6    6    -2   1353.8085  1062.5954  180.0   1.15883  0.00   
+  2  2    -10  -2   1133.4703  927.1428   -180.0  1.15763  0.00   
+  2  2    10   -3   560.7517   456.9863   180.0   1.15752  0.00   
+  2  1    -7   4    9788.7410  7894.1741  -0.0    1.15699  0.01   
+  2  1    11   -1   201.1446   172.4013   -0.0    1.15488  0.00   
+  2  5    5    1    17.3492    14.5872    180.0   1.15443  0.00   
+  2  4    0    3    444.5482   372.8509   -0.0    1.15214  0.00   
+  2  7    -1   -3   228.6421   190.7937   -0.0    1.15103  0.00   
+  2  1    -9   3    465.1198   390.2848   -180.0  1.15086  0.00   
+  2  7    1    -2   487.3760   417.6649   180.0   1.14957  0.00   
+  2  6    -2   -5   3.7614     3.3422     180.0   1.14818  0.00   
+  2  2    -8   -4   1358.9326  1241.1393  -0.0    1.14713  0.00   
+  2  3    9    1    922.6384   840.9132   -180.0  1.14703  0.00   
+  2  1    -3   5    144.8481   131.0137   -0.0    1.14691  0.00   
+  2  4    -6   2    1023.6274  884.2580   -180.0  1.14653  0.00   
+  2  1    11   0    793.3555   673.8595   0.0     1.14593  0.00   
+  2  3    -9   -3   7855.3155  6842.7549  -0.0    1.14539  0.01   
+  2  1    -11  0    56.7732    56.5171    180.0   1.14326  0.00   
+  2  7    -1   -2   256.1012   258.5173   180.0   1.14319  0.00   
+  2  2    10   1    2034.2258  2221.3310  -180.0  1.14260  0.00   
+  2  2    -6   -5   7599.7867  8280.7099  -0.0    1.14253  0.01   
+  2  5    -1   2    0.2350     0.2523     -180.0  1.14237  0.00   
+  2  4    -2   -6   178.8784   159.9954   -0.0    1.14109  0.00   
+  2  5    7    0    1766.9420  1584.2307  0.0     1.14103  0.00   
+  2  3    9    -4   3915.8636  3452.1120  -180.0  1.13977  0.00   
+  2  4    -2   3    778.9282   675.3480   180.0   1.13965  0.00   
+  2  2    -8   3    1114.9888  940.5804   180.0   1.13923  0.00   
+  2  5    1    2    177.3464   151.0052   180.0   1.13897  0.00   
+  2  2    -2   -6   531.5345   457.5743   180.0   1.13875  0.00   
+  2  5    1    -6   100.9961   92.8501    180.0   1.13644  0.00   
+  2  6    4    0    10306.6178 9886.1889  -180.0  1.13618  0.01   
+  2  1    9    -4   6885.1394  6387.1239  180.0   1.13575  0.00   
+  2  7    1    -4   112.0925   104.3489   0.0     1.13318  0.00   
+  2  5    -7   0    666.8924   561.3250   0.0     1.13270  0.00   
+  2  6    4    -5   4648.2983  3560.8356  -0.0    1.13225  0.00   
+  2  7    3    -3   2209.6003  1752.7599  180.0   1.13164  0.00   
+  2  1    7    -5   2221.7823  1876.4532  -0.0    1.13113  0.00   
+  2  4    4    -6   87.6282    74.0198    180.0   1.13073  0.00   
+  2  6    -4   0    10786.0951 8996.3605  -180.0  1.13052  0.01   
+  2  1    1    -6   15.4246    12.7255    180.0   1.13041  0.00   
+  2  4    2    3    35.2630    26.9687    0.0     1.12798  0.00   
+  2  1    11   -2   4508.9342  4054.5939  -180.0  1.12721  0.00   
+  2  2    4    -6   661.2322   617.9103   -180.0  1.12706  0.00   
+  2  1    -11  -1   84.0829    80.5660    180.0   1.12692  0.00   
+  2  0    6    -5   844.3575   825.3110   -0.0    1.12677  0.00   
+  2  0    10   -3   27.6591    25.1309    180.0   1.12560  0.00   
+  2  6    6    -4   1167.6875  1116.6065  -0.0    1.12535  0.00   
+  2  4    -8   1    1370.1935  1428.0735  -0.0    1.12500  0.00   
+  2  4    6    2    469.9281   491.6513   180.0   1.12497  0.00   
+  2  3    -3   -6   2626.0079  2679.1058  0.0     1.12421  0.00   
+  2  1    -11  1    545.7014   520.4388   180.0   1.12385  0.00   
+  2  3    -1   4    64.4957    62.3074    180.0   1.12290  0.00   
+  2  7    -1   -4   327.3067   340.7362   180.0   1.12266  0.00   
+  2  6    -6   -2   5.5388     5.8815     -0.0    1.12259  0.00   
+  2  5    -1   -6   3072.7142  3679.1020  -180.0  1.12188  0.00   
+  2  6    6    -1   16.7304    18.5196    -180.0  1.12105  0.00   
+  2  7    3    -2   403.6745   466.2613   -180.0  1.11981  0.00   
+  2  5    -5   -5   3491.6291  3254.1700  180.0   1.11710  0.00   
+  2  1    -1   -6   1715.6187  1573.1101  -180.0  1.11699  0.00   
+  2  4    -6   -5   13.0547    12.1624    -180.0  1.11621  0.00   
+  2  5    3    -6   3654.2001  3572.8767  0.0     1.11574  0.00   
+  2  3    1    4    595.2313   557.2568   180.0   1.11489  0.00   
+  2  4    8    1    3254.9027  3030.2470  -0.0    1.11486  0.00   
+  2  1    3    5    259.9757   208.8946   -180.0  1.11404  0.00   
+  2  2    -6   4    1972.5933  1626.0861  -0.0    1.11278  0.00   
+  2  6    -6   -3   12054.8218 9170.8262  180.0   1.11104  0.01   
+  2  5    -3   2    30.2131    23.9804    -180.0  1.11049  0.00   
+  2  3    5    -6   94.0408    75.3696    -0.0    1.11017  0.00   
+  2  1    3    -6   4562.6591  3749.4968  0.0     1.10915  0.01   
+  2  7    3    -4   1026.3013  851.8273   -0.0    1.10885  0.00   
+  2  7    -3   -3   9.5167     8.0510     -0.0    1.10731  0.00   
+  2  7    1    -1   620.2918   540.2195   -180.0  1.10485  0.00   
+  2  6    0    1    3169.3145  2851.2916  180.0   1.10441  0.00   
+  2  1    11   1    377.4256   353.4958   0.0     1.10278  0.00   
+  2  7    -3   -2   8.0729     7.6618     -0.0    1.10240  0.00   
+  2  4    10   -2   296.7663   293.9448   -180.0  1.10139  0.00   
+  2  7    -1   -1   568.8858   560.8360   -180.0  1.10125  0.00   
+  2  5    3    2    93.9965    92.4856    -180.0  1.10119  0.00   
+  2  2    8    -5   3811.6058  3728.5603  180.0   1.10077  0.00   
+  2  6    -6   -1   6.4090     6.2337     0.0     1.10033  0.00   
+  2  5    -7   -4   137.3671   136.6182   0.0     1.09716  0.00   
+  2  3    -3   4    143.4515   143.6453   -0.0    1.09706  0.00   
+  2  1    7    4    54.9678    57.0295    -0.0    1.09661  0.00   
+  2  0    8    4    2904.1769  2959.2417  180.0   1.09406  0.00   
+  2  4    -8   -4   3639.3329  3685.4545  -180.0  1.09399  0.00   
+  2  4    -4   3    2195.1776  2186.7268  180.0   1.09385  0.00   
+  2  3    -7   3    1822.7839  1814.2931  0.0     1.09384  0.00   
+  2  1    9    3    310.1889   308.2223   180.0   1.09383  0.00   
+  2  2    -10  2    3.6755     3.3265     -0.0    1.09247  0.00   
+  2  2    8    3    427.8097   379.8198   0.0     1.09126  0.00   
+  2  5    9    -2   1839.3867  1582.6840  -0.0    1.09021  0.00   
+  2  4    10   -1   1.7791     1.7369     -180.0  1.08903  0.00   
+  2  6    -2   1    1.5507     1.5406     -180.0  1.08894  0.00   
+  2  1    -5   5    5578.0082  5646.2565  0.0     1.08884  0.01   
+  2  6    2    1    250.2603   245.3481   -0.0    1.08745  0.00   
+  2  2    -10  -3   624.4303   617.4947   180.0   1.08733  0.00   
+  2  5    7    -5   87.8896    91.0318    -180.0  1.08704  0.00   
+  2  6    -4   -5   385.6511   422.0173   180.0   1.08477  0.00   
+  2  3    -7   -5   2689.9850  3180.2930  0.0     1.08232  0.00   
+  2  5    9    -3   30.5025    37.0056    -180.0  1.08217  0.00   
+  2  4    10   -3   389.1158   496.5346   180.0   1.08176  0.00   
+  2  4    8    -5   357.4595   416.8216   0.0     1.08002  0.00   
+  2  7    -3   -4   408.0059   475.9937   -180.0  1.08002  0.00   
+  2  3    11   -2   960.8294   1209.7235  180.0   1.07973  0.00   
+  2  3    -9   2    874.6878   1162.0253  -0.0    1.07952  0.00   
+  2  1    -11  -2   374.5168   505.5742   -0.0    1.07909  0.00   
+  2  3    11   -1   1892.6081  2531.9784  -180.0  1.07901  0.00   
+  2  4    -4   -6   54.5702    79.4879    0.0     1.07725  0.00   
+  2  7    3    -1   289.7702   517.9063   0.0     1.07642  0.00   
+  2  7    1    -5   13.8447    25.2106    -0.0    1.07626  0.00   
+  2  5    -3   -6   776.9945   1371.1187  180.0   1.07586  0.00   
+  2  2    10   -4   1615.6761  2842.5457  0.0     1.07584  0.00   
+  2  2    -4   -6   110.9013   186.5753   0.0     1.07568  0.00   
+  2  3    3    4    369.5962   560.4316   180.0   1.07511  0.00   
+  2  1    -11  2    397.4269   558.2780   -180.0  1.07370  0.00   
+  2  7    5    -3   707.7108   928.6481   180.0   1.07351  0.00   
+  2  4    4    3    630.7711   818.8776   180.0   1.07348  0.00   
+  2  1    -3   -6   110.4363   135.6225   180.0   1.07233  0.00   
+  2  6    0    -6   3.8636     4.1780     -180.0  1.07161  0.00   
+  2  1    11   -3   503.2134   540.3856   180.0   1.07008  0.00   
+  2  6    2    -6   101.9627   107.8329   0.0     1.06912  0.00   
+  2  6    -6   -4   610.4901   552.9788   0.0     1.06862  0.00   
+  2  5    9    -1   891.8488   1026.4794  0.0     1.06732  0.00   
+  2  2    6    4    3502.7753  4143.5979  0.0     1.06716  0.00   
+  2  7    -3   -1   141.8442   173.9010   0.0     1.06652  0.00   
+  2  2    0    5    1714.6064  1937.9253  0.0     1.06580  0.00   
+  2  0    6    5    312.4134   358.8678   0.0     1.06561  0.00   
+  2  7    -1   -5   2802.6536  3288.8085  0.0     1.06535  0.00   
+  2  5    5    -6   378.9910   447.2840   -180.0  1.06509  0.00   
+  2  0    0    6    44.7813    53.4823    180.0   1.06464  0.00   
+  2  0    10   3    2740.4512  3276.3246  0.0     1.06463  0.00   
+  2  4    6    -6   26.0667    31.3322    -180.0  1.06282  0.00   
+  2  6    6    -5   366.6816   434.3157   -0.0    1.06260  0.00   
+  2  0    12   0    97.0622    112.6819   180.0   1.06244  0.00   
+  2  4    -10  -1   1023.6427  1132.6677  180.0   1.06171  0.00   
+  2  7    5    -2   4091.7282  4496.3914  -180.0  1.06153  0.00   
+  2  0    2    -6   688.9413   748.1993   0.0     1.06104  0.00   
+  2  5    -7   1    880.4884   969.1237   180.0   1.06052  0.00   
+  2  1    -9   -4   1578.2950  1706.8793  -180.0  1.06015  0.00   
+  2  2    -2   5    3082.8878  3313.4198  -180.0  1.05994  0.00   
+  2  3    -9   -4   12.7169    13.6703    -180.0  1.05993  0.00   
+  2  2    6    -6   266.3175   288.6216   -180.0  1.05938  0.00   
+  2  0    12   -1   1292.8769  1340.4500  -0.0    1.05892  0.00   
+  2  1    -7   -5   7.2964     7.5059     -180.0  1.05860  0.00   
+  2  1    5    -6   46.0631    47.4061    -180.0  1.05858  0.00   
+  2  2    10   2    1186.5592  1237.1699  -0.0    1.05797  0.00   
+  2  3    7    3    12.2999    12.9031    -180.0  1.05758  0.00   
+  2  7    3    -5   2101.5128  2239.1302  -180.0  1.05718  0.00   
+  2  6    6    0    440.9747   461.7745   -0.0    1.05659  0.00   
+  2  7    5    -4   1683.2886  2051.4003  0.0     1.05581  0.00   
+  2  4    -10  -2   3085.9148  3145.7849  0.0     1.05450  0.00   
+  2  5    7    1    36.2287    37.2884    180.0   1.05440  0.00   
+  2  6    8    -3   7783.5543  8866.7538  -0.0    1.05196  0.01   
+  2  3    -11  -1   229.7340   261.5320   -0.0    1.05193  0.00   
+  2  5    -5   2    4899.1112  5387.0808  -180.0  1.05131  0.00   
+  2  3    9    2    803.6207   862.2832   -0.0    1.05108  0.00   
+  2  3    11   -3   647.4236   673.7850   180.0   1.05082  0.00   
+  2  6    -6   0    484.7602   488.9045   -0.0    1.04978  0.00   
+  2  6    8    -2   366.2591   331.3808   0.0     1.04899  0.00   
+  2  3    11   0    460.6132   407.0557   -0.0    1.04881  0.00   
+  2  3    -5   -6   1410.3793  1235.7557  -180.0  1.04872  0.00   
+  2  4    10   0    69.3855    61.4161    -0.0    1.04771  0.00   
+  2  5    -9   -2   2521.8515  2208.3085  -0.0    1.04729  0.00   
+  2  5    9    -4   255.0413   228.7958   -180.0  1.04516  0.00   
+  2  6    -2   -6   1459.4695  1293.5044  -0.0    1.04487  0.00   
+  2  6    -4   1    3568.3588  3160.5795  -0.0    1.04485  0.00   
+  2  3    -5   4    2735.0932  2301.6767  -0.0    1.04377  0.00   
+  2  3    9    -5   2124.7490  1817.7670  180.0   1.04328  0.00   
+  2  1    5    5    1853.9616  1623.2967  -0.0    1.04294  0.00   
+  2  3    -11  0    1586.6805  1387.3612  0.0     1.04270  0.00   
+  2  2    2    5    302.4130   264.3036   0.0     1.04269  0.00   
+  2  5    -9   -1   73.1339    62.5557    0.0     1.04240  0.00   
+  2  6    4    1    1211.1268  1021.8291  -0.0    1.04223  0.00   
+  2  4    -10  0    628.4200   554.7785   -0.0    1.04034  0.00   
+  2  2    12   -1   4330.9466  3828.0670  -180.0  1.03971  0.00   
+  2  0    2    6    1672.8453  1492.8101  0.0     1.03949  0.00   
+  2  7    -5   -3   3929.3390  3517.5593  180.0   1.03943  0.00   
+  2  5    5    2    4504.7069  4324.4718  -180.0  1.03825  0.00   
+  2  4    -8   2    304.3145   298.1823   -0.0    1.03802  0.00   
+  2  6    4    -6   1271.2246  1251.2761  -180.0  1.03798  0.00   
+  2  0    12   1    314.4062   335.8693   -0.0    1.03750  0.00   
+  2  7    -5   -2   1331.7016  1492.9651  -180.0  1.03709  0.00   
+  2  7    1    0    1109.4450  1264.8986  -0.0    1.03656  0.00   
+  2  1    -9   4    2.3272     2.8086     180.0   1.03594  0.00   
+  2  1    11   2    1383.0668  1702.3367  180.0   1.03580  0.00   
+  2  7    -1   0    1335.4030  1823.6465  -0.0    1.03529  0.00   
+  2  4    10   -4   6.5283     9.1218     0.0     1.03486  0.00   
+  2  3    -11  -2   1090.4215  1522.0493  -180.0  1.03326  0.00   
+  3  1    1    0    1650.0779  1271.8362  -0.0    3.25053  0.05   
+  3  1    0    1    663.1565   492.3113   -0.0    2.48939  0.02   
+  3  2    0    0    245.8448   149.3210   -0.0    2.29847  0.00   
+  3  1    1    1    311.4178   374.9378   180.0   2.18903  0.01   
+  3  2    1    0    137.4917   152.7063   0.0     2.05581  0.00   
+  3  2    1    1    873.1617   880.1063   -0.0    1.68873  0.03   
+  3  2    2    0    1033.3961  1142.5848  -0.0    1.62526  0.01   
+  3  0    0    2    2158.1296  1418.7512  -0.0    1.48058  0.01   
+  3  3    1    0    358.0959   356.6537   -0.0    1.45368  0.00   
+  3  2    2    1    25.6838    28.2249    180.0   1.42477  0.00   
+  3  3    0    1    845.0413   1054.9284  -0.0    1.36090  0.01   
+  3  1    1    2    402.4404   541.7701   -0.0    1.34739  0.00   
+  3  3    1    1    57.3192    32.7359    0.0     1.30492  0.00   
+  3  3    2    0    12.4211    15.0136    180.0   1.27496  0.00   
+  3  2    0    2    137.9878   145.3496   -0.0    1.24470  0.00   
+  3  2    1    2    46.5608    42.1765    0.0     1.20143  0.00   
+  3  3    2    1    135.2056   154.4569   -0.0    1.17103  0.00   
+  3  4    0    0    495.1209   421.9544   -0.0    1.14924  0.00   
+  3  4    1    0    82.1883    78.6279    180.0   1.11492  0.00   
+  3  2    2    2    532.7163   562.6941   -0.0    1.09451  0.01   
+  3  3    3    0    490.1220   591.9554   -0.0    1.08351  0.00   
+  3  4    1    1    323.2085   271.6222   -0.0    1.04341  0.01   
+  3  3    1    2    196.9284   220.8343   -0.0    1.03729  0.00   
+  4  1    1    0    8319.2412  5230.8975  0.0     5.76555  0.01   
+  4  1    1    -1   2184.5526  1404.6948  0.0     5.75354  0.00   
+  4  0    0    2    10288.0565 6635.0705  0.0     5.70305  0.00   
+  4  2    0    0    710.1380   777.6758   180.0   5.30534  0.00   
+  4  2    0    -2   9663.1365  11507.8256 0.0     5.26818  0.00   
+  4  1    1    1    3812.1828  5912.0003  -180.0  4.69686  0.00   
+  4  1    1    -2   304.7925   470.9216   -180.0  4.67743  0.00   
+  4  1    1    2    1455.1746  1807.7676  -180.0  3.62858  0.00   
+  4  1    1    -3   5346.1865  6212.3576  180.0   3.61365  0.00   
+  4  0    2    0    7123.2869  1738.4352  180.0   3.43395  0.00   
+  4  3    1    -1   2309.1875  1015.6499  -0.0    3.40713  0.00   
+  4  3    1    -2   6205.4066  3189.2181  180.0   3.39969  0.00   
+  4  0    2    1    6132.1253  5007.9341  -0.0    3.28817  0.00   
+  4  2    0    2    12762.9222 11586.9372 -0.0    3.21884  0.00   
+  4  2    0    -4   5309.5047  4998.0528  180.0   3.19396  0.00   
+  4  3    1    0    2454.4753  2138.0352  0.0     3.14442  0.00   
+  4  3    1    -3   3159.5267  2676.2849  180.0   3.12697  0.00   
+  4  4    0    -2   94800.1139 80939.0869 -180.0  2.98311  0.01   
+  4  2    2    -1   90018.8321 75055.6669 -0.0    2.97619  0.02   
+  4  0    2    2    801.3809   793.0056   0.0     2.94183  0.00   
+  4  2    2    0    963.3578   1809.8986  0.0     2.88278  0.00   
+  4  2    2    -2   305.5644   529.5412   -0.0    2.87677  0.00   
+  4  1    1    3    1917.4844  2484.6750  -0.0    2.86366  0.00   
+  4  1    1    -4   4664.6596  5799.3026  -0.0    2.85338  0.00   
+  4  0    0    4    8233.8760  10330.0128 -0.0    2.85152  0.00   
+  4  3    1    1    2864.8061  3753.7637  -180.0  2.75756  0.00   
+  4  3    1    -4   2668.4721  3263.6308  -0.0    2.73799  0.00   
+  4  4    0    0    74856.9508 71065.3522 0.0     2.65267  0.01   
+  4  2    2    1    147225.6063 133018.2915 0.0     2.64315  0.02   
+  4  2    2    -3   74145.9591 66287.2123 -180.0  2.63390  0.01   
+  4  4    0    -4   157240.3959 140601.5020 180.0   2.63409  0.01   
+  4  0    2    3    16113.7630 14182.3578 180.0   2.54839  0.00   
+  4  3    1    2    10127.5374 9773.7716  -180.0  2.37524  0.00   
+  4  3    1    -5   5924.5595  5861.4597  -0.0    2.35774  0.00   
+  4  2    2    2    153.4404   143.8207   -180.0  2.34843  0.00   
+  4  2    2    -4   1040.9352  881.6551   180.0   2.33872  0.00   
+  4  1    1    4    3736.7731  2964.2005  -0.0    2.33565  0.00   
+  4  1    1    -5   455.7801   299.6843   -0.0    2.32848  0.00   
+  4  4    2    -2   1577.3771  1408.3961  -0.0    2.25202  0.00   
+  4  5    1    -2   2261.7406  2124.2649  180.0   2.24512  0.00   
+  4  5    1    -3   555.3663   539.4431   180.0   2.24157  0.00   
+  4  1    3    0    53.0892    52.4920    0.0     2.23781  0.00   
+  4  1    3    -1   4226.2493  4185.4865  -0.0    2.23711  0.00   
+  4  4    2    -1   908.0041   918.6950   0.0     2.21209  0.00   
+  4  4    2    -3   12467.8131 13302.6909 -0.0    2.20666  0.00   
+  4  0    2    4    824.6309   967.0855   180.0   2.19377  0.00   
+  4  5    1    -1   8176.0337  11524.8599 -0.0    2.16607  0.00   
+  4  1    3    1    647.3532   1032.2056  -0.0    2.15698  0.00   
+  4  1    3    -2   6789.7370  10974.1049 0.0     2.15509  0.00   
+  4  5    1    -4   443.5413   710.2140   -180.0  2.15655  0.00   
+  4  2    0    4    1324.0103  1631.1816  0.0     2.13688  0.00   
+  4  2    0    -6   6549.2701  7205.4541  0.0     2.12472  0.00   
+  4  4    2    0    516.7090   728.6225   -180.0  2.09927  0.00   
+  4  4    2    -4   376.4777   548.8603   -180.0  2.09002  0.00   
+  4  4    0    2    272830.1719 285819.3975 180.0   2.07015  0.01   
+  4  2    2    3    290471.7930 292811.2059 0.0     2.06340  0.03   
+  4  2    2    -5   279438.2344 297121.0150 0.0     2.05462  0.03   
+  4  4    0    -6   284757.2508 302255.2171 -180.0  2.05252  0.01   
+  4  3    1    3    1038.8312  1081.3390  -180.0  2.04824  0.00   
+  4  3    1    -6   141.5870   154.7174   -0.0    2.03380  0.00   
+  4  5    1    0    640.4147   771.2571   180.0   2.02755  0.00   
+  4  1    3    2    10536.1323 14025.8755 -0.0    2.01802  0.00   
+  4  1    3    -3   951.4253   1239.2459  -0.0    2.01544  0.00   
+  4  5    1    -5   10987.9103 14161.8097 -0.0    2.01457  0.00   
+  4  3    3    -1   6981.9249  7028.1588  -0.0    1.97739  0.00   
+  4  3    3    -2   187.6456   188.2835   0.0     1.97593  0.00   
+  4  1    1    5    4495.7771  4613.5735  180.0   1.96098  0.00   
+  4  6    0    -2   958.9710   971.2900   180.0   1.96202  0.00   
+  4  1    1    -6   1433.0288  1561.1079  -0.0    1.95579  0.00   
+  4  6    0    -4   15909.8581 17271.3905 -180.0  1.95635  0.00   
+  4  4    2    1    17480.8589 20969.0382 -0.0    1.94314  0.00   
+  4  4    2    -5   62.0981    70.9606    180.0   1.93216  0.00   
+  4  3    3    0    8928.8817  9842.9144  180.0   1.92185  0.00   
+  4  3    3    -3   2491.5227  2771.3393  -0.0    1.91785  0.00   
+  4  0    0    6    1558.9764  1705.9742  -0.0    1.90102  0.00   
+  4  0    2    5    82.9473    90.1521    -180.0  1.90015  0.00   
+  4  5    1    1    2822.4259  2501.9487  -180.0  1.86099  0.00   
+  4  1    3    3    3302.1961  3425.2133  0.0     1.85201  0.00   
+  4  1    3    -4   477.7307   509.1266   -180.0  1.84922  0.00   
+  4  5    1    -6   2718.5113  2899.2946  -180.0  1.84697  0.00   
+  4  3    3    1    3263.8533  3297.9941  -0.0    1.82236  0.00   
+  4  3    3    -4   14294.0882 15085.8470 -180.0  1.81668  0.00   
+  4  2    2    4    1880.9426  2005.0453  180.0   1.81429  0.00   
+  4  2    2    -6   105.9589   110.9061   -0.0    1.80682  0.00   
+  4  3    1    4    1137.4136  1171.2225  -0.0    1.78216  0.00   
+  4  4    2    2    782.3770   570.1032   -0.0    1.77291  0.00   
+  4  3    1    -7   1131.8410  721.1980   -180.0  1.77053  0.00   
+  4  6    0    0    59782.1732 33133.1198 180.0   1.76845  0.00   
+  4  4    2    -6   3512.8811  1198.9309  -0.0    1.76180  0.00   
+  4  6    0    -6   5.8176     2.0503     0.0     1.75606  0.00   
+  4  6    2    -3   388756.2840 370223.1653 -180.0  1.72096  0.02   
+  4  0    4    0    362390.0004 349094.6184 -180.0  1.71698  0.01   
+  4  6    2    -2   535.5774   389.7845   -0.0    1.70356  0.00   
+  4  6    2    -4   2274.6481  1560.6809  180.0   1.69985  0.00   
+  4  0    4    1    4845.0128  3260.3097  -0.0    1.69785  0.00   
+  4  3    3    2    5349.5416  3601.7812  -0.0    1.69795  0.00   
+  4  3    3    -5   13988.6257 10539.6761 0.0     1.69153  0.00   
+  4  5    1    2    3373.5709  2567.9366  -180.0  1.69126  0.00   
+  4  1    1    6    887.2197   741.9382   -0.0    1.68512  0.00   
+  4  1    3    4    55.1564    44.9721    -0.0    1.68331  0.00   
+  4  1    1    -7   15655.8909 12427.4639 -180.0  1.68122  0.00   
+  4  1    3    -5   5923.8565  4682.3563  0.0     1.68062  0.00   
+  4  5    1    -7   334.7556   265.9545   -180.0  1.67774  0.00   
+  4  0    2    6    1061.1460  1003.9433  0.0     1.66317  0.00   
+  4  2    4    -1   2958.3410  2845.3491  180.0   1.65001  0.00   
+  4  6    2    -1   897.3654   866.2401   -180.0  1.65097  0.00   
+  4  7    1    -3   36.7715    35.5149    180.0   1.65109  0.00   
+  4  5    3    -2   352.0071   336.9892   -180.0  1.64846  0.00   
+  4  7    1    -4   581.8513   558.0282   -0.0    1.64911  0.00   
+  4  5    3    -3   1291.9187  1233.8660  -180.0  1.64705  0.00   
+  4  0    4    2    637.8122   611.9468   -180.0  1.64408  0.00   
+  4  6    2    -5   527.3448   505.6692   -180.0  1.64422  0.00   
+  4  2    4    0    725.8900   753.9382   -0.0    1.63356  0.00   
+  4  2    4    -2   4301.3285  4464.8969  180.0   1.63246  0.00   
+  4  7    1    -2   3649.2739  3574.0709  180.0   1.61941  0.00   
+  4  5    3    -1   1023.5333  967.2983   0.0     1.61640  0.00   
+  4  7    1    -5   994.4656   917.7709   -0.0    1.61383  0.00   
+  4  5    3    -4   4205.0683  3838.3842  -180.0  1.61243  0.00   
+  4  4    0    4    71409.4264 64381.9461 180.0   1.60942  0.00   
+  4  4    2    3    30.4933    27.4318    180.0   1.60785  0.00   
+  4  2    2    5    42237.9212 37134.0233 -180.0  1.60520  0.00   
+  4  2    2    -7   91578.5556 66541.2306 0.0     1.59899  0.00   
+  4  4    2    -7   3742.4238  2583.0374  -0.0    1.59749  0.00   
+  4  4    0    -8   54378.8021 36952.8051 0.0     1.59698  0.00   
+  4  2    4    1    2434.2253  1925.9734  0.0     1.58601  0.00   
+  4  2    4    -3   2298.7776  1877.8066  0.0     1.58400  0.00   
+  4  2    0    6    30456.3372 28897.4638 -0.0    1.57530  0.00   
+  4  6    2    0    329.6208   317.5013   -0.0    1.57221  0.00   
+  4  2    0    -8   5006.0797  4975.6390  -180.0  1.56847  0.00   
+  4  3    1    5    1743.3082  1738.5834  180.0   1.56804  0.00   
+  4  3    3    3    481.4802   485.0224   0.0     1.56562  0.00   
+  4  0    4    3    2895.3865  2916.6659  -0.0    1.56481  0.00   
+  4  6    2    -6   1243.1212  1248.0060  -180.0  1.56348  0.00   
+  4  3    3    -6   1531.1187  1493.3859  -180.0  1.55914  0.00   
+  4  3    1    -8   1915.1601  1859.0381  0.0     1.55867  0.00   
+  4  7    1    -1   2088.0415  2043.5569  -0.0    1.55949  0.00   
+  4  5    3    0    3971.5322  3765.4430  180.0   1.55632  0.00   
+  4  7    1    -6   4188.9415  3788.8467  -180.0  1.55121  0.00   
+  4  5    3    -5   1571.0818  1408.2677  0.0     1.55043  0.00   
+  4  5    1    3    1095.9528  787.2913   0.0     1.53242  0.00   
+  4  1    3    5    9.9058     7.3882     -180.0  1.52560  0.00   
+  4  1    3    -6   1618.4811  1156.1808  0.0     1.52315  0.00   
+  4  5    1    -8   7.8646     5.3626     0.0     1.52012  0.00   
+  4  2    4    2    5594.2539  4258.2315  180.0   1.51493  0.00   
+  4  2    4    -4   2991.2636  2489.4083  -0.0    1.51231  0.00   
+  4  6    0    2    9111.6777  8933.0441  180.0   1.50546  0.00   
+  4  6    0    -8   4536.7318  4388.1258  -180.0  1.49275  0.00   
+  4  8    0    -4   21403.1010 20124.4891 0.0     1.49155  0.00   
+  4  4    4    -2   24529.3783 20516.6042 -0.0    1.48809  0.00   
+  4  7    1    0    733.1584   522.5481   0.0     1.48019  0.00   
+  4  6    2    1    712.1334   506.2593   180.0   1.47827  0.00   
+  4  5    3    1    2078.5122  1471.0036  180.0   1.47707  0.00   
+  4  4    4    -1   255.6976   180.6123   180.0   1.47640  0.00   
+  4  1    1    7    12900.6279 9078.3301  -0.0    1.47499  0.00   
+  4  4    4    -3   2374.8847  1670.1467  180.0   1.47478  0.00   
+  4  1    1    -8   10332.9350 7396.6827  0.0     1.47197  0.00   
+  4  0    2    7    3501.3581  2501.2121  180.0   1.47212  0.00   
+  4  0    4    4    805.8542   584.8425   180.0   1.47091  0.00   
+  4  5    3    -6   0.2445     0.1792     -180.0  1.47003  0.00   
+  4  7    1    -7   317.8257   232.1950   -180.0  1.47030  0.00   
+  4  6    2    -7   1448.1003  1083.3730  180.0   1.46861  0.00   
+  4  4    2    4    343.4415   309.1562   -180.0  1.45730  0.00   
+  4  4    2    -8   305.2822   302.7739   -180.0  1.44805  0.00   
+  4  8    0    -2   52590.0962 52330.8230 0.0     1.44605  0.00   
+  4  4    4    0    41712.6576 40429.3778 -180.0  1.44139  0.00   
+  4  8    0    -6   41832.4530 39529.4275 -180.0  1.44000  0.00   
+  4  4    4    -4   59639.7017 54156.0501 0.0     1.43838  0.00   
+  4  3    3    4    5287.3269  4621.2299  -180.0  1.43672  0.00   
+  4  2    2    6    0.9634     0.8067     -180.0  1.43183  0.00   
+  4  3    3    -7   1689.8053  1449.6465  0.0     1.43061  0.00   
+  4  2    4    3    3066.1159  2700.3242  180.0   1.42962  0.00   
+  4  2    2    -8   1905.5891  1820.9010  -0.0    1.42669  0.00   
+  4  2    4    -5   1751.2476  1673.4947  180.0   1.42669  0.00   
+  4  0    0    8    274600.1432 266702.1198 -0.0    1.42576  0.01   
+  4  3    1    6    1260.0796  938.5133   180.0   1.39490  0.00   
+  4  5    1    4    879.0204   766.5576   0.0     1.39016  0.00   
+  4  7    1    1    58.4751    50.2176    -180.0  1.39072  0.00   
+  4  3    1    -9   745.1162   708.1614   -0.0    1.38728  0.00   
+  4  4    4    1    3861.4245  3625.4850  -0.0    1.38775  0.00   
+  4  5    3    2    472.6317   443.0593   -180.0  1.38780  0.00   
+  4  1    3    6    3177.9226  3150.0852  0.0     1.38440  0.00   
+  4  4    4    -5   1231.9173  1225.1621  0.0     1.38373  0.00   
+  4  1    3    -7   486.9450   485.8196   -180.0  1.38224  0.00   
+  4  5    3    -7   1061.5536  1076.1947  180.0   1.38030  0.00   
+  4  7    1    -8   227.9675   231.5071   0.0     1.38019  0.00   
+  4  5    1    -9   3077.7139  3164.8132  -0.0    1.37931  0.00   
+  4  6    2    2    247.0076   255.5793   -180.0  1.37878  0.00   
+  4  0    4    5    363.9512   361.2698   -180.0  1.37183  0.00   
+  4  6    2    -8   3.3380     2.8506     0.0     1.36899  0.00   
+  4  8    2    -4   902.6292   739.6027   180.0   1.36807  0.00   
+  4  7    3    -3   3944.2750  3200.8888  -180.0  1.36535  0.00   
+  4  7    3    -4   539.4662   462.8739   -180.0  1.36423  0.00   
+  4  1    5    0    4533.4102  4375.6610  -180.0  1.36221  0.00   
+  4  1    5    -1   59.0555    57.4577    -0.0    1.36206  0.00   
+  4  8    2    -3   1887.5785  1924.2275  180.0   1.35960  0.00   
+  4  8    2    -5   14650.4732 14164.8560 180.0   1.35708  0.00   
+  4  7    3    -2   6187.9802  6977.6508  0.0     1.34727  0.00   
+  4  1    5    1    7427.9141  7444.3720  0.0     1.34334  0.00   
+  4  7    3    -5   2318.8860  2393.1905  180.0   1.34405  0.00   
+  4  1    5    -2   2870.4485  2804.6259  180.0   1.34289  0.00   
+  4  2    4    4    284.3693   204.8344   -180.0  1.33845  0.00   
+  4  2    4    -6   5900.8938  4278.1404  180.0   1.33544  0.00   
+  4  8    2    -2   223.3683   192.3915   0.0     1.33271  0.00   
+  4  8    2    -6   110.3665   116.8197   0.0     1.32797  0.00   
+  4  8    0    0    119739.8316 126741.6843 0.0     1.32634  0.00   
+  4  4    2    5    12241.0704 12813.0878 0.0     1.32419  0.00   
+  4  4    4    2    106181.8748 113935.1500 0.0     1.32157  0.00   
+  4  0    2    8    320.7775   368.4296   180.0   1.31677  0.00   
+  4  4    4    -6   105062.9337 120764.9996 0.0     1.31695  0.00   
+  4  3    3    5    1083.3043  1245.7871  -0.0    1.31725  0.00   
+  4  4    2    -9   4845.6469  5527.4645  180.0   1.31609  0.00   
+  4  8    0    -8   121156.0685 139298.5816 -0.0    1.31704  0.00   
+  4  3    3    -8   7562.7663  7103.8611  180.0   1.31168  0.00   
+  4  7    3    -1   1065.8428  1033.1476  180.0   1.31217  0.00   
+  4  1    1    8    183.9969   157.0065   180.0   1.31024  0.00   
+  4  1    1    -9   974.6043   715.4446   180.0   1.30784  0.00   
+  4  1    5    2    2385.5718  1740.2895  180.0   1.30770  0.00   
+  4  1    5    -3   10308.1650 7329.8703  -0.0    1.30700  0.00   
+  4  7    3    -6   10535.5412 7549.3128  -0.0    1.30723  0.00   
+  4  6    4    -3   2838.6817  2359.8971  -0.0    1.29963  0.00   
+  4  9    1    -4   1034.9589  841.6525   0.0     1.30030  0.00   
+  4  9    1    -5   304.7984   257.0573   0.0     1.29906  0.00   
+  4  7    1    2    4672.4760  3973.2248  -180.0  1.29857  0.00   
+  4  3    5    -1   730.4803   623.7421   0.0     1.29645  0.00   
+  4  3    5    -2   2583.9825  2194.6100  -0.0    1.29604  0.00   
+  4  5    3    3    395.8740   335.5558   180.0   1.29592  0.00   
+  4  6    4    -2   28.9563    25.6557    0.0     1.29209  0.00   
+  4  4    0    6    19546.1361 18457.9678 180.0   1.29069  0.00   
+  4  6    4    -4   7480.0317  7150.3866  -0.0    1.29046  0.00   
+  4  8    2    -1   9358.3623  8926.3544  180.0   1.29051  0.00   
+  4  5    3    -8   3299.9142  3487.9767  180.0   1.28846  0.00   
+  4  7    1    -9   124.5778   133.2219   180.0   1.28810  0.00   
+  4  2    2    7    15036.4118 16132.0134 -0.0    1.28797  0.00   
+  4  2    2    -9   17796.0421 19772.4866 0.0     1.28370  0.00   
+  4  8    2    -7   387.7377   429.9160   -180.0  1.28407  0.00   
+  4  9    1    -3   5004.4363  5511.7443  180.0   1.28492  0.00   
+  4  4    0    -10  18195.8788 20663.2288 -180.0  1.28212  0.00   
+  4  3    5    0    620.9775   722.7977   -0.0    1.28041  0.00   
+  4  9    1    -6   161.9463   186.6873   -0.0    1.28133  0.00   
+  4  6    2    3    0.3277     0.3811     180.0   1.28055  0.00   
+  4  3    5    -3   5194.6475  6055.8158  -0.0    1.27923  0.00   
+  4  0    4    6    103.3834   118.7931   180.0   1.27420  0.00   
+  4  6    2    -9   393.7876   465.5651   180.0   1.27115  0.00   
+  4  6    4    -1   397.8794   482.3971   -180.0  1.26868  0.00   
+  4  6    4    -5   503.6962   582.4177   -180.0  1.26561  0.00   
+  4  5    1    5    4004.5797  4611.0614  180.0   1.26549  0.00   
+  4  6    0    4    6256.4030  7261.8554  180.0   1.26573  0.00   
+  4  7    3    0    744.3224   803.3752   180.0   1.26387  0.00   
+  4  1    3    7    7768.5771  8425.0002  -0.0    1.26063  0.00   
+  4  1    5    3    31.3603    35.3370    180.0   1.25912  0.00   
+  4  1    3    -8   2748.5072  3098.0510  180.0   1.25875  0.00   
+  4  1    5    -4   2776.2465  3108.3397  180.0   1.25824  0.00   
+  4  7    3    -7   2196.4576  2425.1160  180.0   1.25770  0.00   
+  4  5    1    -10  6728.6174  7049.3284  -180.0  1.25604  0.00   
+  4  6    0    -10  116.1147   117.7654   -180.0  1.25515  0.00   
+  4  3    1    7    1701.8665  1612.3476  -0.0    1.25338  0.00   
+  4  9    1    -2   364.4918   362.0494   0.0     1.25462  0.00   
+  4  3    5    1    9376.9652  8362.0871  0.0     1.24968  0.00   
+  4  4    4    3    18.0909    16.4611    0.0     1.24880  0.00   
+  4  9    1    -7   9684.5467  8740.6456  -180.0  1.24906  0.00   
+  4  3    5    -4   1160.9692  1094.7657  -0.0    1.24785  0.00   
+  4  3    1    -10  3089.1695  2988.3394  180.0   1.24712  0.00   
+  4  2    4    5    1209.6250  1152.6329  0.0     1.24756  0.00   
+  4  2    4    -7   774.2027   792.0635   0.0     1.24464  0.00   
+  4  4    4    -7   6356.7630  6549.1904  -0.0    1.24393  0.00   
+  4  2    0    8    26.7786    27.7310    -0.0    1.24185  0.00   
+  4  2    0    -10  2109.4533  2005.3709  180.0   1.23753  0.00   
+  4  8    2    0    781.0604   732.9650   180.0   1.23725  0.00   
+  4  6    4    0    16955.0885 14166.3731 -0.0    1.23188  0.00   
+  4  8    2    -8   643.4343   628.2707   180.0   1.22970  0.00   
+  4  6    4    -6   122.6446   129.8084   -180.0  1.22767  0.00   
+  4  9    1    -1   3360.0244  2739.1076  -0.0    1.21242  0.00   
+  4  3    3    6    1021.3794  849.7648   0.0     1.20953  0.00   
+  4  4    2    6    494.2204   411.8534   -0.0    1.20817  0.00   
+  4  7    1    3    87.8793    73.2733    180.0   1.20880  0.00   
+  4  3    5    2    4520.3552  3751.2810  0.0     1.20730  0.00   
+  4  5    3    4    9105.4811  7536.3316  -180.0  1.20644  0.00   
+  4  7    3    1    3308.0249  2739.0596  180.0   1.20680  0.00   
+  4  3    5    -5   58.4480    48.9052    180.0   1.20499  0.00   
+  4  3    3    -9   1124.4761  946.3437   -0.0    1.20455  0.00   
+  4  9    1    -8   2790.4914  2323.6447  0.0     1.20542  0.00   
+  4  1    5    4    4406.9587  3945.7493  180.0   1.20201  0.00   
+  4  4    2    -10  179.3582   165.7189   -0.0    1.20113  0.00   
+  4  1    5    -5   709.2981   658.0206   0.0     1.20103  0.00   
+  4  7    3    -8   5.6579     5.4469     0.0     1.19990  0.00   
+  4  5    3    -9   308.2038   300.8905   180.0   1.19932  0.00   
+  4  7    1    -10  8424.1812  8303.3471  -180.0  1.19881  0.00   
+  4  0    2    9    364.4479   269.5198   -0.0    1.18896  0.00   
+  4  5    5    -2   4102.7532  3032.8365  -0.0    1.18912  0.00   
+  4  5    5    -3   0.1365     0.1013     -0.0    1.18859  0.00   
+  4  6    2    4    351.0060   267.9725   180.0   1.18762  0.00   
+  4  10   0    -4   8978.9429  6799.2490  0.0     1.18782  0.00   
+  4  10   0    -6   13103.3720 11101.1633 0.0     1.18572  0.00   
+  4  6    4    1    1512.9901  1321.7259  0.0     1.18510  0.00   
+  4  0    4    7    301.7880   286.3156   180.0   1.18192  0.00   
+  4  6    4    -7   1816.1781  1789.0894  0.0     1.18011  0.00   
+  4  6    2    -10  2.1817     2.2223     -0.0    1.17887  0.00   
+  4  1    1    9    116.9930   122.6223   -0.0    1.17791  0.00   
+  4  8    0    2    30210.2800 31220.8212 180.0   1.17837  0.00   
+  4  5    5    -1   6759.6114  7332.3903  -180.0  1.17692  0.00   
+  4  1    1    -10  682.1621   763.1089   180.0   1.17597  0.00   
+  4  8    2    1    5461.2561  5832.8061  -180.0  1.17735  0.00   
+  4  5    5    -4   4929.0765  5571.7291  -0.0    1.17538  0.00   
+  4  4    4    4    29704.7266 33802.0952 0.0     1.17421  0.00   
+  4  4    4    -8   27637.2319 28621.5898 -180.0  1.16936  0.00   
+  4  8    2    -9   8153.2398  8422.9400  180.0   1.16922  0.00   
+  4  8    0    -10  37418.6238 38278.1410 0.0     1.16862  0.00   
+  4  2    2    8    99.4831    100.3637   0.0     1.16783  0.00   
+  4  2    2    -10  565.9596   559.8646   -0.0    1.16424  0.00   
+  4  2    4    6    15995.2960 13795.2627 180.0   1.16077  0.00   
+  4  9    1    0    195.7040   175.9851   180.0   1.16197  0.00   
+  4  2    4    -8   2900.9398  2419.5319  0.0     1.15802  0.00   
+  4  3    5    3    3749.1829  3138.2953  0.0     1.15688  0.00   
+  4  5    1    6    60.3418    50.4263    0.0     1.15718  0.00   
+  4  3    5    -6   60.9973    51.9951    -0.0    1.15426  0.00   
+  4  9    1    -9   663.7626   565.9331   180.0   1.15406  0.00   
+  4  1    3    8    3232.8100  2762.9987  0.0     1.15308  0.00   
+  4  5    5    0    7812.7502  6676.9914  -0.0    1.15311  0.00   
+  4  1    3    -9   1.5622     1.3349     -0.0    1.15145  0.00   
+  4  5    5    -5   9932.1858  8525.8413  -180.0  1.15071  0.00   
+  4  5    1    -11  1735.5224  1514.2809  0.0     1.14899  0.00   
+  4  9    3    -4   483.1532   427.3228   0.0     1.14629  0.00   
+  4  0    6    0    2895.2819  2615.5401  -0.0    1.14465  0.00   
+  4  9    3    -5   72.9624    64.9448    -0.0    1.14543  0.00   
+  4  7    3    2    5476.5700  4901.6765  -0.0    1.14510  0.00   
+  4  0    0    10   469.7342   424.1488   -0.0    1.14061  0.00   
+  4  1    5    5    5615.4242  5051.9554  -0.0    1.14045  0.00   
+  4  10   0    -2   17434.1353 15994.2642 0.0     1.14128  0.00   
+  4  1    5    -6   6066.1717  5316.7856  180.0   1.13942  0.00   
+  4  0    6    1    1906.8702  1651.7973  180.0   1.13893  0.00   
+  4  7    3    -9   5493.7803  4667.3076  180.0   1.13790  0.00   
+  4  3    1    8    78.9548    68.5373    180.0   1.13627  0.00   
+  4  10   0    -8   1664.5333  1449.5013  0.0     1.13572  0.00   
+  4  9    3    -3   1638.7690  1427.0322  -180.0  1.13571  0.00   
+  4  9    3    -6   2137.1630  1857.0308  -0.0    1.13323  0.00   
+  4  3    1    -11  36.9086    30.9608    0.0     1.13105  0.00   
+  4  6    4    2    3367.8886  2829.0009  0.0     1.13196  0.00   
+  4  6    4    -8   2297.1294  2100.5904  -0.0    1.12652  0.00   
+  4  10   2    -5   7049.4540  6273.0076  0.0     1.12713  0.00   
+  4  8    4    -4   4481.7221  4167.9645  -180.0  1.12601  0.00   
+  4  2    6    -1   3664.0290  3572.9337  180.0   1.12415  0.00   
+  4  7    1    4    5056.9873  4926.0778  -0.0    1.12430  0.00   
+  4  0    6    2    1330.5228  1379.3367  -180.0  1.12227  0.00   
+  4  5    3    5    1896.6458  1970.5581  -180.0  1.12222  0.00   
+  4  10   2    -4   8.8627     9.0494     180.0   1.12256  0.00   
+  4  8    4    -3   3107.5798  3323.0752  -180.0  1.12127  0.00   
+  4  10   2    -6   160.3322   172.4634   180.0   1.12078  0.00   
+  4  5    5    1    654.2548   712.2485   0.0     1.11974  0.00   
+  4  8    4    -5   949.3100   1032.3692  180.0   1.11986  0.00   
+  4  2    6    0    4905.3939  5322.4758  180.0   1.11890  0.00   
+  4  2    6    -2   927.1866   994.3573   180.0   1.11855  0.00   
+  4  5    5    -6   2615.6887  2508.4811  0.0     1.11667  0.00   
+  4  5    3    -10  1716.5325  1596.9477  -0.0    1.11562  0.00   
+  4  7    1    -11  2291.4325  2083.8079  180.0   1.11504  0.00   
+  4  3    3    7    8357.6054  7164.3298  0.0     1.11376  0.00   
+  4  9    3    -2   2268.0489  2020.5894  0.0     1.11462  0.00   
+  4  8    2    2    135.8207   120.7256   0.0     1.11458  0.00   
+  4  9    3    -7   2165.4331  1752.2705  -180.0  1.11072  0.00   
+  4  3    3    -10  317.2785   264.2304   -0.0    1.10935  0.00   
+  4  4    2    7    10776.2730 9265.6668  0.0     1.10753  0.00   
+  4  8    2    -10  41.4765    36.5514    0.0     1.10631  0.00   
+  4  10   2    -3   40826.5523 35155.7336 -180.0  1.10745  0.00   
+  4  9    1    1    4359.3891  3807.3992  -180.0  1.10676  0.00   
+  4  8    4    -2   33186.1678 29375.1685 -180.0  1.10604  0.00   
+  4  2    6    1    29637.0445 27649.7218 -180.0  1.10326  0.00   
+  4  10   2    -7   38103.5824 34974.9980 0.0     1.10405  0.00   
+  4  8    4    -6   32365.5184 30158.4734 0.0     1.10333  0.00   
+  4  2    6    -3   31692.8738 29925.8627 0.0     1.10259  0.00   
+  4  4    2    -11  2259.0827  2173.9599  -0.0    1.10143  0.00   
+  4  3    5    4    73.7008    70.5133    0.0     1.10185  0.00   
+  4  6    2    5    138338.8131 132168.0212 -180.0  1.10194  0.00   
+  4  4    4    5    2796.9686  2698.4902  180.0   1.10116  0.00   
+  4  3    5    -7   3014.7727  2941.2963  0.0     1.09909  0.00   
+  4  9    1    -10  286.2793   280.1095   0.0     1.09842  0.00   
+  4  0    4    8    134535.1882 133981.2566 -180.0  1.09689  0.00   
+  4  4    4    -9   134.0072   134.2336   0.0     1.09649  0.00   
+  4  0    6    3    3388.0182  3404.3078  -0.0    1.09606  0.00   
+  4  6    2    -11  152994.3547 149862.1931 -180.0  1.09395  0.01   
+  4  9    3    -1   997.7906   1114.9248  0.0     1.08472  0.00   
+  4  0    2    10   115.2997   133.8813   0.0     1.08246  0.00   
+  4  10   2    -2   764.9270   879.5887   -0.0    1.08304  0.00   
+  4  7    3    3    5128.0322  5996.8924  180.0   1.08212  0.00   
+  4  8    4    -1   5.5387     6.5208     0.0     1.08156  0.00   
+  4  2    4    7    119.8232   143.6971   180.0   1.08007  0.00   
+  4  9    3    -8   13.9312    16.9827    180.0   1.07970  0.00   
+  4  5    5    2    4290.8647  5313.2455  0.0     1.07932  0.00   
+  4  2    6    2    378.6191   479.4050   0.0     1.07849  0.00   
+  4  2    4    -9   983.1253   1304.1589  -180.0  1.07754  0.00   
+  4  1    5    6    5724.2513  7502.1332  180.0   1.07772  0.00   
+  4  2    6    -4   2382.6735  3161.0844  -0.0    1.07754  0.00   
+  4  10   2    -8   236.8140   301.8089   0.0     1.07827  0.00   
+  4  8    4    -7   678.0715   885.9156   -0.0    1.07776  0.00   
+  4  1    5    -7   7921.7231  11200.7018 0.0     1.07669  0.00   
+  4  5    5    -7   11.4366    16.4754    0.0     1.07578  0.00   
+  4  6    4    3    1056.9098  1519.8317  -180.0  1.07568  0.00   
+  4  7    3    -10  8750.0937  12275.5661 0.0     1.07494  0.00   
+  4  6    0    6    730.3604   879.7019   180.0   1.07295  0.00   
+  4  6    4    -9   783.7445   818.3390   -180.0  1.07009  0.00   
+  4  1    1    10   2467.5211  2600.3949  -180.0  1.06945  0.00   
+  4  11   1    -5   152.0229   157.0576   180.0   1.07073  0.00   
+  4  11   1    -6   5.4160     5.6848     -180.0  1.06988  0.00   
+  4  4    6    -2   2383.3624  2493.4475  -180.0  1.06868  0.00   
+  4  1    1    -11  39.2991    42.1000    0.0     1.06784  0.00   
+  4  7    5    -3   1273.5177  1332.3527  -180.0  1.06865  0.00   
+  4  4    0    8    22459.0960 23538.6581 -0.0    1.06844  0.00   
+  4  7    5    -4   159.5789   168.7888   180.0   1.06812  0.00   
+  4  2    2    9    21524.5589 24390.1592 -0.0    1.06659  0.00   
+  4  6    0    -12  2524.4355  2934.1980  -180.0  1.06465  0.00   
+  4  4    6    -1   1.7500     2.0408     -0.0    1.06432  0.00   
+  4  2    2    -11  18055.6374 21016.5666 -180.0  1.06355  0.00   
+  4  4    6    -3   2427.9760  2830.7068  180.0   1.06372  0.00   
+  4  4    0    -12  24937.8901 28284.0182 -180.0  1.06236  0.00   
+  4  5    1    7    2816.0810  3264.9405  0.0     1.06328  0.00   
+  4  0    6    4    1480.6273  1674.6879  0.0     1.06226  0.00   
+  4  11   1    -4   4525.8387  5116.2715  0.0     1.06224  0.00   
+  4  1    3    9    1490.4381  1611.5969  0.0     1.05980  0.00   
+  4  10   0    0    745.0959   820.0000   0.0     1.06107  0.00   
+  4  7    5    -2   1.5190     1.6452     -0.0    1.05992  0.00   
+  4  11   1    -7   61.2219    66.1688    -180.0  1.05976  0.00   
+  4  1    3    -10  2217.2054  2358.9910  0.0     1.05838  0.00   
+  4  7    5    -5   3655.4967  3888.9960  -180.0  1.05835  0.00   
+  4  5    1    -12  1917.9034  2095.6591  -180.0  1.05617  0.00   
+  4  10   0    -10  4258.5181  4657.4859  0.0     1.05364  0.00   
+  4  4    6    0    1530.6050  1593.6779  0.0     1.05098  0.00   
+  4  8    2    3    20938.7030 22562.3961 180.0   1.05182  0.00   
+  4  10   2    -1   55305.5281 57970.1040 0.0     1.05113  0.00   
+  4  4    6    -4   1189.4175  1172.3456  0.0     1.04981  0.00   
+  4  8    4    0    63672.2411 62179.2569 -180.0  1.04963  0.00   
+  4  9    1    2    135.0397   132.5823   -0.0    1.04974  0.00   
+  4  9    3    0    2575.9890  2357.8098  0.0     1.04814  0.00   
+  4  2    6    3    62286.2225 55933.9917 -180.0  1.04639  0.00   
+  4  7    1    5    1140.1910  1024.0070  0.0     1.04644  0.00   
+  4  2    6    -5   62902.8905 56248.6950 -180.0  1.04524  0.00   
+  4  3    5    5    4086.3244  3649.2329  -0.0    1.04511  0.00   
+  4  10   2    -9   75209.6160 67309.6323 0.0     1.04533  0.00   
+  4  8    4    -8   75798.0048 67605.2429 -180.0  1.04501  0.00   
+  4  5    3    6    1579.1148  1400.7430  -180.0  1.04462  0.00   
+  4  8    2    -11  5.5390     4.8615     0.0     1.04372  0.00   
+  4  11   1    -3   30.7319    27.4309    180.0   1.04507  0.00   
+  4  3    5    -8   437.5924   382.6413   -0.0    1.04233  0.00   
+  4  7    5    -1   5322.3782  4658.8352  -180.0  1.04257  0.00   
+  4  9    3    -9   564.1420   493.2925   -180.0  1.04232  0.00   
+  4  9    1    -11  5625.8249  4944.7798  180.0   1.04133  0.00   
+  4  11   1    -8   6052.5254  5337.9279  0.0     1.04115  0.00   
+  4  7    5    -6   22.7458    20.5786    180.0   1.04009  0.00   
+  4  5    3    -11  173.4824   166.7868   -0.0    1.03858  0.00   
+  4  7    1    -12  564.4331   564.4186   -180.0  1.03797  0.00   
+  4  3    1    9    995.6411   984.3570   -180.0  1.03814  0.00   
+_reflns_number_total  1184
+_reflns_d_resolution_low    6.388
+_reflns_d_resolution_high   1.033
+
+# POWDER DATA TABLE
+_pd_meas_2theta_range_min  10.01313
+_pd_meas_2theta_range_max  119.99238
+_pd_meas_2theta_range_inc  0.02626
+_pd_proc_2theta_range_min  9.98829
+_pd_proc_2theta_range_max  119.96754
+_pd_proc_2theta_range_inc  0.02626
+_pd_proc_number_of_points  4189
+
+loop_
+   _pd_meas_intensity_total
+   _pd_calc_intensity_total
+   _pd_proc_intensity_bkg_calc
+   _pd_proc_ls_weight
+  2813         0            0           0         
+  2745         0            0           0         
+  2776         0            0           0         
+  2785         0            0           0         
+  2782         0            0           0         
+  2882         0            0           0         
+  2803         0            0           0         
+  2814         0            0           0         
+  2742         0            0           0         
+  2818         0            0           0         
+  2748         0            0           0         
+  2745         0            0           0         
+  2804         0            0           0         
+  2716         0            0           0         
+  2742         0            0           0         
+  2710         0            0           0         
+  2727         0            0           0         
+  2722         0            0           0         
+  2626         0            0           0         
+  2702         0            0           0         
+  2593         0            0           0         
+  2680         0            0           0         
+  2577         0            0           0         
+  2644         0            0           0         
+  2632         0            0           0         
+  2627         0            0           0         
+  2612         0            0           0         
+  2572         0            0           0         
+  2598         0            0           0         
+  2619         0            0           0         
+  2601         0            0           0         
+  2574         0            0           0         
+  2534         0            0           0         
+  2532         0            0           0         
+  2549         0            0           0         
+  2613         0            0           0         
+  2502         0            0           0         
+  2641         0            0           0         
+  2604         0            0           0         
+  2615         0            0           0         
+  2489         0            0           0         
+  2479         0            0           0         
+  2485         0            0           0         
+  2477         0            0           0         
+  2494         0            0           0         
+  2492         0            0           0         
+  2534         0            0           0         
+  2466         0            0           0         
+  2520         0            0           0         
+  2512         0            0           0         
+  2461         0            0           0         
+  2497         0            0           0         
+  2540         0            0           0         
+  2353         0            0           0         
+  2493         0            0           0         
+  2449         0            0           0         
+  2389         0            0           0         
+  2451         0            0           0         
+  2435         0            0           0         
+  2384         0            0           0         
+  2416         0            0           0         
+  2343         0            0           0         
+  2442         0            0           0         
+  2367         0            0           0         
+  2424         0            0           0         
+  2391         0            0           0         
+  2392         0            0           0         
+  2464         0            0           0         
+  2440         0            0           0         
+  2374         0            0           0         
+  2423         0            0           0         
+  2302         0            0           0         
+  2241         0            0           0         
+  2306         0            0           0         
+  2428         0            0           0         
+  2281         0            0           0         
+  2201         0            0           0         
+  2327         0            0           0         
+  2295         0            0           0         
+  2342         0            0           0         
+  2191         0            0           0         
+  2319         0            0           0         
+  2355         0            0           0         
+  2336         0            0           0         
+  2206         0            0           0         
+  2250         0            0           0         
+  2308         0            0           0         
+  2293         0            0           0         
+  2247         0            0           0         
+  2230         0            0           0         
+  2204         0            0           0         
+  2325         0            0           0         
+  2294         0            0           0         
+  2211         0            0           0         
+  2215         0            0           0         
+  2283         0            0           0         
+  2216         0            0           0         
+  2151         0            0           0         
+  2138         0            0           0         
+  2214         0            0           0         
+  2158         0            0           0         
+  2125         0            0           0         
+  2042         0            0           0         
+  2136         0            0           0         
+  2146         0            0           0         
+  2184         0            0           0         
+  2068         0            0           0         
+  2152         0            0           0         
+  2168         0            0           0         
+  2080         0            0           0         
+  2112         0            0           0         
+  2177         0            0           0         
+  2128         0            0           0         
+  2089         0            0           0         
+  2060         0            0           0         
+  2089         0            0           0         
+  2097         0            0           0         
+  2165         0            0           0         
+  2069         0            0           0         
+  2028         0            0           0         
+  2009         0            0           0         
+  2160         0            0           0         
+  2066         0            0           0         
+  2044         0            0           0         
+  2038         0            0           0         
+  2001         0            0           0         
+  2100         0            0           0         
+  2076         0            0           0         
+  1993         0            0           0         
+  1941         0            0           0         
+  2004         0            0           0         
+  2054         0            0           0         
+  1963         0            0           0         
+  2057         0            0           0         
+  1997         0            0           0         
+  2003         0            0           0         
+  2041         0            0           0         
+  1962         0            0           0         
+  1978         0            0           0         
+  2009         0            0           0         
+  1916         0            0           0         
+  2044         0            0           0         
+  1989         0            0           0         
+  1903         0            0           0         
+  1988         0            0           0         
+  1981         0            0           0         
+  1948         0            0           0         
+  1923         0            0           0         
+  1955         0            0           0         
+  1948         0            0           0         
+  1973         0            0           0         
+  1891         0            0           0         
+  1962         0            0           0         
+  1842         0            0           0         
+  1916         0            0           0         
+  1978         0            0           0         
+  1955         0            0           0         
+  1867         0            0           0         
+  2006         0            0           0         
+  1840         0            0           0         
+  1863         0            0           0         
+  1866         0            0           0         
+  1858         0            0           0         
+  1852         0            0           0         
+  1784         0            0           0         
+  1812         0            0           0         
+  1862         0            0           0         
+  1889         0            0           0         
+  1888         0            0           0         
+  1846         0            0           0         
+  1851         0            0           0         
+  1843         0            0           0         
+  1843         0            0           0         
+  1772         0            0           0         
+  1793         0            0           0         
+  1858         0            0           0         
+  1864         0            0           0         
+  1812         0            0           0         
+  1849         0            0           0         
+  1752         0            0           0         
+  1762         0            0           0         
+  1788         0            0           0         
+  1765         1694.6668    1694.1131   0.000566572 
+  1777         1691.32582   1690.7553   0.000562746 
+  1844         1687.99244   1687.40419  0.000542299 
+  1709         1684.66675   1684.05973  0.000585138 
+  1756         1681.34882   1680.72193  0.000569476 
+  1778         1678.039     1677.39077  0.00056243 
+  1673         1674.73685   1674.06625  0.000597729 
+  1710         1671.44275   1670.74834  0.000584795 
+  1722         1668.15696   1667.43704  0.00058072 
+  1744         1664.87936   1664.13234  0.000573394 
+  1713         1661.61024   1660.83422  0.000583771 
+  1749         1658.34979   1657.54268  0.000571755 
+  1715         1655.09822   1654.2577   0.00058309 
+  1777         1651.85579   1650.97928  0.000562746 
+  1788         1648.62278   1647.70739  0.000559284 
+  1684         1645.39951   1644.44204  0.000593824 
+  1777         1642.18639   1641.18321  0.000562746 
+  1760         1638.98385   1637.93088  0.000568182 
+  1699         1635.79244   1634.68505  0.000588582 
+  1604         1632.61279   1631.44571  0.000623441 
+  1682         1629.44565   1628.21284  0.00059453 
+  1583         1626.29191   1624.98644  0.000631712 
+  1707         1623.15268   1621.76649  0.000585823 
+  1713         1620.02926   1618.55299  0.000583771 
+  1631         1616.92331   1615.34591  0.000613121 
+  1677         1613.83706   1612.14525  0.000596303 
+  1611         1610.77261   1608.95101  0.000620732 
+  1677         1607.73342   1605.76316  0.000596303 
+  1694         1604.7238    1602.5817   0.000590319 
+  1548         1601.74904   1599.40661  0.000645995 
+  1698         1598.81671   1596.23789  0.000588928 
+  1643         1595.93709   1593.07553  0.000608643 
+  1610         1593.12513   1589.91951  0.000621118 
+  1673         1590.40219   1586.76982  0.000597729 
+  1574         1587.80325   1583.62646  0.000635324 
+  1632         1585.38894   1580.4894   0.000612745 
+  1690         1583.27544   1577.35865  0.000591716 
+  1548         1581.6874    1574.23419  0.000645995 
+  1611         1580.96045   1571.116    0.000620732 
+  1608         1581.03459   1568.00409  0.000621891 
+  1600         1581.48806   1564.89843  0.000625  
+  1622         1583.45571   1561.79902  0.000616523 
+  1668         1587.378     1558.70585  0.00059952 
+  1587         1591.35583   1555.6189   0.00063012 
+  1629         1597.42391   1552.53816  0.000613874 
+  1649         1606.3412    1549.46363  0.000606428 
+  1707         1617.01225   1546.39529  0.000585823 
+  1688         1632.70884   1543.33314  0.000592417 
+  1743         1651.28677   1540.27715  0.000573723 
+  1830         1671.29581   1537.22733  0.000546448 
+  1811         1676.15624   1534.18366  0.000552181 
+  1703         1655.40901   1531.14613  0.000587199 
+  1647         1622.24397   1528.11473  0.000607165 
+  1655         1594.11104   1525.08945  0.00060423 
+  1605         1576.787     1522.07028  0.000623053 
+  1587         1564.72102   1519.05721  0.00063012 
+  1565         1554.60379   1516.05022  0.000638978 
+  1563         1546.62384   1513.04931  0.000639795 
+  1515         1540.89554   1510.05447  0.000660066 
+  1481         1533.94076   1507.06568  0.000675219 
+  1553         1524.72969   1504.08294  0.000643915 
+  1520         1515.67803   1501.10623  0.000657895 
+  1517         1508.52019   1498.13555  0.000659196 
+  1563         1503.11196   1495.17088  0.000639795 
+  1517         1498.68468   1492.21222  0.000659196 
+  1464         1494.77397   1489.25955  0.00068306 
+  1539         1491.15726   1486.31286  0.000649773 
+  1574         1487.72658   1483.37215  0.000635324 
+  1482         1484.42372   1480.4374   0.000674764 
+  1526         1481.21401   1477.5086   0.000655308 
+  1558         1478.07541   1474.58574  0.000641849 
+  1483         1474.99325   1471.66882  0.000674309 
+  1469         1471.95747   1468.75781  0.000680735 
+  1511         1468.96101   1465.85272  0.000661813 
+  1461         1465.99887   1462.95353  0.000684463 
+  1522         1463.06754   1460.06022  0.00065703 
+  1506         1460.1646    1457.1728   0.000664011 
+  1416         1457.2885    1454.29125  0.000706215 
+  1431         1454.43844   1451.41555  0.000698812 
+  1466         1451.61432   1448.54571  0.000682128 
+  1443         1448.8167    1445.6817   0.000693001 
+  1489         1446.04695   1442.82353  0.000671592 
+  1470         1443.30739   1439.97117  0.000680272 
+  1502         1440.60168   1437.12462  0.000665779 
+  1407         1437.93549   1434.28388  0.000710732 
+  1489         1435.31794   1431.44891  0.000671592 
+  1442         1432.76495   1428.61973  0.000693481 
+  1479         1430.30671   1425.79632  0.000676133 
+  1490         1427.99934   1422.97866  0.000671141 
+  1411         1425.91817   1420.16676  0.000708717 
+  1422         1424.02608   1417.36059  0.000703235 
+  1400         1422.32656   1414.56014  0.000714286 
+  1431         1421.07347   1411.76542  0.000698812 
+  1448         1419.97043   1408.97641  0.000690608 
+  1461         1419.22549   1406.19309  0.000684463 
+  1425         1419.45091   1403.41546  0.000701754 
+  1438         1419.4378    1400.64351  0.00069541 
+  1424         1420.92237   1397.87723  0.000702247 
+  1440         1423.18093   1395.1166   0.000694444 
+  1397         1424.92567   1392.36163  0.00071582 
+  1477         1423.42098   1389.61229  0.000677048 
+  1453         1416.51909   1386.86858  0.000688231 
+  1431         1408.44844   1384.13049  0.000698812 
+  1406         1402.25874   1381.398    0.000711238 
+  1380         1398.7376    1378.67112  0.000724638 
+  1410         1396.99403   1375.94983  0.00070922 
+  1353         1396.42886   1373.23411  0.000739098 
+  1381         1396.74794   1370.52396  0.000724113 
+  1470         1397.72809   1367.81938  0.000680272 
+  1384         1399.16247   1365.12034  0.000722543 
+  1337         1400.87858   1362.42684  0.000747943 
+  1412         1402.85516   1359.73888  0.000708215 
+  1364         1405.20625   1357.05643  0.000733138 
+  1399         1407.9463    1354.37949  0.000714796 
+  1413         1410.66248   1351.70806  0.000707714 
+  1404         1412.40958   1349.04212  0.000712251 
+  1380         1412.09464   1346.38165  0.000724638 
+  1391         1409.16445   1343.72666  0.000718907 
+  1316         1403.992     1341.07713  0.000759878 
+  1377         1397.62327   1338.43306  0.000726216 
+  1393         1391.14241   1335.79443  0.000717875 
+  1384         1385.12976   1333.16123  0.000722543 
+  1340         1379.49241   1330.53345  0.000746269 
+  1447         1373.70929   1327.91109  0.000691085 
+  1372         1367.33087   1325.29413  0.000728863 
+  1348         1360.34847   1322.68256  0.00074184 
+  1394         1353.16056   1320.07639  0.00071736 
+  1322         1346.28509   1317.47558  0.00075643 
+  1292         1340.13017   1314.88015  0.000773994 
+  1336         1334.88817   1312.29006  0.000748503 
+  1370         1330.3633    1309.70533  0.000729927 
+  1255         1326.60293   1307.12594  0.000796813 
+  1253         1323.9591    1304.55187  0.000798085 
+  1363         1321.91453   1301.98312  0.000733676 
+  1302         1320.31706   1299.41968  0.000768049 
+  1337         1320.13218   1296.86154  0.000747943 
+  1304         1320.50014   1294.30869  0.000766871 
+  1375         1322.0653    1291.76112  0.000727273 
+  1323         1322.72221   1289.21882  0.000755858 
+  1280         1318.9057    1286.68178  0.00078125 
+  1316         1309.96387   1284.15     0.000759878 
+  1243         1300.09977   1281.62346  0.000804505 
+  1266         1292.02049   1279.10215  0.000789889 
+  1282         1286.31829   1276.58606  0.000780031 
+  1278         1282.01284   1274.0752   0.000782473 
+  1317         1278.41054   1271.56953  0.000759301 
+  1289         1275.17927   1269.06907  0.000775795 
+  1306         1272.16711   1266.57379  0.000765697 
+  1261         1269.2987    1264.08369  0.000793021 
+  1242         1266.53253   1261.59876  0.000805153 
+  1227         1263.84842   1259.11898  0.000814996 
+  1235         1261.22215   1256.64436  0.000809717 
+  1291         1258.65069   1254.17488  0.000774593 
+  1227         1256.12376   1251.71053  0.000814996 
+  1243         1253.64007   1249.2513   0.000804505 
+  1214         1251.19826   1246.79718  0.000823723 
+  1219         1248.79775   1244.34817  0.000820345 
+  1256         1246.43944   1241.90426  0.000796178 
+  1231         1244.12641   1239.46543  0.000812348 
+  1276         1241.86308   1237.03167  0.000783699 
+  1227         1239.65511   1234.60298  0.000814996 
+  1253         1237.51032   1232.17936  0.000798085 
+  1198         1235.43966   1229.76078  0.000834725 
+  1304         1233.45709   1227.34724  0.000766871 
+  1166         1231.58066   1224.93873  0.000857633 
+  1200         1229.83328   1222.53524  0.000833333 
+  1181         1228.24305   1220.13677  0.00084674 
+  1212         1226.843     1217.7433   0.000825083 
+  1231         1225.67045   1215.35482  0.000812348 
+  1229         1224.76711   1212.97133  0.00081367 
+  1172         1224.1809    1210.59282  0.000853242 
+  1178         1223.97653   1208.21927  0.000848896 
+  1221         1224.15559   1205.85069  0.000819001 
+  1201         1224.69467   1203.48705  0.000832639 
+  1174         1225.46437   1201.12835  0.000851789 
+  1176         1226.26198   1198.77459  0.00085034 
+  1188         1226.9754    1196.42575  0.000841751 
+  1141         1227.60084   1194.08182  0.000876424 
+  1167         1228.09222   1191.7428   0.000856898 
+  1154         1228.11085   1189.40867  0.000866551 
+  1206         1226.98254   1187.07943  0.000829187 
+  1195         1224.06232   1184.75507  0.00083682 
+  1213         1219.22817   1182.43558  0.000824402 
+  1178         1212.99097   1180.12095  0.000848896 
+  1220         1206.16368   1177.81117  0.000819672 
+  1137         1199.45083   1175.50624  0.000879507 
+  1131         1193.25287   1173.20614  0.000884173 
+  1186         1187.69815   1170.91086  0.00084317 
+  1157         1182.75857   1168.62041  0.000864304 
+  1106         1178.34485   1166.33475  0.000904159 
+  1118         1174.35768   1164.0539   0.000894454 
+  1146         1170.70824   1161.77784  0.0008726 
+  1087         1167.32395   1159.50656  0.000919963 
+  1175         1164.14784   1157.24006  0.000851064 
+  1085         1161.13594   1154.97831  0.000921659 
+  1101         1158.25461   1152.72133  0.000908265 
+  1068         1155.47819   1150.46909  0.00093633 
+  1151         1152.78691   1148.22158  0.00086881 
+  1135         1150.16557   1145.97881  0.000881057 
+  1078         1147.60658   1143.74076  0.000927644 
+  1177         1145.09211   1141.50742  0.000849618 
+  1142         1142.62119   1139.27879  0.000875657 
+  1138         1140.18363   1137.05485  0.000878735 
+  1143         1137.77972   1134.83559  0.000874891 
+  1098         1135.39981   1132.62101  0.000910747 
+  1124         1133.0439    1130.41111  0.00088968 
+  1121         1130.7176    1128.20586  0.000892061 
+  1173         1128.40148   1126.00527  0.000852515 
+  1085         1126.10629   1123.80932  0.000921659 
+  1106         1123.82291   1121.618    0.000904159 
+  1137         1121.55384   1119.43131  0.000879507 
+  1176         1119.29801   1117.24924  0.00085034 
+  1045         1117.0545    1115.07178  0.000956938 
+  1063         1114.82252   1112.89892  0.000940734 
+  1091         1112.6014    1110.73065  0.00091659 
+  1074         1110.39082   1108.56696  0.000931099 
+  1078         1108.18979   1106.40786  0.000927644 
+  1086         1105.99814   1104.25331  0.00092081 
+  1086         1103.8155    1102.10333  0.00092081 
+  1013         1101.64171   1099.9579   0.000987167 
+  1040         1099.47625   1097.81701  0.000961538 
+  1099         1097.31903   1095.68065  0.000909918 
+  1091         1095.16988   1093.54882  0.00091659 
+  1028         1093.02866   1091.42151  0.000972763 
+  1050         1090.89524   1089.2987   0.000952381 
+  1030         1088.76957   1087.1804   0.000970874 
+  1056         1086.65157   1085.06659  0.00094697 
+  1072         1084.54124   1082.95726  0.000932836 
+  1079         1082.43858   1080.8524   0.000926784 
+  1098         1080.34363   1078.75202  0.000910747 
+  1050         1078.25644   1076.65609  0.000952381 
+  1038         1076.17713   1074.56461  0.000963391 
+  1093         1074.10582   1072.47757  0.000914913 
+  1026         1072.04267   1070.39497  0.000974659 
+  1067         1069.98791   1068.31679  0.000937207 
+  986          1067.94178   1066.24304  0.001014199 
+  1037         1065.90459   1064.17369  0.00096432 
+  1057         1063.87671   1062.10874  0.000946074 
+  1032         1061.85858   1060.04818  0.000968992 
+  1038         1059.8507    1057.99201  0.000963391 
+  989          1057.8537    1055.94022  0.001011122 
+  1022         1055.86828   1053.89279  0.000978474 
+  1105         1053.89531   1051.84973  0.000904977 
+  1008         1051.93581   1049.81102  0.000992063 
+  1041         1049.99096   1047.77665  0.000960615 
+  1024         1048.06223   1045.74662  0.000976562 
+  1014         1046.15135   1043.72091  0.000986193 
+  1029         1044.26039   1041.69953  0.000971817 
+  1025         1042.39189   1039.68245  0.00097561 
+  1041         1040.54895   1037.66969  0.000960615 
+  1004         1038.73534   1035.66121  0.000996016 
+  1046         1036.95577   1033.65703  0.000956023 
+  1066         1035.2161    1031.65712  0.000938086 
+  1013         1033.52364   1029.66149  0.000987167 
+  967          1031.89223   1027.67012  0.001034126 
+  1029         1030.32492   1025.683    0.000971817 
+  1028         1028.84151   1023.70013  0.000972763 
+  920          1027.46435   1021.72151  0.001086957 
+  988          1026.21528   1019.74711  0.001012146 
+  1020         1025.13076   1017.77694  0.000980392 
+  966          1024.25578   1015.81098  0.001035197 
+  997          1023.64856   1013.84923  0.001003009 
+  997          1023.38319   1011.89169  0.001003009 
+  1029         1023.54875   1009.93833  0.000971817 
+  1014         1024.23607   1007.98916  0.000986193 
+  947          1025.52263   1006.04417  0.001055966 
+  993          1027.4012    1004.10334  0.001007049 
+  963          1029.66824   1002.16668  0.001038422 
+  1002         1031.81821   1000.23416  0.000998004 
+  953          1033.01767   998.3058    0.001049318 
+  1034         1032.48208   996.38157   0.000967118 
+  984          1029.88659   994.46147   0.00101626 
+  931          1025.53228   992.54549   0.001074114 
+  981          1020.08325   990.63362   0.001019368 
+  962          1014.28616   988.72587   0.001039501 
+  1004         1008.64958   986.82221   0.000996016 
+  1007         1003.43406   984.92264   0.000993049 
+  977          998.77821    983.02715   0.001023541 
+  957          994.6437     981.13574   0.001044932 
+  976          990.90256    979.2484    0.00102459 
+  944          987.403      977.36511   0.001059322 
+  950          984.11852    975.48588   0.001052632 
+  894          981.06825    973.6107    0.001118568 
+  969          978.24819    971.73955   0.001031992 
+  898          975.63629    969.87243   0.001113586 
+  925          973.17833    968.00933   0.001081081 
+  949          970.83366    966.15024   0.001053741 
+  935          968.57579    964.29516   0.001069519 
+  911          966.38673    962.44408   0.001097695 
+  925          964.25361    960.59699   0.001081081 
+  910          962.16679    958.75389   0.001098901 
+  919          960.11881    956.91476   0.001088139 
+  930          958.10387    955.0796    0.001075269 
+  916          956.11736    953.2484    0.001091703 
+  942          954.15556    951.42115   0.001061571 
+  887          952.21548    949.59785   0.001127396 
+  903          950.29469    947.77849   0.00110742 
+  948          948.39115    945.96306   0.001054852 
+  915          946.50322    944.15155   0.001092896 
+  868          944.62951    942.34396   0.001152074 
+  967          942.77487    940.54027   0.001034126 
+  958          940.92638    938.74049   0.001043841 
+  887          939.09218    936.9446    0.001127396 
+  955          937.26564    935.15259   0.00104712 
+  927          935.44915    933.36447   0.001078749 
+  893          933.64227    931.58021   0.001119821 
+  977          931.84458    929.79982   0.001023541 
+  937          930.05578    928.02329   0.001067236 
+  939          928.2756     926.2506    0.001064963 
+  894          926.50383    924.48176   0.001118568 
+  881          924.74033    922.71675   0.001135074 
+  943          922.985      920.95557   0.001060445 
+  936          921.23776    919.1982    0.001068376 
+  937          919.4986     917.44465   0.001067236 
+  937          917.76773    915.69491   0.001067236 
+  959          916.04482    913.94896   0.001042753 
+  945          914.33016    912.2068    0.001058201 
+  928          912.624      910.46842   0.001077586 
+  842          910.92634    908.73382   0.001187648 
+  862          909.23751    907.00299   0.001160093 
+  952          907.55782    905.27592   0.00105042 
+  852          905.88762    903.55261   0.001173709 
+  859          904.22735    901.83304   0.001164144 
+  890          902.57754    900.11721   0.001123596 
+  867          900.93884    898.40511   0.001153403 
+  872          899.31207    896.69674   0.001146789 
+  852          897.69925    894.99208   0.001173709 
+  886          896.09993    893.29114   0.001128668 
+  824          894.51656    891.5939    0.001213592 
+  893          892.95013    889.90036   0.001119821 
+  858          891.40277    888.2105    0.001165501 
+  882          889.87863    886.52433   0.001133787 
+  837          888.37608    884.84183   0.001194743 
+  858          886.90246    883.163     0.001165501 
+  845          885.45549    881.48784   0.001183432 
+  843          884.02615    879.81632   0.00118624 
+  856          882.61086    878.14845   0.001168224 
+  836          881.22763    876.48423   0.001196172 
+  900          879.89027    874.82363   0.001111111 
+  839          878.61426    873.16666   0.001191895 
+  827          877.41203    871.51331   0.00120919 
+  852          876.29453    869.86357   0.001173709 
+  807          875.27795    868.21743   0.001239157 
+  852          874.38568    866.57489   0.001173709 
+  900          873.6504     864.93595   0.001111111 
+  808          873.11765    863.30058   0.001237624 
+  789          872.8526     861.66879   0.001267427 
+  850          872.95149    860.04057   0.001176471 
+  881          873.56165    858.41592   0.001135074 
+  826          874.92203    856.79482   0.001210654 
+  878          877.45335    855.17727   0.001138952 
+  879          882.01481    853.56326   0.001137656 
+  885          890.63461    851.95278   0.001129944 
+  913          907.59727    850.34583   0.00109529 
+  924          934.71893    848.74241   0.001082251 
+  888          968.91006    847.1425    0.001126126 
+  950          1032.95428   845.54609   0.001052632 
+  1118         1098.73732   843.95319   0.000894454 
+  1196         1211.24303   842.36378   0.00083612 
+  1436         1344.30526   840.77785   0.000696379 
+  1742         1498.84125   839.19541   0.000574053 
+  1706         1500.46507   837.61644   0.000586166 
+  1432         1347.93576   836.04093   0.000698324 
+  1298         1195.67171   834.46889   0.000770416 
+  1055         1035.00725   832.9003    0.000947867 
+  925          942.7817     831.33515   0.001081081 
+  884          899.4625     829.77344   0.001131222 
+  847          876.84254    828.21517   0.001180638 
+  833          863.04685    826.66032   0.00120048 
+  802          853.60102    825.10889   0.001246883 
+  791          846.70584    823.56088   0.001264223 
+  843          841.32763    822.01626   0.00118624 
+  807          836.96393    820.47505   0.001239157 
+  821          833.30053    818.93723   0.001218027 
+  838          830.12288    817.4028    0.001193317 
+  821          827.30543    815.87174   0.001218027 
+  838          824.75934    814.34405   0.001193317 
+  866          822.43051    812.81974   0.001154734 
+  811          820.25896    811.29878   0.001233046 
+  789          818.22087    809.78117   0.001267427 
+  838          816.2968     808.26691   0.001193317 
+  831          814.46146    806.75598   0.001203369 
+  849          812.70606    805.24839   0.001177856 
+  778          811.02114    803.74413   0.001285347 
+  787          809.39991    802.24318   0.001270648 
+  794          807.83777    800.74555   0.001259446 
+  769          806.34939    799.25123   0.00130039 
+  805          804.89859    797.7602    0.001242236 
+  798          803.50814    796.27247   0.001253133 
+  796          802.17357    794.78802   0.001256281 
+  738          800.89587    793.30685   0.001355014 
+  847          799.68409    791.82896   0.001180638 
+  756          798.54564    790.35433   0.001322751 
+  810          797.49074    788.88297   0.001234568 
+  808          796.53309    787.41485   0.001237624 
+  794          795.69082    785.94999   0.001259446 
+  777          794.98839    784.48837   0.001287001 
+  763          794.45896    783.02998   0.001310616 
+  845          794.14777    781.57482   0.001183432 
+  788          794.11848    780.12288   0.001269036 
+  793          794.4626     778.67416   0.001261034 
+  784          795.31485    777.22864   0.00127551 
+  763          796.88294    775.78633   0.001310616 
+  774          799.50328    774.34722   0.00129199 
+  845          803.76373    772.91129   0.001183432 
+  818          810.80371    771.47855   0.001222494 
+  811          822.92104    770.04898   0.001233046 
+  850          844.25955    768.62259   0.001176471 
+  886          878.52109    767.19936   0.001128668 
+  905          916.92326    765.77929   0.001104972 
+  1010         966.07955    764.36237   0.000990099 
+  1153         1055.80983   762.9486    0.000867303 
+  1321         1158.76472   761.53796   0.000757002 
+  1372         1246.51631   760.13046   0.000728863 
+  1302         1307.54719   758.72608   0.000768049 
+  1140         1224.53989   757.32483   0.000877193 
+  945          1120.4834    755.92669   0.001058201 
+  915          1004.12524   754.53166   0.001092896 
+  760          906.01533    753.13973   0.001315789 
+  735          848.85556    751.75089   0.001360544 
+  821          817.04936    750.36514   0.001218027 
+  752          798.05938    748.98248   0.001329787 
+  746          785.59584    747.60289   0.001340483 
+  748          776.74764    746.22638   0.001336898 
+  731          770.09049    744.85293   0.001367989 
+  690          764.85026    743.48253   0.001449275 
+  789          760.56897    742.11519   0.001267427 
+  759          756.96147    740.7509    0.001317523 
+  732          753.84316    739.38964   0.00136612 
+  716          751.08949    738.03142   0.001396648 
+  808          748.61443    736.67622   0.001237624 
+  742          746.35739    735.32405   0.001347709 
+  729          744.2744     733.9749    0.001371742 
+  704          742.33331    732.62875   0.001420455 
+  698          740.51059    731.2856    0.001432665 
+  733          738.78862    729.94545   0.001364256 
+  716          737.15457    728.6083    0.001396648 
+  700          735.59923    727.27413   0.001428571 
+  712          734.11653    725.94293   0.001404494 
+  770          732.70294    724.61471   0.001298701 
+  737          731.35755    723.28946   0.001356852 
+  763          730.082      721.96717   0.001310616 
+  695          728.88092    720.64783   0.001438849 
+  744          727.76318    719.33144   0.001344086 
+  771          726.74079    718.018     0.001297017 
+  751          725.83439    716.70749   0.001331558 
+  711          725.07444    715.39991   0.00140647 
+  696          724.50834    714.09526   0.001436782 
+  720          724.21039    712.79353   0.001388889 
+  772          724.30803    711.49471   0.001295337 
+  751          725.03567    710.1988    0.001331558 
+  738          726.86479    708.90579   0.001355014 
+  703          730.70171    707.61567   0.001422475 
+  755          737.86798    706.32844   0.001324503 
+  713          747.90307    705.0441    0.001402525 
+  785          759.36232    703.76263   0.001273885 
+  837          780.01538    702.48404   0.001194743 
+  885          808.34614    701.20831   0.001129944 
+  932          831.4944     699.93545   0.001072961 
+  895          850.0013     698.66543   0.001117318 
+  875          833.19881    697.39827   0.001142857 
+  809          805.35101    696.13395   0.001236094 
+  760          776.54887    694.87246   0.001315789 
+  736          748.59836    693.61381   0.001358696 
+  712          731.43156    692.35798   0.001404494 
+  725          722.11487    691.10497   0.00137931 
+  702          717.03369    689.85478   0.001424501 
+  693          714.31349    688.60739   0.001443001 
+  695          713.1769     687.3628    0.001438849 
+  739          713.38248    686.12101   0.00135318 
+  679          715.04428    684.88202   0.001472754 
+  679          718.63775    683.6458    0.001472754 
+  709          725.26463    682.41237   0.001410437 
+  754          737.22286    681.18171   0.00132626 
+  747          758.54954    679.95382   0.001338688 
+  789          791.79029    678.72869   0.001267427 
+  838          829.45388    677.50631   0.001193317 
+  899          886.89397    676.28669   0.001112347 
+  1013         980.21184    675.06981   0.000987167 
+  1113         1063.87524   673.85567   0.000898473 
+  1282         1135.19598   672.64427   0.000780031 
+  1238         1116.85792   671.43559   0.000807754 
+  1069         1025.55228   670.22963   0.000935454 
+  913          939.64561    669.0264    0.00109529 
+  824          843.3109     667.82587   0.001213592 
+  728          776.9101     666.62805   0.001373626 
+  713          739.77274    665.43293   0.001402525 
+  662          718.65889    664.2405    0.001510574 
+  648          705.62153    663.05077   0.00154321 
+  661          696.86714    661.86371   0.001512859 
+  643          690.62356    660.67934   0.00155521 
+  698          685.98785    659.49763   0.001432665 
+  678          682.45929    658.3186    0.001474926 
+  678          679.74755    657.14222   0.001474926 
+  698          677.68615    655.9685    0.001432665 
+  669          676.1913     654.79743   0.001494768 
+  674          675.24399    653.62901   0.00148368 
+  657          674.89104    652.46322   0.00152207 
+  657          675.26962    651.30007   0.00152207 
+  637          676.67706    650.13955   0.001569859 
+  665          679.72695    648.98165   0.001503759 
+  676          685.56973    647.82636   0.00147929 
+  682          695.62385    646.67369   0.001466276 
+  708          708.8404     645.52363   0.001412429 
+  744          726.6118     644.37616   0.001344086 
+  737          757.64163    643.2313    0.001356852 
+  877          792.93796    642.08902   0.001140251 
+  924          827.10576    640.94932   0.001082251 
+  960          846.38173    639.81221   0.001041667 
+  919          846.3177     638.67767   0.001088139 
+  910          861.01451    637.5457    0.001098901 
+  996          874.09756    636.41629   0.001004016 
+  1027         908.10497    635.28944   0.00097371 
+  1156         942.21314    634.16514   0.000865052 
+  1051         956.42254    633.04339   0.000951475 
+  950          950.41658    631.92419   0.001052632 
+  855          887.27413    630.80752   0.001169591 
+  771          829.27436    629.69337   0.001297017 
+  688          772.15679    628.58176   0.001453488 
+  653          725.39451    627.47267   0.001531394 
+  622          698.26584    626.36609   0.001607717 
+  678          683.46201    625.26202   0.001474926 
+  613          675.0063     624.16046   0.001631321 
+  638          669.80697    623.06139   0.001567398 
+  586          666.26544    621.96482   0.001706485 
+  647          663.37343    620.87074   0.001545595 
+  671          660.39854    619.77915   0.001490313 
+  670          656.9177     618.69003   0.001492537 
+  645          652.86364    617.60339   0.001550388 
+  635          648.42502    616.51921   0.001574803 
+  632          643.89869    615.4375    0.001582278 
+  625          639.57281    614.35824   0.0016    
+  608          635.6343     613.28144   0.001644737 
+  629          632.14813    612.20709   0.001589825 
+  631          629.09731    611.13517   0.001584786 
+  627          626.42682    610.0657    0.001594896 
+  608          624.07314    608.99865   0.001644737 
+  626          621.97819    607.93404   0.001597444 
+  609          620.09411    606.87184   0.001642036 
+  610          618.38291    605.81207   0.001639344 
+  618          616.81567    604.7547    0.001618123 
+  632          615.37086    603.69974   0.001582278 
+  597          614.03306    602.64718   0.001675042 
+  621          612.79166    601.59702   0.001610306 
+  598          611.64067    600.54925   0.001672241 
+  616          610.57779    599.50386   0.001623377 
+  644          609.60508    598.46086   0.001552795 
+  622          608.72917    597.42023   0.001607717 
+  639          607.96249    596.38197   0.001564945 
+  645          607.32508    595.34608   0.001550388 
+  619          606.8489     594.31255   0.001615509 
+  593          606.58312    593.28138   0.001686341 
+  641          606.60713    592.25255   0.001560062 
+  698          607.05442    591.22608   0.001432665 
+  603          608.16775    590.20194   0.001658375 
+  661          610.42342    589.18014   0.001512859 
+  571          614.75235    588.16067   0.001751313 
+  595          622.66412    587.14352   0.001680672 
+  591          634.63886    586.1287    0.001692047 
+  604          649.28184    585.1162    0.001655629 
+  681          674.16637    584.106     0.001468429 
+  715          706.08124    583.09811   0.001398601 
+  780          730.04343    582.09252   0.001282051 
+  827          737.00884    581.08923   0.00120919 
+  740          713.12809    580.08823   0.001351351 
+  733          689.51051    579.08951   0.001364256 
+  675          663.22163    578.09308   0.001481481 
+  627          639.8843     577.09893   0.001594896 
+  678          629.17633    576.10704   0.001474926 
+  659          626.7557     575.11743   0.001517451 
+  633          626.16038    574.13007   0.001579779 
+  622          623.40678    573.14497   0.001607717 
+  645          615.43827    572.16213   0.001550388 
+  624          608.23223    571.18153   0.001602564 
+  638          600.60667    570.20318   0.001567398 
+  636          593.91746    569.22706   0.001572327 
+  662          589.64209    568.25318   0.001510574 
+  637          586.98501    567.28153   0.001569859 
+  651          585.23462    566.31209   0.001536098 
+  675          584.02226    565.34488   0.001481481 
+  719          583.17708    564.37988   0.001390821 
+  690          582.61229    563.4171    0.001449275 
+  733          582.26582    562.45651   0.001364256 
+  685          582.08936    561.49813   0.001459854 
+  688          582.02702    560.54194   0.001453488 
+  717          582.00271    559.58794   0.0013947 
+  705          581.99725    558.63612   0.00141844 
+  704          582.01759    557.68649   0.001420455 
+  688          582.18141    556.73904   0.001453488 
+  641          582.57485    555.79375   0.001560062 
+  646          583.27434    554.85063   0.001547988 
+  658          584.35478    553.90968   0.001519757 
+  628          585.82855    552.97088   0.001592357 
+  571          587.65676    552.03423   0.001751313 
+  596          589.7555     551.09973   0.001677852 
+  623          592.01201    550.16738   0.001605136 
+  665          594.32538    549.23716   0.001503759 
+  628          596.69221    548.30908   0.001592357 
+  590          599.30215    547.38313   0.001694915 
+  610          602.57854    546.4593    0.001639344 
+  613          607.2295     545.5376    0.001631321 
+  655          614.43166    544.61801   0.001526718 
+  625          626.1365     543.70053   0.0016    
+  666          644.7474     542.78515   0.001501502 
+  680          669.58837    541.87188   0.001470588 
+  648          703.84135    540.96071   0.00154321 
+  753          756.44667    540.05163   0.001328021 
+  852          807.94011    539.14463   0.001173709 
+  947          846.55403    538.23972   0.001055966 
+  969          851.50812    537.33689   0.001031992 
+  909          855.64335    536.43614   0.00110011 
+  1011         884.61333    535.53745   0.00098912 
+  1026         956.25239    534.64083   0.000974659 
+  1181         1131.86811   533.74627   0.00084674 
+  1399         1408.91981   532.85377   0.000714796 
+  1833         1866.19687   531.96332   0.000545554 
+  2623         2578.27608   531.07492   0.000381243 
+  3827         3443.36442   530.18856   0.000261301 
+  5119         4232.46793   529.30424   0.000195351 
+  4549         3842.77482   528.42195   0.000219829 
+  3113         3116.08451   527.5417    0.000321234 
+  2791         2606.64798   526.66346   0.000358295 
+  1745         1815.63877   525.78725   0.000573066 
+  979          1235.11583   524.91306   0.00102145 
+  846          956.23256    524.04088   0.001182033 
+  689          819.6372     523.1707    0.001451379 
+  621          742.03961    522.30253   0.001610306 
+  635          692.87585    521.43636   0.001574803 
+  632          659.7977     520.57218   0.001582278 
+  619          636.55134    519.70999   0.001615509 
+  600          619.68967    518.84979   0.001666667 
+  612          607.21356    517.99157   0.001633987 
+  635          597.90504    517.13533   0.001574803 
+  606          590.96726    516.28105   0.001650165 
+  612          585.81872    515.42875   0.001633987 
+  583          581.95529    514.57841   0.001715266 
+  646          578.87775    513.73003   0.001547988 
+  558          576.13469    512.88361   0.001792115 
+  566          573.44489    512.03913   0.001766784 
+  576          570.75614    511.19661   0.001736111 
+  578          568.18997    510.35602   0.001730104 
+  586          565.97082    509.51738   0.001706485 
+  562          564.36326    508.68066   0.001779359 
+  595          563.66383    507.84588   0.001680672 
+  583          564.21172    507.01302   0.001715266 
+  594          566.51546    506.18209   0.001683502 
+  627          571.64246    505.35307   0.001594896 
+  617          582.17394    504.52596   0.001620746 
+  633          603.37449    503.70076   0.001579779 
+  681          637.48812    502.87746   0.001468429 
+  738          676.98293    502.05607   0.001355014 
+  797          758.5848     501.23657   0.001254705 
+  842          852.75795    500.41896   0.001187648 
+  1078         913.31417    499.60324   0.000927644 
+  1083         877.2335     498.7894    0.000923361 
+  941          807.13978    497.97744   0.001062699 
+  840          766.83263    497.16736   0.001190476 
+  793          696.03725    496.35914   0.001261034 
+  659          649.02711    495.55279   0.001517451 
+  687          635.07644    494.74831   0.001455604 
+  639          641.08164    493.94568   0.001564945 
+  642          664.16846    493.14491   0.001557632 
+  694          706.71486    492.34598   0.001440922 
+  721          770.46785    491.5489    0.001386963 
+  915          855.28951    490.75367   0.001092896 
+  974          988.60624    489.96027   0.001026694 
+  1158         1126.83689   489.1687    0.000863558 
+  1287         1211.13703   488.37896   0.000777001 
+  1213         1191.52452   487.59105   0.000824402 
+  1090         1155.96948   486.80496   0.000917431 
+  1110         1169.12415   486.02069   0.000900901 
+  1095         1214.19395   485.23822   0.000913242 
+  1224         1334.7353    484.45757   0.000816993 
+  1626         1606.04399   483.67872   0.000615006 
+  2153         1975.4756    482.90168   0.000464468 
+  2596         2242.38574   482.12643   0.000385208 
+  2487         2263.49841   481.35297   0.000402091 
+  2268         2098.00144   480.5813    0.000440917 
+  1972         1920.49775   479.81142   0.000507099 
+  1460         1605.39495   479.04332   0.000684932 
+  1195         1303.07286   478.27699   0.00083682 
+  944          1116.83408   477.51244   0.001059322 
+  841          991.0346     476.74965   0.001189061 
+  884          941.47922    475.98863   0.001131222 
+  972          938.23679    475.22937   0.001028807 
+  936          932.80785    474.47187   0.001068376 
+  902          891.3578     473.71612   0.001108647 
+  854          847.1559     472.96212   0.00117096 
+  865          820.4542     472.20986   0.001156069 
+  942          799.16567    471.45935   0.001061571 
+  855          801.97472    470.71057   0.001169591 
+  969          826.34002    469.96353   0.001031992 
+  950          891.14732    469.21821   0.001052632 
+  937          966.29569    468.47462   0.001067236 
+  960          982.96477    467.73275   0.001041667 
+  1089         1029.69059   466.9926    0.000918274 
+  1270         1168.88513   466.25416   0.000787402 
+  1598         1457.75719   465.51744   0.000625782 
+  2221         1925.79947   464.78242   0.000450248 
+  3232         2774.48789   464.0491    0.000309406 
+  5143         4064.6201    463.31748   0.000194439 
+  7421         5755.59678   462.58755   0.000134753 
+  8427         6483.42702   461.85931   0.000118666 
+  5878         4964.71097   461.13277   0.000170126 
+  4824         4166.13197   460.4079    0.000207297 
+  4000         3447.75171   459.68471   0.00025   
+  2122         2091.52811   458.9632    0.000471254 
+  1146         1310.38539   458.24336   0.0008726 
+  935          979.52289    457.52519   0.001069519 
+  843          820.01476    456.80868   0.00118624 
+  726          727.48656    456.09383   0.00137741 
+  684          667.80184    455.38064   0.001461988 
+  690          626.69022    454.6691    0.001449275 
+  679          596.95964    453.95921   0.001472754 
+  653          574.63865    453.25097   0.001531394 
+  603          557.36461    452.54436   0.001658375 
+  540          543.67354    451.8394    0.001851852 
+  548          532.5735     451.13606   0.001824818 
+  558          523.4277     450.43436   0.001792115 
+  550          515.76582    449.73429   0.001818182 
+  532          509.26644    449.03583   0.001879699 
+  548          503.69511    448.339     0.001824818 
+  522          498.86039    447.64378   0.001915709 
+  553          494.63447    446.95017   0.001808318 
+  461          490.90649    446.25817   0.002169197 
+  545          487.59834    445.56778   0.001834862 
+  543          484.64495    444.87898   0.001841621 
+  500          481.99543    444.19179   0.002     
+  482          479.6089     443.50618   0.002074689 
+  471          477.45227    442.82217   0.002123142 
+  519          475.49907    442.13974   0.001926782 
+  489          473.72797    441.45889   0.00204499 
+  457          472.10662    440.77962   0.002188184 
+  499          470.65248    440.10193   0.002004008 
+  516          469.33089    439.42581   0.001937984 
+  458          468.14971    438.75126   0.002183406 
+  453          467.09621    438.07827   0.002207506 
+  481          466.16646    437.40684   0.002079002 
+  460          465.35954    436.73697   0.002173913 
+  477          464.67651    436.06865   0.002096436 
+  452          464.12057    435.40189   0.002212389 
+  476          463.69725    434.73666   0.00210084 
+  480          463.41485    434.07299   0.002083333 
+  442          463.28481    433.41085   0.002262443 
+  455          463.32157    432.75024   0.002197802 
+  397          463.54456    432.09117   0.002518892 
+  501          463.97827    431.43363   0.001996008 
+  439          464.6535     430.77761   0.002277904 
+  480          465.60986    430.12312   0.002083333 
+  438          466.89738    429.47014   0.002283105 
+  458          468.57983    428.81868   0.002183406 
+  421          470.73938    428.16872   0.002375297 
+  463          473.4817     427.52028   0.002159827 
+  456          476.94329    426.87334   0.002192982 
+  477          481.29976    426.2279    0.002096436 
+  488          486.77891    425.58396   0.00204918 
+  460          493.66992    424.94151   0.002173913 
+  485          502.33428    424.30055   0.002061856 
+  553          513.19899    423.66108   0.001808318 
+  560          526.71742    423.02309   0.001785714 
+  556          543.26793    422.38658   0.001798561 
+  566          562.92717    421.75155   0.001766784 
+  620          585.16183    421.11799   0.001612903 
+  665          608.61596    420.4859    0.001503759 
+  638          631.28506    419.85528   0.001567398 
+  738          650.95877    419.22612   0.001355014 
+  787          665.44594    418.59841   0.001270648 
+  754          672.99292    417.97217   0.00132626 
+  773          673.72484    417.34738   0.001293661 
+  860          670.95593    416.72403   0.001162791 
+  807          670.67075    416.10214   0.001239157 
+  822          676.49141    415.48168   0.001216545 
+  802          683.56654    414.86266   0.001246883 
+  791          706.07819    414.24508   0.001264223 
+  740          734.09478    413.62894   0.001351351 
+  660          713.41941    413.01422   0.001515152 
+  662          686.76393    412.40092   0.001510574 
+  655          681.5781     411.78905   0.001526718 
+  629          669.89701    411.1786    0.001589825 
+  590          629.88683    410.56957   0.001694915 
+  578          584.69727    409.96194   0.001730104 
+  553          560.51604    409.35573   0.001808318 
+  540          536.60943    408.75092   0.001851852 
+  478          512.10782    408.14752   0.00209205 
+  475          498.76825    407.54551   0.002105263 
+  502          496.80461    406.9449    0.001992032 
+  543          506.28524    406.34568   0.001841621 
+  551          526.84904    405.74785   0.001814882 
+  572          554.88938    405.15141   0.001748252 
+  667          597.20714    404.55635   0.00149925 
+  736          633.8091     403.96267   0.001358696 
+  762          641.2317     403.37037   0.001312336 
+  695          634.06513    402.77944   0.001438849 
+  637          600.16344    402.18988   0.001569859 
+  559          560.57116    401.60169   0.001788909 
+  481          527.2195     401.01486   0.002079002 
+  465          491.88502    400.42939   0.002150538 
+  433          466.05802    399.84528   0.002309469 
+  425          450.71273    399.26252   0.002352941 
+  439          441.48714    398.68112   0.002277904 
+  430          435.49895    398.10106   0.002325581 
+  391          431.33129    397.52234   0.002557545 
+  407          428.26329    396.94497   0.002457002 
+  427          425.95536    396.36894   0.00234192 
+  394          424.1795     395.79424   0.002538071 
+  401          422.82686    395.22087   0.002493766 
+  419          421.83299    394.64883   0.002386635 
+  400          421.14903    394.07811   0.0025    
+  403          420.7551     393.50872   0.00248139 
+  424          420.62617    392.94065   0.002358491 
+  393          420.72873    392.37389   0.002544529 
+  403          421.01513    391.80845   0.00248139 
+  366          421.4506     391.24432   0.00273224 
+  396          422.04887    390.68149   0.002525253 
+  392          422.89746    390.11997   0.00255102 
+  367          424.16549    389.55975   0.002724796 
+  387          426.14288    389.00082   0.002583979 
+  421          429.34881    388.44319   0.002375297 
+  435          434.75685    387.88685   0.002298851 
+  382          444.19215    387.3318    0.002617801 
+  449          460.45523    386.77804   0.002227171 
+  518          483.54311    386.22556   0.001930502 
+  500          507.81424    385.67435   0.002     
+  534          541.85911    385.12442   0.001872659 
+  576          564.09754    384.57577   0.001736111 
+  546          542.81222    384.02839   0.001831502 
+  530          522.92004    383.48227   0.001886792 
+  532          511.52545    382.93742   0.001879699 
+  465          486.42533    382.39382   0.002150538 
+  459          462.72904    381.85149   0.002178649 
+  442          448.3834     381.31041   0.002262443 
+  402          440.87428    380.77059   0.002487562 
+  413          438.00671    380.23201   0.002421308 
+  428          437.47587    379.69468   0.002336449 
+  439          439.17361    379.15859   0.002277904 
+  437          442.53496    378.62374   0.00228833 
+  400          438.07359    378.09013   0.0025    
+  437          430.24347    377.55775   0.00228833 
+  435          425.94265    377.02661   0.002298851 
+  388          420.43212    376.49669   0.00257732 
+  354          413.76882    375.968     0.002824859 
+  434          409.16288    375.44053   0.002304147 
+  344          406.35288    374.91428   0.002906977 
+  377          404.57705    374.38925   0.00265252 
+  355          403.38034    373.86543   0.002816901 
+  368          402.53749    373.34282   0.002717391 
+  380          402.53756    372.82142   0.002631579 
+  369          402.12588    372.30122   0.002710027 
+  421          401.86325    371.78223   0.002375297 
+  370          402.02761    371.26443   0.002702703 
+  360          402.01512    370.74784   0.002777778 
+  398          402.11823    370.23243   0.002512563 
+  410          402.34199    369.71822   0.002439024 
+  394          402.70311    369.20519   0.002538071 
+  342          403.23699    368.69335   0.002923977 
+  376          404.01074    368.18269   0.002659574 
+  391          405.09913    367.67321   0.002557545 
+  389          406.45705    367.16491   0.002570694 
+  373          408.22038    366.65778   0.002680965 
+  435          410.48212    366.15182   0.002298851 
+  377          412.46377    365.64703   0.00265252 
+  453          414.61653    365.1434    0.002207506 
+  385          417.78453    364.64094   0.002597403 
+  412          420.41206    364.13964   0.002427184 
+  421          421.82346    363.63949   0.002375297 
+  422          422.49973    363.14049   0.002369668 
+  414          422.4445     362.64265   0.002415459 
+  411          422.68842    362.14596   0.00243309 
+  402          423.36849    361.65041   0.002487562 
+  380          424.16037    361.156     0.002631579 
+  391          425.7543     360.66274   0.002557545 
+  424          428.22486    360.17061   0.002358491 
+  414          431.39937    359.67961   0.002415459 
+  422          435.17419    359.18975   0.002369668 
+  432          439.49401    358.70102   0.002314815 
+  419          444.30154    358.21341   0.002386635 
+  405          449.52262    357.72693   0.002469136 
+  406          455.00102    357.24157   0.002463054 
+  444          460.97214    356.75732   0.002252252 
+  431          467.4618     356.27419   0.002320186 
+  450          474.61319    355.79218   0.002222222 
+  443          482.76185    355.31127   0.002257336 
+  449          492.13001    354.83147   0.002227171 
+  489          503.025      354.35278   0.00204499 
+  517          515.765      353.87518   0.001934236 
+  499          530.69701    353.39869   0.002004008 
+  514          548.19277    352.92329   0.001945525 
+  478          568.71478    352.44899   0.00209205 
+  517          592.93011    351.97578   0.001934236 
+  559          621.82375    351.50366   0.001788909 
+  588          656.80725    351.03262   0.00170068 
+  613          699.86305    350.56267   0.001631321 
+  649          753.80019    350.0938    0.001540832 
+  738          822.72388    349.626     0.001355014 
+  754          912.79454    349.15928   0.00132626 
+  953          1033.73042   348.69364   0.001049318 
+  1126         1201.69553   348.22906   0.000888099 
+  1486         1445.43504   347.76555   0.000672948 
+  2008         1822.23968   347.30311   0.000498008 
+  2567         2470.81738   346.84173   0.00038956 
+  3797         3760.56042   346.3814    0.000263366 
+  5951         6392.64773   345.92214   0.000168039 
+  10083        10232.17254  345.46393   0.000099177 
+  17681        17019.20747  345.00677   0.000056558 
+  28614        25194.93853  344.55066   0.000034948 
+  31160        26784.9446   344.0956    0.000032092 
+  18903        18864.62881  343.64159   0.000052902 
+  15969        16347.60252  343.18861   0.000062621 
+  16488        15304.0714   342.73667   0.00006065 
+  9784         9727.6059    342.28578   0.000102208 
+  4062         5075.47652   341.83591   0.000246184 
+  2277         3035.93992   341.38708   0.000439174 
+  1664         2122.20562   340.93927   0.000600962 
+  1367         1626.883     340.49249   0.000731529 
+  1230         1320.4124    340.04674   0.000813008 
+  997          1116.16204   339.60201   0.001003009 
+  974          972.85857    339.15829   0.001026694 
+  884          868.37765    338.7156    0.001131222 
+  798          789.45828    338.27391   0.001253133 
+  724          728.39311    337.83324   0.001381215 
+  680          680.66308    337.39358   0.001470588 
+  673          642.758      336.95493   0.001485884 
+  651          612.23472    336.51727   0.001536098 
+  601          587.7449     336.08062   0.001663894 
+  567          568.21794    335.64497   0.001763668 
+  520          552.84062    335.21032   0.001923077 
+  511          541.07459    334.77666   0.001956947 
+  536          532.62758    334.34399   0.001865672 
+  518          527.40002    333.91231   0.001930502 
+  551          525.28813    333.48162   0.001814882 
+  494          526.23211    333.05191   0.002024291 
+  516          530.41357    332.62318   0.001937984 
+  518          536.82317    332.19544   0.001930502 
+  534          545.87844    331.76867   0.001872659 
+  573          558.70542    331.34288   0.001745201 
+  521          574.38164    330.91805   0.001919386 
+  568          592.32298    330.4942    0.001760563 
+  648          612.83153    330.07132   0.00154321 
+  655          636.25556    329.6494    0.001526718 
+  738          662.80982    329.22844   0.001355014 
+  772          691.57481    328.80845   0.001295337 
+  792          721.10986    328.38941   0.001262626 
+  868          750.90961    327.97133   0.001152074 
+  890          781.53689    327.5542    0.001123596 
+  892          809.68494    327.13802   0.001121076 
+  908          837.078      326.72279   0.001101322 
+  881          848.68037    326.30851   0.001135074 
+  888          821.46687    325.89517   0.001126126 
+  872          785.18656    325.48277   0.001146789 
+  801          751.88094    325.07131   0.001248439 
+  727          705.20692    324.66079   0.001375516 
+  688          652.05643    324.2512    0.001453488 
+  660          605.00488    323.84255   0.001515152 
+  621          564.78811    323.43482   0.001610306 
+  616          530.54197    323.02802   0.001623377 
+  535          501.69228    322.62215   0.001869159 
+  540          477.75957    322.2172    0.001851852 
+  492          458.05469    321.81318   0.00203252 
+  428          441.78659    321.41007   0.002336449 
+  459          428.31162    321.00787   0.002178649 
+  439          417.09311    320.60659   0.002277904 
+  416          407.67236    320.20622   0.002403846 
+  382          399.68539    319.80676   0.002617801 
+  396          392.8493     319.40821   0.002525253 
+  356          386.94494    319.01056   0.002808989 
+  389          381.8038     318.61382   0.002570694 
+  362          377.29265    318.21797   0.002762431 
+  380          373.30697    317.82303   0.002631579 
+  369          369.76404    317.42898   0.002710027 
+  362          366.59758    317.03582   0.002762431 
+  361          363.75481    316.64355   0.002770083 
+  379          361.1932     316.25218   0.002638522 
+  338          358.87819    315.86169   0.00295858 
+  359          356.78368    315.47208   0.002785515 
+  370          354.88934    315.08336   0.002702703 
+  353          353.17059    314.69552   0.002832861 
+  336          351.62017    314.30855   0.00297619 
+  330          350.22804    313.92246   0.003030303 
+  330          348.98932    313.53725   0.003030303 
+  350          347.90718    313.1529    0.002857143 
+  343          346.98306    312.76943   0.002915452 
+  355          346.23044    312.38682   0.002816901 
+  347          345.67175    312.00508   0.002881844 
+  313          345.34246    311.6242    0.003194888 
+  361          345.29949    311.24418   0.002770083 
+  393          345.63505    310.86502   0.002544529 
+  329          346.50306    310.48672   0.003039514 
+  353          348.1794     310.10927   0.002832861 
+  296          351.19721    309.73267   0.003378378 
+  355          356.63834    309.35692   0.002816901 
+  386          366.57647    308.98202   0.002590674 
+  395          383.77002    308.60797   0.002531646 
+  439          406.77947    308.23476   0.002277904 
+  489          432.52417    307.86239   0.00204499 
+  482          456.03775    307.49086   0.002074689 
+  452          447.21394    307.12016   0.002212389 
+  436          427.04928    306.7503    0.002293578 
+  445          419.28435    306.38128   0.002247191 
+  405          410.51353    306.01308   0.002469136 
+  401          390.6435     305.64572   0.002493766 
+  351          374.74483    305.27918   0.002849003 
+  378          365.31412    304.91347   0.002645503 
+  379          359.43839    304.54857   0.002638522 
+  374          355.25082    304.1845    0.002673797 
+  358          352.14115    303.82125   0.002793296 
+  341          350.1125     303.45881   0.002932551 
+  335          349.50016    303.09719   0.002985075 
+  351          349.88118    302.73638   0.002849003 
+  364          351.11497    302.37638   0.002747253 
+  330          351.11326    302.01719   0.003030303 
+  324          346.58065    301.6588    0.00308642 
+  367          342.19572    301.30122   0.002724796 
+  363          339.83655    300.94444   0.002754821 
+  373          336.67267    300.58846   0.002680965 
+  355          332.56932    300.23328   0.002816901 
+  330          330.14064    299.87889   0.003030303 
+  361          328.30187    299.5253    0.002770083 
+  361          327.1604     299.1725    0.002770083 
+  356          326.45125    298.82049   0.002808989 
+  346          326.35322    298.46927   0.002890173 
+  353          326.3285     298.11884   0.002832861 
+  346          326.75439    297.76918   0.002890173 
+  351          327.8845     297.42031   0.002849003 
+  345          329.91512    297.07222   0.002898551 
+  356          332.42881    296.72491   0.002808989 
+  367          335.32567    296.37838   0.002724796 
+  356          336.50429    296.03261   0.002808989 
+  357          334.82597    295.68762   0.00280112 
+  341          333.77023    295.34341   0.002932551 
+  344          334.00998    294.99995   0.002906977 
+  360          333.61424    294.65727   0.002777778 
+  359          333.25258    294.31535   0.002785515 
+  343          334.55593    293.97419   0.002915452 
+  385          338.06644    293.63379   0.002597403 
+  376          344.26469    293.29415   0.002659574 
+  390          353.23966    292.95527   0.002564103 
+  398          366.97909    292.61714   0.002512563 
+  385          386.75315    292.27977   0.002597403 
+  399          414.3879     291.94315   0.002506266 
+  480          445.49469    291.60727   0.002083333 
+  516          489.92949    291.27214   0.001937984 
+  601          481.57909    290.93776   0.001663894 
+  453          439.17886    290.60412   0.002207506 
+  481          423.74167    290.27122   0.002079002 
+  514          424.95213    289.93906   0.001945525 
+  456          397.56319    289.60764   0.002192982 
+  421          371.84057    289.27696   0.002375297 
+  387          359.21152    288.94701   0.002583979 
+  426          353.33594    288.61779   0.002347418 
+  400          351.21694    288.2893    0.0025    
+  367          351.19388    287.96154   0.002724796 
+  392          352.00202    287.63451   0.00255102 
+  381          353.8371     287.3082    0.002624672 
+  412          357.13196    286.98261   0.002427184 
+  370          362.03237    286.65774   0.002702703 
+  376          368.81808    286.3336    0.002659574 
+  384          378.31992    286.01017   0.002604167 
+  401          392.18845    285.68745   0.002493766 
+  437          416.11269    285.36545   0.00228833 
+  443          461.43598    285.04416   0.002257336 
+  546          531.53613    284.72358   0.001831502 
+  609          608.01882    284.40371   0.001642036 
+  725          698.33239    284.08455   0.00137931 
+  669          661.57312    283.76609   0.001494768 
+  620          596.80951    283.44833   0.001612903 
+  561          588.95365    283.13128   0.001782531 
+  616          598.2526     282.81492   0.001623377 
+  611          550.37063    282.49926   0.001636661 
+  591          519.36571    282.1843    0.001692047 
+  621          521.71699    281.87003   0.001610306 
+  630          546.43028    281.55645   0.001587302 
+  652          583.56668    281.24356   0.001533742 
+  642          629.17093    280.93136   0.001557632 
+  626          664.666      280.61985   0.001597444 
+  744          691.97704    280.30902   0.001344086 
+  737          738.87048    279.99888   0.001356852 
+  860          811.34946    279.68942   0.001162791 
+  1003         903.07325    279.38063   0.000997009 
+  1217         1033.71623   279.07253   0.000821693 
+  1449         1238.72498   278.7651    0.000690131 
+  1733         1567.57527   278.45835   0.000577034 
+  2546         2137.93455   278.15226   0.000392773 
+  3778         3264.98477   277.84685   0.00026469 
+  6324         5618.71057   277.54211   0.000158128 
+  11104        9539.71028   277.23804   0.000090058 
+  19360        15939.15256  276.93463   0.000051653 
+  26577        20980.093    276.63189   0.000037627 
+  19862        17210.96212  276.32981   0.000050347 
+  12414        11922.73478  276.02839   0.000080554 
+  12614        11767.6262   275.72763   0.000079277 
+  13109        11661.34743  275.42753   0.000076283 
+  7472         7430.49672   275.12808   0.000133833 
+  3380         3909.46977   274.82929   0.000295858 
+  2025         2349.7543    274.53115   0.000493827 
+  1426         1649.10378   274.23366   0.000701262 
+  1162         1272.32073   273.93682   0.000860585 
+  974          1043.19346   273.64063   0.001026694 
+  854          894.03458    273.34508   0.00117096 
+  765          792.17364    273.05018   0.00130719 
+  737          713.91967    272.75592   0.001356852 
+  653          648.50268    272.4623    0.001531394 
+  606          599.7169     272.16932   0.001650165 
+  550          564.15905    271.87698   0.001818182 
+  523          530.14614    271.58527   0.001912046 
+  529          495.37074    271.2942    0.001890359 
+  479          467.95681    271.00376   0.002087683 
+  437          447.77031    270.71395   0.00228833 
+  390          430.74377    270.42477   0.002564103 
+  435          416.24061    270.13622   0.002298851 
+  409          406.33347    269.8483    0.002444988 
+  394          400.55042    269.56099   0.002538071 
+  394          397.93386    269.27432   0.002538071 
+  452          394.81228    268.98826   0.002212389 
+  385          389.27995    268.70282   0.002597403 
+  361          383.48886    268.41801   0.002770083 
+  398          377.55564    268.1338    0.002512563 
+  389          373.36235    267.85022   0.002570694 
+  391          370.53404    267.56724   0.002557545 
+  381          368.08324    267.28488   0.002624672 
+  369          362.0507     267.00313   0.002710027 
+  384          353.61756    266.72199   0.002604167 
+  337          347.34786    266.44145   0.002967359 
+  335          342.92623    266.16152   0.002985075 
+  351          337.23001    265.8822    0.002849003 
+  320          330.55011    265.60348   0.003125  
+  318          325.00257    265.32535   0.003144654 
+  315          320.59099    265.04783   0.003174603 
+  316          316.99512    264.77091   0.003164557 
+  324          314.03139    264.49458   0.00308642 
+  264          311.60756    264.21884   0.003787879 
+  332          309.64799    263.9437    0.003012048 
+  284          308.06072    263.66915   0.003521127 
+  294          306.70674    263.3952    0.003401361 
+  308          305.42654    263.12183   0.003246753 
+  309          304.07974    262.84904   0.003236246 
+  300          302.60685    262.57685   0.003333333 
+  310          301.03038    262.30523   0.003225806 
+  308          299.40002    262.0342    0.003246753 
+  271          297.75376    261.76375   0.003690037 
+  284          296.13336    261.49388   0.003521127 
+  303          294.57889    261.22459   0.00330033 
+  316          293.14772    260.95588   0.003164557 
+  265          291.90487    260.68774   0.003773585 
+  284          290.10577    260.42017   0.003521127 
+  306          289.27382    260.15318   0.003267974 
+  311          288.65055    259.88675   0.003215434 
+  278          287.87505    259.6209    0.003597122 
+  267          287.72414    259.35562   0.003745318 
+  282          287.82855    259.0909    0.003546099 
+  293          288.14836    258.82674   0.003412969 
+  278          288.59756    258.56315   0.003597122 
+  284          289.03409    258.30012   0.003521127 
+  327          289.39035    258.03765   0.003058104 
+  267          290.3084     257.77574   0.003745318 
+  305          291.67773    257.51439   0.003278689 
+  316          292.83005    257.2536    0.003164557 
+  294          291.78838    256.99335   0.003401361 
+  318          289.95547    256.73367   0.003144654 
+  287          289.41363    256.47453   0.003484321 
+  332          290.06138    256.21595   0.003012048 
+  307          290.99292    255.95791   0.003257329 
+  351          293.54689    255.70042   0.002849003 
+  344          300.19773    255.44348   0.002906977 
+  378          312.82216    255.18708   0.002645503 
+  433          329.84608    254.93123   0.002309469 
+  445          347.58371    254.67592   0.002247191 
+  463          352.67971    254.42115   0.002159827 
+  468          340.88076    254.16691   0.002136752 
+  424          331.43435    253.91322   0.002358491 
+  432          327.14671    253.66006   0.002314815 
+  383          320.15885    253.40744   0.002610966 
+  389          305.80945    253.15535   0.002570694 
+  376          293.56773    252.9038    0.002659574 
+  355          286.21623    252.65277   0.002816901 
+  335          282.18253    252.40228   0.002985075 
+  288          280.06236    252.15231   0.003472222 
+  306          279.21506    251.90287   0.003267974 
+  303          279.63631    251.65395   0.00330033 
+  321          281.89609    251.40556   0.003115265 
+  319          286.12952    251.15769   0.003134796 
+  312          291.16201    250.91035   0.003205128 
+  332          294.69306    250.66352   0.003012048 
+  340          290.28243    250.41721   0.002941176 
+  284          287.42131    250.17142   0.003521127 
+  294          288.06332    249.92615   0.003401361 
+  311          289.55573    249.68139   0.003215434 
+  331          287.91426    249.43715   0.003021148 
+  273          287.86921    249.19341   0.003663004 
+  286          291.07358    248.95019   0.003496503 
+  317          298.07437    248.70748   0.003154574 
+  339          311.59264    248.46527   0.002949853 
+  338          339.00042    248.22357   0.00295858 
+  367          392.38668    247.98238   0.002724796 
+  428          464.07842    247.74169   0.002336449 
+  559          545.84567    247.50151   0.001788909 
+  500          550.87238    247.26182   0.002     
+  426          486.07636    247.02264   0.002347418 
+  415          464.72367    246.78396   0.002409639 
+  443          465.03865    246.54577   0.002257336 
+  439          437.205      246.30808   0.002277904 
+  344          377.69812    246.07089   0.002906977 
+  325          341.68646    245.83419   0.003076923 
+  298          318.22335    245.59798   0.003355705 
+  305          302.71685    245.36226   0.003278689 
+  298          293.65345    245.12704   0.003355705 
+  309          288.44588    244.8923    0.003236246 
+  271          285.43317    244.65805   0.003690037 
+  292          283.7568     244.42429   0.003424658 
+  252          283.02289    244.19101   0.003968254 
+  310          283.04878    243.95822   0.003225806 
+  319          283.45584    243.72591   0.003134796 
+  279          283.59803    243.49408   0.003584229 
+  296          283.84904    243.26273   0.003378378 
+  306          284.6529     243.03186   0.003267974 
+  269          285.8847     242.80146   0.003717472 
+  286          287.18067    242.57155   0.003496503 
+  278          288.67793    242.34211   0.003597122 
+  303          290.62165    242.11314   0.00330033 
+  306          293.06711    241.88464   0.003267974 
+  332          296.09528    241.65662   0.003012048 
+  297          299.93777    241.42907   0.003367003 
+  323          305.18807    241.20199   0.003095975 
+  347          312.77716    240.97537   0.002881844 
+  351          322.90805    240.74922   0.002849003 
+  342          330.71619    240.52354   0.002923977 
+  313          332.70213    240.29832   0.003194888 
+  334          336.68038    240.07357   0.002994012 
+  318          346.93232    239.84928   0.003144654 
+  366          363.9616     239.62544   0.00273224 
+  363          390.47166    239.40207   0.002754821 
+  438          427.36679    239.17916   0.002283105 
+  470          469.2126     238.9567    0.00212766 
+  468          476.84674    238.7347    0.002136752 
+  447          447.24045    238.51316   0.002237136 
+  435          442.62585    238.29206   0.002298851 
+  420          458.05546    238.07142   0.002380952 
+  466          467.99731    237.85124   0.002145923 
+  440          458.54216    237.6315    0.002272727 
+  474          462.34662    237.41221   0.002109705 
+  450          481.86148    237.19337   0.002222222 
+  528          513.15863    236.97498   0.001893939 
+  574          553.00592    236.75703   0.00174216 
+  649          603.47997    236.53953   0.001540832 
+  742          672.55319    236.32247   0.001347709 
+  864          768.7731     236.10585   0.001157407 
+  988          904.22337    235.88967   0.001012146 
+  1061         1103.02012   235.67394   0.000942507 
+  1351         1416.24003   235.45864   0.000740192 
+  2074         1961.53427   235.24378   0.00048216 
+  3063         3064.20939   235.02936   0.000326477 
+  5532         5513.90957   234.81537   0.000180766 
+  9916         9871.88992   234.60182   0.000100847 
+  16911        14891.47851  234.3887    0.000059133 
+  20003        17816.49514  234.17601   0.000049993 
+  13211        11899.08322  233.96376   0.000075694 
+  8660         8862.62653   233.75193   0.000115473 
+  9311         9102.28299   233.54053   0.0001074 
+  10533        10086.61815  233.32957   0.00009494 
+  7024         6559.78493   233.11902   0.000142369 
+  3123         3447.93098   232.90891   0.000320205 
+  1696         2056.66674   232.69921   0.000589623 
+  1132         1433.51802   232.48994   0.000883392 
+  904          1098.71314   232.2811    0.001106195 
+  738          892.3465     232.07267   0.001355014 
+  666          754.93118    231.86467   0.001501502 
+  570          658.62711    231.65708   0.001754386 
+  532          588.73413    231.44991   0.001879699 
+  498          536.93009    231.24316   0.002008032 
+  433          498.49218    231.03683   0.002309469 
+  407          471.27645    230.83091   0.002457002 
+  409          455.88484    230.6254    0.002444988 
+  438          456.01152    230.42031   0.002283105 
+  432          471.81109    230.21563   0.002314815 
+  444          494.73606    230.01136   0.002252252 
+  464          486.53379    229.8075    0.002155172 
+  409          449.33685    229.60405   0.002444988 
+  401          433.36047    229.401     0.002493766 
+  377          425.77838    229.19836   0.00265252 
+  354          408.60916    228.99613   0.002824859 
+  355          374.91424    228.7943    0.002816901 
+  323          350.74792    228.59288   0.003095975 
+  321          333.72244    228.39186   0.003115265 
+  305          318.57879    228.19123   0.003278689 
+  279          307.37219    227.99101   0.003584229 
+  340          299.55995    227.79119   0.002941176 
+  325          293.91658    227.59177   0.003076923 
+  273          289.65658    227.39275   0.003663004 
+  256          286.36886    227.19412   0.00390625 
+  295          283.83827    226.99588   0.003389831 
+  253          281.93604    226.79804   0.003952569 
+  234          280.55686    226.6006    0.004273504 
+  267          279.56658    226.40354   0.003745318 
+  257          278.78569    226.20688   0.003891051 
+  266          278.01483    226.01061   0.003759398 
+  259          277.10274    225.81473   0.003861004 
+  249          276.05117    225.61923   0.004016064 
+  273          274.973      225.42413   0.003663004 
+  263          274.00456    225.22941   0.003802281 
+  266          273.2763     225.03507   0.003759398 
+  266          272.95085    224.84112   0.003759398 
+  243          273.3185     224.64756   0.004115226 
+  226          274.87636    224.45437   0.004424779 
+  271          278.39604    224.26157   0.003690037 
+  259          284.23951    224.06915   0.003861004 
+  265          288.16501    223.8771    0.003773585 
+  233          284.09193    223.68544   0.004291845 
+  237          278.62102    223.49416   0.004219409 
+  224          275.91982    223.30325   0.004464286 
+  252          274.3683     223.11271   0.003968254 
+  257          270.19104    222.92256   0.003891051 
+  258          264.55924    222.73277   0.003875969 
+  227          260.22608    222.54336   0.004405286 
+  233          256.97607    222.35432   0.004291845 
+  262          254.65772    222.16565   0.003816794 
+  244          253.14411    221.97736   0.004098361 
+  232          252.27298    221.78943   0.004310345 
+  258          251.99156    221.60187   0.003875969 
+  238          252.38863    221.41468   0.004201681 
+  235          253.65789    221.22785   0.004255319 
+  255          255.73975    221.04139   0.003921569 
+  245          257.63797    220.85529   0.004081633 
+  283          258.78701    220.66956   0.003533569 
+  223          260.86248    220.48419   0.004484305 
+  241          264.73636    220.29919   0.004149378 
+  292          270.84909    220.11454   0.003424658 
+  285          280.64022    219.93026   0.003508772 
+  251          300.52492    219.74633   0.003984064 
+  344          340.12553    219.56276   0.002906977 
+  403          397.14733    219.37955   0.00248139 
+  477          455.56185    219.1967    0.002096436 
+  504          459.6966     219.0142    0.001984127 
+  415          425.70036    218.83206   0.002409639 
+  371          418.88968    218.65027   0.002695418 
+  406          410.99306    218.46883   0.002463054 
+  402          396.83548    218.28775   0.002487562 
+  386          357.94227    218.10701   0.002590674 
+  344          332.94606    217.92663   0.002906977 
+  302          315.22695    217.7466    0.003311258 
+  294          301.76475    217.56691   0.003401361 
+  289          298.13712    217.38758   0.003460208 
+  272          302.17579    217.20859   0.003676471 
+  323          298.825      217.02994   0.003095975 
+  295          289.24244    216.85165   0.003389831 
+  313          283.50196    216.67369   0.003194888 
+  294          279.99678    216.49608   0.003401361 
+  285          275.23076    216.31881   0.003508772 
+  237          266.49939    216.14189   0.004219409 
+  236          259.44141    215.9653    0.004237288 
+  230          254.12195    215.78906   0.004347826 
+  203          249.47091    215.61315   0.004926108 
+  232          246.37866    215.43759   0.004310345 
+  195          244.59884    215.26236   0.005128205 
+  241          243.65217    215.08747   0.004149378 
+  224          243.25537    214.91291   0.004464286 
+  234          243.28665    214.73869   0.004273504 
+  226          243.70065    214.5648    0.004424779 
+  258          244.34068    214.39125   0.003875969 
+  250          244.78316    214.21803   0.004     
+  238          245.18123    214.04514   0.004201681 
+  254          245.94286    213.87258   0.003937008 
+  215          247.15155    213.70035   0.004651163 
+  200          248.71737    213.52846   0.005     
+  251          250.74331    213.35689   0.003984064 
+  237          253.88999    213.18564   0.004219409 
+  233          259.02562    213.01473   0.004291845 
+  233          266.57425    212.84414   0.004291845 
+  249          272.69488    212.67388   0.004016064 
+  235          271.76762    212.50394   0.004255319 
+  239          269.78793    212.33433   0.0041841 
+  252          271.28395    212.16503   0.003968254 
+  240          275.37837    211.99607   0.004166667 
+  273          278.01068    211.82742   0.003663004 
+  245          279.03293    211.65909   0.004081633 
+  256          281.76973    211.49108   0.00390625 
+  278          286.95384    211.32339   0.003597122 
+  300          294.69374    211.15603   0.003333333 
+  288          305.69171    210.98897   0.003472222 
+  316          321.64715    210.82224   0.003164557 
+  292          345.14999    210.65582   0.003424658 
+  377          375.4024     210.48971   0.00265252 
+  347          396.06247    210.32392   0.002881844 
+  392          401.54605    210.15845   0.00255102 
+  341          412.62516    209.99329   0.002932551 
+  434          435.3486     209.82843   0.002304147 
+  398          462.59946    209.6639    0.002512563 
+  455          481.60024    209.49967   0.002197802 
+  467          496.02695    209.33575   0.002141328 
+  545          512.75755    209.17214   0.001834862 
+  583          532.71411    209.00884   0.001715266 
+  644          555.50996    208.84585   0.001552795 
+  645          579.64801    208.68316   0.001550388 
+  680          602.34222    208.52078   0.001470588 
+  658          620.43199    208.3587    0.001519757 
+  733          632.17707    208.19693   0.001364256 
+  680          638.65705    208.03547   0.001470588 
+  674          643.13672    207.87431   0.00148368 
+  652          648.82545    207.71345   0.001533742 
+  714          656.9886     207.55289   0.00140056 
+  655          668.30538    207.39263   0.001526718 
+  652          685.01777    207.23268   0.001533742 
+  663          704.69932    207.07302   0.001508296 
+  624          718.38664    206.91366   0.001602564 
+  613          711.67492    206.7546    0.001631321 
+  618          695.76085    206.59584   0.001618123 
+  573          677.33889    206.43738   0.001745201 
+  592          654.20399    206.27921   0.001689189 
+  588          621.6704     206.12133   0.00170068 
+  561          580.1417     205.96376   0.001782531 
+  595          538.13247    205.80647   0.001680672 
+  485          497.7179     205.64948   0.002061856 
+  488          459.84957    205.49278   0.00204918 
+  406          425.63802    205.33637   0.002463054 
+  401          395.79323    205.18026   0.002493766 
+  360          370.43755    205.02443   0.002777778 
+  362          349.25083    204.8689    0.002762431 
+  336          331.70168    204.71365   0.00297619 
+  303          317.23342    204.5587    0.00330033 
+  318          305.3617     204.40403   0.003144654 
+  328          295.72593    204.24964   0.00304878 
+  295          288.1437     204.09555   0.003389831 
+  279          282.72206    203.94174   0.003584229 
+  290          279.97184    203.78821   0.003448276 
+  284          280.58993    203.63497   0.003521127 
+  249          282.71437    203.48202   0.004016064 
+  261          278.51629    203.32934   0.003831418 
+  282          269.4926     203.17695   0.003546099 
+  263          263.28835    203.02484   0.003802281 
+  244          260.96393    202.87301   0.004098361 
+  257          259.39111    202.72147   0.003891051 
+  271          254.50735    202.5702    0.003690037 
+  262          249.0366     202.41921   0.003816794 
+  227          245.23995    202.2685    0.004405286 
+  217          242.81836    202.11807   0.004608295 
+  239          241.34076    201.96791   0.0041841 
+  219          240.54017    201.81804   0.00456621 
+  213          240.29326    201.66843   0.004694836 
+  228          240.53775    201.51911   0.004385965 
+  257          241.2265     201.37005   0.003891051 
+  209          242.22739    201.22127   0.004784689 
+  237          243.4067     201.07277   0.004219409 
+  196          244.63142    200.92454   0.005102041 
+  234          245.89387    200.77658   0.004273504 
+  243          247.37891    200.62889   0.004115226 
+  215          249.36523    200.48147   0.004651163 
+  245          251.30132    200.33432   0.004081633 
+  232          250.20174    200.18744   0.004310345 
+  231          246.19881    200.04084   0.004329004 
+  235          242.75264    199.8945    0.004255319 
+  223          240.74906    199.74842   0.004484305 
+  245          239.36187    199.60262   0.004081633 
+  234          237.01893    199.45708   0.004273504 
+  237          234.83636    199.31181   0.004219409 
+  241          234.30646    199.1668    0.004149378 
+  210          234.61339    199.02205   0.004761905 
+  224          233.10566    198.87758   0.004464286 
+  232          231.11912    198.73336   0.004310345 
+  206          231.30641    198.58941   0.004854369 
+  231          234.53507    198.44572   0.004329004 
+  238          240.23327    198.30229   0.004201681 
+  233          244.33383    198.15912   0.004291845 
+  248          243.1285     198.01622   0.004032258 
+  234          240.94652    197.87357   0.004273504 
+  227          238.88753    197.73118   0.004405286 
+  262          238.70346    197.58905   0.003816794 
+  241          240.66718    197.44718   0.004149378 
+  229          243.87695    197.30557   0.004366812 
+  235          248.04138    197.16421   0.004255319 
+  238          245.05045    197.02311   0.004201681 
+  234          237.04837    196.88227   0.004273504 
+  220          232.30126    196.74168   0.004545455 
+  231          231.93736    196.60135   0.004329004 
+  231          233.16218    196.46127   0.004329004 
+  224          231.4684     196.32144   0.004464286 
+  216          228.90565    196.18187   0.00462963 
+  245          228.49839    196.04255   0.004081633 
+  222          230.73829    195.90348   0.004504505 
+  244          236.21478    195.76467   0.004098361 
+  228          246.68339    195.6261    0.004385965 
+  246          265.31964    195.48778   0.004065041 
+  273          295.51427    195.34972   0.003663004 
+  325          345.9867     195.2119    0.003076923 
+  389          396.62759    195.07433   0.002570694 
+  400          370.02602    194.93701   0.0025    
+  369          326.56266    194.79994   0.002710027 
+  327          307.21472    194.66311   0.003058104 
+  284          314.9997     194.52653   0.003521127 
+  327          321.7703     194.3902    0.003058104 
+  297          293.96395    194.25411   0.003367003 
+  302          266.53724    194.11826   0.003311258 
+  259          251.26468    193.98266   0.003861004 
+  245          245.59037    193.84731   0.004081633 
+  222          242.7127     193.71219   0.004504505 
+  242          238.01269    193.57732   0.004132231 
+  216          233.43196    193.44269   0.00462963 
+  256          230.27084    193.30831   0.00390625 
+  225          229.38086    193.17416   0.004444444 
+  216          228.83886    193.04026   0.00462963 
+  220          227.68848    192.90659   0.004545455 
+  226          227.33266    192.77316   0.004424779 
+  264          228.4323     192.63998   0.003787879 
+  229          229.632      192.50703   0.004366812 
+  227          227.6592     192.37432   0.004405286 
+  239          225.79205    192.24184   0.0041841 
+  224          225.47466    192.10961   0.004464286 
+  242          226.50195    191.97761   0.004132231 
+  232          227.10032    191.84584   0.004310345 
+  208          226.5169     191.71431   0.004807692 
+  210          225.7852     191.58302   0.004761905 
+  233          225.46632    191.45196   0.004291845 
+  215          225.3507     191.32113   0.004651163 
+  214          225.29329    191.19054   0.004672897 
+  214          225.29834    191.06018   0.004672897 
+  217          225.42714    190.93005   0.004608295 
+  227          225.7333     190.80016   0.004405286 
+  232          226.29223    190.67049   0.004310345 
+  233          227.25803    190.54106   0.004291845 
+  229          228.91037    190.41186   0.004366812 
+  250          231.62343    190.28288   0.004     
+  217          235.32686    190.15414   0.004608295 
+  218          237.9354     190.02562   0.004587156 
+  245          238.42747    189.89734   0.004081633 
+  196          239.33648    189.76928   0.005102041 
+  244          241.48409    189.64145   0.004098361 
+  229          244.24566    189.51384   0.004366812 
+  226          246.01682    189.38646   0.004424779 
+  244          246.4116     189.25931   0.004098361 
+  242          246.76962    189.13239   0.004132231 
+  237          247.53265    189.00568   0.004219409 
+  227          248.65059    188.87921   0.004405286 
+  231          250.05656    188.75296   0.004329004 
+  242          251.77706    188.62693   0.004132231 
+  221          253.93395    188.50112   0.004524887 
+  248          256.68365    188.37554   0.004032258 
+  226          260.17478    188.25018   0.004424779 
+  235          264.54524    188.12504   0.004255319 
+  249          269.93463    188.00012   0.004016064 
+  273          276.5185     187.87543   0.003663004 
+  288          284.54695    187.75095   0.003472222 
+  296          294.39777    187.62669   0.003378378 
+  278          306.69353    187.50266   0.003597122 
+  314          322.50541    187.37884   0.003184713 
+  319          343.56781    187.25524   0.003134796 
+  365          371.7235     187.13186   0.002739726 
+  410          403.95801    187.0087    0.002439024 
+  421          430.14415    186.88575   0.002375297 
+  456          457.56856    186.76302   0.002192982 
+  499          499.48437    186.64051   0.002004008 
+  556          561.32421    186.51822   0.001798561 
+  576          647.11986    186.39614   0.001736111 
+  712          763.30316    186.27427   0.001404494 
+  785          936.3605     186.15262   0.001273885 
+  1032         1219.64004   186.03118   0.000968992 
+  1613         1732.65185   185.90996   0.000619963 
+  2685         2805.03278   185.78895   0.000372439 
+  4912         5201.8325    185.66815   0.000203583 
+  8649         9282.13757   185.54757   0.00011562 
+  11769        12823.89767  185.4272    0.000084969 
+  9157         10106.65545  185.30704   0.000109206 
+  5255         5966.73151   185.18709   0.000190295 
+  4217         4899.68429   185.06735   0.000237135 
+  5239         5962.97612   184.94782   0.000190876 
+  6169         7171.50451   184.82851   0.000162101 
+  4641         5342.15602   184.7094    0.000215471 
+  2345         2877.48731   184.5905    0.000426439 
+  1334         1667.40759   184.47181   0.000749625 
+  866          1128.57697   184.35333   0.001154734 
+  687          851.79038    184.23505   0.001455604 
+  598          686.22526    184.11699   0.001672241 
+  507          577.8691     183.99913   0.001972387 
+  462          502.6993     183.88147   0.002164502 
+  399          448.26242    183.76403   0.002506266 
+  336          407.52425    183.64679   0.00297619 
+  327          376.2723     183.52975   0.003058104 
+  359          351.85256    183.41292   0.002785515 
+  300          332.54613    183.2963    0.003333333 
+  310          317.24477    183.17988   0.003225806 
+  268          305.28367    183.06366   0.003731343 
+  304          296.39761    182.94764   0.003289474 
+  289          290.83417    182.83183   0.003460208 
+  291          289.64958    182.71623   0.003436426 
+  307          295.02887    182.60082   0.003257329 
+  342          309.06221    182.48562   0.002923977 
+  289          323.75974    182.37062   0.003460208 
+  267          316.38971    182.25582   0.003745318 
+  273          297.26759    182.14122   0.003663004 
+  286          287.76975    182.02682   0.003496503 
+  286          291.79237    181.91262   0.003496503 
+  281          305.6676     181.79862   0.003558719 
+  280          320.15955    181.68482   0.003571429 
+  298          340.27012    181.57121   0.003355705 
+  315          355.39716    181.45781   0.003174603 
+  321          332.31575    181.3446    0.003115265 
+  279          298.42499    181.2316    0.003584229 
+  258          281.37901    181.11879   0.003875969 
+  272          281.50761    181.00617   0.003676471 
+  270          285.04174    180.89376   0.003703704 
+  262          270.65524    180.78154   0.003816794 
+  243          248.65168    180.66951   0.004115226 
+  243          232.85075    180.55768   0.004115226 
+  221          223.11207    180.44605   0.004524887 
+  266          216.96726    180.33461   0.003759398 
+  228          212.78711    180.22337   0.004385965 
+  222          209.71732    180.11232   0.004504505 
+  240          207.32984    180.00146   0.004166667 
+  213          205.39441    179.8908    0.004694836 
+  200          203.77939    179.78033   0.005     
+  214          202.40189    179.67005   0.004672897 
+  214          201.20755    179.55996   0.004672897 
+  203          200.15404    179.45007   0.004926108 
+  205          199.227      179.34037   0.004878049 
+  217          198.40169    179.23086   0.004608295 
+  205          197.66555    179.12154   0.004878049 
+  200          197.01004    179.01241   0.005     
+  221          196.42542    178.90347   0.004524887 
+  199          195.91685    178.79472   0.005025126 
+  194          195.47608    178.68616   0.005154639 
+  192          195.10815    178.57779   0.005208333 
+  222          194.81944    178.46961   0.004504505 
+  219          194.62256    178.36162   0.00456621 
+  185          194.54051    178.25381   0.005405405 
+  212          194.62097    178.14619   0.004716981 
+  204          194.92989    178.03876   0.004901961 
+  196          195.50007    177.93152   0.005102041 
+  219          196.02092    177.82447   0.00456621 
+  192          195.90091    177.7176    0.005208333 
+  191          195.45814    177.61091   0.005235602 
+  194          195.25193    177.50442   0.005154639 
+  200          195.41968    177.39811   0.005     
+  175          195.82142    177.29198   0.005714286 
+  180          196.14922    177.18604   0.005555556 
+  228          196.50931    177.08028   0.004385965 
+  186          197.25663    176.97471   0.005376344 
+  194          198.62014    176.86932   0.005154639 
+  213          200.84612    176.76411   0.004694836 
+  173          204.43769    176.65909   0.005780347 
+  212          210.47673    176.55425   0.004716981 
+  233          221.1029     176.44959   0.004291845 
+  261          239.57252    176.34512   0.003831418 
+  260          265.76296    176.24083   0.003846154 
+  234          279.30737    176.13671   0.004273504 
+  196          262.92418    176.03278   0.005102041 
+  243          243.71807    175.92904   0.004115226 
+  250          236.67052    175.82547   0.004     
+  229          240.69049    175.72208   0.004366812 
+  233          245.31289    175.61887   0.004291845 
+  204          236.68143    175.51584   0.004901961 
+  196          224.53437    175.413     0.005102041 
+  189          218.13868    175.31033   0.005291005 
+  213          217.05814    175.20784   0.004694836 
+  206          220.80414    175.10552   0.004854369 
+  248          226.28306    175.00339   0.004032258 
+  221          223.63675    174.90144   0.004524887 
+  242          215.63598    174.79966   0.004132231 
+  207          210.55567    174.69806   0.004830918 
+  208          209.67174    174.59663   0.004807692 
+  209          211.65105    174.49539   0.004784689 
+  206          211.35246    174.39432   0.004854369 
+  222          207.74694    174.29342   0.004504505 
+  260          205.6417     174.1927    0.003846154 
+  215          206.57762    174.09216   0.004651163 
+  226          210.33391    173.9918    0.004424779 
+  243          214.90722    173.8916    0.004115226 
+  215          218.54983    173.79159   0.004651163 
+  279          225.61387    173.69174   0.003584229 
+  281          240.47       173.59207   0.003558719 
+  273          262.22805    173.49258   0.003663004 
+  229          277.50564    173.39326   0.004366812 
+  266          272.30129    173.29411   0.003759398 
+  252          260.37571    173.19513   0.003968254 
+  263          259.70282    173.09633   0.003802281 
+  286          273.83715    172.9977    0.003496503 
+  298          297.58634    172.89924   0.003355705 
+  295          315.50915    172.80096   0.003389831 
+  314          318.62206    172.70284   0.003184713 
+  307          319.64438    172.6049    0.003257329 
+  304          318.62742    172.50713   0.003289474 
+  331          329.11763    172.40953   0.003021148 
+  398          367.91122    172.3121    0.002512563 
+  456          449.53693    172.21484   0.002192982 
+  510          606.39438    172.11775   0.001960784 
+  664          814.19563    172.02083   0.001506024 
+  694          803.25878    171.92408   0.001440922 
+  618          589.38768    171.8275    0.001618123 
+  448          465.83023    171.73108   0.002232143 
+  425          454.02278    171.63484   0.002352941 
+  453          520.56854    171.53876   0.002207506 
+  420          550.45695    171.44286   0.002380952 
+  420          442.11829    171.34712   0.002380952 
+  320          344.34131    171.25155   0.003125  
+  297          292.40589    171.15614   0.003367003 
+  272          266.98935    171.0609    0.003676471 
+  251          256.38407    170.96583   0.003984064 
+  235          256.20404    170.87093   0.004255319 
+  247          267.35122    170.77619   0.004048583 
+  250          298.50379    170.68162   0.004     
+  335          376.4696     170.58721   0.002985075 
+  428          524.55012    170.49297   0.002336449 
+  493          566.01668    170.3989    0.002028398 
+  437          430.87309    170.30499   0.00228833 
+  391          361.47913    170.21124   0.002557545 
+  391          376.81127    170.11766   0.002557545 
+  454          462.46139    170.02425   0.002202643 
+  497          536.42089    169.93099   0.002012072 
+  448          451.52924    169.83791   0.002232143 
+  357          349.38779    169.74498   0.00280112 
+  296          299.19812    169.65222   0.003378378 
+  280          286.88249    169.55962   0.003571429 
+  285          288.78887    169.46719   0.003508772 
+  259          275.42378    169.37491   0.003861004 
+  263          248.91831    169.2828    0.003802281 
+  235          226.91836    169.19085   0.004255319 
+  201          213.74745    169.09907   0.004975124 
+  220          206.62748    169.00744   0.004545455 
+  194          203.08075    168.91598   0.005154639 
+  194          201.03193    168.82468   0.005154639 
+  191          198.78253    168.73354   0.005235602 
+  218          197.05101    168.64255   0.004587156 
+  202          196.61183    168.55173   0.004950495 
+  184          197.4682     168.46107   0.005434783 
+  191          199.48241    168.37057   0.005235602 
+  183          202.30571    168.28023   0.005464481 
+  207          206.54783    168.19005   0.004830918 
+  199          213.96565    168.10003   0.005025126 
+  211          227.0334     168.01017   0.004739336 
+  210          250.40447    167.92047   0.004761905 
+  256          292.08497    167.83092   0.00390625 
+  299          358.5141     167.74154   0.003344482 
+  295          421.18831    167.65231   0.003389831 
+  378          404.82482    167.56324   0.002645503 
+  302          342.74228    167.47433   0.003311258 
+  270          304.21371    167.38557   0.003703704 
+  262          299.48939    167.29697   0.003816794 
+  283          316.87586    167.20853   0.003533569 
+  287          317.4684     167.12025   0.003484321 
+  261          281.08915    167.03212   0.003831418 
+  246          244.14354    166.94415   0.004065041 
+  199          220.66124    166.85634   0.005025126 
+  197          206.98039    166.76868   0.005076142 
+  206          198.83545    166.68118   0.004854369 
+  190          193.72393    166.59383   0.005263158 
+  179          191.4528     166.50664   0.005586592 
+  174          189.22842    166.4196    0.005747126 
+  199          187.7956     166.33272   0.005025126 
+  166          186.9813     166.246     0.006024096 
+  205          186.7168     166.15942   0.004878049 
+  194          187.02368    166.07301   0.005154639 
+  216          188.01224    165.98674   0.00462963 
+  190          190.28524    165.90063   0.005263158 
+  164          191.9883     165.81468   0.006097561 
+  190          192.01331    165.72887   0.005263158 
+  218          191.07822    165.64322   0.004587156 
+  198          190.45706    165.55773   0.005050505 
+  191          190.3632     165.47238   0.005235602 
+  187          190.72448    165.38719   0.005347594 
+  205          190.99402    165.30215   0.004878049 
+  252          191.0783     165.21727   0.003968254 
+  205          191.93804    165.13253   0.004878049 
+  208          192.85406    165.04795   0.004807692 
+  214          191.31928    164.96352   0.004672897 
+  226          188.50083    164.87924   0.004424779 
+  235          186.67353    164.79511   0.004255319 
+  258          186.21279    164.71113   0.003875969 
+  263          186.85179    164.62731   0.003802281 
+  308          187.52314    164.54363   0.003246753 
+  302          187.72734    164.46011   0.003311258 
+  315          189.02844    164.37673   0.003174603 
+  307          191.73189    164.29351   0.003257329 
+  307          193.11798    164.21043   0.003257329 
+  283          192.28511    164.12751   0.003533569 
+  324          192.68861    164.04473   0.00308642 
+  294          195.94765    163.96211   0.003401361 
+  263          203.39479    163.87963   0.003802281 
+  304          216.28355    163.7973    0.003289474 
+  291          230.61574    163.71512   0.003436426 
+  277          231.99074    163.63309   0.003610108 
+  253          218.90306    163.55121   0.003952569 
+  262          207.91335    163.46947   0.003816794 
+  247          204.39381    163.38789   0.004048583 
+  250          207.4619     163.30645   0.004     
+  239          212.05696    163.22516   0.0041841 
+  232          209.79755    163.14401   0.004310345 
+  233          204.14912    163.06302   0.004291845 
+  241          199.42116    162.98217   0.004149378 
+  234          196.46322    162.90147   0.004273504 
+  218          195.04191    162.82091   0.004587156 
+  196          193.53945    162.7405    0.005102041 
+  213          193.25329    162.66024   0.004694836 
+  208          194.70472    162.58012   0.004807692 
+  212          197.64536    162.50015   0.004716981 
+  230          203.73687    162.42033   0.004347826 
+  251          213.85398    162.34065   0.003984064 
+  217          224.56374    162.26112   0.004608295 
+  208          223.81193    162.18173   0.004807692 
+  228          213.2058     162.10248   0.004385965 
+  221          205.59325    162.02339   0.004524887 
+  215          203.93241    161.94443   0.004651163 
+  233          207.05727    161.86562   0.004291845 
+  216          210.22304    161.78696   0.00462963 
+  203          206.94396    161.70844   0.004926108 
+  218          201.38089    161.63006   0.004587156 
+  202          198.05466    161.55183   0.004950495 
+  201          196.96855    161.47374   0.004975124 
+  198          197.40225    161.3958    0.005050505 
+  205          198.96985    161.318     0.004878049 
+  216          201.63899    161.24034   0.00462963 
+  177          205.60724    161.16282   0.005649718 
+  200          210.80508    161.08545   0.005     
+  254          215.42439    161.00822   0.003937008 
+  203          218.0915     160.93114   0.004926108 
+  230          221.28846    160.85419   0.004347826 
+  273          226.51234    160.77739   0.003663004 
+  257          233.97055    160.70073   0.003891051 
+  240          243.45484    160.62421   0.004166667 
+  313          253.62519    160.54784   0.003194888 
+  310          265.4329     160.4716    0.003225806 
+  274          280.19301    160.39551   0.003649635 
+  313          298.69894    160.31956   0.003194888 
+  320          321.29126    160.24374   0.003125  
+  368          348.01938    160.16807   0.002717391 
+  351          379.32468    160.09255   0.002849003 
+  412          414.60684    160.01716   0.002427184 
+  404          450.02096    159.94191   0.002475248 
+  446          474.42178    159.8668    0.002242152 
+  471          483.72145    159.79183   0.002123142 
+  462          486.12444    159.71701   0.002164502 
+  431          492.44498    159.64232   0.002320186 
+  446          501.29061    159.56777   0.002242152 
+  420          497.48276    159.49336   0.002380952 
+  433          478.28792    159.41909   0.002309469 
+  383          451.8294     159.34497   0.002610966 
+  372          422.05262    159.27097   0.002688172 
+  347          396.36518    159.19712   0.002881844 
+  351          373.9032     159.12341   0.002849003 
+  320          349.11568    159.04984   0.003125  
+  275          324.72614    158.9764    0.003636364 
+  310          302.91249    158.9031    0.003225806 
+  328          282.75102    158.82994   0.00304878 
+  273          265.47669    158.75692   0.003663004 
+  239          251.39438    158.68404   0.0041841 
+  263          239.9671     158.61129   0.003802281 
+  209          230.64753    158.53869   0.004784689 
+  268          223.01343    158.46622   0.003731343 
+  226          216.7337     158.39388   0.004424779 
+  223          211.55515    158.32169   0.004484305 
+  228          207.28365    158.24963   0.004385965 
+  241          203.77352    158.17771   0.004149378 
+  219          200.92021    158.10592   0.00456621 
+  208          198.65075    158.03427   0.004807692 
+  211          196.90316    157.96276   0.004739336 
+  216          195.64779    157.89139   0.00462963 
+  207          195.01039    157.82015   0.004830918 
+  187          195.23812    157.74904   0.005347594 
+  204          196.59011    157.67807   0.004901961 
+  232          198.66866    157.60724   0.004310345 
+  224          199.61544    157.53655   0.004464286 
+  236          199.86755    157.46598   0.004237288 
+  218          201.33977    157.39556   0.004587156 
+  243          202.132      157.32527   0.004115226 
+  222          200.56593    157.25511   0.004504505 
+  195          199.02528    157.18509   0.005128205 
+  231          197.9113     157.11521   0.004329004 
+  255          197.60445    157.04545   0.003921569 
+  243          198.56708    156.97584   0.004115226 
+  227          199.42361    156.90636   0.004405286 
+  215          199.72089    156.83701   0.004651163 
+  246          201.04468    156.76779   0.004065041 
+  264          204.2045     156.69871   0.003787879 
+  278          209.8161     156.62977   0.003597122 
+  251          219.47843    156.56095   0.003984064 
+  243          237.49507    156.49227   0.004115226 
+  312          273.85491    156.42373   0.003205128 
+  308          343.87658    156.35532   0.003246753 
+  346          426.26901    156.28704   0.002890173 
+  330          404.9972     156.21889   0.003030303 
+  332          335.13833    156.15088   0.003012048 
+  302          306.19393    156.083     0.003311258 
+  311          310.96407    156.01525   0.003215434 
+  302          329.24267    155.94763   0.003311258 
+  315          346.12117    155.88015   0.003174603 
+  275          313.2268     155.8128    0.003636364 
+  292          268.78962    155.74558   0.003424658 
+  270          246.93907    155.67849   0.003703704 
+  234          237.48282    155.61154   0.004273504 
+  265          226.71526    155.54472   0.003773585 
+  241          216.13265    155.47802   0.004149378 
+  238          209.45632    155.41146   0.004201681 
+  224          205.84374    155.34504   0.004464286 
+  217          203.12774    155.27874   0.004608295 
+  224          200.48187    155.21257   0.004464286 
+  208          198.74119    155.14654   0.004807692 
+  196          198.16283    155.08063   0.005102041 
+  244          198.7024     155.01486   0.004098361 
+  216          200.31385    154.94921   0.00462963 
+  217          202.84454    154.8837    0.004608295 
+  222          207.10571    154.81832   0.004504505 
+  268          215.36084    154.75307   0.003731343 
+  261          230.90165    154.68794   0.003831418 
+  275          258.07375    154.62295   0.003636364 
+  285          301.13085    154.55809   0.003508772 
+  337          355.92278    154.49336   0.002967359 
+  347          349.86553    154.42875   0.002881844 
+  332          293.04608    154.36428   0.003012048 
+  297          260.63403    154.29993   0.003367003 
+  257          255.59207    154.23572   0.003891051 
+  277          269.96239    154.17163   0.003610108 
+  300          296.22381    154.10768   0.003333333 
+  300          296.34627    154.04385   0.003333333 
+  261          277.92668    153.98015   0.003831418 
+  283          270.97465    153.91658   0.003533569 
+  216          259.38761    153.85314   0.00462963 
+  240          240.74724    153.78982   0.004166667 
+  257          227.96162    153.72664   0.003891051 
+  218          223.62026    153.66358   0.004587156 
+  214          226.14375    153.60065   0.004672897 
+  229          231.18771    153.53785   0.004366812 
+  239          230.07786    153.47518   0.0041841 
+  248          224.07558    153.41263   0.004032258 
+  219          221.36172    153.35022   0.00456621 
+  235          225.27767    153.28793   0.004255319 
+  255          239.00534    153.22576   0.003921569 
+  257          264.8695     153.16373   0.003891051 
+  272          279.57747    153.10182   0.003676471 
+  250          258.48687    153.04004   0.004     
+  239          238.88674    152.97838   0.0041841 
+  265          232.13703    152.91685   0.003773585 
+  230          235.62514    152.85545   0.004347826 
+  217          247.66155    152.79418   0.004608295 
+  247          255.98989    152.73303   0.004048583 
+  229          246.88718    152.67201   0.004366812 
+  226          238.46677    152.61111   0.004424779 
+  233          236.50786    152.55034   0.004291845 
+  254          238.10648    152.4897    0.003937008 
+  219          240.1898     152.42918   0.00456621 
+  245          242.71208    152.36879   0.004081633 
+  251          246.67105    152.30853   0.003984064 
+  263          251.82994    152.24839   0.003802281 
+  266          257.45298    152.18837   0.003759398 
+  264          263.543      152.12848   0.003787879 
+  257          269.90684    152.06872   0.003891051 
+  303          276.94279    152.00908   0.00330033 
+  309          285.3716     151.94957   0.003236246 
+  302          295.24304    151.89018   0.003311258 
+  302          306.34992    151.83091   0.003311258 
+  323          319.03003    151.77177   0.003095975 
+  315          333.87926    151.71276   0.003174603 
+  356          351.38285    151.65387   0.002808989 
+  382          372.12462    151.5951    0.002617801 
+  396          396.98416    151.53646   0.002525253 
+  455          426.49509    151.47794   0.002197802 
+  534          459.67494    151.41955   0.001872659 
+  621          497.5063     151.36128   0.001610306 
+  627          544.28754    151.30313   0.001594896 
+  713          603.66069    151.24511   0.001402525 
+  719          679.64318    151.18721   0.001390821 
+  743          778.03191    151.12944   0.001345895 
+  820          907.04826    151.07179   0.001219512 
+  864          1080.81751   151.01426   0.001157407 
+  1153         1324.7473    150.95686   0.000867303 
+  1379         1683.44875   150.89957   0.000725163 
+  1881         2241.70756   150.84242   0.000531632 
+  2731         3184.53738   150.78538   0.000366166 
+  4343         5001.38867   150.72847   0.000230256 
+  8024         9012.53582   150.67168   0.000124626 
+  14671        17601.24327  150.61501   0.000068162 
+  23139        27863.85335  150.55846   0.000043217 
+  22682        22359.98355  150.50204   0.000044088 
+  13825        12426.93107  150.44574   0.000072333 
+  8333         7867.73826   150.38956   0.000120005 
+  6901         7233.15015   150.33351   0.000144907 
+  8544         9893.40587   150.27757   0.000117041 
+  11554        14712.30387  150.22176   0.00008655 
+  11953        12896.1867   150.16607   0.000083661 
+  7470         7188.55937   150.1105    0.000133869 
+  4025         3966.5502    150.05506   0.000248447 
+  2379         2495.3438    149.99973   0.000420345 
+  1579         1768.44187   149.94453   0.000633312 
+  1177         1352.64376   149.88944   0.000849618 
+  1010         1092.29762   149.83448   0.000990099 
+  775          925.29282    149.77964   0.001290323 
+  721          818.61676    149.72492   0.001386963 
+  679          726.04652    149.67032   0.001472754 
+  580          628.54189    149.61585   0.001724138 
+  558          552.74468    149.56149   0.001792115 
+  447          499.49008    149.50725   0.002237136 
+  434          463.50375    149.45314   0.002304147 
+  386          441.24735    149.39914   0.002590674 
+  371          419.52093    149.34526   0.002695418 
+  345          385.95592    149.29151   0.002898551 
+  362          355.85111    149.23787   0.002762431 
+  337          333.45617    149.18436   0.002967359 
+  318          316.26262    149.13096   0.003144654 
+  294          302.30881    149.07769   0.003401361 
+  276          290.56924    149.02453   0.003623188 
+  294          280.49516    148.9715    0.003401361 
+  275          271.74421    148.91858   0.003636364 
+  290          264.11407    148.86578   0.003448276 
+  272          257.46161    148.8131    0.003676471 
+  246          251.66463    148.76055   0.004065041 
+  245          246.94462    148.70811   0.004081633 
+  244          242.62238    148.65579   0.004098361 
+  248          238.95628    148.60358   0.004032258 
+  227          235.91168    148.5515    0.004405286 
+  242          233.45915    148.49954   0.004132231 
+  242          231.58278    148.44769   0.004132231 
+  235          230.28759    148.39597   0.004255319 
+  243          229.60282    148.34436   0.004115226 
+  240          229.79844    148.29287   0.004166667 
+  252          230.87664    148.2415    0.003968254 
+  263          233.40853    148.19024   0.003802281 
+  259          235.56229    148.13911   0.003861004 
+  231          232.96646    148.08809   0.004329004 
+  233          229.33122    148.03719   0.004291845 
+  231          227.0765     147.98641   0.004329004 
+  224          226.19075    147.93574   0.004464286 
+  231          226.56045    147.8852    0.004329004 
+  228          227.44999    147.83477   0.004385965 
+  199          226.1878     147.78445   0.005025126 
+  218          223.21456    147.73426   0.004587156 
+  215          220.55678    147.68418   0.004651163 
+  215          218.59711    147.63422   0.004651163 
+  247          217.43073    147.58438   0.004048583 
+  218          217.00348    147.53465   0.004587156 
+  239          217.19943    147.48504   0.0041841 
+  230          217.87639    147.43555   0.004347826 
+  215          218.91934    147.38618   0.004651163 
+  213          220.23285    147.33692   0.004694836 
+  230          221.6373     147.28777   0.004347826 
+  275          222.99007    147.23875   0.003636364 
+  240          224.41732    147.18984   0.004166667 
+  249          226.3851     147.14104   0.004016064 
+  277          228.84249    147.09236   0.003610108 
+  280          228.88862    147.0438    0.003571429 
+  273          224.47706    146.99536   0.003663004 
+  264          219.49168    146.94703   0.003787879 
+  297          216.38091    146.89881   0.003367003 
+  267          215.66396    146.85071   0.003745318 
+  273          217.09611    146.80273   0.003663004 
+  278          217.04095    146.75486   0.003597122 
+  230          210.94184    146.70711   0.004347826 
+  257          202.95487    146.65947   0.003891051 
+  262          197.1337     146.61195   0.003816794 
+  247          193.80965    146.56454   0.004048583 
+  255          192.53277    146.51725   0.003921569 
+  219          192.23553    146.47007   0.00456621 
+  227          190.92147    146.42301   0.004405286 
+  229          189.16214    146.37606   0.004366812 
+  231          188.95876    146.32923   0.004329004 
+  215          191.26264    146.28251   0.004651163 
+  225          196.88786    146.2359    0.004444444 
+  211          205.69745    146.18941   0.004739336 
+  204          212.29217    146.14304   0.004901961 
+  202          212.00266    146.09678   0.004950495 
+  217          211.19351    146.05063   0.004608295 
+  203          209.34347    146.00459   0.004926108 
+  198          204.00813    145.95867   0.005050505 
+  210          200.77318    145.91287   0.004761905 
+  197          200.60153    145.86718   0.005076142 
+  212          199.25308    145.8216    0.004716981 
+  215          197.28397    145.77613   0.004651163 
+  226          196.43529    145.73078   0.004424779 
+  223          194.40627    145.68554   0.004484305 
+  216          192.69837    145.64042   0.00462963 
+  220          193.26964    145.5954    0.004545455 
+  198          193.57438    145.55051   0.005050505 
+  182          191.14507    145.50572   0.005494505 
+  191          188.74982    145.46105   0.005235602 
+  198          188.17206    145.41649   0.005050505 
+  211          189.43975    145.37204   0.004739336 
+  198          192.34778    145.3277    0.005050505 
+  171          196.14178    145.28348   0.005847953 
+  193          199.22749    145.23937   0.005181347 
+  168          202.28676    145.19537   0.005952381 
+  226          207.1928     145.15149   0.004424779 
+  220          214.3415     145.10771   0.004545455 
+  202          223.58955    145.06405   0.004950495 
+  233          236.12675    145.0205    0.004291845 
+  256          251.6154     144.97706   0.00390625 
+  278          259.15044    144.93374   0.003597122 
+  262          254.97826    144.89052   0.003816794 
+  237          252.00716    144.84742   0.004219409 
+  297          256.57817    144.80443   0.003367003 
+  290          268.99444    144.76155   0.003448276 
+  287          287.60318    144.71878   0.003484321 
+  298          305.91037    144.67612   0.003355705 
+  295          320.78281    144.63358   0.003389831 
+  332          341.98238    144.59114   0.003012048 
+  374          380.72139    144.54882   0.002673797 
+  407          447.15593    144.5066    0.002457002 
+  499          560.5915     144.4645    0.002004008 
+  758          770.83732    144.42251   0.001319261 
+  1177         1216.55706   144.38063   0.000849618 
+  1926         2187.96863   144.33886   0.000519211 
+  2968         3688.49948   144.2972    0.000336927 
+  3336         3625.66874   144.25565   0.00029976 
+  2217         2183.16568   144.21421   0.00045106 
+  1368         1341.04223   144.17288   0.000730994 
+  1046         1064.6922    144.13166   0.000956023 
+  1114         1178.92456   144.09055   0.000897666 
+  1479         1705.29256   144.04955   0.000676133 
+  1775         2222.8033    144.00866   0.00056338 
+  1564         1661.1782    143.96788   0.000639386 
+  1026         988.9526     143.92721   0.000974659 
+  646          651.01352    143.88665   0.001547988 
+  494          490.02191    143.84619   0.002024291 
+  366          396.31833    143.80585   0.00273224 
+  340          336.4483     143.76562   0.002941176 
+  261          297.85575    143.72549   0.003831418 
+  296          273.38468    143.68548   0.003378378 
+  264          258.74642    143.64557   0.003787879 
+  239          248.74919    143.60577   0.0041841 
+  224          236.67758    143.56609   0.004464286 
+  236          223.4075     143.52651   0.004237288 
+  225          212.55896    143.48703   0.004444444 
+  227          204.34919    143.44767   0.004405286 
+  208          198.21769    143.40842   0.004807692 
+  201          193.6384     143.36927   0.004975124 
+  165          190.24007    143.33023   0.006060606 
+  167          187.82319    143.2913    0.005988024 
+  211          186.36977    143.25248   0.004739336 
+  205          186.03126    143.21377   0.004878049 
+  195          186.87873    143.17516   0.005128205 
+  181          187.73925    143.13666   0.005524862 
+  185          186.07091    143.09827   0.005405405 
+  180          182.93945    143.05999   0.005555556 
+  181          181.19459    143.02181   0.005524862 
+  170          180.45477    142.98374   0.005882353 
+  208          181.07496    142.94578   0.004807692 
+  183          182.88907    142.90793   0.005464481 
+  186          184.99891    142.87018   0.005376344 
+  228          186.70109    142.83254   0.004385965 
+  201          189.58278    142.79501   0.004975124 
+  207          195.37445    142.75758   0.004830918 
+  239          206.09615    142.72026   0.0041841 
+  230          225.25495    142.68305   0.004347826 
+  254          262.62177    142.64594   0.003937008 
+  300          337.69543    142.60894   0.003333333 
+  418          468.73737    142.57205   0.002392344 
+  475          565.4901     142.53526   0.002105263 
+  487          470.67098    142.49858   0.002053388 
+  400          349.28649    142.46201   0.0025    
+  350          288.84866    142.42554   0.002857143 
+  275          276.31503    142.38918   0.003636364 
+  307          302.53218    142.35292   0.003257329 
+  340          359.86386    142.31677   0.002941176 
+  365          372.8541     142.28072   0.002739726 
+  311          302.99172    142.24478   0.003215434 
+  270          243.44862    142.20895   0.003703704 
+  227          211.7931     142.17322   0.004405286 
+  220          196.03688    142.13759   0.004545455 
+  250          187.36656    142.10207   0.004     
+  214          181.98376    142.06666   0.004672897 
+  193          179.00763    142.03135   0.005181347 
+  213          178.45979    141.99614   0.004694836 
+  186          180.50718    141.96104   0.005376344 
+  222          183.86464    141.92605   0.004504505 
+  186          183.84164    141.89116   0.005376344 
+  188          179.77418    141.85637   0.005319149 
+  200          176.47778    141.82169   0.005     
+  207          175.73043    141.78711   0.004830918 
+  219          177.57406    141.75264   0.00456621 
+  192          182.29888    141.71827   0.005208333 
+  205          188.9613     141.68401   0.004878049 
+  196          191.48797    141.64985   0.005102041 
+  204          186.41712    141.61579   0.004901961 
+  194          180.40349    141.58184   0.005154639 
+  206          177.78003    141.54799   0.004854369 
+  179          178.81741    141.51424   0.005586592 
+  197          183.40053    141.4806    0.005076142 
+  196          189.764      141.44706   0.005102041 
+  185          190.5969     141.41362   0.005405405 
+  196          183.99836    141.38029   0.005102041 
+  192          177.54022    141.34706   0.005208333 
+  178          174.23344    141.31393   0.005617978 
+  188          173.76431    141.28091   0.005319149 
+  172          175.44032    141.24798   0.005813953 
+  192          177.28188    141.21516   0.005208333 
+  195          176.19478    141.18245   0.005128205 
+  191          173.45143    141.14983   0.005235602 
+  177          171.86175    141.11732   0.005649718 
+  168          171.75265    141.08491   0.005952381 
+  207          171.94507    141.05261   0.004830918 
+  181          171.51007    141.0204    0.005524862 
+  176          170.89665    140.9883    0.005681818 
+  191          170.5034     140.9563    0.005235602 
+  210          170.68224    140.9244    0.004761905 
+  205          171.51203    140.8926    0.004878049 
+  209          172.8058     140.8609    0.004784689 
+  230          174.01884    140.82931   0.004347826 
+  177          174.95801    140.79782   0.005649718 
+  193          176.15005    140.76642   0.005181347 
+  200          177.85539    140.73513   0.005     
+  207          180.13721    140.70394   0.004830918 
+  199          183.10807    140.67285   0.005025126 
+  220          186.92117    140.64187   0.004545455 
+  209          191.28441    140.61098   0.004784689 
+  202          194.70327    140.58019   0.004950495 
+  200          196.9024     140.54951   0.005     
+  210          199.69272    140.51892   0.004761905 
+  193          203.94012    140.48844   0.005181347 
+  201          209.92369    140.45805   0.004975124 
+  255          218.06324    140.42777   0.003921569 
+  250          228.78229    140.39758   0.004     
+  269          241.51563    140.3675    0.003717472 
+  288          253.60094    140.33752   0.003472222 
+  270          262.31227    140.30763   0.003703704 
+  319          271.98858    140.27785   0.003134796 
+  318          287.36559    140.24816   0.003144654 
+  312          310.50025    140.21857   0.003205128 
+  316          343.54473    140.18909   0.003164557 
+  379          388.40044    140.1597    0.002638522 
+  388          442.71953    140.13041   0.00257732 
+  459          507.58212    140.10122   0.002178649 
+  544          603.4955     140.07213   0.001838235 
+  729          761.83641    140.04314   0.001371742 
+  959          1041.12903   140.01425   0.001042753 
+  1483         1594.09891   139.98546   0.000674309 
+  2601         2790.22829   139.95676   0.000384468 
+  4626         5133.20294   139.92817   0.000216169 
+  6246         7159.54278   139.89967   0.000160102 
+  5101         5286.81022   139.87127   0.00019604 
+  3026         3022.66849   139.84297   0.000330469 
+  1929         1966.95177   139.81476   0.000518403 
+  1621         1695.31626   139.78666   0.000616903 
+  1973         2012.96943   139.75865   0.000506842 
+  2615         3018.96947   139.73074   0.000382409 
+  3248         3883.37      139.70293   0.000307882 
+  2600         2825.68706   139.67521   0.000384615 
+  1567         1620.68027   139.6476    0.000638162 
+  935          1001.6791    139.62008   0.001069519 
+  699          708.65867    139.59265   0.001430615 
+  533          551.13268    139.56533   0.001876173 
+  402          455.61764    139.5381    0.002487562 
+  371          393.70819    139.51097   0.002695418 
+  353          348.43291    139.48393   0.002832861 
+  293          313.67628    139.45699   0.003412969 
+  259          287.97414    139.43015   0.003861004 
+  248          268.64761    139.40341   0.004032258 
+  241          253.13532    139.37676   0.004149378 
+  220          242.40895    139.35021   0.004545455 
+  222          234.5217     139.32375   0.004504505 
+  240          227.24499    139.29739   0.004166667 
+  207          220.42669    139.27113   0.004830918 
+  218          214.3081     139.24496   0.004587156 
+  207          208.37774    139.21889   0.004830918 
+  214          203.26817    139.19291   0.004672897 
+  163          198.67808    139.16703   0.006134969 
+  190          195.15635    139.14124   0.005263158 
+  196          192.7691     139.11555   0.005102041 
+  179          191.20383    139.08996   0.005586592 
+  167          189.81694    139.06446   0.005988024 
+  201          188.38909    139.03905   0.004975124 
+  222          186.92868    139.01374   0.004504505 
+  171          185.09052    138.98852   0.005847953 
+  188          182.48458    138.9634    0.005319149 
+  208          179.67449    138.93838   0.004807692 
+  199          177.36091    138.91345   0.005025126 
+  170          175.63654    138.88861   0.005882353 
+  182          174.42559    138.86386   0.005494505 
+  192          173.66087    138.83922   0.005208333 
+  212          173.15603    138.81466   0.004716981 
+  185          172.61759    138.7902    0.005405405 
+  181          172.4192     138.76583   0.005524862 
+  164          173.2772     138.74156   0.006097561 
+  182          175.53118    138.71738   0.005494505 
+  217          178.62151    138.69329   0.004608295 
+  200          182.45732    138.6693    0.005     
+  231          190.17324    138.6454    0.004329004 
+  237          200.36646    138.62159   0.004219409 
+  237          197.88121    138.59788   0.004219409 
+  237          186.37779    138.57426   0.004219409 
+  190          179.33362    138.55073   0.005263158 
+  202          177.18845    138.52729   0.004950495 
+  181          178.08614    138.50395   0.005524862 
+  175          182.49344    138.4807    0.005714286 
+  215          189.41558    138.45754   0.004651163 
+  232          189.42299    138.43448   0.004310345 
+  197          181.27719    138.4115    0.005076142 
+  199          174.46832    138.38862   0.005025126 
+  156          170.86306    138.36583   0.006410256 
+  189          169.42262    138.34313   0.005291005 
+  187          169.34005    138.32053   0.005347594 
+  182          169.97302    138.29801   0.005494505 
+  209          170.15909    138.27559   0.004784689 
+  197          169.22814    138.25326   0.005076142 
+  202          168.14959    138.23102   0.004950495 
+  178          167.54814    138.20887   0.005617978 
+  184          167.37646    138.18681   0.005434783 
+  163          167.49923    138.16484   0.006134969 
+  178          167.88967    138.14297   0.005617978 
+  171          168.70098    138.12118   0.005847953 
+  176          170.1874     138.09949   0.005681818 
+  199          172.66554    138.07788   0.005025126 
+  208          175.61225    138.05637   0.004807692 
+  190          176.54645    138.03494   0.005263158 
+  203          174.75525    138.01361   0.004926108 
+  192          172.92286    137.99236   0.005208333 
+  189          172.35221    137.97121   0.005291005 
+  181          173.15371    137.95014   0.005524862 
+  191          175.34046    137.92917   0.005235602 
+  189          178.94155    137.90828   0.005291005 
+  211          183.26131    137.88749   0.004739336 
+  195          187.83567    137.86678   0.005128205 
+  218          193.27549    137.84616   0.004587156 
+  205          200.18943    137.82563   0.004878049 
+  231          211.32045    137.80519   0.004329004 
+  244          224.75888    137.78484   0.004098361 
+  217          228.03892    137.76458   0.004608295 
+  198          218.93324    137.7444    0.005050505 
+  228          209.93874    137.72432   0.004385965 
+  225          206.51901    137.70432   0.004444444 
+  238          207.50245    137.68441   0.004201681 
+  233          211.73685    137.66459   0.004291845 
+  214          218.89087    137.64486   0.004672897 
+  246          224.73255    137.62521   0.004065041 
+  240          226.18708    137.60565   0.004166667 
+  262          229.64545    137.58618   0.003816794 
+  218          239.35272    137.5668    0.004587156 
+  271          249.2575     137.54751   0.003690037 
+  237          248.15599    137.5283    0.004219409 
+  281          241.62776    137.50918   0.003558719 
+  264          239.69985    137.49014   0.003787879 
+  251          244.98217    137.4712    0.003984064 
+  271          258.07171    137.45234   0.003690037 
+  286          278.96732    137.43356   0.003496503 
+  358          301.00938    137.41488   0.002793296 
+  316          310.58471    137.39628   0.003164557 
+  340          313.86524    137.37776   0.002941176 
+  384          327.70292    137.35933   0.002604167 
+  359          359.91421    137.34099   0.002785515 
+  415          407.11509    137.32273   0.002409639 
+  440          451.29281    137.30456   0.002272727 
+  411          471.99991    137.28648   0.00243309 
+  448          486.24955    137.26848   0.002232143 
+  479          524.19863    137.25057   0.002087683 
+  533          598.10722    137.23274   0.001876173 
+  640          720.11944    137.21499   0.0015625 
+  904          913.55588    137.19733   0.001106195 
+  1143         1227.27367   137.17976   0.000874891 
+  1780         1791.67644   137.16227   0.000561798 
+  2966         2960.38039   137.14487   0.000337154 
+  5341         5389.41449   137.12755   0.000187231 
+  7909         8734.46849   137.11031   0.000126438 
+  7600         8163.52253   137.09316   0.000131579 
+  5005         4864.19337   137.0761    0.0001998 
+  3068         2896.31071   137.05911   0.000325945 
+  2220         2123.02723   137.04221   0.00045045 
+  2109         2075.24971   137.0254    0.000474158 
+  2669         2731.53938   137.00867   0.000374672 
+  3685         4198.88646   136.99202   0.00027137 
+  4090         4876.0004    136.97545   0.000244499 
+  3107         3277.59493   136.95897   0.000321854 
+  1928         1879.63549   136.94258   0.000518672 
+  1140         1172.70883   136.92626   0.000877193 
+  820          829.50353    136.91003   0.001219512 
+  613          644.40804    136.89388   0.001631321 
+  502          532.20813    136.87781   0.001992032 
+  447          458.96005    136.86183   0.002237136 
+  409          408.97868    136.84592   0.002444988 
+  334          373.95453    136.8301    0.002994012 
+  312          348.96252    136.81437   0.003205128 
+  276          330.47048    136.79871   0.003623188 
+  290          314.29973    136.78314   0.003448276 
+  307          299.05392    136.76765   0.003257329 
+  286          286.92785    136.75223   0.003496503 
+  288          278.32118    136.73691   0.003472222 
+  318          271.75585    136.72166   0.003144654 
+  260          266.26981    136.70649   0.003846154 
+  289          263.24164    136.69141   0.003460208 
+  279          263.24993    136.6764    0.003584229 
+  265          264.49138    136.66148   0.003773585 
+  259          261.3055     136.64663   0.003861004 
+  260          249.84836    136.63187   0.003846154 
+  244          236.93792    136.61719   0.004098361 
+  238          226.90886    136.60259   0.004201681 
+  236          220.04822    136.58807   0.004237288 
+  235          216.47731    136.57362   0.004255319 
+  252          216.03431    136.55926   0.003968254 
+  251          216.82078    136.54498   0.003984064 
+  234          214.952      136.53078   0.004273504 
+  257          211.57246    136.51665   0.003891051 
+  250          211.40788    136.50261   0.004     
+  252          216.27418    136.48865   0.003968254 
+  250          225.39815    136.47476   0.004     
+  284          236.74898    136.46095   0.003521127 
+  276          243.70657    136.44723   0.003623188 
+  251          236.32065    136.43358   0.003984064 
+  249          223.54963    136.42001   0.004016064 
+  248          216.34525    136.40651   0.004032258 
+  245          216.64841    136.3931    0.004081633 
+  229          223.95798    136.37977   0.004366812 
+  258          236.87639    136.36651   0.003875969 
+  253          250.28778    136.35333   0.003952569 
+  230          251.9513     136.34023   0.004347826 
+  245          242.47172    136.3272    0.004081633 
+  253          234.77105    136.31425   0.003952569 
+  264          233.29259    136.30138   0.003787879 
+  231          237.84543    136.28859   0.004329004 
+  212          247.68057    136.27588   0.004716981 
+  215          257.60292    136.26324   0.004651163 
+  214          256.48772    136.25068   0.004672897 
+  230          246.20231    136.23819   0.004347826 
+  232          236.3719     136.22578   0.004310345 
+  211          226.68716    136.21345   0.004739336 
+  212          217.86659    136.20119   0.004716981 
+  207          212.89629    136.18901   0.004830918 
+  191          211.41738    136.17691   0.005235602 
+  215          209.267      136.16488   0.004651163 
+  209          203.61755    136.15293   0.004784689 
+  232          198.49267    136.14105   0.004310345 
+  185          195.44318    136.12925   0.005405405 
+  195          193.66164    136.11752   0.005128205 
+  192          194.43678    136.10587   0.005208333 
+  191          196.6471     136.09429   0.005235602 
+  190          196.58272    136.08279   0.005263158 
+  206          189.13851    136.07137   0.004854369 
+  209          179.65201    136.06001   0.004784689 
+  190          174.42384    136.04874   0.005263158 
+  187          173.43125    136.03753   0.005347594 
+  168          175.91571    136.0264    0.005952381 
+  160          180.42415    136.01535   0.00625   
+  197          184.09611    136.00437   0.005076142 
+  181          185.66432    135.99346   0.005524862 
+  200          186.29209    135.98262   0.005     
+  202          191.94587    135.97186   0.004950495 
+  199          203.78058    135.96117   0.005025126 
+  201          211.87923    135.95056   0.004975124 
+  180          204.21977    135.94002   0.005555556 
+  186          189.65043    135.92955   0.005376344 
+  153          178.27188    135.91915   0.006535948 
+  161          171.94785    135.90883   0.00621118 
+  157          170.38426    135.89858   0.006369427 
+  184          173.07632    135.8884    0.005434783 
+  186          178.09079    135.87829   0.005376344 
+  158          178.76914    135.86826   0.006329114 
+  161          171.83386    135.85829   0.00621118 
+  175          163.7491     135.8484    0.005714286 
+  154          158.06124    135.83858   0.006493506 
+  181          154.5554     135.82883   0.005524862 
+  164          152.48115    135.81916   0.006097561 
+  157          151.34491    135.80955   0.006369427 
+  195          150.91981    135.80001   0.005128205 
+  156          151.14037    135.79055   0.006410256 
+  157          152.06821    135.78116   0.006369427 
+  136          154.02697    135.77183   0.007352941 
+  137          157.04019    135.76258   0.00729927 
+  177          159.05111    135.7534    0.005649718 
+  155          157.29829    135.74428   0.006451613 
+  142          153.87027    135.73524   0.007042254 
+  172          151.40088    135.72627   0.005813953 
+  163          150.23278    135.71737   0.006134969 
+  163          150.06292    135.70853   0.006134969 
+  165          150.63883    135.69977   0.006060606 
+  147          151.74031    135.69107   0.006802721 
+  139          152.13641    135.68245   0.007194245 
+  143          150.89372    135.67389   0.006993007 
+  137          149.44932    135.6654    0.00729927 
+  137          148.68582    135.65698   0.00729927 
+  160          148.10428    135.64863   0.00625   
+  158          147.1683     135.64035   0.006329114 
+  146          146.20933    135.63213   0.006849315 
+  158          145.5424     135.62398   0.006329114 
+  151          145.20119    135.61591   0.006622517 
+  134          145.14052    135.60789   0.007462687 
+  167          145.32257    135.59995   0.005988024 
+  125          145.64367    135.59207   0.008     
+  146          145.81968    135.58426   0.006849315 
+  153          145.80475    135.57652   0.006535948 
+  140          145.91329    135.56885   0.007142857 
+  157          146.31573    135.56124   0.006369427 
+  179          147.02856    135.5537    0.005586592 
+  169          147.9752     135.54622   0.00591716 
+  144          149.04439    135.53881   0.006944444 
+  171          150.42385    135.53147   0.005847953 
+  166          152.74208    135.52419   0.006024096 
+  175          156.72583    135.51698   0.005714286 
+  168          163.02059    135.50984   0.005952381 
+  173          170.69459    135.50276   0.005780347 
+  201          174.62135    135.49575   0.004975124 
+  166          172.77644    135.4888    0.006024096 
+  177          170.93201    135.48191   0.005649718 
+  180          171.35867    135.4751    0.005555556 
+  212          171.80927    135.46834   0.004716981 
+  167          170.2979     135.46165   0.005988024 
+  164          169.40971    135.45503   0.006097561 
+  159          170.14733    135.44847   0.006289308 
+  186          169.47782    135.44197   0.005376344 
+  169          167.10482    135.43554   0.00591716 
+  181          166.17398    135.42917   0.005524862 
+  187          167.39045    135.42287   0.005347594 
+  186          169.30421    135.41663   0.005376344 
+  171          171.09009    135.41045   0.005847953 
+  162          173.09291    135.40434   0.00617284 
+  176          173.38242    135.39829   0.005681818 
+  168          172.45746    135.3923    0.005952381 
+  184          173.59935    135.38637   0.005434783 
+  194          176.62756    135.38051   0.005154639 
+  171          177.27156    135.37471   0.005847953 
+  184          174.97326    135.36898   0.005434783 
+  142          173.87105    135.3633    0.007042254 
+  168          175.08347    135.35769   0.005952381 
+  177          177.27007    135.35214   0.005649718 
+  177          181.01812    135.34665   0.005649718 
+  186          188.40251    135.34122   0.005376344 
+  207          201.30442    135.33585   0.004830918 
+  200          221.02387    135.33055   0.005     
+  234          254.53137    135.3253    0.004273504 
+  307          315.82661    135.32012   0.003257329 
+  342          396.3091     135.315     0.002923977 
+  398          400.44658    135.30994   0.002512563 
+  369          324.39149    135.30494   0.002710027 
+  284          267.48688    135.29999   0.003521127 
+  305          244.63597    135.29511   0.003278689 
+  255          246.8931     135.29029   0.003921569 
+  247          269.15076    135.28553   0.004048583 
+  282          305.42429    135.28083   0.003546099 
+  287          338.09123    135.27619   0.003484321 
+  274          325.64582    135.27161   0.003649635 
+  270          277.14529    135.26708   0.003703704 
+  266          244.2858     135.26262   0.003759398 
+  215          233.83488    135.25821   0.004651163 
+  246          239.84064    135.25387   0.004065041 
+  248          254.00129    135.24958   0.004032258 
+  246          263.64305    135.24535   0.004065041 
+  257          267.03319    135.24118   0.003891051 
+  268          279.80289    135.23707   0.003731343 
+  308          322.36958    135.23301   0.003246753 
+  375          408.14891    135.22901   0.002666667 
+  395          487.45485    135.22508   0.002531646 
+  387          444.09577    135.22119   0.002583979 
+  339          357.70059    135.21737   0.002949853 
+  283          307.32782    135.2136    0.003533569 
+  267          292.88523    135.20989   0.003745318 
+  296          311.75268    135.20624   0.003378378 
+  316          371.24669    135.20264   0.003164557 
+  367          471.75061    135.1991    0.002724796 
+  355          530.4714     135.19561   0.002816901 
+  367          448.21944    135.19218   0.002724796 
+  293          337.50393    135.18881   0.003412969 
+  266          270.65797    135.1855    0.003759398 
+  216          239.52508    135.18223   0.00462963 
+  241          231.20535    135.17903   0.004149378 
+  234          240.99091    135.17588   0.004273504 
+  240          264.96403    135.17278   0.004166667 
+  217          274.49685    135.16975   0.004608295 
+  244          243.44703    135.16676   0.004098361 
+  206          208.83818    135.16383   0.004854369 
+  180          187.56956    135.16095   0.005555556 
+  194          175.9314     135.15813   0.005154639 
+  190          169.43198    135.15537   0.005263158 
+  194          165.21702    135.15265   0.005154639 
+  184          162.18837    135.15      0.005434783 
+  163          160.27152    135.14739   0.006134969 
+  167          159.40874    135.14484   0.005988024 
+  223          159.51699    135.14234   0.004484305 
+  172          160.62607    135.1399    0.005813953 
+  177          162.6861     135.1375    0.005649718 
+  190          165.02079    135.13516   0.005263158 
+  176          167.32879    135.13288   0.005681818 
+  192          171.05575    135.13064   0.005208333 
+  188          177.3502     135.12846   0.005319149 
+  185          185.89005    135.12633   0.005405405 
+  198          195.33396    135.12426   0.005050505 
+  228          200.21163    135.12223   0.004385965 
+  204          199.70247    135.12026   0.004901961 
+  203          203.71108    135.11834   0.004926108 
+  171          219.5765     135.11647   0.005847953 
+  206          244.099      135.11465   0.004854369 
+  203          246.94167    135.11288   0.004926108 
+  178          224.53978    135.11117   0.005617978 
+  198          207.51019    135.1095    0.005050505 
+  179          198.83227    135.10788   0.005586592 
+  193          193.33882    135.10632   0.005181347 
+  179          192.89881    135.10481   0.005586592 
+  173          200.2801     135.10334   0.005780347 
+  186          213.19572    135.10193   0.005376344 
+  193          217.14463    135.10056   0.005181347 
+  199          205.45131    135.09925   0.005025126 
+  184          195.19841    135.09798   0.005434783 
+  219          192.62254    135.09677   0.00456621 
+  212          198.13649    135.0956    0.004716981 
+  227          214.56761    135.09448   0.004405286 
+  275          251.29689    135.09341   0.003636364 
+  378          325.69417    135.09239   0.002645503 
+  497          432.81209    135.09142   0.002012072 
+  438          439.39039    135.09049   0.002283105 
+  391          337.97081    135.08962   0.002557545 
+  279          267.53445    135.08879   0.003584229 
+  253          235.1274     135.08801   0.003952569 
+  251          224.50094    135.08728   0.003984064 
+  273          231.5922     135.08659   0.003663004 
+  295          261.98338    135.08596   0.003389831 
+  339          321.18961    135.08536   0.002949853 
+  361          361.27629    135.08482   0.002770083 
+  311          329.10952    135.08432   0.003215434 
+  262          284.45389    135.08387   0.003816794 
+  255          249.52353    135.08347   0.003921569 
+  227          228.26227    135.08311   0.004405286 
+  195          218.51898    135.0828    0.005128205 
+  225          218.65002    135.08254   0.004444444 
+  237          229.43309    135.08232   0.004219409 
+  218          246.28222    135.08214   0.004587156 
+  197          254.20041    135.08202   0.005076142 
+  181          246.64171    135.08193   0.005524862 
+  196          235.78942    135.0819    0.005102041 
+  210          233.29901    135.0819    0.004761905 
+  190          230.96312    135.08195   0.005263158 
+  161          217.00838    135.08205   0.00621118 
+  169          205.91556    135.08219   0.00591716 
+  192          203.06042    135.08238   0.005208333 
+  212          201.46317    135.08261   0.004716981 
+  204          196.37638    135.08288   0.004901961 
+  180          193.37442    135.0832    0.005555556 
+  203          197.40212    135.08356   0.004926108 
+  192          206.93521    135.08396   0.005208333 
+  202          214.81074    135.08441   0.004950495 
+  213          222.84894    135.0849    0.004694836 
+  165          225.55695    135.08544   0.006060606 
+  184          213.12219    135.08601   0.005434783 
+  195          196.03697    135.08663   0.005128205 
+  153          183.94457    135.08729   0.006535948 
+  179          177.07283    135.088     0.005586592 
+  196          174.04346    135.08874   0.005102041 
+  190          174.8986     135.08953   0.005263158 
+  166          179.48623    135.09036   0.006024096 
+  156          184.02134    135.09123   0.006410256 
+  150          181.18522    135.09214   0.006666667 
+  168          172.50633    135.0931    0.005952381 
+  162          164.7141     135.09409   0.00617284 
+  159          159.37549    135.09513   0.006289308 
+  169          155.63025    135.09621   0.00591716 
+  148          152.89132    135.09732   0.006756757 
+  151          150.74039    135.09848   0.006622517 
+  176          149.46266    135.09968   0.005681818 
+  152          148.62476    135.10092   0.006578947 
+  173          148.10326    135.1022    0.005780347 
+  161          147.82894    135.10351   0.00621118 
+  191          147.77721    135.10487   0.005235602 
+  157          147.95312    135.10627   0.006369427 
+  154          148.26974    135.1077    0.006493506 
+  155          149.03937    135.10918   0.006451613 
+  149          150.15545    135.11069   0.006711409 
+  180          151.37143    135.11225   0.005555556 
+  166          152.34615    135.11384   0.006024096 
+  160          153.38987    135.11547   0.00625   
+  178          155.02952    135.11714   0.005617978 
+  144          156.56978    135.11884   0.006944444 
+  169          156.70943    135.12059   0.00591716 
+  151          156.40004    135.12237   0.006622517 
+  178          157.22901    135.12419   0.005617978 
+  146          159.73621    135.12605   0.006849315 
+  196          163.76735    135.12794   0.005102041 
+  152          167.90795    135.12987   0.006578947 
+  165          169.20732    135.13184   0.006060606 
+  177          167.89957    135.13384   0.005649718 
+  159          166.62482    135.13589   0.006289308 
+  163          166.46458    135.13796   0.006134969 
+  174          168.10429    135.14008   0.005747126 
+  170          171.79016    135.14223   0.005882353 
+  183          178.2347     135.14441   0.005464481 
+  177          187.96343    135.14664   0.005649718 
+  174          199.75465    135.14889   0.005747126 
+  196          212.4535     135.15119   0.005102041 
+  192          221.93247    135.15351   0.005208333 
+  194          218.75139    135.15588   0.005154639 
+  158          207.20969    135.15827   0.006329114 
+  181          197.65008    135.16071   0.005524862 
+  199          192.70677    135.16317   0.005025126 
+  181          191.71619    135.16567   0.005524862 
+  199          193.63893    135.16821   0.005025126 
+  182          197.81313    135.17078   0.005494505 
+  200          203.44812    135.17338   0.005     
+  191          205.87805    135.17602   0.005235602 
+  201          201.81012    135.17869   0.004975124 
+  201          196.11746    135.1814    0.004975124 
+  171          192.58904    135.18413   0.005847953 
+  188          191.51171    135.1869    0.005319149 
+  203          192.35289    135.18971   0.004926108 
+  215          194.78082    135.19254   0.004651163 
+  180          198.64501    135.19541   0.005555556 
+  217          203.32025    135.19831   0.004608295 
+  210          206.76268    135.20125   0.004761905 
+  206          207.92654    135.20421   0.004854369 
+  211          209.01492    135.20721   0.004739336 
+  222          211.89472    135.21024   0.004504505 
+  218          216.79028    135.2133    0.004587156 
+  199          221.66265    135.21639   0.005025126 
+  191          223.36619    135.21951   0.005235602 
+  188          223.31012    135.22267   0.005319149 
+  225          224.33748    135.22585   0.004444444 
+  206          224.87293    135.22907   0.004854369 
+  214          224.82499    135.23231   0.004672897 
+  194          226.86054    135.23559   0.005154639 
+  230          232.07575    135.23889   0.004347826 
+  226          239.92759    135.24223   0.004424779 
+  222          247.89028    135.2456    0.004504505 
+  216          252.51582    135.24899   0.00462963 
+  200          254.78374    135.25242   0.005     
+  232          257.40854    135.25587   0.004310345 
+  226          261.07032    135.25936   0.004424779 
+  223          271.34412    135.26287   0.004484305 
+  258          299.62994    135.26641   0.003875969 
+  314          365.03288    135.26998   0.003184713 
+  383          489.33535    135.27358   0.002610966 
+  411          603.88397    135.27721   0.00243309 
+  414          522.18345    135.28087   0.002415459 
+  326          384.31003    135.28455   0.003067485 
+  261          303.26295    135.28826   0.003831418 
+  247          264.02794    135.292     0.004048583 
+  228          248.73636    135.29577   0.004385965 
+  242          252.77186    135.29957   0.004132231 
+  240          282.33648    135.30339   0.004166667 
+  311          343.01202    135.30724   0.003215434 
+  292          375.55048    135.31111   0.003424658 
+  276          312.12016    135.31501   0.003623188 
+  228          246.04575    135.31894   0.004385965 
+  228          209.18119    135.3229    0.004385965 
+  183          190.16428    135.32688   0.005464481 
+  173          179.70849    135.33089   0.005780347 
+  178          173.3844     135.33492   0.005617978 
+  168          169.22448    135.33898   0.005952381 
+  185          166.11743    135.34307   0.005405405 
+  174          163.65141    135.34718   0.005747126 
+  183          161.93337    135.35131   0.005464481 
+  172          161.01245    135.35547   0.005813953 
+  183          160.92641    135.35966   0.005464481 
+  168          161.82984    135.36387   0.005952381 
+  179          163.84862    135.36811   0.005586592 
+  176          166.26813    135.37237   0.005681818 
+  162          166.35541    135.37665   0.00617284 
+  175          163.4041     135.38096   0.005714286 
+  151          160.21214    135.38529   0.006622517 
+  185          158.52373    135.38965   0.005405405 
+  222          158.32162    135.39403   0.004504505 
+  173          158.01362    135.39843   0.005780347 
+  164          156.78173    135.40286   0.006097561 
+  166          156.21914    135.4073    0.006024096 
+  177          156.33484    135.41178   0.005649718 
+  169          155.67127    135.41627   0.00591716 
+  180          154.13982    135.42079   0.005555556 
+  172          152.98975    135.42533   0.005813953 
+  187          152.71346    135.42989   0.005347594 
+  160          153.06832    135.43448   0.00625   
+  161          153.51737    135.43909   0.00621118 
+  156          154.21329    135.44371   0.006410256 
+  160          155.73502    135.44837   0.00625   
+  173          156.62269    135.45304   0.005780347 
+  137          155.26808    135.45773   0.00729927 
+  155          152.79562    135.46245   0.006451613 
+  154          150.73706    135.46718   0.006493506 
+  161          149.45711    135.47194   0.00621118 
+  156          148.77744    135.47672   0.006410256 
+  154          148.68302    135.48152   0.006493506 
+  140          149.21808    135.48633   0.007142857 
+  158          150.15223    135.49117   0.006329114 
+  129          150.57394    135.49603   0.007751938 
+  162          149.79732    135.50091   0.00617284 
+  150          148.49527    135.50581   0.006666667 
+  133          147.43247    135.51073   0.007518797 
+  157          146.82663    135.51567   0.006369427 
+  141          146.63106    135.52062   0.007092199 
+  148          146.77327    135.5256    0.006756757 
+  140          147.10797    135.5306    0.007142857 
+  148          147.23024    135.53561   0.006756757 
+  147          146.876      135.54064   0.006802721 
+  148          146.41106    135.5457    0.006756757 
+  160          146.14399    135.55077   0.00625   
+  167          146.12526    135.55586   0.005988024 
+  148          146.34802    135.56096   0.006756757 
+  148          146.82631    135.56609   0.006756757 
+  116          147.59412    135.57123   0.00862069 
+  153          148.60407    135.57639   0.006535948 
+  159          149.51368    135.58157   0.006289308 
+  155          149.97384    135.58676   0.006451613 
+  150          150.30678    135.59197   0.006666667 
+  172          150.88746    135.5972    0.005813953 
+  145          151.78047    135.60245   0.006896552 
+  159          152.93045    135.60771   0.006289308 
+  164          154.21879    135.61299   0.006097561 
+  177          155.67205    135.61829   0.005649718 
+  160          157.44716    135.6236    0.00625   
+  152          159.66792    135.62893   0.006578947 
+  165          162.56128    135.63427   0.006060606 
+  169          166.85216    135.63963   0.00591716 
+  166          173.96362    135.64501   0.006024096 
+  181          186.40685    135.6504    0.005524862 
+  176          207.90808    135.6558    0.005681818 
+  210          239.34018    135.66123   0.004761905 
+  219          258.79988    135.66666   0.00456621 
+  190          237.98987    135.67211   0.005263158 
+  177          207.93812    135.67758   0.005649718 
+  179          189.33223    135.68306   0.005586592 
+  182          180.53637    135.68856   0.005494505 
+  172          178.22509    135.69407   0.005813953 
+  182          181.28906    135.69959   0.005494505 
+  198          190.5864     135.70513   0.005050505 
+  197          206.75612    135.71068   0.005076142 
+  205          220.66653    135.71625   0.004878049 
+  202          216.81897    135.72183   0.004950495 
+  182          208.16557    135.72742   0.005494505 
+  176          202.78205    135.73302   0.005681818 
+  179          195.91511    135.73864   0.005586592 
+  195          188.42309    135.74428   0.005128205 
+  195          182.95402    135.74992   0.005128205 
+  195          178.62361    135.75558   0.005128205 
+  180          175.24194    135.76125   0.005555556 
+  163          174.03363    135.76693   0.006134969 
+  169          175.52574    135.77263   0.00591716 
+  169          179.43182    135.77833   0.00591716 
+  182          183.59558    135.78405   0.005494505 
+  186          184.82654    135.78978   0.005376344 
+  146          184.53706    135.79553   0.006849315 
+  154          186.49788    135.80128   0.006493506 
+  210          191.5145     135.80705   0.004761905 
+  174          197.41584    135.81282   0.005747126 
+  190          199.26381    135.81861   0.005263158 
+  192          197.01374    135.82441   0.005208333 
+  180          195.91156    135.83022   0.005555556 
+  188          197.48772    135.83604   0.005319149 
+  176          203.55641    135.84187   0.005681818 
+  208          220.08576    135.84771   0.004807692 
+  266          257.67466    135.85356   0.003759398 
+  267          328.07462    135.85943   0.003745318 
+  341          400.02408    135.8653    0.002932551 
+  308          367.44683    135.87118   0.003246753 
+  257          287.90583    135.87707   0.003891051 
+  226          237.91606    135.88297   0.004424779 
+  204          214.38761    135.88889   0.004901961 
+  210          206.05009    135.89481   0.004761905 
+  190          207.87979    135.90073   0.005263158 
+  212          219.85407    135.90667   0.004716981 
+  225          246.46197    135.91262   0.004444444 
+  239          280.37082    135.91858   0.0041841 
+  211          271.68915    135.92454   0.004739336 
+  210          227.27469    135.93051   0.004761905 
+  173          195.63874    135.9365    0.005780347 
+  199          179.50738    135.94249   0.005025126 
+  193          172.07254    135.94848   0.005181347 
+  161          168.73608    135.95449   0.00621118 
+  160          166.68321    135.9605    0.00625   
+  170          165.1109     135.96653   0.005882353 
+  156          163.51231    135.97256   0.006410256 
+  157          161.79801    135.97859   0.006369427 
+  137          161.14379    135.98464   0.00729927 
+  155          162.19651    135.99069   0.006451613 
+  168          164.66476    135.99675   0.005952381 
+  169          167.34819    136.00281   0.00591716 
+  153          168.40677    136.00888   0.006535948 
+  170          168.22226    136.01496   0.005882353 
+  158          169.48819    136.02105   0.006329114 
+  182          174.14886    136.02714   0.005494505 
+  194          183.45415    136.03324   0.005154639 
+  182          197.37914    136.03934   0.005494505 
+  199          211.91537    136.04545   0.005025126 
+  188          220.83359    136.05157   0.005319149 
+  193          219.80742    136.05769   0.005181347 
+  183          207.70057    136.06382   0.005464481 
+  169          192.36656    136.06995   0.00591716 
+  152          181.00077    136.07609   0.006578947 
+  171          175.10308    136.08223   0.005847953 
+  158          174.09111    136.08838   0.006329114 
+  190          177.18697    136.09454   0.005263158 
+  163          182.47003    136.1007    0.006134969 
+  159          186.24618    136.10686   0.006289308 
+  162          185.75358    136.11303   0.00617284 
+  174          179.76911    136.1192    0.005747126 
+  142          171.09314    136.12538   0.007042254 
+  142          163.82719    136.13156   0.007042254 
+  157          158.975      136.13775   0.006369427 
+  132          155.98178    136.14394   0.007575758 
+  158          154.18751    136.15013   0.006329114 
+  174          153.19791    136.15633   0.005747126 
+  155          152.70857    136.16253   0.006451613 
+  159          152.3812     136.16873   0.006289308 
+  147          152.04519    136.17494   0.006802721 
+  156          151.84099    136.18116   0.006410256 
+  167          151.97374    136.18737   0.005988024 
+  151          152.54706    136.19359   0.006622517 
+  157          153.65026    136.19981   0.006369427 
+  176          155.44988    136.20604   0.005681818 
+  157          158.2066     136.21226   0.006369427 
+  153          162.09557    136.21849   0.006535948 
+  162          166.33742    136.22472   0.00617284 
+  139          168.91822    136.23096   0.007194245 
+  172          169.47201    136.2372    0.005813953 
+  166          169.79935    136.24344   0.006024096 
+  149          170.08749    136.24968   0.006711409 
+  144          169.20687    136.25592   0.006944444 
+  159          168.39431    136.26217   0.006289308 
+  150          169.38782    136.26841   0.006666667 
+  174          172.97132    136.27466   0.005747126 
+  164          179.73599    136.28091   0.006097561 
+  203          190.56539    136.28717   0.004926108 
+  211          208.10861    136.29342   0.004739336 
+  216          238.0282     136.29967   0.00462963 
+  264          279.66301    136.30593   0.003787879 
+  247          298.32344    136.31219   0.004048583 
+  256          271.5057     136.31845   0.00390625 
+  211          239.46999    136.3247    0.004739336 
+  219          216.21851    136.33096   0.00456621 
+  188          199.65208    136.33722   0.005319149 
+  202          190.16154    136.34348   0.004950495 
+  168          187.98359    136.34974   0.005952381 
+  190          193.79874    136.35601   0.005263158 
+  211          208.71054    136.36227   0.004739336 
+  231          225.58213    136.36853   0.004329004 
+  220          222.48035    136.37479   0.004545455 
+  207          205.11566    136.38105   0.004830918 
+  168          190.44881    136.38731   0.005952381 
+  194          179.33102    136.39358   0.005154639 
+  169          171.12075    136.39984   0.00591716 
+  173          165.72874    136.4061    0.005780347 
+  177          162.44416    136.41236   0.005649718 
+  162          160.55641    136.41862   0.00617284 
+  168          159.5958     136.42487   0.005952381 
+  173          159.27814    136.43113   0.005780347 
+  137          159.40424    136.43739   0.00729927 
+  177          159.78691    136.44364   0.005649718 
+  160          160.34023    136.4499    0.00625   
+  189          161.09593    136.45615   0.005291005 
+  169          162.07992    136.4624    0.00591716 
+  189          163.31111    136.46865   0.005291005 
+  185          164.84504    136.4749    0.005405405 
+  179          166.79437    136.48115   0.005586592 
+  159          169.33513    136.48739   0.006289308 
+  172          172.67002    136.49364   0.005813953 
+  175          176.80279    136.49988   0.005714286 
+  168          180.99709    136.50612   0.005952381 
+  218          184.3832     136.51236   0.004587156 
+  187          187.86033    136.51859   0.005347594 
+  190          192.70919    136.52483   0.005263158 
+  202          199.15999    136.53106   0.004950495 
+  198          207.44028    136.53729   0.005050505 
+  201          218.8365     136.54351   0.004975124 
+  237          235.23981    136.54974   0.004219409 
+  230          259.23179    136.55596   0.004347826 
+  265          294.67802    136.56218   0.003773585 
+  341          346.95351    136.5684    0.002932551 
+  447          428.91173    136.57461   0.002237136 
+  555          579.14373    136.58082   0.001801802 
+  892          872.72308    136.58703   0.001121076 
+  1325         1391.59807   136.59323   0.000754717 
+  1598         1892.10543   136.59943   0.000625782 
+  1242         1637.14125   136.60563   0.000805153 
+  979          1064.3909    136.61182   0.00102145 
+  676          702.29029    136.61801   0.00147929 
+  477          525.4928     136.6242    0.002096436 
+  445          451.33384    136.63039   0.002247191 
+  443          439.91848    136.63657   0.002257336 
+  506          492.5923     136.64274   0.001976285 
+  654          641.07756    136.64892   0.001529052 
+  830          908.13042    136.65508   0.001204819 
+  807          1082.02163   136.66125   0.001239157 
+  717          862.46975    136.66741   0.0013947 
+  482          583.55029    136.67357   0.002074689 
+  378          419.15898    136.67972   0.002645503 
+  308          332.24658    136.68587   0.003246753 
+  279          282.41273    136.69201   0.003584229 
+  267          250.98992    136.69816   0.003745318 
+  185          229.54984    136.70429   0.005405405 
+  211          214.47366    136.71042   0.004739336 
+  198          203.99273    136.71655   0.005050505 
+  195          196.19291    136.72267   0.005128205 
+  186          190.43112    136.72879   0.005376344 
+  199          186.94339    136.7349    0.005025126 
+  194          184.69756    136.74101   0.005154639 
+  189          181.47759    136.74712   0.005291005 
+  183          176.92021    136.75321   0.005464481 
+  132          172.40251    136.75931   0.007575758 
+  153          168.25903    136.7654    0.006535948 
+  163          164.73614    136.77148   0.006134969 
+  161          162.08639    136.77756   0.00621118 
+  148          160.21022    136.78363   0.006756757 
+  155          158.95488    136.7897    0.006451613 
+  162          158.19381    136.79576   0.00617284 
+  172          157.67816    136.80182   0.005813953 
+  173          157.08855    136.80788   0.005780347 
+  177          156.50617    136.81392   0.005649718 
+  185          156.22891    136.81996   0.005405405 
+  155          156.34916    136.826     0.006451613 
+  161          156.74276    136.83203   0.00621118 
+  168          157.18949    136.83806   0.005952381 
+  162          157.56662    136.84407   0.00617284 
+  179          157.91537    136.85009   0.005586592 
+  178          158.17116    136.8561    0.005617978 
+  166          158.24774    136.8621    0.006024096 
+  179          158.47608    136.86809   0.005586592 
+  169          159.19897    136.87409   0.00591716 
+  186          160.62389    136.88007   0.005376344 
+  162          162.98461    136.88605   0.00617284 
+  205          166.6199     136.89202   0.004878049 
+  164          172.08554    136.89799   0.006097561 
+  182          180.30219    136.90395   0.005494505 
+  195          192.97629    136.9099    0.005128205 
+  191          213.12345    136.91585   0.005235602 
+  182          241.16219    136.92179   0.005494505 
+  213          260.70231    136.92773   0.004694836 
+  213          249.27029    136.93366   0.004694836 
+  186          223.98959    136.93958   0.005376344 
+  181          202.81855    136.9455    0.005524862 
+  164          189.24553    136.95141   0.006097561 
+  151          182.44731    136.95731   0.006622517 
+  204          180.8808     136.96321   0.004901961 
+  151          183.93425    136.9691    0.006622517 
+  167          192.45129    136.97498   0.005988024 
+  173          206.47393    136.98086   0.005780347 
+  188          217.90965    136.98673   0.005319149 
+  182          215.83219    136.9926    0.005494505 
+  167          209.29649    136.99846   0.005988024 
+  174          206.97517    137.00431   0.005747126 
+  204          206.32061    137.01016   0.004901961 
+  202          199.90193    137.01599   0.004950495 
+  174          188.58746    137.02183   0.005747126 
+  194          178.64935    137.02765   0.005154639 
+  175          172.29723    137.03347   0.005714286 
+  186          169.0685     137.03928   0.005376344 
+  197          168.16771    137.04509   0.005076142 
+  191          169.2738     137.05089   0.005235602 
+  198          172.71687    137.05668   0.005050505 
+  179          178.59114    137.06246   0.005586592 
+  189          185.08804    137.06824   0.005291005 
+  178          188.89998    137.07401   0.005617978 
+  175          190.47231    137.07977   0.005714286 
+  197          192.04236    137.08553   0.005076142 
+  196          192.2009     137.09128   0.005102041 
+  194          187.85368    137.09703   0.005154639 
+  177          181.25091    137.10276   0.005649718 
+  205          176.6108     137.10849   0.004878049 
+  199          175.06553    137.11422   0.005025126 
+  180          175.32991    137.11993   0.005555556 
+  165          175.03366    137.12564   0.006060606 
+  158          174.06754    137.13134   0.006329114 
+  176          174.10753    137.13704   0.005681818 
+  183          175.25513    137.14273   0.005464481 
+  176          176.09132    137.14841   0.005681818 
+  171          174.74885    137.15409   0.005847953 
+  176          171.97089    137.15975   0.005681818 
+  166          170.03291    137.16541   0.006024096 
+  181          169.683      137.17107   0.005524862 
+  187          170.36574    137.17672   0.005347594 
+  207          170.86978    137.18236   0.004830918 
+  219          170.85329    137.18799   0.00456621 
+  195          171.1632     137.19362   0.005128205 
+  206          172.29821    137.19924   0.004854369 
+  201          174.31625    137.20485   0.004975124 
+  233          177.22841    137.21045   0.004291845 
+  216          181.12786    137.21605   0.00462963 
+  216          186.20346    137.22165   0.00462963 
+  194          192.7383     137.22723   0.005154639 
+  215          200.93558    137.23281   0.004651163 
+  246          210.58747    137.23838   0.004065041 
+  246          221.66028    137.24395   0.004065041 
+  257          235.74431    137.24951   0.003891051 
+  269          255.35984    137.25506   0.003717472 
+  305          283.53802    137.2606    0.003278689 
+  388          325.05811    137.26614   0.00257732 
+  438          388.65321    137.27168   0.002283105 
+  554          491.58485    137.2772    0.001805054 
+  831          669.52517    137.28272   0.001203369 
+  1332         993.71482    137.28823   0.000750751 
+  1943         1564.96519   137.29374   0.000514668 
+  2380         2226.97025   137.29924   0.000420168 
+  2195         2126.13467   137.30473   0.000455581 
+  1533         1434.88025   137.31022   0.000652316 
+  1097         927.41565    137.31569   0.000911577 
+  797          662.14032    137.32117   0.001254705 
+  647          538.95058    137.32664   0.001545595 
+  600          496.42809    137.3321    0.001666667 
+  662          516.39425    137.33755   0.001510574 
+  731          613.50344    137.343     0.001367989 
+  1033         830.58012    137.34844   0.000968054 
+  1229         1159.78115   137.35388   0.00081367 
+  1219         1251.61272   137.35931   0.000820345 
+  913          927.44702    137.36473   0.00109529 
+  685          618.23053    137.37015   0.001459854 
+  497          440.44321    137.37556   0.002012072 
+  368          345.80716    137.38096   0.002717391 
+  318          292.90666    137.38636   0.003144654 
+  302          260.18529    137.39176   0.003311258 
+  234          237.53633    137.39714   0.004273504 
+  241          220.82137    137.40253   0.004149378 
+  220          208.45372    137.4079    0.004545455 
+  240          199.29951    137.41327   0.004166667 
+  227          192.46932    137.41864   0.004405286 
+  194          187.36017    137.424     0.005154639 
+  190          183.62283    137.42935   0.005263158 
+  190          181.10212    137.4347    0.005263158 
+  178          179.76285    137.44004   0.005617978 
+  198          179.51411    137.44538   0.005050505 
+  192          180.09396    137.45072   0.005208333 
+  207          181.38584    137.45604   0.004830918 
+  171          182.65736    137.46136   0.005847953 
+  173          181.66123    137.46668   0.005780347 
+  205          178.23336    137.47199   0.004878049 
+  190          174.88372    137.4773    0.005263158 
+  190          172.83424    137.4826    0.005263158 
+  179          171.63914    137.4879    0.005586592 
+  184          170.63325    137.49319   0.005434783 
+  164          170.15507    137.49848   0.006097561 
+  194          170.87189    137.50376   0.005154639 
+  174          173.16495    137.50904   0.005747126 
+  174          177.07323    137.51432   0.005747126 
+  222          181.77336    137.51959   0.004504505 
+  193          185.89285    137.52485   0.005181347 
+  192          190.3468     137.53012   0.005208333 
+  212          199.65038    137.53537   0.004716981 
+  220          218.5719     137.54063   0.004545455 
+  244          250.25171    137.54588   0.004098361 
+  249          284.65674    137.55112   0.004016064 
+  259          284.35346    137.55636   0.003861004 
+  258          251.02989    137.5616    0.003875969 
+  218          222.69186    137.56683   0.004587156 
+  214          208.65075    137.57207   0.004672897 
+  191          205.52596    137.57729   0.005235602 
+  197          210.27186    137.58252   0.005076142 
+  222          221.88876    137.58774   0.004504505 
+  202          234.1709     137.59295   0.004950495 
+  220          238.29627    137.59817   0.004545455 
+  233          242.75068    137.60338   0.004291845 
+  231          244.72106    137.60859   0.004329004 
+  233          228.94428    137.61379   0.004291845 
+  224          207.89524    137.619     0.004464286 
+  198          192.93921    137.6242    0.005050505 
+  188          184.54079    137.62939   0.005319149 
+  195          181.31549    137.63459   0.005128205 
+  156          182.33087    137.63978   0.006410256 
+  170          185.67662    137.64497   0.005882353 
+  181          185.18021    137.65016   0.005524862 
+  161          178.90466    137.65535   0.00621118 
+  161          173.09828    137.66054   0.00621118 
+  165          170.2483     137.66572   0.006060606 
+  154          169.72032    137.6709    0.006493506 
+  173          170.28515    137.67608   0.005780347 
+  161          171.27609    137.68126   0.00621118 
+  200          172.61617    137.68644   0.005     
+  174          173.48154    137.69161   0.005747126 
+  196          173.39301    137.69679   0.005102041 
+  158          173.40775    137.70196   0.006329114 
+  176          173.07461    137.70714   0.005681818 
+  174          170.88193    137.71231   0.005747126 
+  163          167.79574    137.71748   0.006134969 
+  174          165.54934    137.72265   0.005747126 
+  160          164.63554    137.72783   0.00625   
+  183          164.82101    137.733     0.005464481 
+  181          165.7131     137.73817   0.005524862 
+  171          166.90334    137.74334   0.005847953 
+  195          167.77385    137.74851   0.005128205 
+  176          168.41443    137.75369   0.005681818 
+  169          169.33734    137.75886   0.00591716 
+  175          169.99376    137.76403   0.005714286 
+  192          169.94474    137.76921   0.005208333 
+  183          169.79785    137.77438   0.005464481 
+  173          169.7082     137.77956   0.005780347 
+  196          169.50539    137.78474   0.005102041 
+  199          169.49062    137.78992   0.005025126 
+  190          169.95192    137.7951    0.005263158 
+  197          170.94154    137.80028   0.005076142 
+  204          172.41758    137.80546   0.004901961 
+  206          174.35036    137.81065   0.004854369 
+  210          176.75117    137.81584   0.004761905 
+  215          179.66885    137.82103   0.004651163 
+  229          183.15686    137.82622   0.004366812 
+  215          187.17083    137.83142   0.004651163 
+  214          191.45331    137.83661   0.004672897 
+  204          196.3402     137.84182   0.004901961 
+  211          202.16446    137.84702   0.004739336 
+  237          209.36739    137.85223   0.004219409 
+  240          218.38651    137.85744   0.004166667 
+  257          229.81521    137.86265   0.003891051 
+  259          244.5992     137.86787   0.003861004 
+  267          264.4128     137.87309   0.003745318 
+  294          291.90929    137.87832   0.003401361 
+  349          331.76764    137.88355   0.00286533 
+  382          390.09242    137.88879   0.002617801 
+  419          467.19484    137.89403   0.002386635 
+  531          542.02505    137.89927   0.001883239 
+  626          618.07146    137.90452   0.001597444 
+  857          758.9407     137.90978   0.001166861 
+  1172         1045.19044   137.91504   0.000853242 
+  1956         1597.75409   137.9203    0.000511247 
+  2769         2527.47695   137.92557   0.000361141 
+  3219         3374.28897   137.93085   0.000310655 
+  2697         2958.87093   137.93613   0.000370782 
+  1901         1963.17426   137.94142   0.000526039 
+  1329         1296.26634   137.94672   0.000752445 
+  1022         955.19725    137.95202   0.000978474 
+  838          789.81454    137.95733   0.001193317 
+  779          720.81282    137.96265   0.001283697 
+  834          742.48473    137.96797   0.001199041 
+  929          876.29158    137.9733    0.001076426 
+  1262         1152.84792   137.97864   0.000792393 
+  1629         1585.021     137.98399   0.000613874 
+  1720         1908.49803   137.98934   0.000581395 
+  1459         1591.44086   137.99471   0.000685401 
+  990          1064.98444   138.00008   0.001010101 
+  759          719.11545    138.00546   0.001317523 
+  545          529.37352    138.01085   0.001834862 
+  458          426.43454    138.01625   0.002183406 
+  394          369.50601    138.02166   0.002538071 
+  366          340.14358    138.02707   0.00273224 
+  337          328.65152    138.0325    0.002967359 
+  302          318.25425    138.03794   0.003311258 
+  272          293.70044    138.04338   0.003676471 
+  274          267.82991    138.04884   0.003649635 
+  261          250.9369     138.05431   0.003831418 
+  263          242.70126    138.05979   0.003802281 
+  246          240.6119     138.06528   0.004065041 
+  210          240.4524     138.07078   0.004761905 
+  200          236.26676    138.07629   0.005     
+  204          227.61915    138.08182   0.004901961 
+  207          219.28886    138.08736   0.004830918 
+  183          212.72646    138.09291   0.005464481 
+  172          206.60259    138.09847   0.005813953 
+  200          201.09934    138.10404   0.005     
+  207          197.36009    138.10963   0.004830918 
+  185          195.84687    138.11523   0.005405405 
+  172          196.63298    138.12085   0.005813953 
+  181          199.54196    138.12647   0.005524862 
+  195          203.21715    138.13212   0.005128205 
+  194          204.75242    138.13777   0.005154639 
+  196          202.9964     138.14344   0.005102041 
+  194          199.68465    138.14913   0.005154639 
+  154          196.79183    138.15483   0.006493506 
+  166          195.00878    138.16054   0.006024096 
+  179          194.15372    138.16628   0.005586592 
+  190          193.13559    138.17202   0.005263158 
+  198          191.69204    138.17779   0.005050505 
+  184          191.63462    138.18357   0.005434783 
+  195          194.26302    138.18936   0.005128205 
+  172          199.58485    138.19517   0.005813953 
+  184          205.98272    138.201     0.005434783 
+  192          209.2131     138.20685   0.005208333 
+  201          204.95557    138.21272   0.004975124 
+  197          196.09193    138.2186    0.005076142 
+  178          189.18919    138.2245    0.005617978 
+  195          185.6253     138.23042   0.005128205 
+  157          183.89467    138.23636   0.006369427 
+  197          182.89545    138.24232   0.005076142 
+  180          183.07555    138.24829   0.005555556 
+  162          185.06476    138.25429   0.00617284 
+  195          189.03966    138.2603    0.005128205 
+  187          194.58043    138.26634   0.005347594 
+  182          199.72703    138.2724    0.005494505 
+  194          200.61207    138.27848   0.005154639 
+  183          195.1328     138.28457   0.005464481 
+  186          186.90273    138.29069   0.005376344 
+  180          179.82628    138.29684   0.005555556 
+  182          174.95485    138.303     0.005494505 
+  171          171.94173    138.30919   0.005847953 
+  189          170.30481    138.31539   0.005291005 
+  176          169.74891    138.32163   0.005681818 
+  191          170.20889    138.32788   0.005235602 
+  176          171.79936    138.33416   0.005681818 
+  172          174.61475    138.34046   0.005813953 
+  169          178.14274    138.34679   0.00591716 
+  171          180.9106     138.35314   0.005847953 
+  193          181.67072    138.35951   0.005181347 
+  173          180.04011    138.36591   0.005780347 
+  175          177.29914    138.37234   0.005714286 
+  160          175.8067     138.37879   0.00625   
+  197          176.8279     138.38527   0.005076142 
+  163          180.59445    138.39177   0.006134969 
+  176          186.01243    138.3983    0.005681818 
+  206          189.36252    138.40486   0.004854369 
+  155          187.30347    138.41144   0.006451613 
+  155          182.16882    138.41806   0.006451613 
+  167          177.87586    138.4247    0.005988024 
+  144          175.47459    138.43137   0.006944444 
+  157          173.94277    138.43807   0.006369427 
+  169          172.66633    138.44479   0.00591716 
+  187          172.41782    138.45155   0.005347594 
+  197          173.99487    138.45834   0.005076142 
+  208          177.77426    138.46515   0.004807692 
+  184          183.57034    138.472     0.005434783 
+  196          189.52389    138.47888   0.005102041 
+  202          192.44223    138.48579   0.004950495 
+  196          192.1143     138.49273   0.005102041 
+  172          190.3304     138.4997    0.005813953 
+  237          187.10187    138.5067    0.004219409 
+  198          183.28924    138.51374   0.005050505 
+  180          180.55007    138.52081   0.005555556 
+  185          179.41423    138.52791   0.005405405 
+  176          179.70607    138.53505   0.005681818 
+  186          181.35005    138.54222   0.005376344 
+  195          184.34803    138.54943   0.005128205 
+  200          188.12661    138.55667   0.005     
+  225          191.8176     138.56394   0.004444444 
+  232          195.31713    138.57126   0.004310345 
+  231          199.25867    138.5786    0.004329004 
+  199          203.75452    138.58599   0.005025126 
+  215          209.16303    138.59341   0.004651163 
+  229          216.84576    138.60087   0.004366812 
+  263          227.91248    138.60836   0.003802281 
+  278          243.16039    138.61589   0.003597122 
+  304          263.22233    138.62347   0.003289474 
+  349          288.86689    138.63108   0.00286533 
+  362          323.52207    138.63873   0.002762431 
+  448          377.98578    138.64642   0.002232143 
+  593          472.83428    138.65414   0.001686341 
+  829          646.41597    138.66191   0.001206273 
+  1164         959.88981    138.66972   0.000859107 
+  1636         1431.76283   138.67757   0.000611247 
+  1695         1719.78358   138.68547   0.000589971 
+  1407         1403.02116   138.6934    0.000710732 
+  1064         948.59013    138.70138   0.00093985 
+  773          659.41681    138.7094    0.001293661 
+  623          506.8966     138.71746   0.001605136 
+  480          432.75503    138.72557   0.002083333 
+  478          405.88446    138.73372   0.00209205 
+  486          418.1891     138.74191   0.002057613 
+  565          476.62757    138.75015   0.001769912 
+  655          595.26363    138.75844   0.001526718 
+  820          780.50777    138.76677   0.001219512 
+  983          980.63406    138.77515   0.001017294 
+  887          949.70062    138.78357   0.001127396 
+  735          700.14512    138.79204   0.001360544 
+  523          493.23466    138.80056   0.001912046 
+  428          372.29243    138.80913   0.002336449 
+  331          305.44323    138.81775   0.003021148 
+  315          267.91331    138.82641   0.003174603 
+  247          247.17125    138.83512   0.004048583 
+  275          237.90293    138.84389   0.003636364 
+  279          236.78904    138.8527    0.003584229 
+  260          235.15331    138.86156   0.003846154 
+  269          222.82284    138.87048   0.003717472 
+  231          206.57493    138.87945   0.004329004 
+  179          194.30926    138.88847   0.005586592 
+  193          186.5729     138.89754   0.005181347 
+  212          182.25293    138.90666   0.004716981 
+  186          180.49924    138.91584   0.005376344 
+  206          180.31884    138.92507   0.004854369 
+  193          179.07458    138.93436   0.005181347 
+  167          174.79211    138.9437    0.005988024 
+  178          169.98147    138.9531    0.005617978 
+  176          166.42978    138.96255   0.005681818 
+  152          164.0617     138.97206   0.006578947 
+  162          162.53522    138.98163   0.00617284 
+  167          161.71632    138.99125   0.005988024 
+  157          161.62476    139.00093   0.006369427 
+  163          162.33531    139.01067   0.006134969 
+  166          163.80977    139.02047   0.006024096 
+  150          165.59194    139.03033   0.006666667 
+  154          166.82933    139.04024   0.006493506 
+  183          166.41616    139.05022   0.005464481 
+  178          164.62455    139.06026   0.005617978 
+  172          163.21377    139.07036   0.005813953 
+  155          163.01656    139.08052   0.006451613 
+  194          164.008      139.09075   0.005154639 
+  164          165.69735    139.10104   0.006097561 
+  187          166.73088    139.11139   0.005347594 
+  173          165.74922    139.1218    0.005780347 
+  150          163.59267    139.13228   0.006666667 
+  205          161.7296     139.14282   0.004878049 
+  150          160.43584    139.15343   0.006666667 
+  158          159.55309    139.16411   0.006329114 
+  162          159.18628    139.17485   0.00617284 
+  167          159.47941    139.18566   0.005988024 
+  167          160.61445    139.19654   0.005988024 
+  165          162.87617    139.20748   0.006060606 
+  157          166.52453    139.2185    0.006369427 
+  179          171.6156     139.22958   0.005586592 
+  159          177.45782    139.24073   0.006289308 
+  165          182.12483    139.25196   0.006060606 
+  173          182.60681    139.26325   0.005780347 
+  153          178.13714    139.27462   0.006535948 
+  161          172.25431    139.28605   0.00621118 
+  172          167.90493    139.29756   0.005813953 
+  171          165.80341    139.30915   0.005847953 
+  180          165.89631    139.3208    0.005555556 
+  179          168.05006    139.33254   0.005586592 
+  170          171.61573    139.34434   0.005882353 
+  188          174.2881     139.35622   0.005319149 
+  166          174.2212     139.36818   0.006024096 
+  168          173.98706    139.38022   0.005952381 
+  148          174.93774    139.39233   0.006756757 
+  163          175.18148    139.40452   0.006134969 
+  183          173.33364    139.41678   0.005464481 
+  163          170.14742    139.42913   0.006134969 
+  182          167.01656    139.44156   0.005494505 
+  169          164.80502    139.45406   0.00591716 
+  171          163.66056    139.46665   0.005847953 
+  172          163.4609     139.47932   0.005813953 
+  158          163.70821    139.49207   0.006329114 
+  165          163.21695    139.5049    0.006060606 
+  182          161.34155    139.51781   0.005494505 
+  166          159.53199    139.53081   0.006024096 
+  163          158.77549    139.5439    0.006134969 
+  168          159.01342    139.55706   0.005952381 
+  172          159.79195    139.57032   0.005813953 
+  177          160.76172    139.58366   0.005649718 
+  165          162.2452     139.59708   0.006060606 
+  200          164.8318     139.6106    0.005     
+  157          168.67174    139.6242    0.006369427 
+  163          172.77095    139.63789   0.006134969 
+  160          174.80322    139.65167   0.00625   
+  161          173.71089    139.66554   0.00621118 
+  172          170.2972     139.6795    0.005813953 
+  164          165.64534    139.69355   0.006097561 
+  183          161.2918     139.70769   0.005464481 
+  153          158.13655    139.72193   0.006535948 
+  178          156.21934    139.73626   0.005617978 
+  163          155.34643    139.75068   0.006134969 
+  163          155.4        139.7652    0.006134969 
+  143          156.36987    139.77981   0.006993007 
+  162          158.20297    139.79452   0.00617284 
+  139          160.38636    139.80932   0.007194245 
+  155          161.76676    139.82422   0.006451613 
+  163          161.75464    139.83922   0.006134969 
+  166          160.73846    139.85432   0.006024096 
+  147          159.26903    139.86952   0.006802721 
+  159          158.16164    139.88481   0.006289308 
+  167          157.86247    139.90021   0.005988024 
+  177          158.2167     139.91571   0.005649718 
+  158          158.60187    139.93131   0.006329114 
+  180          158.48805    139.94701   0.005555556 
+  168          158.26331    139.96281   0.005952381 
+  170          158.42305    139.97872   0.005882353 
+  152          159.02423    139.99473   0.006578947 
+  170          160.13217    140.01085   0.005882353 
+  161          161.65519    140.02708   0.00621118 
+  155          163.48422    140.04341   0.006451613 
+  170          165.17536    140.05985   0.005882353 
+  152          165.2177     140.07639   0.006578947 
+  160          163.16563    140.09305   0.00625   
+  156          160.59383    140.10981   0.006410256 
+  171          158.52676    140.12669   0.005847953 
+  185          156.72605    140.14367   0.005405405 
+  155          155.56583    140.16077   0.006451613 
+  166          154.96727    140.17798   0.006024096 
+  149          154.85335    140.1953    0.006711409 
+  152          155.1811     140.21273   0.006578947 
+  151          155.87919    140.23029   0.006622517 
+  180          156.8772     140.24795   0.005555556 
+  159          158.05045    140.26573   0.006289308 
+  168          158.74682    140.28363   0.005952381 
+  184          158.60116    140.30165   0.005434783 
+  174          158.40646    140.31978   0.005747126 
+  188          158.73908    140.33803   0.005319149 
+  147          159.39444    140.35641   0.006802721 
+  152          159.30617    140.3749    0.006578947 
+  169          158.25279    140.39351   0.00591716 
+  129          156.78252    140.41225   0.007751938 
+  144          155.41351    140.43111   0.006944444 
+  164          154.49243    140.45009   0.006097561 
+  148          154.14307    140.4692    0.006756757 
+  167          154.37042    140.48843   0.005988024 
+  156          155.16124    140.50779   0.006410256 
+  161          156.47545    140.52727   0.00621118 
+  163          158.13642    140.54688   0.006134969 
+  151          159.90186    140.56662   0.006622517 
+  121          161.42658    140.58649   0.008264463 
+  166          162.45329    140.60649   0.006024096 
+  155          163.14061    140.62662   0.006451613 
+  170          163.41637    140.64688   0.005882353 
+  154          162.57052    140.66727   0.006493506 
+  170          160.6309     140.6878    0.005882353 
+  149          158.57655    140.70846   0.006711409 
+  167          157.07011    140.72925   0.005988024 
+  174          156.30444    140.75018   0.005747126 
+  163          156.23223    140.77124   0.006134969 
+  162          156.69202    140.79245   0.00617284 
+  149          157.48077    140.81378   0.006711409 
+  169          158.47937    140.83526   0.00591716 
+  146          159.76991    140.85688   0.006849315 
+  156          161.52881    140.87864   0.006410256 
+  146          163.14883    140.90054   0.006849315 
+  171          163.16878    140.92258   0.005847953 
+  144          161.26071    140.94476   0.006944444 
+  167          158.74505    140.96709   0.005988024 
+  153          156.64252    140.98956   0.006535948 
+  172          155.19342    141.01218   0.005813953 
+  151          154.32715    141.03494   0.006622517 
+  164          153.92461    141.05785   0.006097561 
+  151          153.89288    141.08091   0.006622517 
+  142          154.16337    141.10412   0.007042254 
+  150          154.71754    141.12747   0.006666667 
+  154          155.49686    141.15098   0.006493506 
+  159          156.27504    141.17464   0.006289308 
+  153          156.61469    141.19845   0.006535948 
+  136          156.30118    141.22241   0.007352941 
+  141          155.76144    141.24653   0.007092199 
+  143          155.46184    141.2708    0.006993007 
+  152          155.45281    141.29523   0.006578947 
+  145          155.49237    141.31981   0.006896552 
+  127          155.58595    141.34456   0.007874016 
+  158          156.01066    141.36946   0.006329114 
+  159          156.93454    141.39452   0.006289308 
+  162          158.47541    141.41973   0.00617284 
+  145          160.71632    141.44512   0.006896552 
+  175          163.47572    141.47066   0.005714286 
+  174          165.86867    141.49636   0.005747126 
+  196          166.58058    141.52223   0.005102041 
+  151          165.62279    141.54827   0.006622517 
+  189          164.44664    141.57447   0.005291005 
+  175          164.11692    141.60083   0.005714286 
+  154          164.84505    141.62737   0.006493506 
+  162          166.41473    141.65407   0.00617284 
+  152          168.3538     141.68094   0.006578947 
+  185          170.08539    141.70798   0.005405405 
+  173          172.05873    141.73519   0.005780347 
+  168          175.51448    141.76258   0.005952381 
+  165          180.65123    141.79014   0.006060606 
+  189          185.03834    141.81787   0.005291005 
+  163          184.79689    141.84577   0.006134969 
+  163          180.11338    141.87386   0.006134969 
+  194          174.96453    141.90212   0.005154639 
+  172          171.41591    141.93055   0.005813953 
+  195          169.5245     141.95917   0.005128205 
+  171          168.94109    141.98797   0.005847953 
+  164          169.59729    142.01694   0.006097561 
+  178          170.53448    142.0461    0.005617978 
+  156          171.70294    142.07544   0.006410256 
+  165          173.33615    142.10497   0.006060606 
+  187          175.54963    142.13468   0.005347594 
+  185          177.78957    142.16457   0.005405405 
+  174          178.85286    142.19466   0.005747126 
+  213          177.93852    142.22493   0.004694836 
+  200          176.41228    142.25538   0.005     
+  220          175.96893    142.28603   0.004545455 
+  206          177.01378    142.31687   0.004854369 
+  212          179.41256    142.3479    0.004716981 
+  213          182.69368    142.37912   0.004694836 
+  189          185.53475    142.41054   0.005291005 
+  186          186.50604    142.44215   0.005376344 
+  200          186.14425    142.47396   0.005     
+  195          186.1154     142.50596   0.005128205 
+  189          186.76592    142.53816   0.005291005 
+  215          188.27665    142.57056   0.004651163 
+  216          190.83997    142.60316   0.00462963 
+  181          194.72146    142.63596   0.005524862 
+  216          200.12065    142.66896   0.00462963 
+  242          206.96973    142.70217   0.004132231 
+  232          214.49229    142.73558   0.004310345 
+  229          221.54606    142.76919   0.004366812 
+  246          228.19749    142.80301   0.004065041 
+  260          235.28178    142.83704   0.003846154 
+  284          243.51469    142.87128   0.003521127 
+  277          254.2489     142.90572   0.003610108 
+  313          269.13118    142.94038   0.003194888 
+  337          289.78503    142.97525   0.002967359 
+  348          318.45617    143.01033   0.002873563 
+  356          358.92295    143.04562   0.002808989 
+  460          418.11233    143.08113   0.002173913 
+  596          509.3309     143.11685   0.001677852 
+  799          658.73217    143.15279   0.001251564 
+  1134         914.74294    143.18895   0.000881834 
+  1569         1349.8844    143.22533   0.000637349 
+  2143         1977.91572   143.26192   0.000466636 
+  2341         2398.26883   143.29874   0.000427168 
+  1963         2053.34365   143.33578   0.000509424 
+  1468         1425.67272   143.37305   0.000681199 
+  1050         978.65824    143.41053   0.000952381 
+  858          721.77084    143.44825   0.001165501 
+  669          582.35333    143.48619   0.001494768 
+  629          510.74301    143.52436   0.001589825 
+  578          482.27496    143.56276   0.001730104 
+  612          489.43307    143.60139   0.001633987 
+  618          538.16525    143.64025   0.001618123 
+  727          648.97038    143.67934   0.001375516 
+  982          855.72047    143.71866   0.00101833 
+  1228         1159.11435   143.75822   0.000814332 
+  1191         1344.16548   143.79802   0.000839631 
+  1132         1147.10128   143.83805   0.000883392 
+  832          826.86792    143.87833   0.001201923 
+  687          600.7532     143.91884   0.001455604 
+  479          467.53606    143.95959   0.002087683 
+  480          390.22214    144.00058   0.002083333 
+  360          343.3493     144.04182   0.002777778 
+  326          313.11946    144.0833    0.003067485 
+  308          292.47451    144.12502   0.003246753 
+  302          277.65748    144.16699   0.003311258 
+  287          266.35416    144.20921   0.003484321 
+  254          257.08311    144.25168   0.003937008 
+  240          249.35737    144.2944    0.004166667 
+  213          242.96708    144.33737   0.004694836 
+  221          237.70927    144.38059   0.004524887 
+  242          233.34438    144.42406   0.004132231 
+  236          229.58694    144.46779   0.004237288 
+  236          225.81981    144.51178   0.004237288 
+  224          221.50448    144.55602   0.004464286 
+  192          217.00286    144.60052   0.005208333 
+  229          212.93188    144.64529   0.004366812 
+  219          209.50519    144.69031   0.00456621 
+  188          206.66322    144.73559   0.005319149 
+  194          204.28009    144.78114   0.005154639 
+  209          202.25388    144.82695   0.004784689 
+  200          200.5374     144.87303   0.005     
+  187          199.1281     144.91937   0.005347594 
+  217          198.02482    144.96599   0.004608295 
+  214          197.2233     145.01287   0.004672897 
+  190          196.69426    145.06002   0.005263158 
+  195          196.23293    145.10745   0.005128205 
+  186          195.58779    145.15515   0.005376344 
+  201          194.92624    145.20312   0.004975124 
+  202          194.59488    145.25137   0.004950495 
+  222          194.71021    145.2999    0.004504505 
+  219          195.19408    145.3487    0.00456621 
+  172          195.88632    145.39779   0.005813953 
+  189          196.57931    145.44715   0.005291005 
+  219          197.08367    145.4968    0.00456621 
+  195          197.30378    145.54673   0.005128205 
+  202          197.27384    145.59695   0.004950495 
+  198          197.08837    145.64745   0.005050505 
+  179          196.88936    145.69824   0.005586592 
+  193          196.8526     145.74932   0.005181347 
+  177          197.15609    145.80069   0.005649718 
+  187          197.97819    145.85235   0.005347594 
+  205          199.51644    145.90431   0.004878049 
+  210          202.02962    145.95655   0.004761905 
+  211          205.90937    146.0091    0.004739336 
+  213          211.72778    146.06194   0.004694836 
+  231          220.11571    146.11508   0.004329004 
+  212          230.57781    146.16851   0.004716981 
+  202          238.70953    146.22225   0.004950495 
+  230          239.64794    146.27629   0.004347826 
+  212          236.55799    146.33064   0.004716981 
+  219          232.42283    146.38529   0.00456621 
+  205          226.55861    146.44024   0.004878049 
+  225          219.30732    146.4955    0.004444444 
+  236          212.29412    146.55108   0.004237288 
+  189          206.56428    146.60696   0.005291005 
+  190          202.33904    146.66315   0.005263158 
+  216          199.59978    146.71966   0.00462963 
+  191          198.4128     146.77648   0.005235602 
+  220          198.98812    146.83362   0.004545455 
+  190          201.35512    146.89107   0.005263158 
+  190          204.11259    146.94885   0.005263158 
+  218          204.23369    147.00694   0.004587156 
+  203          201.81214    147.06535   0.004926108 
+  205          198.9757     147.12409   0.004878049 
+  203          195.71138    147.18315   0.004926108 
+  188          191.68665    147.24254   0.005319149 
+  205          187.43585    147.30226   0.004878049 
+  197          183.6132     147.3623    0.005076142 
+  196          180.51337    147.42267   0.005102041 
+  187          178.15291    147.48338   0.005347594 
+  176          176.42097    147.54442   0.005681818 
+  193          175.09651    147.60579   0.005181347 
+  188          173.89196    147.6675    0.005319149 
+  177          172.75984    147.72954   0.005649718 
+  180          171.96151    147.79193   0.005555556 
+  184          171.76111    147.85465   0.005434783 
+  184          172.32853    147.91772   0.005434783 
+  180          173.74394    147.98113   0.005555556 
+  169          175.76321    148.04488   0.00591716 
+  177          177.32657    148.10898   0.005649718 
+  181          176.93368    148.17343   0.005524862 
+  175          174.61452    148.23822   0.005714286 
+  166          171.88039    148.30337   0.006024096 
+  157          169.75269    148.36887   0.006369427 
+  151          168.40546    148.43472   0.006622517 
+  174          167.64117    148.50093   0.005747126 
+  169          167.23473    148.56749   0.00591716 
+  176          167.10043    148.63441   0.005681818 
+  192          167.18376    148.70169   0.005208333 
+  155          167.44484    148.76933   0.006451613 
+  162          168.00144    148.83734   0.00617284 
+  170          168.99061    148.90571   0.005882353 
+  170          170.24273    148.97444   0.005882353 
+  168          171.10154    149.04354   0.005952381 
+  166          171.03486    149.11301   0.006024096 
+  171          170.46671    149.18285   0.005847953 
+  149          170.14467    149.25306   0.006711409 
+  179          170.42815    149.32365   0.005586592 
+  155          171.41513    149.39461   0.006451613 
+  176          173.1743     149.46594   0.005681818 
+  171          175.84383    149.53766   0.005847953 
+  194          179.66586    149.60975   0.005154639 
+  178          185.0893     149.68223   0.005617978 
+  208          193.06253    149.75509   0.004807692 
+  190          205.59941    149.82833   0.005263158 
+  217          226.49726    149.90196   0.004608295 
+  283          261.60777    149.97597   0.003533569 
+  266          314.59829    150.05038   0.003759398 
+  286          364.05692    150.12517   0.003496503 
+  268          357.46034    150.20036   0.003731343 
+  269          309.63176    150.27594   0.003717472 
+  219          267.12253    150.35192   0.00456621 
+  231          238.97655    150.4283    0.004329004 
+  222          223.1254     150.50507   0.004504505 
+  230          216.68443    150.58224   0.004347826 
+  226          217.63841    150.65982   0.004424779 
+  221          225.59019    150.7378    0.004524887 
+  233          241.63718    150.81618   0.004291845 
+  241          268.18538    150.89497   0.004149378 
+  282          306.94509    150.97417   0.003546099 
+  278          348.30231    151.05378   0.003597122 
+  297          368.78362    151.13381   0.003367003 
+  265          358.67951    151.21424   0.003773585 
+  231          318.94226    151.29509   0.004329004 
+  234          273.87352    151.37636   0.004273504 
+  253          241.10033    151.45805   0.003952569 
+  234          219.99953    151.54016   0.004273504 
+  196          207.47157    151.62268   0.005102041 
+  196          200.96966    151.70564   0.005102041 
+  224          198.94182    151.78901   0.004464286 
+  194          200.81823    151.87282   0.005154639 
+  183          206.65179    151.95705   0.005464481 
+  218          216.80637    152.04172   0.004587156 
+  189          230.42269    152.12681   0.005291005 
+  225          239.67554    152.21234   0.004444444 
+  194          233.40171    152.29831   0.005154639 
+  180          217.46775    152.38471   0.005555556 
+  184          203.13164    152.47155   0.005434783 
+  185          192.86299    152.55884   0.005405405 
+  178          185.72797    152.64656   0.005617978 
+  186          180.86181    152.73473   0.005376344 
+  189          177.63258    152.82335   0.005291005 
+  175          175.55171    152.91241   0.005714286 
+  184          174.28416    153.00192   0.005434783 
+  168          173.60278    153.09189   0.005952381 
+  181          173.31961    153.1823    0.005524862 
+  189          173.26362    153.27317   0.005291005 
+  161          173.3089     153.3645    0.00621118 
+  163          173.37447    153.45629   0.006134969 
+  154          173.46881    153.54854   0.006493506 
+  164          173.67646    153.64125   0.006097561 
+  174          173.9792     153.73442   0.005747126 
+  162          174.26218    153.82806   0.00617284 
+  168          174.58789    153.92216   0.005952381 
+  160          175.16182    154.01674   0.00625   
+  153          176.02855    154.11178   0.006535948 
+  138          176.76004    154.2073    0.007246377 
+  176          176.64536    154.3033    0.005681818 
+  162          175.65266    154.39977   0.00617284 
+  170          174.45324    154.49671   0.005882353 
+  162          173.49035    154.59414   0.00617284 
+  183          172.72447    154.69205   0.005464481 
+  165          172.00157    154.79045   0.006060606 
+  157          171.36271    154.88932   0.006369427 
+  163          170.93808    154.98869   0.006134969 
+  157          170.80365    155.08855   0.006369427 
+  145          170.99047    155.1889    0.006896552 
+  168          171.51258    155.28974   0.005952381 
+  158          172.37268    155.39107   0.006329114 
+  169          173.4737     155.4929    0.00591716 
+  168          174.38014    155.59524   0.005952381 
+  150          174.41136    155.69807   0.006666667 
+  146          173.43476    155.8014    0.006849315 
+  183          172.0864     155.90524   0.005464481 
+  169          170.92738    156.00959   0.00591716 
+  160          170.0651     156.11444   0.00625   
+  171          169.40233    156.2198    0.005847953 
+  165          168.88601    156.32568   0.006060606 
+  154          168.49209    156.43207   0.006493506 
+  162          168.19674    156.53898   0.00617284 
+  184          168.02209    156.6464    0.005434783 
+  143          168.00673    156.75434   0.006993007 
+  170          168.16427    156.86281   0.005882353 
+  164          168.4631     156.9718    0.006097561 
+  161          168.79518    157.08131   0.00621118 
+  167          168.99031    157.19135   0.005988024 
+  173          168.96737    157.30193   0.005780347 
+  196          168.85292    157.41303   0.005102041 
+  188          168.82093    157.52467   0.005319149 
+  170          168.9478     157.63684   0.005882353 
+  167          169.23071    157.74955   0.005988024 
+  160          169.60901    157.8628    0.00625   
+  168          169.97632    157.97659   0.005952381 
+  154          170.26558    158.09092   0.006493506 
+  171          170.53753    158.2058    0.005847953 
+  164          170.88173    158.32123   0.006097561 
+  166          171.33699    158.43721   0.006024096 
+  171          171.90082    158.55373   0.005847953 
+  162          172.55341    158.67082   0.00617284 
+  185          173.27786    158.78845   0.005405405 
+  172          174.05414    158.90665   0.005813953 
+  218          174.83162    159.0254    0.004587156 
+  183          175.59197    159.14472   0.005464481 
+  158          176.43059    159.2646    0.006329114 
+  196          177.49237    159.38504   0.005102041 
+  173          178.89768    159.50606   0.005780347 
+  172          180.74655    159.62764   0.005813953 
+  206          183.12868    159.7498    0.004854369 
+  174          186.0281     159.87252   0.005747126 
+  173          188.97902    159.99583   0.005780347 
+  186          190.87557    160.11971   0.005376344 
+  189          190.94887    160.24418   0.005291005 
+  174          189.88722    160.36922   0.005747126 
+  168          188.89432    160.49485   0.005952381 
+  166          188.56463    160.62107   0.006024096 
+  187          188.99856    160.74788   0.005347594 
+  205          190.17524    160.87527   0.004878049 
+  209          192.05262    161.00326   0.004784689 
+  197          194.37752    161.13185   0.005076142 
+  196          196.62111    161.26103   0.005102041 
+  191          198.53752    161.39081   0.005235602 
+  196          200.38996    161.52119   0.005102041 
+  174          202.41727    161.65218   0.005747126 
+  210          204.84154    161.78377   0.004761905 
+  209          207.83295    161.91597   0.004784689 
+  212          211.24126    162.04878   0.004716981 
+  194          215.06387    162.1822    0.005154639 
+  223          219.91589    162.31624   0.004484305 
+  195          226.34141    162.45089   0.005128205 
+  203          232.37261    162.58617   0.004926108 
+  208          234.78657    162.72206   0.004807692 
+  187          236.26393    162.85858   0.005347594 
+  224          242.07776    162.99572   0.004464286 
+  237          255.58871    163.13349   0.004219409 
+  282          280.6528     163.27188   0.003546099 
+  296          323.66901    163.41092   0.003378378 
+  370          389.54424    163.55058   0.002702703 
+  363          457.15222    163.69088   0.002754821 
+  361          459.69984    163.83182   0.002770083 
+  328          394.65303    163.9734    0.00304878 
+  295          329.34936    164.11563   0.003389831 
+  289          287.11642    164.2585    0.003460208 
+  287          263.49419    164.40201   0.003484321 
+  236          251.39551    164.54618   0.004237288 
+  244          244.55894    164.691     0.004098361 
+  217          239.22731    164.83647   0.004608295 
+  222          235.74173    164.9826    0.004504505 
+  239          235.47327    165.12939   0.0041841 
+  245          240.11469    165.27684   0.004081633 
+  254          252.23029    165.42495   0.003937008 
+  238          275.21302    165.57373   0.004201681 
+  301          309.47956    165.72318   0.003322259 
+  275          336.33693    165.8733    0.003636364 
+  272          324.07936    166.02409   0.003676471 
+  262          288.7507     166.17556   0.003816794 
+  222          259.40884    166.3277    0.004504505 
+  249          240.22089    166.48052   0.004016064 
+  220          227.40105    166.63403   0.004545455 
+  217          218.4272     166.78822   0.004608295 
+  205          212.24555    166.94309   0.004878049 
+  205          207.99772    167.09866   0.004878049 
+  202          204.83453    167.25491   0.004950495 
+  209          202.28733    167.41186   0.004784689 
+  185          200.21812    167.56951   0.005405405 
+  209          198.5433     167.72785   0.004784689 
+  202          197.29825    167.8869    0.004950495 
+  205          196.63276    168.04665   0.004878049 
+  192          196.61248    168.2071    0.005208333 
+  194          196.99095    168.36827   0.005154639 
+  207          197.6764     168.53014   0.004830918 
+  206          198.10096    168.69273   0.004854369 
+  222          197.94894    168.85603   0.004504505 
+  208          197.26279    169.02005   0.004807692 
+  166          196.42226    169.18479   0.006024096 
+  175          195.64636    169.35025   0.005714286 
+  201          194.84889    169.51643   0.004975124 
+  155          194.08336    169.68335   0.006451613 
+  218          193.52688    169.85099   0.004587156 
+  191          193.18201    170.01937   0.005235602 
+  196          192.9893     170.18848   0.005102041 
+  203          193.01835    170.35833   0.004926108 
+  172          193.30438    170.52891   0.005813953 
+  183          193.91654    170.70024   0.005464481 
+  194          194.53022    170.87232   0.005154639 
+  176          194.83084    171.04514   0.005681818 
+  172          194.83794    171.21871   0.005813953 
+  200          194.88353    171.39303   0.005     
+  177          195.23661    171.56811   0.005649718 
+  203          195.95814    171.74395   0.004926108 
+  203          196.943      171.92054   0.004926108 
+  223          198.02528    172.0979    0.004484305 
+  189          199.04452    172.27602   0.005291005 
+  230          199.73475    172.45491   0.004347826 
+  203          199.92292    172.63456   0.004926108 
+  193          199.86051    172.815     0.005181347 
+  189          199.93778    172.9962    0.005291005 
+  204          200.34721    173.17818   0.004901961 
+  186          201.08045    173.36094   0.005376344 
+  207          202.00764    173.54449   0.004830918 
+  187          203.00077    173.72882   0.005347594 
+  209          204.09089    173.91394   0.004784689 
+  204          205.42255    174.09984   0.004901961 
+  206          207.12074    174.28655   0.004854369 
+  181          209.27939    174.47404   0.005524862 
+  239          211.99571    174.66233   0.0041841 
+  179          215.36643    174.85143   0.005586592 
+  208          219.40293    175.04133   0.004807692 
+  205          223.861      175.23203   0.004878049 
+  243          228.10265    175.42354   0.004115226 
+  229          231.24886    175.61586   0.004366812 
+  221          233.03482    175.809     0.004524887 
+  218          234.2948     176.00295   0.004587156 
+  232          235.75052    176.19772   0.004310345 
+  213          237.08298    176.39332   0.004694836 
+  227          237.58587    176.58974   0.004405286 
+  214          237.2891     176.78698   0.004672897 
+  216          236.79779    176.98505   0.00462963 
+  243          236.58636    177.18396   0.004115226 
+  217          236.8804     177.3837    0.004608295 
+  240          237.79193    177.58428   0.004166667 
+  232          239.36955    177.7857    0.004310345 
+  235          241.61533    177.98796   0.004255319 
+  234          244.45452    178.19107   0.004273504 
+  258          247.60719    178.39503   0.003875969 
+  213          250.52776    178.59983   0.004694836 
+  227          252.87304    178.8055    0.004405286 
+  230          255.01154    179.01201   0.004347826 
+  278          257.51343    179.21939   0.003597122 
+  243          260.46975    179.42763   0.004115226 
+  284          263.57806    179.63674   0.003521127 
+  292          266.72351    179.84671   0.003424658 
+  293          270.2392     180.05755   0.003412969 
+  329          274.94093    180.26927   0.003039514 
+  330          282.13883    180.48186   0.003030303 
+  316          293.32366    180.69533   0.003164557 
+  331          309.24042    180.90968   0.003021148 
+  345          326.61603    181.12491   0.002898551 
+  345          335.00109    181.34104   0.002898551 
+  356          329.19918    181.55805   0.002808989 
+  358          318.75864    181.77595   0.002793296 
+  313          311.50806    181.99476   0.003194888 
+  327          308.45914    182.21445   0.003058104 
+  352          308.67725    182.43505   0.002840909 
+  341          311.44358    182.65656   0.002932551 
+  376          316.31687    182.87897   0.002659574 
+  341          322.96786    183.10229   0.002932551 
+  352          331.18598    183.32652   0.002840909 
+  342          341.02807    183.55167   0.002923977 
+  386          352.96804    183.77774   0.002590674 
+  401          367.78826    184.00472   0.002493766 
+  389          386.26715    184.23264   0.002570694 
+  417          408.21325    184.46147   0.002398082 
+  403          430.21748    184.69124   0.00248139 
+  470          447.6346     184.92194   0.00212766 
+  468          463.07474    185.15358   0.002136752 
+  497          482.61463    185.38615   0.002012072 
+  568          508.95289    185.61967   0.001760563 
+  589          542.94363    185.85413   0.001697793 
+  638          586.0775     186.08954   0.001567398 
+  722          641.77078    186.32589   0.001385042 
+  736          715.31912    186.5632    0.001358696 
+  910          812.95668    186.80147   0.001098901 
+  1038         940.29947    187.04069   0.000963391 
+  1277         1105.27728   187.28088   0.000783085 
+  1628         1334.28043   187.52203   0.000614251 
+  2021         1680.61436   187.76415   0.000494805 
+  2750         2229.49248   188.00724   0.000363636 
+  3989         3115.62122   188.25131   0.000250689 
+  5741         4518.73625   188.49635   0.000174186 
+  7669         6468.65858   188.74237   0.000130395 
+  8485         8085.59613   188.98937   0.000117855 
+  7618         7685.64237   189.23736   0.000131268 
+  5883         5771.5179    189.48634   0.000169981 
+  4284         3997.37356   189.73631   0.000233427 
+  3307         2817.48743   189.98728   0.000302389 
+  2583         2099.96818   190.23924   0.000387147 
+  2056         1672.92077   190.4922    0.000486381 
+  1744         1423.08743   190.74617   0.000573394 
+  1586         1285.70544   191.00114   0.000630517 
+  1603         1229.21266   191.25713   0.00062383 
+  1519         1249.66153   191.51413   0.000658328 
+  1740         1364.94098   191.77214   0.000574713 
+  2123         1615.684     192.03117   0.000471032 
+  2662         2072.141     192.29123   0.000375657 
+  3399         2818.59686   192.55231   0.000294204 
+  4017         3791.52101   192.81442   0.000248942 
+  4195         4356.43989   193.07756   0.000238379 
+  3650         3827.34533   193.34174   0.000273973 
+  2866         2801.34648   193.60695   0.000348918 
+  2192         1969.87936   193.8732    0.000456204 
+  1630         1429.13866   194.1405    0.000613497 
+  1296         1092.35357   194.40885   0.000771605 
+  1084         879.10174    194.67825   0.000922509 
+  922          738.27114    194.9487    0.001084599 
+  751          640.26291    195.2202    0.001331558 
+  670          568.31763    195.49277   0.001492537 
+  587          513.07759    195.7664    0.001703578 
+  537          469.60931    196.0411    0.001862197 
+  462          435.25928    196.31686   0.002164502 
+  439          408.14139    196.5937    0.002277904 
+  429          386.77613    196.87161   0.002331002 
+  418          370.01701    197.15061   0.002392344 
+  377          356.88443    197.43068   0.00265252 
+  360          346.29655    197.71184   0.002777778 
+  353          337.09357    197.99409   0.002832861 
+  359          328.72398    198.27743   0.002785515 
+  365          321.55616    198.56187   0.002739726 
+  326          316.32671    198.84741   0.003067485 
+  318          313.60051    199.13404   0.003144654 
+  300          313.15277    199.42178   0.003333333 
+  320          312.89071    199.71063   0.003125  
+  281          309.03829    200.00059   0.003558719 
+  278          300.8396     200.29167   0.003597122 
+  296          291.69106    200.58386   0.003378378 
+  301          284.07967    200.87718   0.003322259 
+  280          278.48679    201.17162   0.003571429 
+  258          274.57622    201.46718   0.003875969 
+  275          271.98653    201.76388   0.003636364 
+  254          270.54919    202.06172   0.003937008 
+  271          270.04615    202.36069   0.003690037 
+  252          270.08124    202.6608    0.003968254 
+  262          270.42179    202.96206   0.003816794 
+  275          271.34771    203.26446   0.003636364 
+  257          273.67017    203.56802   0.003891051 
+  264          278.4517     203.87273   0.003787879 
+  268          286.62502    204.17859   0.003731343 
+  251          298.46778    204.48562   0.003984064 
+  259          312.68168    204.79382   0.003861004 
+  285          324.82758    205.10318   0.003508772 
+  274          325.60487    205.41371   0.003649635 
+  265          311.87814    205.72542   0.003773585 
+  278          293.8984     206.03831   0.003597122 
+  268          279.56662    206.35238   0.003731343 
+  273          270.06137    206.66763   0.003663004 
+  236          264.42225    206.98407   0.004237288 
+  231          261.70083    207.30171   0.004329004 
+  262          261.28204    207.62053   0.003816794 
+  274          262.8361     207.94056   0.003649635 
+  237          266.31651    208.26179   0.004219409 
+  241          272.0835     208.58423   0.004149378 
+  220          281.01142    208.90788   0.004545455 
+  231          294.71862    209.23273   0.004329004 
+#--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--#
+
+# start Validation Reply Form
+vrf_PLAT741_NEW3minmill_phase_1 # for all atoms in 1_quartz
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+vrf_PLAT741_NEW3minmill_phase_3 # for all atoms in 3_pyrrhotite
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+vrf_PLAT741_NEW3minmill_phase_4 # for all atoms in 4_rutile
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+vrf_PLAT741_NEW3minmill_phase_2 # for all atoms in 2_albite
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT155_NEW3minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT141_NEW3minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT142_NEW3minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT143_NEW3minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT144_NEW3minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT145_NEW3minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT146_NEW3minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT151_NEW3minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+# end Validation Reply Form

--- a/data/hamish/vb5042sup8.cif
+++ b/data/hamish/vb5042sup8.cif
@@ -1,0 +1,6669 @@
+
+data_NEW5minmill_publ
+_audit_creation_method  "created in GSAS-II"
+_audit_creation_date  2021-08-04T18:39
+_audit_author_name  "McDougall, Hamish"
+_audit_update_record
+   "2021-08-04T18:39  Initial software-generated CIF"
+_pd_block_id  2021-08-04T18:39|NEW5minmill|McDougallHamish|Overall
+# GSAS-II edited template follows Publication_Template
+#=============================================================================
+# this information describes the project, paper etc. for the CIF             #
+# Acta Cryst. Section C papers and editorial correspondence is generated     #
+# from the information in this section                                       #
+#                                                                            #
+#   (from)   CIF submission form for Rietveld refinements (Acta Cryst. C)    #
+#                                                 Version 14 December 1998   #
+#=============================================================================
+# 1. SUBMISSION DETAILS
+
+_publ_contact_author_name            "Suzanne Neville; Vanessa Peterson; Christophe Didier"   # Name of author for correspondence
+_publ_contact_author_address             # Address of author for correspondence
+; ?
+;
+_publ_contact_author_email           "s.neville@unsw.edu.au; vanessa.peterson@ansto.gov.au; drchristophedidier@gmail.com"
+_publ_contact_author_fax             ?
+_publ_contact_author_phone           ?
+
+_publ_contact_letter
+; ?
+;
+   
+_publ_requested_journal              ?
+_publ_requested_coeditor_name        ?
+_publ_requested_category             ?   # Acta C: one of CI/CM/CO/FI/FM/FO
+
+#==============================================================================
+
+# 2. PROCESSING SUMMARY (IUCr Office Use Only)
+
+_journal_data_validation_number      ?
+
+_journal_date_recd_electronic        ?
+_journal_date_to_coeditor            ?
+_journal_date_from_coeditor          ?
+_journal_date_accepted               ?
+_journal_date_printers_first         ?
+_journal_date_printers_final         ?
+_journal_date_proofs_out             ?
+_journal_date_proofs_in              ?
+_journal_coeditor_name               ?
+_journal_coeditor_code               ?
+_journal_coeditor_notes
+; ?
+;
+_journal_techeditor_code             ?
+_journal_techeditor_notes
+; ?
+;
+_journal_coden_ASTM                  ?
+_journal_name_full                   ?
+_journal_year                        ?
+_journal_volume                      ?
+_journal_issue                       ?
+_journal_page_first                  ?
+_journal_page_last                   ?
+_journal_paper_category              ?
+_journal_suppl_publ_number           ?
+_journal_suppl_publ_pages            ?
+
+#==============================================================================
+
+# 3. TITLE AND AUTHOR LIST
+
+_publ_section_title
+; ?
+;
+_publ_section_title_footnote
+; ?
+;         
+ 
+# The loop structure below should contain the names and addresses of all 
+# authors, in the required order of publication. Repeat as necessary.
+
+loop_
+	_publ_author_name
+        _publ_author_footnote
+	_publ_author_address
+ ?                                   #<--'Last name, first name' 
+; ?
+;
+; ?
+;
+
+#==============================================================================
+
+# 4. TEXT
+
+_publ_section_synopsis
+;  ?
+;
+_publ_section_abstract                         
+; ?
+;          
+_publ_section_comment                          
+; ?
+;
+_publ_section_exptl_prep      # Details of the preparation of the sample(s)
+                              # should be given here. 
+; ?
+;
+_publ_section_exptl_refinement                  
+; ?
+;
+_publ_section_references
+; ?
+;
+_publ_section_figure_captions
+; ?
+;
+_publ_section_acknowledgements
+; ?
+;
+
+#=============================================================================
+# 5. OVERALL REFINEMENT & COMPUTING DETAILS
+
+_refine_special_details
+; ?
+;
+_pd_proc_ls_special_details
+; ?
+;
+
+# The following items are used to identify the programs used.
+_computing_molecular_graphics     ?
+_computing_publication_material   ?
+
+_refine_ls_weighting_scheme       ?        
+_refine_ls_weighting_details      ?
+_refine_ls_hydrogen_treatment     ?        
+_refine_ls_extinction_method      ?        
+_refine_ls_extinction_coef        ?         
+_refine_ls_number_constraints     ?        
+
+_refine_ls_restrained_S_all       ?        
+_refine_ls_restrained_S_obs       ?
+
+#==============================================================================
+# 6. SAMPLE PREPARATION DATA
+
+# (In the unusual case where multiple samples are used in a single
+#  Rietveld study, this information should be moved into the phase
+#  blocks)
+
+# The following three fields describe the preparation of the material.
+# The cooling rate is in K/min.  The pressure at which the sample was  
+# prepared is in kPa.  The temperature of preparation is in K.
+               
+_pd_prep_cool_rate                N/A        
+_pd_prep_pressure                 101.3        
+_pd_prep_temperature              298         
+
+_pd_char_colour                   ?       # use ICDD colour descriptions
+
+data_NEW5minmill_overall
+_pd_proc_info_datetime  2021-08-04T18:39
+_pd_calc_method  "Rietveld Refinement"
+_computing_structure_refinement
+   "GSAS-II (Toby & Von Dreele, J. Appl. Cryst. 46, 544-549, 2013)"
+_refine_ls_number_parameters  30
+_refine_ls_goodness_of_fit_all  2.319
+_refine_ls_shift/su_max  0.1113
+
+# OVERALL WEIGHTED R-FACTOR
+_refine_ls_wR_factor_obs  0.09317
+_refine_ls_matrix_type  full
+# POINTERS TO PHASE AND HISTOGRAM BLOCKS
+loop_   _pd_phase_block_id
+  2021-08-04T18:39|NEW5minmill|phase_0|McDougallHamish
+  2021-08-04T18:39|NEW5minmill|phase_2|McDougallHamish
+  2021-08-04T18:39|NEW5minmill|phase_4|McDougallHamish
+  2021-08-04T18:39|NEW5minmill|phase_1|McDougallHamish
+  2021-08-04T18:39|NEW5minmill|phase_3|McDougallHamish
+_pd_block_diffractogram_id
+;
+2021-08-04T18:39|NEW5minmill|McDougallHamish|PANalytical,Co-EmpyreanII_hist_0
+;
+
+data_NEW5minmill_phase_0
+# Information for phase 0
+_pd_block_id  2021-08-04T18:39|NEW5minmill|phase_0|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for FeS2 follows
+_pd_phase_name  FeS2
+_cell_length_a  5.419730(29)
+_cell_length_b  5.419730(29)
+_cell_length_c  5.419730(29)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  90
+_cell_volume  159.1963(26)
+_exptl_crystal_density_diffrn  5.0054
+_symmetry_cell_setting  cubic
+_symmetry_space_group_name_H-M  "P a -3"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  z,x,y
+     3  y,z,x
+     4  1/2+x,y,1/2-z
+     5  1/2-z,1/2+x,y
+     6  y,1/2-z,1/2+x
+     7  -z,1/2+x,1/2-y
+     8  1/2-y,-z,1/2+x
+     9  1/2+y,1/2-z,-x
+    10  -x,1/2+y,1/2-z
+    11  1/2-z,-x,1/2+y
+    12  1/2+x,1/2-y,-z
+    13  -x,-y,-z
+    14  -z,-x,-y
+    15  -y,-z,-x
+    16  1/2-x,-y,1/2+z
+    17  1/2+z,1/2-x,-y
+    18  -y,1/2+z,1/2-x
+    19  z,1/2-x,1/2+y
+    20  1/2+y,z,1/2-x
+    21  1/2-y,1/2+z,x
+    22  x,1/2-y,1/2+z
+    23  1/2+z,x,1/2-y
+    24  1/2-x,1/2+y,z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Fe1    Fe   0.00000     0.00000     0.00000     1.000      Uiso 0.0079(3)  4   
+S2     S    0.38533(11) 0.38533     0.38533     1.000      Uiso 0.0097(3)  8   
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Fe   4      11.7695    7.3573     3.5222     2.3045     4.7611     0.3072     15.3535    76.8805    1.0369     0.945
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S    8      6.9053     5.2034     1.4379     1.5863     1.4679     22.2151    0.2536     56.172     0.8669     0.2847
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Fe S2"
+_chemical_formula_weight  119.97
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Fe1    S2     2.26580(16)   1_555    4_455 yes
+  Fe1    S2     2.26580(16)   1_555    5_545 yes
+  Fe1    S2     2.26580(16)   1_555    6_554 yes
+  Fe1    S2     2.26580(16)   1_555    7_545 yes
+  Fe1    S2     2.26580(16)   1_555    8_554 yes
+  Fe1    S2     2.2658(5)    1_555    9_455 yes
+  S2     Fe1    2.26580(16)   1_555    4_555 yes
+  S2     Fe1    2.26580(16)   1_555    5_555 yes
+  S2     Fe1    2.2658(5)    1_555    6_555 yes
+  S2     S2     2.1528(7)    1_555   13_666 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.2144(14), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW5minmill_phase_2
+# Information for phase 2
+_pd_block_id  2021-08-04T18:39|NEW5minmill|phase_2|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for NaAlSi3O8 follows
+_pd_phase_name  NaAlSi3O8
+_cell_length_a  8.137
+_cell_length_b  12.785
+_cell_length_c  7.1583
+_cell_angle_alpha  94.26
+_cell_angle_beta   116.6
+_cell_angle_gamma  87.71
+_cell_volume  664.008
+_exptl_crystal_density_diffrn  2.6230
+_symmetry_cell_setting  triclinic
+_symmetry_space_group_name_H-M  "C -1"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -x,-y,-z
+     3  1/2+x,1/2+y,z
+     4  1/2-x,1/2-y,-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Al1    Al3+ 0.00887     0.16846     0.20805     1.000      Uani 0.007      4   
+Si1    Si4+ 0.00375     0.82051     0.23737     1.000      Uani 0.006      4   
+Si2    Si4+ 0.69162     0.11021     0.31466     1.000      Uani 0.006      4   
+Si3    Si4+ 0.68129     0.88190     0.36076     1.000      Uani 0.006      4   
+Na1    Na1+ 0.26799     0.98865     0.14650     1.000      Uani 0.031      4   
+O1     O2-  0.00490     0.13103     0.96660     1.000      Uani 0.012      4   
+O2     O2-  0.59176     0.99756     0.28040     1.000      Uani 0.008      4   
+O3     O2-  0.81230     0.10966     0.19010     1.000      Uani 0.014      4   
+O4     O2-  0.82000     0.85101     0.25870     1.000      Uani 0.018      4   
+O5     O2-  0.01288     0.30238     0.27060     1.000      Uani 0.011      4   
+O6     O2-  0.02329     0.69368     0.22910     1.000      Uani 0.011      4   
+O7     O2-  0.20780     0.10896     0.38900     1.000      Uani 0.011      4   
+O8     O2-  0.18400     0.86817     0.43620     1.000      Uani 0.012      4   
+
+loop_
+   _atom_site_aniso_label
+   _atom_site_aniso_U_11
+   _atom_site_aniso_U_22
+   _atom_site_aniso_U_33
+   _atom_site_aniso_U_12
+   _atom_site_aniso_U_13
+   _atom_site_aniso_U_23
+Al1    0.0074      0.0068      0.0061      -0.0009     0.0031      0.0004      
+Si1    0.0068      0.0065      0.0055      0.0011      0.0030      0.0008      
+Si2    0.0061      0.0055      0.0073      -0.0002     0.0025      0.0004      
+Si3    0.0060      0.0055      0.0074      0.0006      0.0028      0.0009      
+Na1    0.0136      0.0471      0.0315      -0.0050     0.0084      -0.0219     
+O1     0.0164      0.0122      0.0074      -0.0002     0.0067      0.0014      
+O2     0.0074      0.0056      0.0119      0.0003      0.0033      0.0020      
+O3     0.0117      0.0130      0.0162      -0.0040     0.0093      -0.0017     
+O4     0.0134      0.0179      0.0216      0.0046      0.0129      0.0020      
+O5     0.0103      0.0076      0.0150      -0.0020     0.0052      -0.0009     
+O6     0.0101      0.0071      0.0145      0.0022      0.0034      0.0012      
+O7     0.0120      0.0129      0.0080      0.0024      0.0013      0.0015      
+O8     0.0140      0.0140      0.0084      -0.0026     -0.0002     -0.0006     
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Al   4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Na   4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  O    32     ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si   12     ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Al Na O8 Si3"
+_chemical_formula_weight  262.22
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Al1    O1     1.74519      1_555    1_554 yes
+  Al1    O3     1.7429       1_555    1_455 yes
+  Al1    O5     1.73509      1_555    1_555 yes
+  Al1    O7     1.74556      1_555    1_555 yes
+  Si1    O1     1.59985      1_555    2_566 yes
+  Si1    O4     1.59997      1_555    1_455 yes
+  Si1    O6     1.62225      1_555    1_555 yes
+  Si1    O8     1.61907      1_555    1_555 yes
+  Si2    O2     1.63011      1_555    1_545 yes
+  Si2    O3     1.59435      1_555    1_555 yes
+  Si2    O6     1.61836      1_555    3_545 yes
+  Si2    O8     1.6168       1_555    2_666 yes
+  Si3    O2     1.64718      1_555    1_555 yes
+  Si3    O4     1.61975      1_555    1_555 yes
+  Si3    O5     1.59682      1_555    3_555 yes
+  Si3    O7     1.60203      1_555    2_666 yes
+  Na1    O1     2.66887      1_555    1_564 yes
+  Na1    O1     2.53079      1_555    2_566 yes
+  Na1    O2     2.3704       1_555    1_555 yes
+  Na1    O3     2.45321      1_555    2_665 yes
+  Na1    O7     2.43384      1_555    1_565 yes
+  O1     Al1    1.74519      1_555    1_556 yes
+  O1     Si1    1.59985      1_555    2_566 yes
+  O1     Na1    2.66887      1_555    1_546 yes
+  O1     Na1    2.53079      1_555    2_566 yes
+  O2     Si2    1.63011      1_555    1_565 yes
+  O2     Si3    1.64718      1_555    1_555 yes
+  O2     Na1    2.3704       1_555    1_555 yes
+  O3     Al1    1.7429       1_555    1_655 yes
+  O3     Si2    1.59435      1_555    1_555 yes
+  O3     Na1    2.45321      1_555    2_665 yes
+  O4     Si1    1.59997      1_555    1_655 yes
+  O4     Si3    1.61975      1_555    1_555 yes
+  O5     Al1    1.73509      1_555    1_555 yes
+  O5     Si3    1.59682      1_555    3_445 yes
+  O6     Si1    1.62225      1_555    1_555 yes
+  O6     Si2    1.61836      1_555    3_455 yes
+  O7     Al1    1.74556      1_555    1_555 yes
+  O7     Si3    1.60203      1_555    2_666 yes
+  O7     Na1    2.43384      1_555    1_545 yes
+  O8     Si1    1.61907      1_555    1_555 yes
+  O8     Si2    1.6168       1_555    2_666 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Al1    O3     102.836       1_554  1_555    1_455 yes
+  O1     Al1    O5     116.047       1_554  1_555    1_555 yes
+  O3     Al1    O5     112.215       1_455  1_555    1_555 yes
+  O1     Al1    O7     104.004       1_554  1_555    1_555 yes
+  O3     Al1    O7     111.151       1_455  1_555    1_555 yes
+  O5     Al1    O7     110.14        1_555  1_555    1_555 yes
+  O1     Si1    O4     109.433       2_566  1_555    1_455 yes
+  O1     Si1    O6     112.47        2_566  1_555    1_555 yes
+  O4     Si1    O6     108.187       1_455  1_555    1_555 yes
+  O1     Si1    O8     107.176       2_566  1_555    1_555 yes
+  O4     Si1    O8     111.446       1_455  1_555    1_555 yes
+  O6     Si1    O8     108.16        1_555  1_555    1_555 yes
+  O2     Si2    O3     111.144       1_545  1_555    1_555 yes
+  O2     Si2    O6     104.24        1_545  1_555    3_545 yes
+  O3     Si2    O6     112.114       1_555  1_555    3_545 yes
+  O2     Si2    O8     106.97        1_545  1_555    2_666 yes
+  O3     Si2    O8     111.591       1_555  1_555    2_666 yes
+  O6     Si2    O8     110.422       3_545  1_555    2_666 yes
+  O2     Si3    O4     107.269       1_555  1_555    1_555 yes
+  O2     Si3    O5     105.914       1_555  1_555    3_555 yes
+  O4     Si3    O5     110.224       1_555  1_555    3_555 yes
+  O2     Si3    O7     108.565       1_555  1_555    2_666 yes
+  O4     Si3    O7     110.208       1_555  1_555    2_666 yes
+  O5     Si3    O7     114.328       3_555  1_555    2_666 yes
+  Al1    O1     Si1    141.397       1_556  1_555    2_566 yes
+  Si2    O2     Si3    130.019       1_565  1_555    1_555 yes
+  Si2    O2     Na1    120.351       1_565  1_555    1_555 yes
+  Si3    O2     Na1    108.811       1_555  1_555    1_555 yes
+  Al1    O3     Si2    139.461       1_655  1_555    1_555 yes
+  Si1    O4     Si3    161.151       1_655  1_555    1_555 yes
+  Al1    O5     Si3    129.689       1_555  1_555    3_445 yes
+  Si1    O6     Si2    135.676       1_555  1_555    3_455 yes
+  Al1    O7     Si3    133.943       1_555  1_555    2_666 yes
+  Si1    O8     Si2    151.747       1_555  1_555    2_666 yes
+_pd_proc_ls_pref_orient_corr  none
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.129(9), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW5minmill_phase_4
+# Information for phase 4
+_pd_block_id  2021-08-04T18:39|NEW5minmill|phase_4|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Pyrrhotite 4M follows
+_pd_phase_name  "Pyrrhotite 4M"
+_cell_length_a  11.941(30)
+_cell_length_b  6.860(4)
+_cell_length_c  12.83(3)
+_cell_angle_alpha  90
+_cell_angle_beta   117.28(6)
+_cell_angle_gamma  90
+_cell_volume  934.2(4)
+_exptl_crystal_density_diffrn  4.6032
+_symmetry_cell_setting  monoclinic
+_symmetry_space_group_name_H-M  "C 2/c"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -x,y,1/2-z
+     3  -x,-y,-z
+     4  x,-y,1/2+z
+     5  1/2+x,1/2+y,z
+     6  1/2-x,1/2+y,1/2-z
+     7  1/2-x,1/2-y,-z
+     8  1/2+x,1/2-y,1/2+z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+S1     S    0.01800     0.38330     0.11960     1.000      Uiso 0.010      8   
+S2     S    0.02910     0.11420     0.63900     1.000      Uiso 0.010      8   
+Fe3    Fe   0.10860     0.10250     0.49980     1.000      Uiso 0.010      8   
+S4     S    0.23410     0.13550     0.38260     1.000      Uiso 0.010      8   
+Fe5    Fe   0.24180     0.36600     0.24680     1.000      Uiso 0.010      8   
+S6     S    0.26790     0.13400     0.12360     1.000      Uiso 0.010      8   
+Fe7    Fe   0.38720     0.15000     0.01260     1.000      Uiso 0.010      8   
+Fe8    Fe   0.00000     0.14720     0.25000     1.000      Uiso 0.010      4   
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Fe   28     11.7695    7.3573     3.5222     2.3045     4.7611     0.3072     15.3535    76.8805    1.0369     0.945
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S    32     6.9053     5.2034     1.4379     1.5863     1.4679     22.2151    0.2536     56.172     0.8669     0.2847
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Fe7 S8"
+_chemical_formula_weight  647.41
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  S1     Fe3    2.49405      1_555    2_555 yes
+  S1     Fe5    2.41283      1_555    1_555 yes
+  S1     Fe7    2.38878      1_555    5_455 yes
+  S1     Fe7    2.44353      1_555    7_555 yes
+  S1     Fe8    2.40803      1_555    1_555 yes
+  S2     Fe3    2.37734      1_555    1_555 yes
+  S2     Fe3    2.32405      1_555    3_556 yes
+  S2     Fe5    2.44444      1_555    7_556 yes
+  S2     Fe7    2.36627      1_555    8_456 yes
+  S2     Fe8    2.41215      1_555    3_556 yes
+  Fe3    S1     2.49405      1_555    2_555 yes
+  Fe3    S2     2.37734      1_555    1_555 yes
+  Fe3    S2     2.32405      1_555    3_556 yes
+  Fe3    S6     2.45036      1_555    4_556 yes
+  S4     Fe5    2.38574      1_555    1_555 yes
+  Fe5    S1     2.41283      1_555    1_555 yes
+  Fe5    S2     2.44444      1_555    7_556 yes
+  Fe5    S4     2.38574      1_555    1_555 yes
+  Fe5    S6     2.36232      1_555    1_555 yes
+  S6     Fe3    2.45036      1_555    4_555 yes
+  S6     Fe5    2.36232      1_555    1_555 yes
+  S6     Fe7    2.43506      1_555    1_555 yes
+  S6     Fe7    2.39022      1_555    7_555 yes
+  Fe7    S1     2.38878      1_555    5_545 yes
+  Fe7    S1     2.44353      1_555    7_555 yes
+  Fe7    S2     2.36627      1_555    8_555 yes
+  Fe7    S6     2.43506      1_555    1_555 yes
+  Fe7    S6     2.39022      1_555    7_555 yes
+  Fe8    S1     2.40803      1_555    1_555 yes
+  Fe8    S1     2.40803      1_555    2_555 yes
+  Fe8    S2     2.41215      1_555    3_556 yes
+  Fe8    S2     2.41215      1_555    4_555 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.0309(25), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW5minmill_phase_1
+# Information for phase 1
+_pd_block_id  2021-08-04T18:39|NEW5minmill|phase_1|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for SiO2 follows
+_pd_phase_name  SiO2
+_cell_length_a  4.9154(4)
+_cell_length_b  4.9154(4)
+_cell_length_c  5.4060(4)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  120
+_cell_volume  113.117(9)
+_exptl_crystal_density_diffrn  2.6461
+_symmetry_cell_setting  trigonal
+_symmetry_space_group_name_H-M  "P 32 2 1"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -y,x-y,2/3+z
+     3  y-x,-x,1/3+z
+     4  y,x,-z
+     5  -x,y-x,2/3-z
+     6  x-y,-y,1/3-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Si1    Si4+ 0.47000     0.00000     0.66670     1.000      Uani 0.006      3   
+O1     O2-  0.41460     0.26780     0.78543     1.000      Uani 0.011      6   
+
+loop_
+   _atom_site_aniso_label
+   _atom_site_aniso_U_11
+   _atom_site_aniso_U_22
+   _atom_site_aniso_U_33
+   _atom_site_aniso_U_12
+   _atom_site_aniso_U_13
+   _atom_site_aniso_U_23
+Si1    0.0073      0.0059      0.0053      0.0029      0.0003      0.0006      
+O1     0.0120      0.0105      0.0118      0.0065      -0.0029     -0.0040     
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  O    6      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si   3      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  3
+_chemical_formula_sum  "O2 Si"
+_chemical_formula_weight  60.08
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Si1    O1     1.60542      1_555    1_555 yes
+  Si1    O1     1.61173      1_555    2_654 yes
+  Si1    O1     1.61147      1_555    5_656 yes
+  Si1    O1     1.60556      1_555    6_556 yes
+  O1     Si1    1.60542      1_555    1_555 yes
+  O1     Si1    1.61173      1_555    3_665 yes
+  O1     Si1    1.61147      1_555    5_666 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Si1    O1     110.255       1_555  1_555    2_654 yes
+  O1     Si1    O1     108.748       1_555  1_555    5_656 yes
+  O1     Si1    O1     109.683       2_654  1_555    5_656 yes
+  O1     Si1    O1     109.16        1_555  1_555    6_556 yes
+  O1     Si1    O1     108.728       2_654  1_555    6_556 yes
+  O1     Si1    O1     110.26        5_656  1_555    6_556 yes
+  Si1    O1     Si1    143.832       1_555  1_555    3_665 yes
+  Si1    O1     Si1    143.835       1_555  1_555    5_666 yes
+  Si1    O1     Si1    0.009         3_665  1_555    5_666 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.183(9), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW5minmill_phase_3
+# Information for phase 3
+_pd_block_id  2021-08-04T18:39|NEW5minmill|phase_3|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for TiO2 follows
+_pd_phase_name  TiO2
+_cell_length_a  4.5996(11)
+_cell_length_b  4.5996(11)
+_cell_length_c  2.9608(10)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  90
+_cell_volume  62.639(25)
+_exptl_crystal_density_diffrn  4.2361
+_symmetry_cell_setting  tetragonal
+_symmetry_space_group_name_H-M  "P 42/m n m"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  1/2-y,1/2+x,1/2+z
+     3  -x,-y,z
+     4  1/2+y,1/2-x,1/2+z
+     5  1/2-x,1/2+y,1/2+z
+     6  -y,-x,z
+     7  1/2+x,1/2-y,1/2+z
+     8  y,x,z
+     9  -x,-y,-z
+    10  1/2+y,1/2-x,1/2-z
+    11  x,y,-z
+    12  1/2-y,1/2+x,1/2-z
+    13  1/2+x,1/2-y,1/2-z
+    14  y,x,-z
+    15  1/2-x,1/2+y,1/2-z
+    16  -y,-x,-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Ti1    Ti4+ 0.00000     0.00000     0.00000     1.000      Uani 0.006      2   
+O1     O2-  0.30493     0.30493     0.00000     1.000      Uani 0.006      4   
+
+loop_
+   _atom_site_aniso_label
+   _atom_site_aniso_U_11
+   _atom_site_aniso_U_22
+   _atom_site_aniso_U_33
+   _atom_site_aniso_U_12
+   _atom_site_aniso_U_13
+   _atom_site_aniso_U_23
+Ti1    0.0070      0.0070      0.0047      -0.0002     0.0000      0.0000      
+O1     0.0060      0.0060      0.0045      -0.0019     0.0000      0.0000      
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  O    4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Ti   2      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  2
+_chemical_formula_sum  "O2 Ti"
+_chemical_formula_weight  79.9
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Ti1    O1     1.98351      1_555    1_555 yes
+  Ti1    O1     1.94979      1_555    2_544 yes
+  Ti1    O1     1.94979      1_555    2_545 yes
+  Ti1    O1     1.98351      1_555    3_555 yes
+  Ti1    O1     1.94979      1_555    4_454 yes
+  Ti1    O1     1.94979      1_555    4_455 yes
+  O1     Ti1    1.98351      1_555    1_555 yes
+  O1     Ti1    1.94979      1_555    2_554 yes
+  O1     Ti1    1.94979      1_555    2_555 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Ti1    O1     90            1_555  1_555    2_544 yes
+  O1     Ti1    O1     90            1_555  1_555    2_545 yes
+  O1     Ti1    O1     98.799        2_544  1_555    2_545 yes
+  O1     Ti1    O1     180           1_555  1_555    3_555 yes
+  O1     Ti1    O1     90            2_544  1_555    3_555 yes
+  O1     Ti1    O1     90            2_545  1_555    3_555 yes
+  O1     Ti1    O1     90            1_555  1_555    4_454 yes
+  O1     Ti1    O1     81.201        2_544  1_555    4_454 yes
+  O1     Ti1    O1     180           2_545  1_555    4_454 yes
+  O1     Ti1    O1     90            3_555  1_555    4_454 yes
+  O1     Ti1    O1     90            1_555  1_555    4_455 yes
+  O1     Ti1    O1     180           2_544  1_555    4_455 yes
+  O1     Ti1    O1     81.201        2_545  1_555    4_455 yes
+  O1     Ti1    O1     90            3_555  1_555    4_455 yes
+  O1     Ti1    O1     98.799        4_454  1_555    4_455 yes
+  Ti1    O1     Ti1    130.601       1_555  1_555    2_554 yes
+  Ti1    O1     Ti1    130.601       1_555  1_555    2_555 yes
+  Ti1    O1     Ti1    98.799        2_554  1_555    2_555 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.150, 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW5minmill_pwd_0
+_pd_proc_ls_profile_function
+;
+Finger-Cox-Jephcoat function parameters U, V, W, X, Y, SH/L:
+  peak variance(Gauss) = Utan(Th)^2^+Vtan(Th)+W:
+  peak HW(Lorentz) = X/cos(Th)+Ytan(Th); SH/L = S/L+H/L
+  U, V, W in (centideg)^2^, X & Y in centideg
+    0.000, 0.000, 1.089, 0.882, 1.689, 0.058, 
+;
+# Information for histogram 0: PWDR BAT3_5min_milla_30mm_MonicaHamish_Ruoming_step size 0_5_min_mill_a.xrdml Scan 1
+_pd_block_id
+;
+2021-08-04T18:39|NEW5minmill|McDougallHamish|PANalytical,Co-EmpyreanII_hist_0
+;
+# GSAS-II edited template follows Instrument_Template
+#==============================================================================
+# 9. INSTRUMENT CHARACTERIZATION
+
+_exptl_special_details
+; ?
+;
+
+# if regions of the data are excluded, the reason(s) are supplied here:
+_pd_proc_info_excluded_regions
+; ?
+;
+
+# The following item is used to identify the equipment used to record 
+# the powder pattern when the diffractogram was measured at a laboratory 
+# other than the authors' home institution, e.g. when neutron or synchrotron
+# radiation is used.
+
+_pd_instr_location
+; ?
+;
+_pd_calibration_special_details           # description of the method used
+                                          # to calibrate the instrument
+; ?
+;
+
+_diffrn_source                    Co-Ka       
+_diffrn_source_target             Co
+_diffrn_source_type               Graded_Flat
+_diffrn_measurement_device_type   Panalytical_Reflection_Transmission       
+_diffrn_detector                  PIXcel1D       
+_diffrn_detector_type             Empyrean_II       # make or model of detector
+
+_pd_meas_scan_method              ?       # options are 'step', 'cont',
+                                          # 'tof', 'fixed' or
+                                          # 'disp' (= dispersive)
+_pd_meas_special_details
+;  ?
+;
+
+# The following two items identify the program(s) used (if appropriate).
+_computing_data_collection        ?        
+_computing_data_reduction         ?                   
+
+# Describe any processing performed on the data, prior to refinement.
+# For example: a manual Lp correction or a precomputed absorption correction
+_pd_proc_info_data_reduction      ?
+
+# The following item is used for angular dispersive measurements only.
+
+_diffrn_radiation_monochromator   ?        
+
+# The following items are used to define the size of the instrument.
+# Not all distances are appropriate for all instrument types.
+
+_pd_instr_dist_src/mono           ?
+_pd_instr_dist_mono/spec          ?
+_pd_instr_dist_src/spec           ?
+_pd_instr_dist_spec/anal          ?
+_pd_instr_dist_anal/detc          ?
+_pd_instr_dist_spec/detc          ?
+
+# 10. Specimen size and mounting information
+
+# The next three fields give the specimen dimensions in mm.  The equatorial 
+# plane contains the incident and diffracted beam.
+
+_pd_spec_size_axial               ?       # perpendicular to 
+                                          # equatorial plane
+
+_pd_spec_size_equat               ?       # parallel to 
+                                          # scattering vector 
+                                          # in transmission
+
+_pd_spec_size_thick               ?       # parallel to 
+                                          # scattering vector 
+                                          # in reflection
+
+_pd_spec_mounting                         # This field should be
+                                          # used to give details of the 
+                                          # container.
+; ?
+;
+
+_pd_spec_mount_mode               ?       # options are 'reflection' 
+                                          # or 'transmission'
+    
+_pd_spec_shape                    ?       # options are 'cylinder' 
+                                          # 'flat_sheet' or 'irregular'
+
+
+loop_
+     _atom_type_symbol
+     _atom_type_scat_dispersion_real
+     _atom_type_scat_dispersion_imag
+     _atom_type_scat_dispersion_source
+  Al        0.255   0.328   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Fe       -3.332   0.490   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Na        0.167   0.167   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  O         0.063   0.044   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S         0.371   0.733   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si        0.298   0.438   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Ti       -0.063   2.321   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+_diffrn_radiation_type  K\a~1,2~
+loop_
+   _diffrn_radiation_wavelength
+   _diffrn_radiation_wavelength_wt
+   _diffrn_radiation_wavelength_id
+  1.78892         1.0             1     
+  1.79278         0.5000          2     
+
+# PHASE TABLE
+loop_
+   _pd_phase_id
+   _pd_phase_block_id
+   _pd_phase_mass_%
+  0  2021-08-04T18:39|NEW5minmill|phase_0|McDougallHamish  0.8029(27)
+  2  2021-08-04T18:39|NEW5minmill|phase_2|McDougallHamish  0.0912(23)
+  4  2021-08-04T18:39|NEW5minmill|phase_4|McDougallHamish  0.0413(14)
+  1  2021-08-04T18:39|NEW5minmill|phase_1|McDougallHamish  0.0580(9)
+  3  2021-08-04T18:39|NEW5minmill|phase_3|McDougallHamish  0.0065(5)
+loop_
+   _gsas_proc_phase_R_F_factor
+   _gsas_proc_phase_R_Fsqd_factor
+   _gsas_proc_phase_id
+   _gsas_proc_phase_block_id
+    0.02912  0.06495  0  2021-08-04T18:39|NEW5minmill|phase_0|McDougallHamish
+    0.06917  0.15075  2  2021-08-04T18:39|NEW5minmill|phase_2|McDougallHamish
+    0.05582  0.09704  4  2021-08-04T18:39|NEW5minmill|phase_4|McDougallHamish
+    0.05993  0.14633  1  2021-08-04T18:39|NEW5minmill|phase_1|McDougallHamish
+    0.04930  0.09668  3  2021-08-04T18:39|NEW5minmill|phase_3|McDougallHamish
+_pd_proc_ls_prof_R_factor     0.07083
+_pd_proc_ls_prof_wR_factor    0.09317
+_gsas_proc_ls_prof_R_B_factor   0.08891
+_gsas_proc_ls_prof_wR_B_factor  0.11185
+_pd_proc_ls_prof_wR_expected  0.04032
+_diffrn_radiation_probe  x-ray
+_diffrn_radiation_polarisn_ratio  0.7000
+_pd_proc_ls_background_function
+;
+Background function: "chebyschev-1" function with 7 terms:
+    442.2(14), -516.5(22), 392.6(21), -195.8(19), 105.9(18), 
+    -33.3(13), 12.8(12), 
+;
+_diffrn_ambient_temperature  300
+_diffrn_ambient_pressure  100
+
+# STRUCTURE FACTOR TABLE
+loop_
+   _pd_refln_phase_id
+   _refln_index_h
+   _refln_index_k
+   _refln_index_l
+   _refln_F_squared_meas
+   _refln_F_squared_calc
+   _refln_phase_calc
+   _refln_d_spacing
+   _gsas_i100_meas
+  0  1    1    1    970.6116   857.3528   0.0     3.12908  25.86  
+  0  2    0    0    6738.2609  6339.6750  -0.0    2.70987  99.52  
+  0  2    1    0    3439.5149  3299.2276  0.0     2.42378  80.24  
+  0  2    1    1    1726.7036  1684.8090  -180.0  2.21260  66.40  
+  0  2    2    0    3200.4430  3314.7358  -0.0    1.91616  45.42  
+  0  2    2    1    37.8137    39.3552    -0.0    1.80658  0.95   
+  0  3    1    1    4873.9326  5161.4979  -0.0    1.63411  100.00 
+  0  2    2    2    2168.5371  2329.4918  0.0     1.56454  13.64  
+  0  3    0    2    2772.3874  2959.0267  -0.0    1.50316  24.30  
+  0  3    1    2    532.5664   552.2034   0.0     1.44848  8.75   
+  0  3    2    1    1536.9834  1593.6556  180.0   1.44848  25.26  
+  0  4    0    0    384.2169   325.7156   -180.0  1.35493  1.42   
+  0  3    2    2    39.8474    41.6412    -0.0    1.31448  0.57   
+  0  4    1    0    100.5664   105.0935   -0.0    1.31448  0.71   
+  0  4    1    1    61.1449    57.0935    180.0   1.27744  0.84   
+  0  3    3    1    560.7789   589.9787   -0.0    1.24337  7.51   
+  0  4    0    2    882.8590   871.7121   0.0     1.21189  5.80   
+  0  4    2    0    882.8590   871.7121   0.0     1.21189  5.80   
+  0  4    1    2    1.5173     1.5200     -0.0    1.18268  0.02   
+  0  4    2    1    1261.0621  1263.3276  -180.0  1.18268  16.36  
+  0  3    3    2    667.2141   642.3643   0.0     1.15549  8.61   
+  0  4    2    2    1046.2901  1002.5247  0.0     1.10630  13.62  
+  0  4    3    0    124.0373   125.7646   -0.0    1.08395  0.82   
+  0  4    1    3    60.6366    68.7836    -180.0  1.06290  0.82   
+  0  4    3    1    21.0107    23.8336    0.0     1.06290  0.28   
+  0  3    3    3    1686.1221  1496.5925  -0.0    1.04303  7.83   
+  0  5    1    1    3488.8974  3096.7257  -0.0    1.04303  48.62  
+  1  1    0    0    245.2690   242.5123   180.0   4.25687  0.48   
+  1  1    0    1    726.6254   634.4637   120.0   3.34446  0.87   
+  1  1    0    -1   1728.6013  1509.3536  -120.0  3.34446  2.07   
+  1  1    1    0    369.7698   343.8218   -155.6  2.45771  0.23   
+  1  1    0    2    272.5890   298.8477   -120.0  2.28185  0.15   
+  1  1    0    -2   78.5977    86.1691    -60.0   2.28185  0.04   
+  1  1    1    1    92.4053    96.0493    82.9    2.23735  0.09   
+  1  2    0    0    307.7820   308.9250   -0.0    2.12844  0.14   
+  1  2    0    -1   86.2873    77.2128    60.0    1.98046  0.03   
+  1  2    0    1    206.7454   185.0027   -60.0   1.98046  0.08   
+  1  1    1    2    535.1577   602.8170   9.8     1.81841  0.35   
+  1  0    0    3    89.0095    94.4583    0.0     1.80200  0.01   
+  1  2    0    2    90.2323    82.0787    60.0    1.67223  0.03   
+  1  2    0    -2   400.3722   364.1936   120.0   1.67223  0.11   
+  1  1    0    -3   204.2412   203.8424   180.0   1.65944  0.06   
+  1  1    0    3    2.5890     2.5840     0.0     1.65944  0.00   
+  1  2    1    0    15.8292    14.6393    -38.9   1.60895  0.01   
+  1  2    1    -1   292.0889   356.3201   95.9    1.54210  0.14   
+  1  2    1    1    251.4256   306.7148   -109.6  1.54210  0.12   
+  1  1    1    3    138.8989   142.5670   117.5   1.45323  0.06   
+  1  3    0    0    76.2653    76.3507    -180.0  1.41896  0.02   
+  1  2    1    -2   368.0958   413.7822   -123.3  1.38255  0.15   
+  1  2    1    2    114.2824   128.4666   143.4   1.38255  0.05   
+  1  2    0    -3   240.5906   292.6563   -0.0    1.37530  0.05   
+  1  2    0    3    847.0399   1030.3459  0.0     1.37530  0.17   
+  1  3    0    -1   678.9740   815.7970   -120.0  1.37247  0.13   
+  1  3    0    1    0.8444     1.0146     -60.0   1.37247  0.00   
+  1  1    0    -4   109.2835   120.2809   -120.0  1.28814  0.02   
+  1  1    0    4    360.1800   396.4255   120.0   1.28814  0.07   
+  1  3    0    -2   174.6427   208.2996   120.0   1.25636  0.03   
+  1  3    0    2    398.1686   474.9032   -120.0  1.25636  0.07   
+  1  2    2    0    304.9756   371.0385   -16.5   1.22885  0.05   
+  1  2    1    -3   61.4417    71.0028    179.1   1.20017  0.02   
+  1  2    1    3    260.8000   301.3836   -134.8  1.20017  0.09   
+  1  2    2    1    97.4452    105.5817   88.6    1.19828  0.03   
+  1  1    1    4    346.2970   334.1523   -14.4   1.18425  0.12   
+  1  3    1    0    360.2727   361.5244   121.4   1.18064  0.12   
+  1  3    1    -1   202.8465   189.9002   -18.5   1.15346  0.07   
+  1  3    1    1    67.7214    63.3992    16.4    1.15346  0.02   
+  1  2    0    4    61.7525    70.6740    120.0   1.14093  0.01   
+  1  2    0    -4   1.2870     1.4729     -120.0  1.14093  0.00   
+  1  2    2    2    3.7956     3.3501     -9.8    1.11867  0.00   
+  1  3    0    3    64.2389    62.7207    -180.0  1.11482  0.01   
+  1  3    0    -3   6.8473     6.6855     -0.0    1.11482  0.00   
+  1  3    1    -2   277.2696   304.3259   -8.9    1.08194  0.10   
+  1  3    1    2    113.2849   124.3393   59.1    1.08194  0.04   
+  1  4    0    0    135.0593   168.1758   0.0     1.06422  0.02   
+  1  1    0    -5   388.5114   346.2573   120.0   1.04793  0.07   
+  1  1    0    5    145.7621   129.9092   -120.0  1.04793  0.03   
+  1  4    0    -1   36.1789    31.4040    60.0    1.04418  0.01   
+  1  4    0    1    333.7129   289.6701   120.0   1.04418  0.06   
+  1  2    1    4    170.4079   240.8736   -129.5  1.03485  0.06   
+  1  2    1    -4   7.6843     10.8619    51.2    1.03485  0.00   
+  2  0    0    1    1597.7964  685.7541   180.0   6.38786  0.05   
+  2  0    2    0    895.0359   396.3962   180.0   6.37466  0.01   
+  2  1    1    0    559.3383   238.2363   -0.0    6.33955  0.01   
+  2  1    -1   0    801.0726   287.4879   -0.0    6.29869  0.01   
+  2  1    1    -1   871.0644   406.2352   180.0   5.91009  0.01   
+  2  1    -1   -1   746.8181   415.6378   -180.0  5.58552  0.01   
+  2  0    2    -1   10.1648    16.5792    0.0     4.66174  0.00   
+  2  0    2    1    3.1163     1.8371     180.0   4.37623  0.00   
+  2  2    0    -1   22042.8296 21037.4763 -0.0    4.02732  0.13   
+  2  1    -1   1    3934.2336  3767.3897  -0.0    3.85265  0.03   
+  2  1    1    1    9734.5902  10390.3834 0.0     3.77565  0.08   
+  2  1    3    0    8567.7243  5886.9121  180.0   3.68167  0.05   
+  2  1    3    -1   5939.0294  4505.3267  0.0     3.66562  0.03   
+  2  1    -3   0    12710.1208 11675.3013 180.0   3.65766  0.06   
+  2  2    0    0    1.8511     2.5781     0.0     3.63776  0.00   
+  2  1    1    -2   4491.9300  4328.5159  0.0     3.50520  0.03   
+  2  2    2    -1   2533.8585  1650.0035  180.0   3.48122  0.01   
+  2  1    -3   -1   59.2346    12.1276    0.0     3.43616  0.00   
+  2  1    -1   -2   5647.2138  5251.4578  0.0     3.37264  0.04   
+  2  2    -2   -1   358.2004   364.8637   0.0     3.33313  0.00   
+  2  2    0    -2   26107.3593 26655.4799 -180.0  3.21484  0.12   
+  2  0    0    2    39753.4496 37071.8044 -180.0  3.19393  0.28   
+  2  0    4    0    26944.3301 25362.8195 180.0   3.18733  0.10   
+  2  2    2    0    13674.2896 13873.6743 180.0   3.16977  0.06   
+  2  2    -2   0    15448.0036 14946.6082 -180.0  3.14934  0.06   
+  2  1    -3   1    13672.2651 11175.2497 -180.0  2.96418  0.05   
+  2  2    2    -2   7976.3293  7187.5067  0.0     2.95504  0.03   
+  2  0    2    -2   6065.1206  5310.5610  0.0     2.93060  0.03   
+  2  0    4    -1   8721.4832  8585.7945  0.0     2.92677  0.03   
+  2  1    3    1    5970.7697  6897.0276  180.0   2.86133  0.02   
+  2  1    3    -2   1543.5287  1923.0466  -0.0    2.83885  0.01   
+  2  2    -2   -2   167.8510   183.4547   -0.0    2.79276  0.00   
+  2  0    2    2    191.2460   191.6414   0.0     2.78600  0.00   
+  2  0    4    1    401.1000   387.5360   -0.0    2.78271  0.00   
+  2  2    0    1    110.4720   109.5836   -0.0    2.68712  0.00   
+  2  3    1    -1   422.5997   431.0071   -180.0  2.66293  0.00   
+  2  1    -3   -2   6878.1104  6171.6319  -0.0    2.63839  0.02   
+  2  3    -1   -1   37.5870    33.5476    -180.0  2.62530  0.00   
+  2  2    4    -1   15397.7878 12550.4891 -180.0  2.55995  0.03   
+  2  3    1    -2   2009.2877  1812.0722  180.0   2.53704  0.00   
+  2  1    -1   2    1034.4311  667.2869   180.0   2.51139  0.00   
+  2  2    -2   1    2137.3388  1686.7859  -180.0  2.49495  0.01   
+  2  3    -1   -2   550.7996   451.5613   180.0   2.48043  0.00   
+  2  1    1    2    131.5783   110.2849   180.0   2.46610  0.00   
+  2  2    2    1    1484.9621  1367.0046  -180.0  2.45771  0.00   
+  2  2    -4   -1   10970.6946 10453.7459 -180.0  2.44277  0.02   
+  2  1    5    -1   4294.2472  4093.1663  -0.0    2.42941  0.01   
+  2  1    5    0    56.3669    64.0884    180.0   2.41202  0.00   
+  2  2    4    0    3446.7410  3944.1458  -0.0    2.40628  0.01   
+  2  1    -5   0    1965.7117  2230.8323  180.0   2.40074  0.00   
+  2  2    -4   0    1819.7527  2079.3222  -0.0    2.38844  0.00   
+  2  3    1    0    1364.0717  1565.2946  -0.0    2.38575  0.00   
+  2  3    -1   0    1781.0580  2090.0863  -0.0    2.37918  0.00   
+  2  2    0    -3   6.2504     7.3701     180.0   2.35133  0.00   
+  2  2    4    -2   2.4401     2.9331     0.0     2.34729  0.00   
+  2  1    1    -3   111.1183   110.8373   -0.0    2.33656  0.00   
+  2  0    4    -2   1027.7615  884.3144   -180.0  2.33087  0.00   
+  2  3    3    -1   18524.9186 9809.7794  180.0   2.31766  0.03   
+  2  1    -5   -1   2148.1657  1044.9800  0.0     2.31526  0.00   
+  2  1    -1   -3   2105.7826  2291.2470  -0.0    2.27750  0.01   
+  2  2    2    -3   168.8133   155.6865   -0.0    2.26146  0.00   
+  2  3    3    -2   17.1848    15.9172    0.0     2.25070  0.00   
+  2  3    -3   -1   2699.0979  2703.2457  -180.0  2.24518  0.00   
+  2  1    -3   2    841.7306   824.7896   -0.0    2.22556  0.00   
+  2  0    4    2    1729.1576  2085.0250  0.0     2.18812  0.00   
+  2  2    -4   -2   1189.0247  1431.8638  0.0     2.18799  0.00   
+  2  1    -5   1    3656.6450  4194.8986  180.0   2.18493  0.01   
+  2  2    -2   -3   1314.7405  1851.4932  0.0     2.15451  0.00   
+  2  1    5    -2   211.8399   312.7232   -180.0  2.15169  0.00   
+  2  3    1    -3   158.1236   204.6119   0.0     2.13824  0.00   
+  2  3    -3   -2   415.2992   512.1941   180.0   2.13724  0.00   
+  2  1    3    2    167.2028   174.4523   -180.0  2.13433  0.00   
+  2  0    0    3    454.9181   454.6548   -0.0    2.12929  0.00   
+  2  0    6    0    10181.4597 11042.6256 -0.0    2.12489  0.02   
+  2  1    3    -3   564.4860   674.2906   -180.0  2.11876  0.00   
+  2  1    5    1    4082.7726  4734.7647  180.0   2.11595  0.01   
+  2  3    3    0    1319.6009  1496.6439  -180.0  2.11318  0.00   
+  2  3    -3   0    125.0057   182.7827   -180.0  2.09956  0.00   
+  2  3    -1   -3   1805.7056  2416.5634  0.0     2.08973  0.00   
+  2  2    -4   1    7263.9089  8370.0925  180.0   2.07604  0.01   
+  2  0    2    -3   266.4130   286.8930   -180.0  2.05903  0.00   
+  2  0    6    -1   75.8425    83.9001    -0.0    2.05549  0.00   
+  2  2    4    1    2654.5427  2723.1302  180.0   2.03350  0.00   
+  2  4    0    -2   1331.8976  1673.8545  -0.0    2.01366  0.00   
+  2  1    -5   -2   918.9591   976.2191   -0.0    2.00557  0.00   
+  2  4    0    -1   2982.4013  3207.5402  -0.0    2.00025  0.00   
+  2  2    0    2    828.4968   914.6787   0.0     1.99827  0.00   
+  2  1    -3   -3   2086.2833  2006.9284  -0.0    1.99351  0.00   
+  2  0    2    3    1565.1975  1320.4879  0.0     1.98235  0.00   
+  2  0    6    1    5408.0754  4760.1395  0.0     1.97919  0.01   
+  2  3    -1   1    2138.6768  1778.1424  0.0     1.97162  0.00   
+  2  3    3    -3   914.0840   747.2487   -180.0  1.97003  0.00   
+  2  3    1    1    1105.8271  1049.8991  0.0     1.96352  0.00   
+  2  2    4    -3   220.4512   210.6125   -180.0  1.96339  0.00   
+  2  4    2    -2   1513.2806  1505.1300  0.0     1.94723  0.00   
+  2  2    -2   2    4259.4731  4434.5615  -0.0    1.92633  0.01   
+  2  4    2    -1   184.9416   195.3738   0.0     1.92397  0.00   
+  2  2    6    -1   24.3870    25.7092    -0.0    1.91781  0.00   
+  2  4    -2   -2   14507.5481 14612.2943 -0.0    1.89414  0.02   
+  2  4    -2   -1   81.7718    83.9894    180.0   1.89341  0.00   
+  2  3    5    -1   3196.5905  3253.1319  -180.0  1.88804  0.00   
+  2  2    2    2    10945.2698 11147.4650 -0.0    1.88782  0.02   
+  2  3    -3   -3   374.3102   242.1347   -0.0    1.86184  0.00   
+  2  3    5    -2   225.1295   151.7748   -180.0  1.86122  0.00   
+  2  4    0    -3   15784.0021 17227.6438 -180.0  1.84958  0.02   
+  2  2    -6   -1   641.2491   630.1904   -180.0  1.84310  0.00   
+  2  1    -5   2    33.9473    32.7906    -180.0  1.84286  0.00   
+  2  2    6    0    7066.1929  5973.8074  -0.0    1.84084  0.01   
+  2  2    6    -2   2722.0729  2234.4122  -180.0  1.83281  0.00   
+  2  1    -1   3    2640.1051  2403.8627  -180.0  1.82957  0.01   
+  2  2    -6   0    11732.7341 11170.3478 0.0     1.82883  0.01   
+  2  2    -4   -3   360.5082   351.5785   -0.0    1.82817  0.00   
+  2  0    4    -3   6221.2363  6600.1943  180.0   1.82454  0.01   
+  2  3    -5   -1   503.8540   547.0575   -180.0  1.82305  0.00   
+  2  0    6    -2   8632.6142  9376.7847  -180.0  1.82300  0.01   
+  2  4    0    0    14813.5249 16544.7345 -0.0    1.81888  0.02   
+  2  3    -3   1    1287.3929  1388.1619  -0.0    1.81269  0.00   
+  2  4    2    -3   1627.9184  1698.2109  -0.0    1.80678  0.00   
+  2  1    1    3    12531.4100 13204.6231 -180.0  1.80269  0.03   
+  2  3    3    1    632.2133   659.8672   -0.0    1.79396  0.00   
+  2  1    5    -3   37.5158    36.9138    180.0   1.79152  0.00   
+  2  1    7    -1   312.3863   370.2527   -180.0  1.78554  0.00   
+  2  2    0    -4   24381.2246 29304.7955 0.0     1.78457  0.04   
+  2  1    7    0    1449.0925  1186.7943  -0.0    1.76994  0.00   
+  2  3    5    0    503.1200   192.4714   -180.0  1.76391  0.00   
+  2  1    -7   0    5030.3152  1861.7091  0.0     1.76369  0.01   
+  2  1    5    2    5362.9062  1478.1411  -180.0  1.75728  0.01   
+  2  3    -5   -2   874.8326   292.8600   -180.0  1.75539  0.00   
+  2  2    2    -4   10872.7556 5374.4235  180.0   1.75260  0.02   
+  2  4    2    0    6511.4096  3240.2714  180.0   1.75255  0.01   
+  2  3    -5   0    1.1423     0.6787     -180.0  1.75073  0.00   
+  2  4    -2   -3   1909.7609  1498.9920  -180.0  1.74735  0.00   
+  2  4    -2   0    1840.8683  1478.3757  -180.0  1.74562  0.00   
+  2  4    4    -2   13900.5312 11156.5991 -180.0  1.74061  0.01   
+  2  3    1    -4   16.1024    11.6942    0.0     1.73791  0.00   
+  2  1    1    -4   1184.4524  931.5858   180.0   1.73044  0.00   
+  2  0    4    3    1693.1688  1649.4123  180.0   1.72108  0.00   
+  2  1    -7   -1   557.9828   544.5769   -0.0    1.72100  0.00   
+  2  2    -4   2    5200.6264  5111.9528  -180.0  1.72066  0.01   
+  2  0    6    2    4062.6808  4043.0244  180.0   1.71979  0.01   
+  2  2    -6   -2   5818.7011  5843.5104  180.0   1.71808  0.01   
+  2  1    -3   3    3850.8954  3889.7621  0.0     1.71755  0.01   
+  2  4    4    -1   3335.7556  3425.3612  -0.0    1.71605  0.00   
+  2  3    -1   -4   34.5668    26.3196    -0.0    1.70384  0.00   
+  2  3    5    -3   2291.2396  1781.5059  180.0   1.70048  0.00   
+  2  1    -1   -4   1474.4199  1087.2281  180.0   1.69839  0.00   
+  2  2    -2   -4   7452.0304  6607.2640  -0.0    1.68632  0.01   
+  2  2    -6   1    131.3221   111.8094   180.0   1.68403  0.00   
+  2  1    -7   1    1321.6617  1037.6002  0.0     1.67991  0.00   
+  2  1    7    -2   3544.1680  3014.1863  0.0     1.67337  0.00   
+  2  4    -4   -1   3642.0513  3113.5342  -0.0    1.67328  0.00   
+  2  1    -5   -3   354.1888   322.6770   -180.0  1.66739  0.00   
+  2  2    4    2    7698.4031  6980.1241  -180.0  1.66673  0.01   
+  2  4    -4   -2   3301.3094  2996.9232  -180.0  1.66656  0.00   
+  2  1    3    3    625.2856   605.4945   0.0     1.65314  0.00   
+  2  3    3    -4   499.9937   474.5918   180.0   1.65084  0.00   
+  2  2    6    1    15.7241    15.0623    180.0   1.64996  0.00   
+  2  4    4    -3   85.9167    81.5092    0.0     1.64497  0.00   
+  2  1    3    -4   1331.7327  1267.0308  -180.0  1.64299  0.00   
+  2  2    6    -3   410.7566   438.3802   0.0     1.63845  0.00   
+  2  1    7    1    908.3293   959.6711   0.0     1.63566  0.00   
+  2  5    1    -2   59.0243    62.3555    -180.0  1.62122  0.00   
+  2  2    4    -4   7.1994     6.6299     0.0     1.60885  0.00   
+  2  3    -1   2    261.5094   237.1891   -180.0  1.60779  0.00   
+  2  4    0    -4   28.4739    25.5451    0.0     1.60742  0.00   
+  2  5    -1   -2   124.4599   104.4782   -0.0    1.60481  0.00   
+  2  3    1    2    5.2445     3.3755     -180.0  1.59704  0.00   
+  2  0    0    4    2677.9775  1719.5025  -0.0    1.59697  0.00   
+  2  0    8    0    6622.1561  4104.7411  -0.0    1.59366  0.01   
+  2  3    -5   -3   7621.6485  7048.0684  -180.0  1.58673  0.01   
+  2  4    2    -4   5906.1466  5767.4424  -180.0  1.58523  0.01   
+  2  4    4    0    82.5661    80.5872    180.0   1.58489  0.00   
+  2  3    -5   1    3529.6163  3541.7994  0.0     1.57987  0.00   
+  2  1    -7   -2   98.1449    106.0592   180.0   1.57566  0.00   
+  2  4    -4   0    908.1788   972.7791   180.0   1.57467  0.00   
+  2  4    0    1    1228.3147  1313.3627  0.0     1.57405  0.00   
+  2  0    2    -4   6446.9555  6835.8768  -180.0  1.57267  0.01   
+  2  5    1    -1   1742.2836  1838.8969  0.0     1.57223  0.00   
+  2  5    1    -3   4.3625     4.5305     0.0     1.57056  0.00   
+  2  0    8    -1   4793.8420  5105.5113  -180.0  1.56971  0.00   
+  2  3    -3   -4   206.5644   222.0271   -180.0  1.56739  0.00   
+  2  1    -3   -4   1103.3413  1168.3240  -180.0  1.56437  0.00   
+  2  5    -1   -1   3402.8447  3532.8589  -0.0    1.56314  0.00   
+  2  3    5    1    6291.8262  6630.5027  -0.0    1.55930  0.01   
+  2  2    0    3    1671.7128  1763.6711  -180.0  1.55911  0.00   
+  2  4    -4   -3   632.9302   668.2938   0.0     1.55805  0.00   
+  2  0    6    -3   50.7263    50.4752    180.0   1.55391  0.00   
+  2  5    -1   -3   3081.4358  3177.9812  180.0   1.54983  0.00   
+  2  5    3    -2   1777.6431  1684.3120  0.0     1.53962  0.00   
+  2  3    7    -1   378.1945   255.3064   -0.0    1.53554  0.00   
+  2  4    -2   -4   6708.9038  4566.3850  180.0   1.53333  0.01   
+  2  4    -2   1    482.7903   360.2122   -0.0    1.53138  0.00   
+  2  2    -2   3    5192.2185  3884.5431  0.0     1.52972  0.01   
+  2  1    -5   3    148.1925   114.2358   180.0   1.52775  0.00   
+  2  0    2    4    2661.1339  1999.2534  180.0   1.52655  0.00   
+  2  3    7    -2   1887.6700  1417.6951  180.0   1.52649  0.00   
+  2  4    2    1    68.5714    55.0425    -0.0    1.52494  0.00   
+  2  0    8    1    67.1347    53.4117    0.0     1.52385  0.00   
+  2  3    -3   2    921.4088   713.5252   0.0     1.52351  0.00   
+  2  2    -6   -3   1360.2585  972.3599   180.0   1.52111  0.00   
+  2  1    -7   2    2568.6620  2092.8268  180.0   1.51406  0.00   
+  2  2    -4   -4   3957.8519  3475.0688  -180.0  1.51008  0.00   
+  2  2    8    -1   8901.8321  8932.7653  0.0     1.50687  0.01   
+  2  5    3    -3   10648.7285 11216.4371 -0.0    1.50125  0.01   
+  2  2    2    3    245.5853   261.4234   0.0     1.49966  0.00   
+  2  5    -3   -2   1221.9096  1283.3165  0.0     1.49852  0.00   
+  2  4    6    -2   1568.6419  1643.4734  -180.0  1.49804  0.00   
+  2  3    3    2    2769.7578  2828.3266  0.0     1.49651  0.00   
+  2  5    3    -1   1476.8988  1375.8687  180.0   1.49230  0.00   
+  2  1    7    -3   1048.4549  963.7100   -0.0    1.49138  0.00   
+  2  3    5    -4   1155.5674  976.7543   0.0     1.48741  0.00   
+  2  3    -7   -1   5.0215     4.1505     -180.0  1.48641  0.00   
+  2  2    -6   2    2696.7849  2225.9899  -180.0  1.48209  0.00   
+  2  1    5    -4   630.9222   569.2303   -0.0    1.48061  0.00   
+  2  4    4    -4   1019.0278  936.8644   -0.0    1.47752  0.00   
+  2  4    6    -1   2651.3158  2425.3077  -0.0    1.47727  0.00   
+  2  2    8    -2   2288.8795  2036.6290  -0.0    1.46947  0.00   
+  2  5    -3   -1   2505.7412  2250.7625  180.0   1.46932  0.00   
+  2  0    4    -4   1774.8652  1799.2981  0.0     1.46530  0.00   
+  2  2    8    0    16940.7581 17372.8918 180.0   1.46378  0.01   
+  2  0    8    -2   2621.4480  2670.5014  0.0     1.46338  0.00   
+  2  3    7    0    1372.4271  1344.4772  -0.0    1.46164  0.00   
+  2  0    6    3    10318.0929 9727.2084  -180.0  1.45874  0.01   
+  2  2    -8   -1   297.0693   277.6153   0.0     1.45806  0.00   
+  2  2    -8   0    15333.1748 14971.6548 -180.0  1.45572  0.01   
+  2  1    5    3    82.9564    84.4701    0.0     1.45352  0.00   
+  2  3    -7   0    1823.3370  1874.7884  -0.0    1.45113  0.00   
+  2  5    -3   -3   3864.8165  3973.0050  -0.0    1.44873  0.00   
+  2  1    7    2    335.5408   339.6716   180.0   1.44736  0.00   
+  2  5    1    0    462.1422   468.7582   0.0     1.44694  0.00   
+  2  5    -1   0    272.4316   282.6566   0.0     1.44450  0.00   
+  2  3    -7   -2   393.6317   407.5222   -180.0  1.44435  0.00   
+  2  5    1    -4   363.2903   376.0669   -0.0    1.44434  0.00   
+  2  4    6    -3   4725.9166  4799.2632  180.0   1.44037  0.00   
+  2  3    7    -3   2131.1267  2066.9126  0.0     1.43858  0.00   
+  2  4    -6   -1   13914.9030 13974.0377 -0.0    1.43651  0.01   
+  2  1    -1   4    1976.6007  1747.7612  -0.0    1.43156  0.00   
+  2  2    6    2    15300.3645 14127.5120 -180.0  1.43067  0.02   
+  2  4    -6   -2   10712.5984 11494.7453 -180.0  1.42772  0.01   
+  2  3    1    -5   46.7032    54.5453    0.0     1.42498  0.00   
+  2  2    -4   3    7935.7127  9304.7725  -0.0    1.42492  0.01   
+  2  5    -1   -4   5276.1773  6191.0063  0.0     1.42367  0.00   
+  2  2    0    -5   534.4107   530.6717   -0.0    1.41970  0.00   
+  2  2    6    -4   4124.7651  4109.1661  -0.0    1.41942  0.00   
+  2  4    -4   1    2207.6228  2328.2327  -180.0  1.41643  0.00   
+  2  1    1    4    9389.8539  9765.5200  -0.0    1.41417  0.01   
+  2  2    2    -5   139.0749   102.1798   180.0   1.40774  0.00   
+  2  4    4    1    6472.9699  4251.1055  -180.0  1.40628  0.01   
+  2  1    9    -1   489.3369   313.3806   180.0   1.40427  0.00   
+  2  3    -1   -5   875.8501   559.2035   180.0   1.40173  0.00   
+  2  5    5    -2   178.3543   121.8591   180.0   1.39689  0.00   
+  2  4    -4   -4   475.3106   333.7965   -180.0  1.39638  0.00   
+  2  5    3    -4   12768.6905 10290.7248 -180.0  1.39407  0.01   
+  2  0    4    4    693.5445   603.2489   180.0   1.39300  0.00   
+  2  1    9    0    6820.4401  6061.3448  -180.0  1.39244  0.00   
+  2  0    8    2    899.6342   841.8614   -0.0    1.39135  0.00   
+  2  1    -7   -3   9.0418     8.6161     0.0     1.39082  0.00   
+  2  2    -8   -2   414.3314   389.1003   0.0     1.38958  0.00   
+  2  1    -9   0    5226.4859  5032.6219  -180.0  1.38852  0.00   
+  2  3    -5   -4   736.2155   712.8918   180.0   1.38828  0.00   
+  2  1    -5   -4   12.3911    12.2841    -0.0    1.38705  0.00   
+  2  4    6    0    6930.4531  6881.9956  0.0     1.38694  0.01   
+  2  2    -8   1    2490.1733  2583.5813  -0.0    1.38353  0.00   
+  2  3    -5   2    100.6397   107.7060   180.0   1.38139  0.00   
+  2  1    -3   4    10187.7155 11498.8556 180.0   1.38001  0.01   
+  2  3    3    -5   528.8669   601.2645   -0.0    1.37984  0.00   
+  2  5    3    0    1814.3591  2064.1961  180.0   1.37983  0.00   
+  2  2    4    3    6700.6223  7682.9819  -0.0    1.37735  0.01   
+  2  4    -6   0    2511.5779  2929.6322  0.0     1.37669  0.00   
+  2  5    -3   0    1599.7832  1846.9850  -180.0  1.37349  0.00   
+  2  4    0    -5   8428.9149  9852.1453  -0.0    1.37263  0.01   
+  2  5    5    -3   894.4178   1000.1841  -0.0    1.37203  0.00   
+  2  1    1    -5   65.5562    51.8333    180.0   1.36876  0.00   
+  2  2    8    -3   1302.0139  897.0709   0.0     1.36740  0.00   
+  2  2    -2   -5   1285.2891  890.9937   -180.0  1.36475  0.00   
+  2  1    -9   -1   3180.3265  2521.2414  180.0   1.36346  0.00   
+  2  4    2    -5   13035.6905 11335.5971 180.0   1.36264  0.01   
+  2  2    8    1    3944.6498  3611.9875  -180.0  1.35827  0.00   
+  2  5    5    -1   1013.3201  870.4892   -180.0  1.35737  0.00   
+  2  4    -6   -3   4646.5489  4126.3352  180.0   1.35385  0.00   
+  2  3    -7   1    648.0771   576.4772   0.0     1.35312  0.00   
+  2  1    9    -2   15494.4387 16147.0686 0.0     1.35152  0.01   
+  2  6    0    -2   16034.0835 16981.3924 180.0   1.35133  0.01   
+  2  1    -9   1    3418.2052  3741.5161  -0.0    1.35032  0.00   
+  2  1    -1   -5   9576.9952  10683.9602 -0.0    1.34891  0.01   
+  2  3    5    2    192.5920   209.3398   0.0     1.34817  0.00   
+  2  5    -5   -2   512.5815   568.7530   180.0   1.34647  0.00   
+  2  4    0    2    18183.3936 20266.7951 180.0   1.34356  0.02   
+  2  6    0    -3   405.4791   424.9852   0.0     1.34244  0.00   
+  2  3    -7   -3   956.0205   987.1236   180.0   1.34218  0.00   
+  2  5    -3   -4   20.3995    19.4544    -0.0    1.34037  0.00   
+  2  3    7    1    730.6433   545.2034   0.0     1.33504  0.00   
+  2  1    3    4    400.2831   303.9072   180.0   1.33473  0.00   
+  2  2    4    -5   2648.7976  2138.1647  -0.0    1.33359  0.00   
+  2  6    2    -2   7207.5607  7470.5514  0.0     1.33146  0.00   
+  2  3    -1   3    527.5130   551.6386   -0.0    1.32984  0.00   
+  2  5    -5   -1   3081.5634  3077.6343  -180.0  1.32879  0.00   
+  2  1    -7   3    866.0421   845.5145   -180.0  1.32789  0.00   
+  2  1    3    -5   13271.5609 12956.3684 180.0   1.32785  0.01   
+  2  4    6    -4   1246.5253  1219.1637  0.0     1.32754  0.00   
+  2  6    2    -3   6.1860     6.0091     -0.0    1.32656  0.00   
+  2  4    -2   -5   3329.0988  3146.4347  0.0     1.32203  0.00   
+  2  1    9    1    1070.6918  1105.1306  -0.0    1.32057  0.00   
+  2  4    -2   2    2149.8971  2255.4357  0.0     1.32028  0.00   
+  2  3    1    3    3073.4479  3237.6008  0.0     1.32015  0.00   
+  2  2    -6   -4   109.0008   114.0134   0.0     1.31919  0.00   
+  2  3    -3   -5   2084.5538  2179.7868  180.0   1.31918  0.00   
+  2  0    6    -4   3255.5650  3685.3963  0.0     1.31717  0.00   
+  2  0    8    -3   4222.2892  4546.6333  -0.0    1.31636  0.00   
+  2  6    -2   -2   348.6221   330.6363   180.0   1.31265  0.00   
+  2  4    2    2    594.2908   505.4413   0.0     1.30914  0.00   
+  2  5    -5   -3   7408.7013  6208.9517  0.0     1.30653  0.00   
+  2  3    7    -4   13.8019    11.5530    -180.0  1.30602  0.00   
+  2  6    0    -1   882.4968   635.2341   -0.0    1.30261  0.00   
+  2  6    -2   -3   6558.3528  4797.6968  0.0     1.30107  0.00   
+  2  1    7    -4   1118.7640  816.7390   180.0   1.30069  0.00   
+  2  4    4    -5   1042.1917  839.8412   -180.0  1.29576  0.00   
+  2  5    -1   1    760.5766   560.8179   -180.0  1.29287  0.00   
+  2  5    5    -4   133.1859   102.0732   -0.0    1.29210  0.00   
+  2  5    1    1    269.2952   213.0414   180.0   1.29128  0.00   
+  2  5    1    -5   1276.4191  1297.0866  -180.0  1.28850  0.00   
+  2  1    -9   -2   6669.3289  7594.2794  0.0     1.28440  0.00   
+  2  3    -3   3    3354.7257  3821.2749  180.0   1.28422  0.00   
+  2  2    -6   3    87.8502    97.9036    -0.0    1.28363  0.00   
+  2  3    5    -5   2764.6180  3037.5557  -0.0    1.28334  0.00   
+  2  6    2    -1   2369.5143  2446.8719  180.0   1.28151  0.00   
+  2  4    8    -2   15911.4940 16043.2073 -0.0    1.27998  0.01   
+  2  6    0    -4   4882.7836  4642.8182  0.0     1.27913  0.00   
+  2  1    -5   4    0.2979     0.2762     -0.0    1.27885  0.00   
+  2  0    0    5    1629.1216  1504.7953  0.0     1.27757  0.00   
+  2  2    -8   -3   1133.9531  969.8153   0.0     1.27578  0.00   
+  2  1    -3   -5   1892.1475  1649.0848  -180.0  1.27554  0.00   
+  2  0    10   0    5991.4710  5612.4673  -0.0    1.27493  0.00   
+  2  3    9    -1   629.8932   567.6734   180.0   1.27318  0.00   
+  2  3    9    -2   207.7059   209.3409   0.0     1.27118  0.00   
+  2  6    -2   -1   598.0334   604.9530   -180.0  1.27102  0.00   
+  2  5    -1   -5   3180.4708  3287.3648  -0.0    1.27057  0.00   
+  2  4    -6   1    2067.9792  2157.0193  180.0   1.27033  0.00   
+  2  2    0    4    4633.7886  5970.9564  -0.0    1.26862  0.00   
+  2  6    2    -4   2020.0899  2642.8907  -180.0  1.26852  0.00   
+  2  0    2    -5   3035.5866  4140.6925  180.0   1.26818  0.00   
+  2  2    -8   2    11358.0706 15669.9235 0.0     1.26800  0.01   
+  2  5    5    0    1114.6329  1539.1640  -0.0    1.26791  0.00   
+  2  0    10   -1   654.5441   722.1628   -180.0  1.26570  0.00   
+  2  4    8    -1   134.4447   116.1733   180.0   1.26381  0.00   
+  2  2    -4   -5   38.4523    34.2839    180.0   1.26302  0.00   
+  2  1    -9   2    449.0978   407.6104   0.0     1.26267  0.00   
+  2  6    4    -2   3812.8613  4060.9393  -0.0    1.26012  0.00   
+  2  1    7    3    1313.0168  1423.0605  -180.0  1.25993  0.00   
+  2  5    -5   0    1133.1217  1251.7915  -0.0    1.25974  0.00   
+  2  4    6    1    31.0378    35.4122    180.0   1.25938  0.00   
+  2  6    4    -3   4996.8805  5742.7030  -180.0  1.25904  0.00   
+  2  3    3    3    30.6044    34.1056    0.0     1.25855  0.00   
+  2  2    -2   4    2258.1496  2630.4316  180.0   1.25569  0.00   
+  2  5    3    -5   6826.3807  7849.9862  180.0   1.25548  0.00   
+  2  1    9    -3   416.8733   446.4585   -180.0  1.25310  0.00   
+  2  4    -4   2    3152.5684  2913.1494  0.0     1.24747  0.00   
+  2  4    8    -3   1649.5998  1591.0184  -180.0  1.24643  0.00   
+  2  5    -3   1    152.5103   154.1169   -180.0  1.24419  0.00   
+  2  4    -6   -4   4711.4030  4649.8078  0.0     1.24074  0.00   
+  2  1    5    -5   21.1501    20.8490    -0.0    1.24058  0.00   
+  2  6    -2   -4   117.9710   116.0421   -0.0    1.24022  0.00   
+  2  5    3    1    880.4836   865.0651   -180.0  1.23993  0.00   
+  2  0    6    4    4501.3470  4402.8269  -0.0    1.23960  0.00   
+  2  0    8    3    2674.8433  2523.8232  0.0     1.23892  0.00   
+  2  5    7    -2   54.0563    48.4702    -180.0  1.23815  0.00   
+  2  0    2    5    6.9290     6.1649     -0.0    1.23770  0.00   
+  2  3    -9   -1   2185.7524  1878.7146  -180.0  1.23697  0.00   
+  2  0    10   1    88.5088    69.0195    180.0   1.23540  0.00   
+  2  2    8    -4   0.8474     0.6712     -0.0    1.23509  0.00   
+  2  2    2    4    277.5528   202.3679   180.0   1.23305  0.00   
+  2  2    10   -1   893.4662   674.5837   -0.0    1.23266  0.00   
+  2  2    6    3    699.5127   591.5126   -0.0    1.23202  0.00   
+  2  4    -8   -1   1608.2340  1660.8265  180.0   1.22975  0.00   
+  2  4    4    2    6166.3624  7216.8110  -0.0    1.22886  0.01   
+  2  6    -4   -2   6350.7874  7429.0559  0.0     1.22874  0.00   
+  2  4    -4   -5   5150.1538  5935.8119  180.0   1.22833  0.00   
+  2  3    9    0    193.3937   207.1256   180.0   1.22722  0.00   
+  2  2    8    2    15449.2933 16367.8700 -0.0    1.22501  0.01   
+  2  3    -7   2    4.1820     4.4310     -180.0  1.22493  0.00   
+  2  5    7    -3   695.0245   701.3947   180.0   1.22357  0.00   
+  2  5    -5   -4   547.5227   527.2945   -180.0  1.22255  0.00   
+  2  2    6    -5   96.6780    93.3157    -0.0    1.22244  0.00   
+  2  3    9    -3   4079.9632  3989.5508  -0.0    1.22187  0.00   
+  2  4    -8   -2   15991.0804 15576.6760 0.0     1.22139  0.01   
+  2  1    5    4    3266.0203  2923.6151  -180.0  1.22003  0.00   
+  2  3    -9   0    74.8341    63.1939    -0.0    1.21922  0.00   
+  2  6    -4   -3   1.9816     1.6171     -180.0  1.21643  0.00   
+  2  6    4    -1   11.1753    10.2523    180.0   1.21473  0.00   
+  2  2    10   -2   3480.3886  3195.8904  -180.0  1.21471  0.00   
+  2  3    -7   -4   10.3126    9.5153     0.0     1.21279  0.00   
+  2  6    0    0    14066.2091 13100.2263 0.0     1.21259  0.01   
+  2  1    9    2    1878.5295  1749.7864  0.0     1.21259  0.00   
+  2  0    4    -5   55.1788    51.4047    -180.0  1.21258  0.00   
+  2  1    -7   -4   721.7062   673.8718   0.0     1.21254  0.00   
+  2  6    4    -4   205.8398   199.9465   0.0     1.21185  0.00   
+  2  0    10   -2   2515.7857  2393.1814  180.0   1.21068  0.00   
+  2  3    -9   -2   2.5158     2.4088     0.0     1.20966  0.00   
+  2  5    7    -1   979.0799   919.5910   -0.0    1.20764  0.00   
+  2  5    -3   -5   1784.1120  1669.4106  -180.0  1.20756  0.00   
+  2  2    10   0    13.2599    11.8619    180.0   1.20601  0.00   
+  2  3    -5   -5   5811.3143  5223.5291  -0.0    1.20426  0.01   
+  2  4    8    0    2169.9643  2036.1638  -180.0  1.20314  0.00   
+  2  2    -10  0    1095.6617  1234.3417  180.0   1.20037  0.00   
+  2  2    -10  -1   1790.6892  1881.5821  0.0     1.19900  0.00   
+  2  2    -4   4    0.0040     0.0043     180.0   1.19841  0.00   
+  2  3    -5   3    4836.8901  5149.8089  -180.0  1.19827  0.00   
+  2  6    -4   -1   4121.3065  4013.4094  180.0   1.19705  0.00   
+  2  4    -8   0    2143.3521  1701.7086  -180.0  1.19422  0.00   
+  2  4    6    -5   6565.9412  5356.2972  -0.0    1.19366  0.00   
+  2  6    2    0    8198.8599  6359.8747  -180.0  1.19287  0.01   
+  2  3    1    -6   224.3193   172.0799   180.0   1.19278  0.00   
+  2  3    7    2    280.1634   210.6961   180.0   1.19262  0.00   
+  2  6    -2   0    2676.8775  1825.4606  -180.0  1.18959  0.00   
+  2  5    -7   -2   349.0978   235.2689   -180.0  1.18926  0.00   
+  2  5    5    -5   656.0314   652.0282   -0.0    1.18202  0.00   
+  2  6    0    -5   1880.9696  1859.8386  -0.0    1.18139  0.00   
+  2  5    -7   -1   1143.7345  1170.6276  -0.0    1.17956  0.00   
+  2  3    -1   -6   9896.5585  10651.6340 0.0     1.17652  0.01   
+  2  1    -9   -3   3266.5328  3479.3329  -0.0    1.17569  0.00   
+  2  4    0    -6   652.9998   694.8770   -180.0  1.17567  0.00   
+  2  6    2    -5   650.8973   690.4314   180.0   1.17553  0.00   
+  2  4    8    -4   4718.0642  5262.2410  180.0   1.17365  0.00   
+  2  1    -1   5    40.1511    44.3347    0.0     1.17349  0.00   
+  2  2    0    -6   3059.0572  3262.2227  -180.0  1.17258  0.00   
+  2  4    2    -6   699.7026   785.7923   0.0     1.17185  0.00   
+  2  4    -8   -3   448.1193   512.5086   -0.0    1.17167  0.00   
+  2  1    -5   -5   4667.5795  5414.4867  -180.0  1.17131  0.00   
+  2  3    3    -6   2793.2633  3178.6335  180.0   1.16840  0.00   
+  2  5    7    -4   5205.6997  5932.4007  0.0     1.16833  0.00   
+  2  2    2    -6   389.8015   444.4424   0.0     1.16828  0.00   
+  2  0    8    -4   6747.9899  6734.2463  -180.0  1.16544  0.00   
+  2  3    5    3    9586.7936  9033.3981  -180.0  1.16397  0.01   
+  2  6    -4   -4   1416.9505  1331.0105  -180.0  1.16381  0.00   
+  2  3    7    -5   1259.4391  1180.8749  180.0   1.16377  0.00   
+  2  3    -9   1    29.4704    24.5109    -0.0    1.16177  0.00   
+  2  1    1    5    2374.5187  1984.2370  0.0     1.16142  0.00   
+  2  2    -10  1    489.8657   408.7012   -180.0  1.16134  0.00   
+  2  0    4    5    4516.0332  3674.6390  -180.0  1.16082  0.00   
+  2  6    6    -3   713.1311   572.9928   0.0     1.16041  0.00   
+  2  5    -5   1    10.2433    8.2052     180.0   1.16017  0.00   
+  2  7    1    -3   409.0354   326.8856   180.0   1.15995  0.00   
+  2  2    4    4    418.9544   334.7388   180.0   1.15990  0.00   
+  2  0    10   2    2342.0836  1953.1670  -180.0  1.15916  0.00   
+  2  5    -7   -3   16.5682    13.9221    0.0     1.15905  0.00   
+  2  6    6    -2   1256.5097  1062.5954  180.0   1.15883  0.00   
+  2  2    -10  -2   1062.0485  927.1428   -180.0  1.15763  0.00   
+  2  2    10   -3   521.9804   456.9863   180.0   1.15752  0.00   
+  2  1    -7   4    8962.8695  7894.1741  -0.0    1.15699  0.01   
+  2  1    11   -1   185.0294   172.4013   -0.0    1.15488  0.00   
+  2  5    5    1    15.8832    14.5872    180.0   1.15443  0.00   
+  2  4    0    3    419.6892   372.8509   -0.0    1.15214  0.00   
+  2  7    -1   -3   226.9447   190.7937   -0.0    1.15103  0.00   
+  2  1    -9   3    462.5081   390.2848   -180.0  1.15086  0.00   
+  2  7    1    -2   498.2203   417.6649   180.0   1.14957  0.00   
+  2  6    -2   -5   4.1049     3.3422     180.0   1.14818  0.00   
+  2  2    -8   -4   1323.3114  1241.1393  -0.0    1.14713  0.00   
+  2  3    9    1    894.8281   840.9132   -180.0  1.14703  0.00   
+  2  1    -3   5    140.1332   131.0137   -0.0    1.14691  0.00   
+  2  4    -6   2    983.9974   884.2580   -180.0  1.14653  0.00   
+  2  1    11   0    734.3507   673.8595   0.0     1.14593  0.00   
+  2  3    -9   -3   6873.2793  6842.7549  -0.0    1.14539  0.00   
+  2  1    -11  0    52.2751    56.5171    180.0   1.14326  0.00   
+  2  7    -1   -2   236.8211   258.5173   180.0   1.14319  0.00   
+  2  2    10   1    2003.1122  2221.3310  -180.0  1.14260  0.00   
+  2  2    -6   -5   7512.8369  8280.7099  -0.0    1.14253  0.01   
+  2  5    -1   2    0.2320     0.2523     -180.0  1.14237  0.00   
+  2  4    -2   -6   145.5558   159.9954   -0.0    1.14109  0.00   
+  2  5    7    0    1433.7688  1584.2307  0.0     1.14103  0.00   
+  2  3    9    -4   3287.1387  3452.1120  -180.0  1.13977  0.00   
+  2  4    -2   3    643.9415   675.3480   180.0   1.13965  0.00   
+  2  2    -8   3    920.0440   940.5804   180.0   1.13923  0.00   
+  2  5    1    2    150.5002   151.0052   180.0   1.13897  0.00   
+  2  2    -2   -6   456.3159   457.5743   180.0   1.13875  0.00   
+  2  5    1    -6   102.5472   92.8501    180.0   1.13644  0.00   
+  2  6    4    0    11126.4919 9886.1889  -180.0  1.13618  0.01   
+  2  1    9    -4   7590.5865  6387.1239  180.0   1.13575  0.00   
+  2  7    1    -4   113.1499   104.3489   0.0     1.13318  0.00   
+  2  5    -7   0    629.8327   561.3250   0.0     1.13270  0.00   
+  2  6    4    -5   3947.2538  3560.8356  -0.0    1.13225  0.00   
+  2  7    3    -3   1998.6521  1752.7599  180.0   1.13164  0.00   
+  2  1    7    -5   2150.1861  1876.4532  -0.0    1.13113  0.00   
+  2  4    4    -6   85.4478    74.0198    180.0   1.13073  0.00   
+  2  6    -4   0    10358.6460 8996.3605  -180.0  1.13052  0.01   
+  2  1    1    -6   14.6203    12.7255    180.0   1.13041  0.00   
+  2  4    2    3    37.8355    26.9687    0.0     1.12798  0.00   
+  2  1    11   -2   5333.3722  4054.5939  -180.0  1.12721  0.00   
+  2  2    4    -6   810.1471   617.9103   -180.0  1.12706  0.00   
+  2  1    -11  -1   105.7789   80.5660    180.0   1.12692  0.00   
+  2  0    6    -5   1086.8977  825.3110   -0.0    1.12677  0.00   
+  2  0    10   -3   30.9734    25.1309    180.0   1.12560  0.00   
+  2  6    6    -4   1334.9548  1116.6065  -0.0    1.12535  0.00   
+  2  4    -8   1    1557.6102  1428.0735  -0.0    1.12500  0.00   
+  2  4    6    2    532.9234   491.6513   180.0   1.12497  0.00   
+  2  3    -3   -6   2525.1900  2679.1058  0.0     1.12421  0.00   
+  2  1    -11  1    479.5915   520.4388   180.0   1.12385  0.00   
+  2  3    -1   4    57.9482    62.3074    180.0   1.12290  0.00   
+  2  7    -1   -4   322.8438   340.7362   180.0   1.12266  0.00   
+  2  6    -6   -2   5.5620     5.8815     -0.0    1.12259  0.00   
+  2  5    -1   -6   3186.6707  3679.1020  -180.0  1.12188  0.00   
+  2  6    6    -1   17.0780    18.5196    -180.0  1.12105  0.00   
+  2  7    3    -2   573.8522   466.2613   -180.0  1.11981  0.00   
+  2  5    -5   -5   3218.6294  3254.1700  180.0   1.11710  0.00   
+  2  1    -1   -6   1548.1293  1573.1101  -180.0  1.11699  0.00   
+  2  4    -6   -5   13.2413    12.1624    -180.0  1.11621  0.00   
+  2  5    3    -6   4020.2813  3572.8767  0.0     1.11574  0.00   
+  2  3    1    4    580.4218   557.2568   180.0   1.11489  0.00   
+  2  4    8    1    3161.2955  3030.2470  -0.0    1.11486  0.00   
+  2  1    3    5    235.6873   208.8946   -180.0  1.11404  0.00   
+  2  2    -6   4    1942.3187  1626.0861  -0.0    1.11278  0.00   
+  2  6    -6   -3   10549.4680 9170.8262  180.0   1.11104  0.01   
+  2  5    -3   2    27.2018    23.9804    -180.0  1.11049  0.00   
+  2  3    5    -6   85.0816    75.3696    -0.0    1.11017  0.00   
+  2  1    3    -6   4096.5235  3749.4968  0.0     1.10915  0.00   
+  2  7    3    -4   918.9486   851.8273   -0.0    1.10885  0.00   
+  2  7    -3   -3   8.8751     8.0510     -0.0    1.10731  0.00   
+  2  7    1    -1   599.0543   540.2195   -180.0  1.10485  0.00   
+  2  6    0    1    3110.5933  2851.2916  180.0   1.10441  0.00   
+  2  1    11   1    378.3620   353.4958   0.0     1.10278  0.00   
+  2  7    -3   -2   8.2740     7.6618     -0.0    1.10240  0.00   
+  2  4    10   -2   306.3559   293.9448   -180.0  1.10139  0.00   
+  2  7    -1   -1   582.5976   560.8360   -180.0  1.10125  0.00   
+  2  5    3    2    95.9879    92.4856    -180.0  1.10119  0.00   
+  2  2    8    -5   3896.1608  3728.5603  180.0   1.10077  0.00   
+  2  6    -6   -1   6.6221     6.2337     0.0     1.10033  0.00   
+  2  5    -7   -4   129.6086   136.6182   0.0     1.09716  0.00   
+  2  3    -3   4    136.1787   143.6453   -0.0    1.09706  0.00   
+  2  1    7    4    54.4690    57.0295    -0.0    1.09661  0.00   
+  2  0    8    4    3292.7438  2959.2417  180.0   1.09406  0.00   
+  2  4    -8   -4   4110.7938  3685.4545  -180.0  1.09399  0.00   
+  2  4    -4   3    2458.6154  2186.7268  180.0   1.09385  0.00   
+  2  3    -7   3    2040.8119  1814.2931  0.0     1.09384  0.00   
+  2  1    9    3    347.0460   308.2223   180.0   1.09383  0.00   
+  2  2    -10  2    4.6648     3.3265     -0.0    1.09247  0.00   
+  2  2    8    3    539.3952   379.8198   0.0     1.09126  0.00   
+  2  5    9    -2   2505.9766  1582.6840  -0.0    1.09021  0.00   
+  2  4    10   -1   2.5152     1.7369     -180.0  1.08903  0.00   
+  2  6    -2   1    2.2278     1.5406     -180.0  1.08894  0.00   
+  2  1    -5   5    8181.3215  5646.2565  0.0     1.08884  0.01   
+  2  6    2    1    352.4606   245.3481   -0.0    1.08745  0.00   
+  2  2    -10  -3   861.7093   617.4947   180.0   1.08733  0.00   
+  2  5    7    -5   121.3846   91.0318    -180.0  1.08704  0.00   
+  2  6    -4   -5   460.2220   422.0173   180.0   1.08477  0.00   
+  2  3    -7   -5   3043.3851  3180.2930  0.0     1.08232  0.00   
+  2  5    9    -3   34.8607    37.0056    -180.0  1.08217  0.00   
+  2  4    10   -3   458.5478   496.5346   180.0   1.08176  0.00   
+  2  4    8    -5   356.4862   416.8216   0.0     1.08002  0.00   
+  2  7    -3   -4   406.9688   475.9937   -180.0  1.08002  0.00   
+  2  3    11   -2   991.3995   1209.7235  180.0   1.07973  0.00   
+  2  3    -9   2    924.8909   1162.0253  -0.0    1.07952  0.00   
+  2  1    -11  -2   395.8522   505.5742   -0.0    1.07909  0.00   
+  2  3    11   -1   1981.5297  2531.9784  -180.0  1.07901  0.00   
+  2  4    -4   -6   40.2526    79.4879    0.0     1.07725  0.00   
+  2  7    3    -1   250.6002   517.9063   0.0     1.07642  0.00   
+  2  7    1    -5   12.3344    25.2106    -0.0    1.07626  0.00   
+  2  5    -3   -6   717.5836   1371.1187  180.0   1.07586  0.00   
+  2  2    10   -4   1491.5120  2842.5457  0.0     1.07584  0.00   
+  2  2    -4   -6   101.0975   186.5753   0.0     1.07568  0.00   
+  2  3    3    4    300.9064   560.4316   180.0   1.07511  0.00   
+  2  1    -11  2    324.5856   558.2780   -180.0  1.07370  0.00   
+  2  7    5    -3   548.2242   928.6481   180.0   1.07351  0.00   
+  2  4    4    3    484.3101   818.8776   180.0   1.07348  0.00   
+  2  1    -3   -6   107.4029   135.6225   180.0   1.07233  0.00   
+  2  6    0    -6   3.6445     4.1780     -180.0  1.07161  0.00   
+  2  1    11   -3   408.3705   540.3856   180.0   1.07008  0.00   
+  2  6    2    -6   60.4788    107.8329   0.0     1.06912  0.00   
+  2  6    -6   -4   306.1462   552.9788   0.0     1.06862  0.00   
+  2  5    9    -1   652.5194   1026.4794  0.0     1.06732  0.00   
+  2  2    6    4    2682.7839  4143.5979  0.0     1.06716  0.00   
+  2  7    -3   -1   126.1189   173.9010   0.0     1.06652  0.00   
+  2  2    0    5    1440.4261  1937.9253  0.0     1.06580  0.00   
+  2  0    6    5    262.2085   358.8678   0.0     1.06561  0.00   
+  2  7    -1   -5   2354.2672  3288.8085  0.0     1.06535  0.00   
+  2  5    5    -6   319.7441   447.2840   -180.0  1.06509  0.00   
+  2  0    0    6    40.5392    53.4823    180.0   1.06464  0.00   
+  2  0    10   3    2488.9128  3276.3246  0.0     1.06463  0.00   
+  2  4    6    -6   27.3220    31.3322    -180.0  1.06282  0.00   
+  2  6    6    -5   376.1086   434.3157   -0.0    1.06260  0.00   
+  2  0    12   0    97.4211    112.6819   180.0   1.06244  0.00   
+  2  4    -10  -1   968.5252   1132.6677  180.0   1.06171  0.00   
+  2  7    5    -2   3873.8382  4496.3914  -180.0  1.06153  0.00   
+  2  0    2    -6   663.5824   748.1993   0.0     1.06104  0.00   
+  2  5    -7   1    816.8899   969.1237   180.0   1.06052  0.00   
+  2  1    -9   -4   1411.9185  1706.8793  -180.0  1.06015  0.00   
+  2  2    -2   5    2747.2209  3313.4198  -180.0  1.05994  0.00   
+  2  3    -9   -4   11.3370    13.6703    -180.0  1.05993  0.00   
+  2  2    6    -6   233.0996   288.6216   -180.0  1.05938  0.00   
+  2  0    12   -1   1079.1947  1340.4500  -0.0    1.05892  0.00   
+  2  1    -7   -5   6.2047     7.5059     -180.0  1.05860  0.00   
+  2  1    5    -6   39.2107    47.4061    -180.0  1.05858  0.00   
+  2  2    10   2    1042.0503  1237.1699  -0.0    1.05797  0.00   
+  2  3    7    3    11.2102    12.9031    -180.0  1.05758  0.00   
+  2  7    3    -5   1953.3475  2239.1302  -180.0  1.05718  0.00   
+  2  6    6    0    400.0425   461.7745   -0.0    1.05659  0.00   
+  2  7    5    -4   1953.1987  2051.4003  0.0     1.05581  0.00   
+  2  4    -10  -2   2596.8179  3145.7849  0.0     1.05450  0.00   
+  2  5    7    1    30.8993    37.2884    180.0   1.05440  0.00   
+  2  6    8    -3   7485.8403  8866.7538  -0.0    1.05196  0.00   
+  2  3    -11  -1   221.2417   261.5320   -0.0    1.05193  0.00   
+  2  5    -5   2    4654.0358  5387.0808  -180.0  1.05131  0.00   
+  2  3    9    2    749.6681   862.2832   -0.0    1.05108  0.00   
+  2  3    11   -3   591.9482   673.7850   180.0   1.05082  0.00   
+  2  6    -6   0    469.9349   488.9045   -0.0    1.04978  0.00   
+  2  6    8    -2   346.8765   331.3808   0.0     1.04899  0.00   
+  2  3    11   0    431.8583   407.0557   -0.0    1.04881  0.00   
+  2  3    -5   -6   1318.5442  1235.7557  -180.0  1.04872  0.00   
+  2  4    10   0    69.0136    61.4161    -0.0    1.04771  0.00   
+  2  5    -9   -2   2521.1608  2208.3085  -0.0    1.04729  0.00   
+  2  5    9    -4   251.8560   228.7958   -180.0  1.04516  0.00   
+  2  6    -2   -6   1441.9475  1293.5044  -0.0    1.04487  0.00   
+  2  6    -4   1    3525.3901  3160.5795  -0.0    1.04485  0.00   
+  2  3    -5   4    2653.2204  2301.6767  -0.0    1.04377  0.00   
+  2  3    9    -5   2075.5694  1817.7670  180.0   1.04328  0.00   
+  2  1    5    5    1846.0354  1623.2967  -0.0    1.04294  0.00   
+  2  3    -11  0    1594.4220  1387.3612  0.0     1.04270  0.00   
+  2  2    2    5    303.9499   264.3036   0.0     1.04269  0.00   
+  2  5    -9   -1   73.5383    62.5557    0.0     1.04240  0.00   
+  2  6    4    1    1214.6439  1021.8291  -0.0    1.04223  0.00   
+  2  4    -10  0    622.2127   554.7785   -0.0    1.04034  0.00   
+  2  2    12   -1   4330.6990  3828.0670  -180.0  1.03971  0.00   
+  2  0    2    6    1683.5239  1492.8101  0.0     1.03949  0.00   
+  2  7    -5   -3   3960.6847  3517.5593  180.0   1.03943  0.00   
+  2  5    5    2    4388.3358  4324.4718  -180.0  1.03825  0.00   
+  2  4    -8   2    293.8053   298.1823   -0.0    1.03802  0.00   
+  2  6    4    -6   1227.6578  1251.2761  -180.0  1.03798  0.00   
+  2  0    12   1    313.9048   335.8693   -0.0    1.03750  0.00   
+  2  7    -5   -2   1372.7763  1492.9651  -180.0  1.03709  0.00   
+  2  7    1    0    1136.0255  1264.8986  -0.0    1.03656  0.00   
+  2  1    -9   4    2.3073     2.8086     180.0   1.03594  0.00   
+  2  1    11   2    1361.1730  1702.3367  180.0   1.03580  0.00   
+  2  7    -1   0    1330.4339  1823.6465  -0.0    1.03529  0.00   
+  2  4    10   -4   6.5366     9.1218     0.0     1.03486  0.00   
+  2  3    -11  -2   1016.2031  1522.0493  -180.0  1.03326  0.00   
+  3  1    1    0    1398.6835  1272.1960  -0.0    3.25240  0.03   
+  3  1    0    1    571.8130   492.3261   -0.0    2.48960  0.01   
+  3  2    0    0    176.9896   149.2681   -0.0    2.29979  0.00   
+  3  1    1    1    308.3231   375.0754   180.0   2.18945  0.01   
+  3  2    1    0    138.5574   152.8791   0.0     2.05700  0.00   
+  3  2    1    1    982.2782   880.5338   -0.0    1.68932  0.02   
+  3  2    2    0    1011.1246  1143.6505  -0.0    1.62620  0.01   
+  3  0    0    2    1552.1771  1418.4422  -0.0    1.48041  0.00   
+  3  3    1    0    354.8654   356.9070   -0.0    1.45452  0.00   
+  3  2    2    1    24.6789    28.2573    180.0   1.42536  0.00   
+  3  3    0    1    1045.9935  1055.8168  -0.0    1.36148  0.01   
+  3  1    1    2    494.7908   541.7767   -0.0    1.34739  0.00   
+  3  3    1    1    41.0006    32.7751    0.0     1.30549  0.00   
+  3  3    2    0    17.6911    15.0361    180.0   1.27569  0.00   
+  3  2    0    2    143.8955   145.3634   -0.0    1.24480  0.00   
+  3  2    1    2    39.1723    42.1898    0.0     1.20157  0.00   
+  3  3    2    1    132.7810   154.5513   -0.0    1.17158  0.00   
+  3  4    0    0    498.4845   422.4216   -0.0    1.14990  0.00   
+  3  4    1    0    87.5090    78.7516    180.0   1.11556  0.00   
+  3  2    2    2    628.7071   562.9323   -0.0    1.09473  0.00   
+  3  3    3    0    598.2465   592.6880   -0.0    1.08413  0.00   
+  3  4    1    1    313.9758   271.8807   -0.0    1.04392  0.00   
+  3  3    1    2    206.0552   220.9289   -0.0    1.03753  0.00   
+  4  1    1    0    10161.0593 5229.6750  0.0     5.76131  0.01   
+  4  1    1    -1   2716.3131  1404.4379  0.0     5.75024  0.00   
+  4  0    0    2    13792.9390 6634.7144  0.0     5.70210  0.00   
+  4  2    0    0    1225.4327  777.7431   180.0   5.30658  0.00   
+  4  2    0    -2   18323.0717 11511.0018 0.0     5.27220  0.01   
+  4  1    1    1    5691.8746  5910.3865  -180.0  4.69381  0.00   
+  4  1    1    -2   424.3736   470.8478   -180.0  4.67589  0.00   
+  4  1    1    2    1777.0674  1807.1380  -180.0  3.62670  0.00   
+  4  1    1    -3   6502.3186  6211.6446  180.0   3.61292  0.00   
+  4  0    2    0    5737.3448  1737.1571  180.0   3.43004  0.00   
+  4  3    1    -1   2264.4085  1015.7401  -0.0    3.40758  0.00   
+  4  3    1    -2   6265.3398  3189.8450  180.0   3.40071  0.00   
+  4  0    2    1    5290.7372  5004.2608  -0.0    3.28468  0.00   
+  4  2    0    2    12124.6508 11585.2987 -0.0    3.21813  0.00   
+  4  2    0    -4   5237.1652  4999.3745  180.0   3.19515  0.00   
+  4  3    1    0    2321.8052  2137.9524  0.0     3.14425  0.00   
+  4  3    1    -3   2977.5078  2676.9934  180.0   3.12812  0.00   
+  4  4    0    -2   103112.3281 80975.7674 180.0   2.98514  0.01   
+  4  2    2    -1   97178.0296 75021.6217 -0.0    2.97414  0.02   
+  4  0    2    2    888.0953   792.4753   0.0     2.93924  0.00   
+  4  2    2    0    1642.7631  1808.6435  0.0     2.88066  0.00   
+  4  2    2    -2   479.3830   529.2778   -0.0    2.87512  0.00   
+  4  1    1    3    2200.4317  2483.8849  -0.0    2.86245  0.00   
+  4  1    1    -4   4989.8260  5798.6291  -0.0    2.85296  0.00   
+  4  0    0    4    8839.0016  10329.5453 -0.0    2.85105  0.00   
+  4  3    1    1    3529.3489  3753.1651  -180.0  2.75703  0.00   
+  4  3    1    -4   2977.1950  3264.5994  -0.0    2.73895  0.00   
+  4  4    0    0    75399.0416 71082.4735 0.0     2.65329  0.01   
+  4  2    2    1    146036.7218 132924.3238 0.0     2.64126  0.02   
+  4  2    2    -3   73375.4705 66256.8188 -180.0  2.63274  0.01   
+  4  4    0    -4   155469.1747 140708.2869 180.0   2.63610  0.01   
+  4  0    2    3    16772.0645 14172.9119 180.0   2.54660  0.00   
+  4  3    1    2    8574.8719  9771.0786  -180.0  2.37461  0.00   
+  4  3    1    -5   5065.7517  5863.2949  -0.0    2.35845  0.00   
+  4  2    2    2    132.4601   143.7186   -180.0  2.34690  0.00   
+  4  2    2    -4   911.6827   881.3280   180.0   2.33794  0.00   
+  4  1    1    4    3276.9810  2963.0551  -0.0    2.33480  0.00   
+  4  1    1    -5   387.6634   299.6422   -0.0    2.32818  0.00   
+  4  4    2    -2   1474.9584  1408.2385  -0.0    2.25179  0.00   
+  4  5    1    -2   2173.3716  2125.2391  180.0   2.24606  0.00   
+  4  5    1    -3   543.9069   539.7611   180.0   2.24278  0.00   
+  4  1    3    0    51.9214    52.4285    0.0     2.23539  0.00   
+  4  1    3    -1   4138.5890  4180.6260  -0.0    2.23475  0.00   
+  4  4    2    -1   887.1011   918.4883   0.0     2.21165  0.00   
+  4  4    2    -3   12230.3999 13302.5266 -0.0    2.20664  0.00   
+  4  0    2    4    829.2837   966.4675   180.0   2.19254  0.00   
+  4  5    1    -1   9843.7886  11528.3975 -0.0    2.16665  0.00   
+  4  1    3    1    786.4328   1030.9651  -0.0    2.15474  0.00   
+  4  1    3    -2   8290.5113  10961.7549 0.0     2.15300  0.00   
+  4  5    1    -4   552.1304   710.7068   -180.0  2.15784  0.00   
+  4  2    0    4    1390.8997  1630.6538  0.0     2.13629  0.00   
+  4  2    0    -6   6457.9704  7206.8043  0.0     2.12506  0.00   
+  4  4    2    0    553.3538   728.3764   -180.0  2.09868  0.00   
+  4  4    2    -4   429.1237   548.8985   -180.0  2.09014  0.00   
+  4  4    0    2    264681.7694 285788.8251 180.0   2.06997  0.01   
+  4  2    2    3    274228.0064 292603.8723 0.0     2.06220  0.02   
+  4  2    2    -5   271118.7453 297029.3238 0.0     2.05410  0.02   
+  4  4    0    -6   275838.4974 302463.3977 -180.0  2.05368  0.01   
+  4  3    1    3    988.5080   1080.9561  -180.0  2.04762  0.00   
+  4  3    1    -6   144.7722   154.7557   -0.0    2.03429  0.00   
+  4  5    1    0    707.6942   771.3638   180.0   2.02778  0.00   
+  4  1    3    2    12383.8018 14009.0017 -0.0    2.01610  0.00   
+  4  1    3    -3   1097.9996  1237.9441  -0.0    2.01373  0.00   
+  4  5    1    -5   12526.3244 14172.6029 -0.0    2.01578  0.00   
+  4  3    3    -1   8021.1242  7021.6149  -0.0    1.97598  0.00   
+  4  3    3    -2   215.1942   188.1236   0.0     1.97464  0.00   
+  4  1    1    5    4695.7447  4611.6517  180.0   1.96035  0.00   
+  4  6    0    -2   1029.9243  972.0328   180.0   1.96310  0.00   
+  4  1    1    -6   1550.1709  1560.8783  -0.0    1.95555  0.00   
+  4  6    0    -4   17239.2500 17289.1164 -180.0  1.95785  0.00   
+  4  4    2    1    20722.4417 20959.5475 -0.0    1.94249  0.00   
+  4  4    2    -5   70.9535    70.9719    180.0   1.93235  0.00   
+  4  3    3    0    9635.1539  9832.9281  180.0   1.92044  0.00   
+  4  3    3    -3   2750.1068  2769.1433  -0.0    1.91675  0.00   
+  4  0    0    6    1794.9120  1705.5770  -0.0    1.90070  0.00   
+  4  0    2    5    95.2273    90.1136    -180.0  1.89927  0.00   
+  4  5    1    1    3372.3313  2501.8974  -180.0  1.86097  0.00   
+  4  1    3    3    3743.9677  3420.8545  0.0     1.85046  0.00   
+  4  1    3    -4   541.7963   508.5661   -180.0  1.84789  0.00   
+  4  5    1    -6   3093.2000  2901.7349  -180.0  1.84800  0.00   
+  4  3    3    1    3239.3641  3294.5080  -0.0    1.82104  0.00   
+  4  3    3    -4   14605.0790 15075.0579 -180.0  1.81580  0.00   
+  4  2    2    4    1941.7987  2003.6984  180.0   1.81335  0.00   
+  4  2    2    -6   108.5120   110.8678   -0.0    1.80646  0.00   
+  4  3    1    4    1190.9602  1170.6904  -0.0    1.78161  0.00   
+  4  4    2    2    772.8460   569.7667   -0.0    1.77225  0.00   
+  4  3    1    -7   1044.3244  721.4003   -180.0  1.77086  0.00   
+  4  6    0    0    53796.1101 33144.7445 180.0   1.76886  0.00   
+  4  4    2    -6   3008.0688  1199.1369  -0.0    1.76200  0.00   
+  4  6    0    -6   5.3524     2.0494     0.0     1.75740  0.00   
+  4  6    2    -3   413369.1211 370342.6891 -180.0  1.72135  0.02   
+  4  0    4    0    379015.4442 348520.2203 -180.0  1.71502  0.01   
+  4  6    2    -2   490.2048   389.8445   -0.0    1.70379  0.00   
+  4  6    2    -4   2002.1968  1561.3298  180.0   1.70035  0.00   
+  4  0    4    1    4255.0563  3255.5368  -0.0    1.69595  0.00   
+  4  3    3    2    4699.8153  3597.9604  -0.0    1.69678  0.00   
+  4  3    3    -5   13038.4715 10533.0605 0.0     1.69085  0.00   
+  4  5    1    2    3188.9942  2567.5159  -180.0  1.69108  0.00   
+  4  1    1    6    890.5728   741.7087   -0.0    1.68462  0.00   
+  4  1    3    4    54.7200    44.8806    -0.0    1.68207  0.00   
+  4  1    1    -7   15254.4314 12425.2148 -180.0  1.68102  0.00   
+  4  1    3    -5   5788.0725  4677.9319  0.0     1.67959  0.00   
+  4  5    1    -7   330.3244   266.1178   -180.0  1.67858  0.00   
+  4  0    2    6    1083.2289  1003.3066  0.0     1.66251  0.00   
+  4  2    4    -1   2983.6471  2840.4331  180.0   1.64836  0.00   
+  4  6    2    -1   910.2792   866.2894   -180.0  1.65103  0.00   
+  4  7    1    -3   37.3349    35.5473    180.0   1.65196  0.00   
+  4  5    3    -2   353.7115   336.8182   -180.0  1.64796  0.00   
+  4  7    1    -4   587.0479   558.6115   -0.0    1.65013  0.00   
+  4  5    3    -3   1293.1472  1233.3662  -180.0  1.64667  0.00   
+  4  0    4    2    627.8563   610.8347   -180.0  1.64234  0.00   
+  4  6    2    -5   527.6174   505.9910   -180.0  1.64479  0.00   
+  4  2    4    0    728.4302   752.6524   -0.0    1.63191  0.00   
+  4  2    4    -2   4296.6452  4457.3392  180.0   1.63090  0.00   
+  4  7    1    -2   3583.3456  3576.7634  180.0   1.62008  0.00   
+  4  5    3    -1   1009.4543  966.7480   0.0     1.61582  0.00   
+  4  7    1    -5   965.7087   918.8077   -0.0    1.61492  0.00   
+  4  5    3    -4   4116.5734  3837.2028  -180.0  1.61215  0.00   
+  4  4    0    4    71498.3185 64363.4327 180.0   1.60907  0.00   
+  4  4    2    3    31.3016    27.4571    180.0   1.60723  0.00   
+  4  2    2    5    44180.1997 37113.4833 -180.0  1.60445  0.00   
+  4  2    2    -7   89232.3696 66526.2849 0.0     1.59872  0.00   
+  4  4    2    -7   3539.6985  2583.5958  -0.0    1.59767  0.00   
+  4  4    0    -8   50736.6981 36968.8690 0.0     1.59758  0.00   
+  4  2    4    1    2129.6286  1922.5667  0.0     1.58444  0.00   
+  4  2    4    -3   2025.8226  1874.8256  0.0     1.58260  0.00   
+  4  2    0    6    28376.1295 28884.2226 -0.0    1.57487  0.00   
+  4  6    2    0    309.6709   317.4820   -0.0    1.57212  0.00   
+  4  2    0    -8   4811.5358  4976.1849  -180.0  1.56856  0.00   
+  4  3    1    5    1678.7006  1737.5450  180.0   1.56754  0.00   
+  4  3    3    3    469.4194   484.1567   0.0     1.56460  0.00   
+  4  0    4    3    2830.7697  2912.7742  -0.0    1.56329  0.00   
+  4  6    2    -6   1211.9175  1248.6891  -180.0  1.56406  0.00   
+  4  3    3    -6   1465.8725  1492.6482  -180.0  1.55863  0.00   
+  4  3    1    -8   1824.2375  1859.5355  0.0     1.55889  0.00   
+  4  7    1    -1   1998.7490  2044.5361  -0.0    1.55994  0.00   
+  4  5    3    0    3754.7091  3762.4243  180.0   1.55570  0.00   
+  4  7    1    -6   3825.2341  3794.0712  -180.0  1.55228  0.00   
+  4  5    3    -5   1409.9730  1408.0138  0.0     1.55026  0.00   
+  4  5    1    3    1035.4118  786.9396   0.0     1.53215  0.00   
+  4  1    3    5    9.5090     7.4040     -180.0  1.52461  0.00   
+  4  1    3    -6   1497.2294  1154.7668  0.0     1.52235  0.00   
+  4  5    1    -8   6.9483     5.3528     0.0     1.52078  0.00   
+  4  2    4    2    5103.5108  4249.5793  180.0   1.51351  0.00   
+  4  2    4    -4   2880.7641  2485.6081  -0.0    1.51110  0.00   
+  4  6    0    2    9294.2357  8932.9238  -180.0  1.50545  0.00   
+  4  6    0    -8   4685.7213  4394.0447  -180.0  1.49370  0.00   
+  4  8    0    -4   21842.2696 20160.8586 0.0     1.49257  0.00   
+  4  4    4    -2   23779.1963 20480.1013 -0.0    1.48707  0.00   
+  4  7    1    0    604.2144   522.7716   0.0     1.48044  0.00   
+  4  6    2    1    585.2389   505.6757   180.0   1.47808  0.00   
+  4  5    3    1    1728.1722  1469.6671  180.0   1.47644  0.00   
+  4  4    4    -1   215.3184   180.4672   180.0   1.47533  0.00   
+  4  1    1    7    10913.6147 9073.7476  -0.0    1.47458  0.00   
+  4  4    4    -3   2017.4966  1669.1331  180.0   1.47384  0.00   
+  4  1    1    -8   8866.0177  7394.9747  0.0     1.47180  0.00   
+  4  0    2    7    2988.1627  2498.9699  180.0   1.47161  0.00   
+  4  0    4    4    663.7715   580.4637   180.0   1.46962  0.00   
+  4  5    3    -6   0.2067     0.1792     -180.0  1.46994  0.00   
+  4  7    1    -7   276.6434   232.5805   -180.0  1.47129  0.00   
+  4  6    2    -7   1226.8209  1086.2533  180.0   1.46915  0.00   
+  4  4    2    4    320.6998   308.8901   -180.0  1.45674  0.00   
+  4  4    2    -8   301.6949   302.8403   -180.0  1.44820  0.00   
+  4  8    0    -2   52083.0829 52363.8924 0.0     1.44673  0.00   
+  4  4    4    0    40843.8244 40392.3461 -180.0  1.44033  0.00   
+  4  8    0    -6   39821.0784 39567.5729 -180.0  1.44114  0.00   
+  4  4    4    -4   55708.2851 54113.8315 0.0     1.43756  0.00   
+  4  3    3    4    4820.4118  4615.5819  -180.0  1.43585  0.00   
+  4  2    2    6    0.8525     0.8040     -180.0  1.43122  0.00   
+  4  3    3    -7   1516.9921  1448.7554  0.0     1.43021  0.00   
+  4  2    4    3    2724.0225  2695.6766  180.0   1.42837  0.00   
+  4  2    2    -8   1772.2539  1820.4729  -0.0    1.42648  0.00   
+  4  2    4    -5   1609.3681  1670.8630  180.0   1.42567  0.00   
+  4  0    0    8    256429.0699 266624.8860 -0.0    1.42553  0.01   
+  4  3    1    6    1201.6634  937.5789   180.0   1.39446  0.00   
+  4  5    1    4    845.7377   766.3808   0.0     1.38986  0.00   
+  4  7    1    1    56.6412    50.2194    -180.0  1.39081  0.00   
+  4  3    1    -9   747.2248   708.4063   -0.0    1.38743  0.00   
+  4  4    4    1    3776.2768  3621.8553  -0.0    1.38673  0.00   
+  4  5    3    2    464.8886   442.5561   -180.0  1.38718  0.00   
+  4  1    3    6    3129.5576  3145.4290  0.0     1.38361  0.00   
+  4  4    4    -5   1207.8227  1224.0544  0.0     1.38303  0.00   
+  4  1    3    -7   470.7554   485.6557   -180.0  1.38162  0.00   
+  4  5    3    -7   1027.8538  1076.1332  180.0   1.38026  0.00   
+  4  7    1    -8   223.2558   231.7311   0.0     1.38107  0.00   
+  4  5    1    -9   3013.3707  3167.9679  -0.0    1.37983  0.00   
+  4  6    2    2    240.7691   255.5256   -180.0  1.37852  0.00   
+  4  0    4    5    389.9833   361.1834   -180.0  1.37075  0.00   
+  4  6    2    -8   3.2746     2.8431     0.0     1.36948  0.00   
+  4  8    2    -4   888.2208   740.2662   180.0   1.36861  0.00   
+  4  7    3    -3   4083.3492  3200.8854  -180.0  1.36535  0.00   
+  4  7    3    -4   577.0898   462.9328   -180.0  1.36431  0.00   
+  4  1    5    0    4901.2773  4364.7672  -180.0  1.36069  0.00   
+  4  1    5    -1   64.2333    57.2889    -0.0    1.36055  0.00   
+  4  8    2    -3   2151.7622  1925.6545  180.0   1.36003  0.00   
+  4  8    2    -5   15966.3431 14179.0382 180.0   1.35770  0.00   
+  4  7    3    -2   6823.3382  6976.5819  0.0     1.34718  0.00   
+  4  1    5    1    7680.2821  7425.4301  0.0     1.34187  0.00   
+  4  7    3    -5   2382.8045  2393.8480  180.0   1.34421  0.00   
+  4  1    5    -2   2925.7948  2797.4080  180.0   1.34145  0.00   
+  4  2    4    4    242.3340   204.6053   -180.0  1.33738  0.00   
+  4  2    4    -6   5029.3420  4273.0755  180.0   1.33461  0.00   
+  4  8    2    -2   215.7546   192.4880   0.0     1.33301  0.00   
+  4  8    2    -6   120.6620   116.9523   0.0     1.32863  0.00   
+  4  8    0    0    130793.8018 126800.3949 0.0     1.32665  0.00   
+  4  4    2    5    13190.5556 12801.5839 0.0     1.32369  0.00   
+  4  4    4    2    114896.5378 113771.8246 0.0     1.32063  0.00   
+  4  0    2    8    367.0640   368.1735   180.0   1.31637  0.00   
+  4  4    4    -6   120287.9779 120657.2769 0.0     1.31637  0.00   
+  4  3    3    5    1238.1794  1244.0810  -0.0    1.31652  0.00   
+  4  4    2    -9   5522.6755  5528.4059  180.0   1.31621  0.00   
+  4  8    0    -8   137948.1035 139513.1700 -0.0    1.31805  0.00   
+  4  3    3    -8   7888.5551  7099.8097  180.0   1.31138  0.00   
+  4  7    3    -1   1128.6862  1032.7529  180.0   1.31200  0.00   
+  4  1    1    8    181.0324   157.0017   180.0   1.30990  0.00   
+  4  1    1    -9   863.7340   715.2980   180.0   1.30769  0.00   
+  4  1    5    2    2137.5033  1735.0835  180.0   1.30631  0.00   
+  4  1    5    -3   9109.1290  7311.1267  -0.0    1.30567  0.00   
+  4  7    3    -6   9154.4025  7552.3208  -0.0    1.30744  0.00   
+  4  6    4    -3   2860.7915  2357.8645  -0.0    1.29916  0.00   
+  4  9    1    -4   1067.8198  842.7244   0.0     1.30105  0.00   
+  4  9    1    -5   318.3318   257.4524   0.0     1.29990  0.00   
+  4  7    1    2    4753.2969  3973.0463  -180.0  1.29855  0.00   
+  4  3    5    -1   758.5173   622.2524   0.0     1.29521  0.00   
+  4  3    5    -2   2684.3221  2189.8756  -0.0    1.29483  0.00   
+  4  5    3    3    408.0462   335.4555   180.0   1.29534  0.00   
+  4  6    4    -2   30.5354    25.6064    0.0     1.29156  0.00   
+  4  4    0    6    21102.8806 18442.5072 180.0   1.29035  0.00   
+  4  6    4    -4   8082.2950  7144.9543  -0.0    1.29006  0.00   
+  4  8    2    -1   10346.8016 8929.7467  180.0   1.29068  0.00   
+  4  5    3    -8   3685.6079  3487.9205  180.0   1.28845  0.00   
+  4  7    1    -9   143.2387   133.2598   180.0   1.28886  0.00   
+  4  2    2    7    16457.8495 16111.0142 -0.0    1.28747  0.00   
+  4  2    2    -9   19257.9613 19763.8670 0.0     1.28352  0.00   
+  4  8    2    -7   419.8460   430.4622   -180.0  1.28473  0.00   
+  4  9    1    -3   5427.5902  5518.4835  180.0   1.28555  0.00   
+  4  4    0    -10  20334.9619 20679.5221 -180.0  1.28244  0.00   
+  4  3    5    0    746.4336   721.1362   -0.0    1.27918  0.00   
+  4  9    1    -6   184.3724   187.0371   -0.0    1.28223  0.00   
+  4  6    2    3    0.3858     0.3799     180.0   1.28025  0.00   
+  4  3    5    -3   6362.3325  6042.5647  -0.0    1.27809  0.00   
+  4  0    4    6    122.9495   118.5712   180.0   1.27330  0.00   
+  4  6    2    -9   463.9838   465.9159   180.0   1.27156  0.00   
+  4  6    4    -1   440.9875   481.8034   -180.0  1.26812  0.00   
+  4  6    4    -5   568.2734   582.0359   -180.0  1.26528  0.00   
+  4  5    1    5    4517.6624  4608.3387  180.0   1.26517  0.00   
+  4  6    0    4    7021.8739  7258.6407  180.0   1.26554  0.00   
+  4  7    3    0    823.8732   802.9350   180.0   1.26364  0.00   
+  4  1    3    7    8266.9422  8415.8665  -0.0    1.25999  0.00   
+  4  1    5    3    33.2990    35.1951    180.0   1.25786  0.00   
+  4  1    3    -8   2939.8431  3095.2520  180.0   1.25825  0.00   
+  4  1    5    -4   2918.3365  3100.6595  180.0   1.25705  0.00   
+  4  7    3    -7   2297.1554  2426.3364  180.0   1.25793  0.00   
+  4  5    1    -10  6633.7744  7054.3026  -180.0  1.25644  0.00   
+  4  6    0    -10  111.0904   117.7386   180.0   1.25577  0.00   
+  4  3    1    7    1597.5722  1611.7435  -0.0    1.25300  0.00   
+  4  9    1    -2   344.5615   362.3661   0.0     1.25511  0.00   
+  4  3    5    1    8875.2529  8342.7401  0.0     1.24850  0.00   
+  4  4    4    3    17.4666    16.4758    0.0     1.24795  0.00   
+  4  9    1    -7   9263.7517  8756.2353  -180.0  1.24997  0.00   
+  4  3    5    -4   1144.4562  1092.6264  -0.0    1.24681  0.00   
+  4  3    1    -10  3145.4404  2988.6873  180.0   1.24721  0.00   
+  4  2    4    5    1202.5092  1150.4100  0.0     1.24664  0.00   
+  4  2    4    -7   806.6475   790.8449   0.0     1.24395  0.00   
+  4  4    4    -7   6670.1774  6544.6644  -0.0    1.24346  0.00   
+  4  2    0    8    28.5508    27.6700    -0.0    1.24152  0.00   
+  4  2    0    -10  2252.7656  2005.3801  180.0   1.23754  0.00   
+  4  8    2    0    828.4509   733.0590   180.0   1.23732  0.00   
+  4  6    4    0    15652.7425 14150.5162 -0.0    1.23130  0.00   
+  4  8    2    -8   666.8229   629.1269   180.0   1.23034  0.00   
+  4  6    4    -6   127.3967   129.7572   -180.0  1.22741  0.00   
+  4  9    1    -1   2961.2497  2740.8756  -0.0    1.21277  0.00   
+  4  3    3    6    902.9926   848.1601   0.0     1.20890  0.00   
+  4  4    2    6    441.2857   411.4999   -0.0    1.20772  0.00   
+  4  7    1    3    78.0874    73.2829    180.0   1.20869  0.00   
+  4  3    5    2    4046.4967  3743.5564  0.0     1.20620  0.00   
+  4  5    3    4    8136.0574  7528.8432  -180.0  1.20590  0.00   
+  4  7    3    1    2957.6236  2737.5316  180.0   1.20652  0.00   
+  4  3    5    -5   52.1531    48.8777    180.0   1.20407  0.00   
+  4  3    3    -9   1011.9324  945.5909   -0.0    1.20431  0.00   
+  4  9    1    -8   2515.6071  2327.4244  0.0     1.20630  0.00   
+  4  1    5    4    3947.0351  3936.6827  180.0   1.20088  0.00   
+  4  4    2    -10  166.8596   165.7584   -0.0    1.20122  0.00   
+  4  1    5    -5   656.8798   656.4639   0.0     1.19998  0.00   
+  4  7    3    -8   5.4520     5.4517     0.0     1.20014  0.00   
+  4  5    3    -9   302.8783   300.8910   180.0   1.19933  0.00   
+  4  7    1    -10  8354.5860  8313.3744  -180.0  1.19946  0.00   
+  4  0    2    9    359.6482   269.4603   -0.0    1.18862  0.00   
+  4  5    5    -2   4010.1566  3026.7927  -0.0    1.18828  0.00   
+  4  5    5    -3   0.1308     0.1003     -0.0    1.18780  0.00   
+  4  6    2    4    342.2807   267.8752   180.0   1.18731  0.00   
+  4  10   0    -4   9074.1219  6809.0115  0.0     1.18854  0.00   
+  4  10   0    -6   13704.7010 11123.4673 0.0     1.18659  0.00   
+  4  6    4    1    1470.2460  1319.9528  0.0     1.18452  0.00   
+  4  0    4    7    294.7408   286.2811   180.0   1.18118  0.00   
+  4  6    4    -7   1807.3287  1788.2732  0.0     1.17991  0.00   
+  4  6    2    -10  2.2199     2.2157     -0.0    1.17922  0.00   
+  4  1    1    9    120.5790   122.6216   -0.0    1.17762  0.00   
+  4  8    0    2    30992.8375 31222.7748 180.0   1.17842  0.00   
+  4  5    5    -1   7070.1500  7318.5371  -180.0  1.17606  0.00   
+  4  1    1    -10  735.4264   763.0185   180.0   1.17582  0.00   
+  4  8    2    1    5714.9750  5832.5257  -180.0  1.17732  0.00   
+  4  5    5    -4   5308.0393  5562.6575  -0.0    1.17465  0.00   
+  4  4    4    4    32011.4836 33768.6937 0.0     1.17345  0.00   
+  4  4    4    -8   27305.0420 28608.1528 -180.0  1.16897  0.00   
+  4  8    2    -9   8017.6019  8433.5515  180.0   1.16981  0.00   
+  4  8    0    -10  36506.9257 38318.7221 0.0     1.16940  0.00   
+  4  2    2    8    97.3650    100.3659   0.0     1.16740  0.00   
+  4  2    2    -10  597.0314   559.6903   -0.0    1.16409  0.00   
+  4  2    4    6    15991.4856 13773.5602 180.0   1.15999  0.00   
+  4  9    1    0    198.8338   175.9916   180.0   1.16219  0.00   
+  4  2    4    -8   2736.9279  2416.2326  0.0     1.15746  0.00   
+  4  3    5    3    3476.3748  3131.8290  0.0     1.15587  0.00   
+  4  5    1    6    56.6873    50.4438    0.0     1.15687  0.00   
+  4  3    5    -6   57.2533    51.7225    -0.0    1.15345  0.00   
+  4  9    1    -9   625.0191   566.6209   180.0   1.15488  0.00   
+  4  1    3    8    3085.5013  2760.3092  0.0     1.15255  0.00   
+  4  5    5    0    7481.1427  6664.3182  -0.0    1.15226  0.00   
+  4  1    3    -9   1.5182     1.3292     -0.0    1.15104  0.00   
+  4  5    5    -5   9806.0630  8512.5139  -180.0  1.15005  0.00   
+  4  5    1    -11  1748.7232  1515.0727  0.0     1.14930  0.00   
+  4  9    3    -4   462.9012   427.5713   0.0     1.14651  0.00   
+  4  0    6    0    2592.0627  2607.2585  -0.0    1.14335  0.00   
+  4  9    3    -5   68.5806    64.9887    -0.0    1.14572  0.00   
+  4  7    3    2    5020.5261  4898.3011  -0.0    1.14479  0.00   
+  4  0    0    10   419.9997   423.9774   -0.0    1.14042  0.00   
+  4  1    5    5    5077.4998  5040.6794  -0.0    1.13946  0.00   
+  4  10   0    -2   15727.7268 16012.7283 0.0     1.14177  0.00   
+  4  1    5    -6   5462.6834  5306.9420  180.0   1.13852  0.00   
+  4  0    6    1    1734.8693  1646.7726  180.0   1.13764  0.00   
+  4  7    3    -9   4852.9692  4669.6471  180.0   1.13814  0.00   
+  4  3    1    8    75.6532    68.5267    180.0   1.13593  0.00   
+  4  10   0    -8   1575.9502  1452.6450  0.0     1.13661  0.00   
+  4  9    3    -3   1578.2628  1427.5891  -180.0  1.13586  0.00   
+  4  9    3    -6   2069.7480  1858.5777  -0.0    1.13357  0.00   
+  4  3    1    -11  35.8201    30.9624    0.0     1.13111  0.00   
+  4  6    4    2    3247.8384  2825.7667  0.0     1.13139  0.00   
+  4  6    4    -8   2501.5534  2099.7238  -0.0    1.12638  0.00   
+  4  10   2    -5   7770.0919  6286.6782  0.0     1.12768  0.00   
+  4  8    4    -4   4854.9734  4165.8140  -180.0  1.12590  0.00   
+  4  2    6    -1   3615.7779  3553.5119  180.0   1.12294  0.00   
+  4  7    1    4    5199.2406  4924.4150  -0.0    1.12414  0.00   
+  4  0    6    2    1432.4573  1374.7221  -180.0  1.12103  0.00   
+  4  5    3    5    2008.0482  1968.1837  -180.0  1.12173  0.00   
+  4  10   2    -4   9.2192     9.0481     180.0   1.12303  0.00   
+  4  8    4    -3   3452.5094  3322.1983  -180.0  1.12110  0.00   
+  4  10   2    -6   177.5370   172.5017   180.0   1.12139  0.00   
+  4  5    5    1    772.5602   710.7095   0.0     1.11892  0.00   
+  4  8    4    -5   1119.6182  1032.2344  180.0   1.11980  0.00   
+  4  2    6    0    5688.7351  5313.5186  180.0   1.11770  0.00   
+  4  2    6    -2   1060.1420  992.1704   180.0   1.11737  0.00   
+  4  5    5    -6   2702.6929  2504.3983  0.0     1.11609  0.00   
+  4  5    3    -10  1734.2921  1596.9973  -0.0    1.11563  0.00   
+  4  7    1    -11  2267.4792  2086.4076  180.0   1.11558  0.00   
+  4  3    3    7    8107.6030  7157.0451  0.0     1.11322  0.00   
+  4  9    3    -2   2226.6826  2020.9809  0.0     1.11470  0.00   
+  4  8    2    2    133.5257   120.6943   0.0     1.11448  0.00   
+  4  9    3    -7   1981.9637  1753.9793  -180.0  1.11109  0.00   
+  4  3    3    -10  291.5190   264.2352   -0.0    1.10916  0.00   
+  4  4    2    7    10076.0737 9258.4011  0.0     1.10712  0.00   
+  4  8    2    -10  39.7986    36.6125    0.0     1.10685  0.00   
+  4  10   2    -3   38397.3076 35175.3194 -180.0  1.10783  0.00   
+  4  9    1    1    4140.5653  3808.5155  -180.0  1.10688  0.00   
+  4  8    4    -2   31816.0280 29365.9440 -180.0  1.10582  0.00   
+  4  2    6    1    29389.7952 27603.3788 -180.0  1.10209  0.00   
+  4  10   2    -7   37811.9626 35007.4599 0.0     1.10469  0.00   
+  4  8    4    -6   32313.2129 30157.9471 0.0     1.10332  0.00   
+  4  2    6    -3   31675.8569 29876.5059 0.0     1.10147  0.00   
+  4  4    2    -11  2305.6237  2174.2563  -0.0    1.10149  0.00   
+  4  3    5    4    74.2073    70.2503    0.0     1.10094  0.00   
+  4  6    2    5    140193.1855 132083.1961 -180.0  1.10162  0.00   
+  4  4    4    5    2837.6823  2695.5379  180.0   1.10049  0.00   
+  4  3    5    -7   3043.3871  2935.8897  0.0     1.09840  0.00   
+  4  9    1    -10  292.0263   280.6925   0.0     1.09916  0.00   
+  4  0    4    8    142072.5409 133810.4963 -180.0  1.09627  0.00   
+  4  4    4    -9   142.7539   134.0615   0.0     1.09618  0.00   
+  4  0    6    3    3805.7058  3394.6812  -0.0    1.09489  0.00   
+  4  6    2    -11  173308.4284 149954.2083 -180.0  1.09424  0.01   
+  4  9    3    -1   1237.5389  1114.9345  0.0     1.08472  0.00   
+  4  0    2    10   129.5720   133.7463   0.0     1.08217  0.00   
+  4  10   2    -2   901.4906   880.0363   -0.0    1.08332  0.00   
+  4  7    3    3    5702.4030  5992.6594  180.0   1.08180  0.00   
+  4  8    4    -1   6.0602     6.5257     0.0     1.08130  0.00   
+  4  2    4    7    117.5697   143.3075   180.0   1.07941  0.00   
+  4  9    3    -8   14.6512    16.9764    180.0   1.08008  0.00   
+  4  5    5    2    4041.5849  5303.2273  0.0     1.07854  0.00   
+  4  2    6    2    327.0398   478.4922   0.0     1.07737  0.00   
+  4  2    4    -9   870.4928   1302.6387  -180.0  1.07708  0.00   
+  4  1    5    6    4933.2676  7487.6933  180.0   1.07686  0.00   
+  4  2    6    -4   2044.1713  3157.1192  -0.0    1.07650  0.00   
+  4  10   2    -8   238.2231   302.2474   0.0     1.07892  0.00   
+  4  8    4    -7   628.9331   885.9347   -0.0    1.07779  0.00   
+  4  1    5    -7   7135.1893  11179.0961 0.0     1.07592  0.00   
+  4  5    5    -7   10.5082    16.4924    0.0     1.07528  0.00   
+  4  6    4    3    968.0858   1517.8392  -180.0  1.07514  0.00   
+  4  7    3    -10  7831.9758  12282.4680 0.0     1.07517  0.00   
+  4  6    0    6    624.5227   878.8629   180.0   1.07271  0.00   
+  4  6    4    -9   588.3110   818.1178   -180.0  1.06998  0.00   
+  4  1    1    10   1818.1429  2599.2609  -180.0  1.06919  0.00   
+  4  11   1    -5   116.7797   157.2990   180.0   1.07138  0.00   
+  4  11   1    -6   4.1780     5.7019     -180.0  1.07059  0.00   
+  4  4    6    -2   1743.7980  2486.6852  -180.0  1.06771  0.00   
+  4  1    1    -11  29.5496    42.1348    0.0     1.06771  0.00   
+  4  7    5    -3   923.4307   1330.6239  -180.0  1.06818  0.00   
+  4  4    0    8    16336.2359 23528.0251 -0.0    1.06815  0.00   
+  4  7    5    -4   118.2972   168.5700   180.0   1.06768  0.00   
+  4  2    2    9    18091.0749 24375.6868 -0.0    1.06623  0.00   
+  4  6    0    -12  2276.5103  2937.0054  -180.0  1.06505  0.00   
+  4  4    6    -1   1.6727     2.0175     -0.0    1.06334  0.00   
+  4  2    2    -11  17379.6391 21012.4971 -180.0  1.06342  0.00   
+  4  4    6    -3   2369.6453  2823.1169  180.0   1.06278  0.00   
+  4  4    0    -12  23836.1011 28292.0837 -180.0  1.06253  0.00   
+  4  5    1    7    2728.5531  3262.8752  0.0     1.06298  0.00   
+  4  0    6    4    1418.3046  1669.4504  0.0     1.06119  0.00   
+  4  11   1    -4   4298.8474  5124.0743  0.0     1.06281  0.00   
+  4  1    3    9    1362.0070  1610.0884  0.0     1.05935  0.00   
+  4  10   0    0    697.3963   820.9631   0.0     1.06132  0.00   
+  4  7    5    -2   1.3851     1.6376     -0.0    1.05941  0.00   
+  4  11   1    -7   56.2778    66.3589    -180.0  1.06052  0.00   
+  4  1    3    -10  2022.3025  2357.2538  0.0     1.05804  0.00   
+  4  7    5    -5   3337.0061  3884.8061  -180.0  1.05797  0.00   
+  4  5    1    -12  1847.6239  2096.7871  -180.0  1.05642  0.00   
+  4  10   0    -10  4117.4741  4668.9149  0.0     1.05444  0.00   
+  4  4    6    0    1529.6660  1589.3411  0.0     1.05001  0.00   
+  4  8    2    3    20354.9023 22554.2584 180.0   1.05168  0.00   
+  4  10   2    -1   52875.4219 57998.0764 0.0     1.05132  0.00   
+  4  4    6    -4   1185.8457  1169.3238  0.0     1.04893  0.00   
+  4  8    4    0    61815.8255 62135.0799 -180.0  1.04934  0.00   
+  4  9    1    2    129.1196   132.5963   -0.0    1.04977  0.00   
+  4  9    3    0    2471.6869  2357.4816  0.0     1.04808  0.00   
+  4  2    6    3    60794.4302 55791.9290 -180.0  1.04535  0.00   
+  4  7    1    5    1107.1857  1023.6228  0.0     1.04625  0.00   
+  4  2    6    -5   61906.5674 56117.4536 -180.0  1.04429  0.00   
+  4  3    5    5    4014.6009  3639.8966  -0.0    1.04431  0.00   
+  4  10   2    -9   73068.8925 67415.9583 0.0     1.04597  0.00   
+  4  8    4    -8   73901.6887 67615.2048 -180.0  1.04507  0.00   
+  4  5    3    6    1545.4143  1399.1370  -180.0  1.04417  0.00   
+  4  8    2    -11  5.3763     4.8686     0.0     1.04420  0.00   
+  4  11   1    -3   29.9118    27.5035    180.0   1.04555  0.00   
+  4  3    5    -8   426.5411   381.8895   -0.0    1.04174  0.00   
+  4  7    5    -1   5203.4874  4651.8504  -180.0  1.04205  0.00   
+  4  9    3    -9   551.4426   493.6091   -180.0  1.04271  0.00   
+  4  9    1    -11  5541.8624  4955.0317  180.0   1.04200  0.00   
+  4  11   1    -8   5981.4500  5349.6895  0.0     1.04191  0.00   
+  4  7    5    -6   22.1617    20.5772    180.0   1.03976  0.00   
+  4  5    3    -11  171.6355   166.7886   -0.0    1.03860  0.00   
+  4  7    1    -12  576.0771   564.9314   -180.0  1.03842  0.00   
+  4  3    1    9    969.8708   983.5490   -180.0  1.03783  0.00   
+_reflns_number_total  1184
+_reflns_d_resolution_low    6.388
+_reflns_d_resolution_high   1.033
+
+# POWDER DATA TABLE
+_pd_meas_2theta_range_min  10.01313
+_pd_meas_2theta_range_max  119.99238
+_pd_meas_2theta_range_inc  0.02626
+_pd_proc_2theta_range_min  9.98829
+_pd_proc_2theta_range_max  119.96754
+_pd_proc_2theta_range_inc  0.02626
+_pd_proc_number_of_points  4189
+
+loop_
+   _pd_meas_intensity_total
+   _pd_calc_intensity_total
+   _pd_proc_intensity_bkg_calc
+   _pd_proc_ls_weight
+  2695         0            0           0         
+  2699         0            0           0         
+  2711         0            0           0         
+  2682         0            0           0         
+  2674         0            0           0         
+  2701         0            0           0         
+  2743         0            0           0         
+  2521         0            0           0         
+  2698         0            0           0         
+  2664         0            0           0         
+  2681         0            0           0         
+  2637         0            0           0         
+  2644         0            0           0         
+  2597         0            0           0         
+  2569         0            0           0         
+  2594         0            0           0         
+  2562         0            0           0         
+  2609         0            0           0         
+  2529         0            0           0         
+  2557         0            0           0         
+  2570         0            0           0         
+  2564         0            0           0         
+  2571         0            0           0         
+  2460         0            0           0         
+  2519         0            0           0         
+  2612         0            0           0         
+  2602         0            0           0         
+  2501         0            0           0         
+  2460         0            0           0         
+  2492         0            0           0         
+  2457         0            0           0         
+  2537         0            0           0         
+  2505         0            0           0         
+  2401         0            0           0         
+  2499         0            0           0         
+  2500         0            0           0         
+  2462         0            0           0         
+  2426         0            0           0         
+  2387         0            0           0         
+  2484         0            0           0         
+  2421         0            0           0         
+  2512         0            0           0         
+  2451         0            0           0         
+  2385         0            0           0         
+  2478         0            0           0         
+  2377         0            0           0         
+  2404         0            0           0         
+  2352         0            0           0         
+  2341         0            0           0         
+  2372         0            0           0         
+  2440         0            0           0         
+  2312         0            0           0         
+  2375         0            0           0         
+  2425         0            0           0         
+  2366         0            0           0         
+  2426         0            0           0         
+  2294         0            0           0         
+  2322         0            0           0         
+  2355         0            0           0         
+  2304         0            0           0         
+  2261         0            0           0         
+  2289         0            0           0         
+  2214         0            0           0         
+  2248         0            0           0         
+  2296         0            0           0         
+  2295         0            0           0         
+  2211         0            0           0         
+  2198         0            0           0         
+  2298         0            0           0         
+  2197         0            0           0         
+  2215         0            0           0         
+  2272         0            0           0         
+  2296         0            0           0         
+  2289         0            0           0         
+  2192         0            0           0         
+  2241         0            0           0         
+  2260         0            0           0         
+  2331         0            0           0         
+  2267         0            0           0         
+  2197         0            0           0         
+  2217         0            0           0         
+  2279         0            0           0         
+  2136         0            0           0         
+  2216         0            0           0         
+  2186         0            0           0         
+  2145         0            0           0         
+  2211         0            0           0         
+  2205         0            0           0         
+  2156         0            0           0         
+  2167         0            0           0         
+  2163         0            0           0         
+  2147         0            0           0         
+  2142         0            0           0         
+  2166         0            0           0         
+  2139         0            0           0         
+  2145         0            0           0         
+  2103         0            0           0         
+  2091         0            0           0         
+  2017         0            0           0         
+  2095         0            0           0         
+  2104         0            0           0         
+  2138         0            0           0         
+  2105         0            0           0         
+  2103         0            0           0         
+  2090         0            0           0         
+  2137         0            0           0         
+  2112         0            0           0         
+  1972         0            0           0         
+  2172         0            0           0         
+  2011         0            0           0         
+  2005         0            0           0         
+  2054         0            0           0         
+  2035         0            0           0         
+  1969         0            0           0         
+  1948         0            0           0         
+  2041         0            0           0         
+  1992         0            0           0         
+  2055         0            0           0         
+  2016         0            0           0         
+  1965         0            0           0         
+  2056         0            0           0         
+  1997         0            0           0         
+  1899         0            0           0         
+  1972         0            0           0         
+  1990         0            0           0         
+  1978         0            0           0         
+  1975         0            0           0         
+  1964         0            0           0         
+  1912         0            0           0         
+  1954         0            0           0         
+  1960         0            0           0         
+  1833         0            0           0         
+  1896         0            0           0         
+  1931         0            0           0         
+  1965         0            0           0         
+  1933         0            0           0         
+  1964         0            0           0         
+  1950         0            0           0         
+  1901         0            0           0         
+  1952         0            0           0         
+  1846         0            0           0         
+  1927         0            0           0         
+  1900         0            0           0         
+  1883         0            0           0         
+  1880         0            0           0         
+  1926         0            0           0         
+  1932         0            0           0         
+  1895         0            0           0         
+  1869         0            0           0         
+  1840         0            0           0         
+  1851         0            0           0         
+  1818         0            0           0         
+  1789         0            0           0         
+  1834         0            0           0         
+  1871         0            0           0         
+  1840         0            0           0         
+  1813         0            0           0         
+  1811         0            0           0         
+  1786         0            0           0         
+  1876         0            0           0         
+  1742         0            0           0         
+  1761         0            0           0         
+  1796         0            0           0         
+  1880         0            0           0         
+  1741         0            0           0         
+  1790         0            0           0         
+  1718         0            0           0         
+  1815         0            0           0         
+  1783         0            0           0         
+  1780         0            0           0         
+  1711         0            0           0         
+  1784         0            0           0         
+  1784         0            0           0         
+  1875         0            0           0         
+  1759         0            0           0         
+  1763         0            0           0         
+  1684         0            0           0         
+  1735         0            0           0         
+  1777         0            0           0         
+  1755         0            0           0         
+  1764         0            0           0         
+  1710         1699.64338   1699.08492  0.000584795 
+  1703         1696.25017   1695.67625  0.000587199 
+  1731         1692.86407   1692.27424  0.000577701 
+  1675         1689.48567   1688.87887  0.000597015 
+  1681         1686.1148    1685.49015  0.000594884 
+  1690         1682.75139   1682.10804  0.000591716 
+  1721         1679.39568   1678.73255  0.000581058 
+  1745         1676.04777   1675.36367  0.000573066 
+  1694         1672.70774   1672.00137  0.000590319 
+  1773         1669.37571   1668.64566  0.000564016 
+  1682         1666.05182   1665.29652  0.00059453 
+  1606         1662.73619   1661.95394  0.000622665 
+  1630         1659.42901   1658.61791  0.000613497 
+  1651         1656.13047   1655.28842  0.000605694 
+  1680         1652.84078   1651.96546  0.000595238 
+  1691         1649.56021   1648.64901  0.000591366 
+  1669         1646.28906   1645.33907  0.000599161 
+  1713         1643.02767   1642.03563  0.000583771 
+  1668         1639.77646   1638.73867  0.00059952 
+  1668         1636.53591   1635.44819  0.00059952 
+  1735         1633.3066    1632.16417  0.000576369 
+  1603         1630.08921   1628.88661  0.00062383 
+  1654         1626.88457   1625.61549  0.000604595 
+  1609         1623.69368   1622.3508   0.000621504 
+  1560         1620.51777   1619.09253  0.000641026 
+  1652         1617.35834   1615.84068  0.000605327 
+  1659         1614.21728   1612.59522  0.000602773 
+  1588         1611.09698   1609.35616  0.000629723 
+  1661         1608.00049   1606.12348  0.000602047 
+  1578         1604.9318    1602.89716  0.000633714 
+  1659         1601.89622   1599.67721  0.000602773 
+  1657         1598.90097   1596.4636   0.0006035 
+  1622         1595.95616   1593.25633  0.000616523 
+  1628         1593.07653   1590.05539  0.000614251 
+  1560         1590.28461   1586.86076  0.000641026 
+  1583         1587.61759   1583.67245  0.000631712 
+  1554         1585.14207   1580.49043  0.000643501 
+  1645         1582.98063   1577.31469  0.000607903 
+  1630         1581.33474   1574.14523  0.000613497 
+  1552         1580.34818   1570.98204  0.00064433 
+  1685         1579.81428   1567.8251   0.000593472 
+  1640         1580.04446   1564.6744   0.000609756 
+  1552         1581.27033   1561.52994  0.00064433 
+  1594         1582.97993   1558.3917   0.000627353 
+  1646         1586.51106   1555.25968  0.000607533 
+  1630         1592.04594   1552.13386  0.000613497 
+  1554         1596.84405   1549.01423  0.000643501 
+  1569         1606.19627   1545.90078  0.000637349 
+  1680         1618.93519   1542.79351  0.000595238 
+  1599         1630.53913   1539.6924   0.000625391 
+  1679         1638.99683   1536.59744  0.000595593 
+  1717         1631.7816    1533.50863  0.000582411 
+  1610         1611.68353   1530.42594  0.000621118 
+  1582         1589.44511   1527.34938  0.000632111 
+  1591         1573.31218   1524.27893  0.000628536 
+  1608         1562.67856   1521.21458  0.000621891 
+  1561         1553.44458   1518.15632  0.000640615 
+  1639         1545.77853   1515.10414  0.000610128 
+  1517         1539.89104   1512.05803  0.000659196 
+  1559         1534.1303    1509.01798  0.000641437 
+  1605         1526.37839   1505.98398  0.000623053 
+  1463         1518.02242   1502.95603  0.000683527 
+  1519         1510.75402   1499.9341   0.000658328 
+  1501         1505.08251   1496.91819  0.000666223 
+  1500         1500.47829   1493.9083   0.000666667 
+  1598         1496.46445   1490.9044   0.000625782 
+  1551         1492.78311   1487.90649  0.000644745 
+  1518         1489.30542   1484.91457  0.000658762 
+  1525         1485.96385   1481.92861  0.000655738 
+  1532         1482.71957   1478.94862  0.000652742 
+  1466         1479.54854   1475.97457  0.000682128 
+  1484         1476.43505   1473.00647  0.000673854 
+  1467         1473.36851   1470.0443   0.000681663 
+  1463         1470.34162   1467.08804  0.000683527 
+  1496         1467.34928   1464.1377   0.000668449 
+  1505         1464.38795   1461.19326  0.000664452 
+  1396         1461.45524   1458.25471  0.000716332 
+  1481         1458.54965   1455.32204  0.000675219 
+  1510         1455.67045   1452.39524  0.000662252 
+  1534         1452.81755   1449.4743   0.00065189 
+  1515         1449.99155   1446.55921  0.000660066 
+  1463         1447.20952   1443.64997  0.000683527 
+  1396         1444.44223   1440.74655  0.000716332 
+  1420         1441.71652   1437.84896  0.000704225 
+  1477         1439.02168   1434.95718  0.000677048 
+  1507         1436.37317   1432.0712   0.00066357 
+  1494         1433.78352   1429.19102  0.000669344 
+  1522         1431.27496   1426.31661  0.00065703 
+  1452         1428.88805   1423.44799  0.000688705 
+  1437         1426.68807   1420.58512  0.000695894 
+  1414         1424.72971   1417.72801  0.000707214 
+  1493         1422.85608   1414.87664  0.000669792 
+  1406         1421.18256   1412.03101  0.000711238 
+  1395         1420.02061   1409.1911   0.000716846 
+  1376         1419.19378   1406.3569   0.000726744 
+  1475         1418.40078   1403.52841  0.000677966 
+  1451         1418.39895   1400.70562  0.00068918 
+  1462         1419.04747   1397.88851  0.000683995 
+  1417         1420.17466   1395.07708  0.000705716 
+  1455         1421.70819   1392.27131  0.000687285 
+  1447         1421.36095   1389.47121  0.000691085 
+  1383         1417.0314    1386.67675  0.000723066 
+  1397         1410.42431   1383.88793  0.00071582 
+  1415         1404.40371   1381.10473  0.000706714 
+  1382         1400.45553   1378.32716  0.000723589 
+  1458         1398.29466   1375.55519  0.000685871 
+  1473         1397.34522   1372.78883  0.000678887 
+  1413         1397.28665   1370.02805  0.000707714 
+  1339         1397.96577   1367.27286  0.000746826 
+  1324         1399.25378   1364.52324  0.000755287 
+  1358         1400.94356   1361.77918  0.000736377 
+  1421         1402.69119   1359.04067  0.00070373 
+  1411         1404.01725   1356.30771  0.000708717 
+  1372         1404.38088   1353.58027  0.000728863 
+  1316         1403.41086   1350.85837  0.000759878 
+  1379         1401.04      1348.14198  0.000725163 
+  1441         1397.50972   1345.43109  0.000693963 
+  1395         1393.2225    1342.7257   0.000716846 
+  1399         1388.52002   1340.0258   0.000714796 
+  1323         1383.56102   1337.33137  0.000755858 
+  1414         1378.31308   1334.64241  0.000707214 
+  1378         1372.69752   1331.95891  0.000725689 
+  1375         1366.71046   1329.28086  0.000727273 
+  1395         1360.48732   1326.60825  0.000716846 
+  1396         1354.24703   1323.94107  0.000716332 
+  1386         1348.20819   1321.27931  0.000721501 
+  1437         1342.53281   1318.62297  0.000695894 
+  1371         1337.32033   1315.97202  0.000729395 
+  1354         1332.6348    1313.32647  0.000738552 
+  1301         1328.52038   1310.68631  0.00076864 
+  1296         1324.89379   1308.05152  0.000771605 
+  1338         1321.64626   1305.4221   0.000747384 
+  1366         1319.05266   1302.79803  0.000732064 
+  1284         1317.07945   1300.17931  0.000778816 
+  1369         1315.30049   1297.56593  0.00073046 
+  1321         1314.35589   1294.95788  0.000757002 
+  1338         1314.13389   1292.35514  0.000747384 
+  1374         1314.42697   1289.75772  0.000727802 
+  1319         1314.94325   1287.16561  0.00075815 
+  1298         1312.96045   1284.57878  0.000770416 
+  1292         1306.74181   1281.99724  0.000773994 
+  1251         1298.461     1279.42097  0.000799361 
+  1318         1290.68749   1276.84997  0.000758725 
+  1271         1284.74291   1274.28422  0.000786782 
+  1313         1280.22951   1271.72372  0.000761615 
+  1189         1276.50666   1269.16846  0.000841043 
+  1355         1273.20648   1266.61843  0.000738007 
+  1258         1270.14959   1264.07362  0.000794913 
+  1284         1267.24819   1261.53402  0.000778816 
+  1223         1264.45574   1258.99963  0.000817661 
+  1277         1261.74559   1256.47042  0.000783085 
+  1253         1259.10174   1253.9464   0.000798085 
+  1278         1256.5144    1251.42756  0.000782473 
+  1313         1253.97783   1248.91388  0.000761615 
+  1289         1251.48897   1246.40536  0.000775795 
+  1228         1249.0468    1243.90199  0.000814332 
+  1284         1246.66256   1241.40376  0.000778816 
+  1258         1244.31739   1238.91066  0.000794913 
+  1274         1242.02547   1236.42268  0.000784929 
+  1241         1239.79749   1233.93981  0.000805802 
+  1212         1237.63003   1231.46205  0.000825083 
+  1246         1235.53766   1228.98938  0.000802568 
+  1229         1233.53231   1226.5218   0.00081367 
+  1230         1231.62881   1224.0593   0.000813008 
+  1217         1229.84554   1221.60187  0.000821693 
+  1244         1228.20486   1219.14949  0.000803859 
+  1261         1226.73315   1216.70217  0.000793021 
+  1213         1225.46026   1214.25989  0.000824402 
+  1131         1224.41803   1211.82264  0.000884173 
+  1171         1223.63702   1209.39042  0.000853971 
+  1193         1223.13792   1206.96321  0.000838223 
+  1176         1222.92768   1204.54102  0.00085034 
+  1258         1222.98496   1202.12382  0.000794913 
+  1184         1223.24385   1199.71161  0.000844595 
+  1141         1223.56472   1197.30438  0.000876424 
+  1186         1223.7062    1194.90212  0.00084317 
+  1206         1223.32534   1192.50483  0.000829187 
+  1204         1222.05139   1190.11249  0.000830565 
+  1193         1219.62636   1187.7251   0.000838223 
+  1139         1216.02944   1185.34265  0.000877963 
+  1145         1211.48977   1182.96512  0.000873362 
+  1141         1206.38176   1180.59252  0.000876424 
+  1162         1201.08252   1178.22483  0.000860585 
+  1271         1195.87614   1175.86204  0.000786782 
+  1188         1190.9315    1173.50415  0.000841751 
+  1134         1186.30833   1171.15114  0.000881834 
+  1181         1182.01801   1168.80301  0.00084674 
+  1142         1178.03062   1166.45975  0.000875657 
+  1197         1174.30933   1164.12136  0.000835422 
+  1175         1170.81664   1161.78781  0.000851064 
+  1189         1167.51029   1159.45911  0.000841043 
+  1124         1164.36884   1157.13524  0.00088968 
+  1204         1161.34948   1154.8162   0.000830565 
+  1140         1158.44156   1152.50197  0.000877193 
+  1106         1155.62038   1150.19256  0.000904159 
+  1161         1152.87474   1147.88795  0.000861326 
+  1134         1150.19286   1145.58812  0.000881834 
+  1128         1147.56514   1143.29309  0.000886525 
+  1233         1144.98383   1141.00283  0.00081103 
+  1134         1142.44257   1138.71734  0.000881834 
+  1114         1139.93614   1136.4366   0.000897666 
+  1167         1137.46025   1134.16062  0.000856898 
+  1130         1135.01135   1131.88938  0.000884956 
+  1166         1132.58646   1129.62287  0.000857633 
+  1184         1130.1831    1127.36109  0.000844595 
+  1151         1127.79918   1125.10403  0.00086881 
+  1123         1125.43293   1122.85167  0.000890472 
+  1119         1123.08285   1120.60402  0.000893655 
+  1162         1120.74766   1118.36106  0.000860585 
+  1116         1118.42627   1116.12278  0.000896057 
+  1122         1116.11775   1113.88917  0.000891266 
+  1079         1113.82127   1111.66024  0.000926784 
+  1131         1111.53614   1109.43596  0.000884173 
+  1144         1109.26177   1107.21634  0.000874126 
+  1092         1106.99763   1105.00135  0.000915751 
+  1120         1104.74327   1102.791    0.000892857 
+  1084         1102.49831   1100.58528  0.000922509 
+  1123         1100.26241   1098.38418  0.000890472 
+  1083         1098.03528   1096.18768  0.000923361 
+  1134         1095.81668   1093.99579  0.000881834 
+  1006         1093.6064    1091.80849  0.000994036 
+  1123         1091.40426   1089.62577  0.000890472 
+  1023         1089.21013   1087.44763  0.000977517 
+  1119         1087.0239    1085.27406  0.000893655 
+  1103         1084.84547   1083.10506  0.000906618 
+  1068         1082.67479   1080.9406   0.00093633 
+  1079         1080.51184   1078.78069  0.000926784 
+  1087         1078.3566    1076.62531  0.000919963 
+  1050         1076.20909   1074.47447  0.000952381 
+  1000         1074.06937   1072.32814  0.001     
+  1098         1071.9375    1070.18633  0.000910747 
+  1066         1069.81358   1068.04901  0.000938086 
+  1054         1067.69776   1065.9162   0.000948767 
+  1023         1065.5902    1063.78787  0.000977517 
+  998          1063.4911    1061.66403  0.001002004 
+  1106         1061.40072   1059.54465  0.000904159 
+  1013         1059.31936   1057.42974  0.000987167 
+  1017         1057.24735   1055.31929  0.000983284 
+  1028         1055.18513   1053.21328  0.000972763 
+  1070         1053.13667   1051.11172  0.000934579 
+  1013         1051.09554   1049.01458  0.000987167 
+  1036         1049.06591   1046.92187  0.000965251 
+  1071         1047.05031   1044.83358  0.000933707 
+  968          1045.04613   1042.74969  0.001033058 
+  1084         1043.05622   1040.67021  0.000922509 
+  1023         1041.08182   1038.59511  0.000977517 
+  1030         1039.12446   1036.5244   0.000970874 
+  1046         1037.18678   1034.45807  0.000956023 
+  949          1035.26918   1032.39611  0.001053741 
+  1039         1033.37509   1030.33851  0.000962464 
+  977          1031.50802   1028.28526  0.001023541 
+  1013         1029.67082   1026.23636  0.000987167 
+  961          1027.86845   1024.19179  0.001040583 
+  1012         1026.10648   1022.15155  0.000988142 
+  1033         1024.39169   1020.11564  0.000968054 
+  1032         1022.73243   1018.08404  0.000968992 
+  983          1021.13906   1016.05674  0.001017294 
+  991          1019.62432   1014.03375  0.001009082 
+  1002         1018.20386   1012.01504  0.000998004 
+  997          1016.89692   1010.00062  0.001003009 
+  1024         1015.72674   1007.99047  0.000976562 
+  1051         1014.72069   1005.98459  0.000951475 
+  989          1013.91004   1003.98297  0.001011122 
+  996          1013.3276    1001.9856   0.001004016 
+  1027         1013.00221   999.99248   0.00097371 
+  1023         1012.94836   998.00359   0.000977517 
+  924          1013.14678   996.01893   0.001082251 
+  1007         1013.51694   994.0385    0.000993049 
+  993          1013.88996   992.06227   0.001007049 
+  973          1014.00161   990.09026   0.001027749 
+  951          1013.53716   988.12244   0.001051525 
+  1000         1012.23211   986.15881   0.001     
+  980          1009.97691   984.19937   0.001020408 
+  945          1006.85306   982.2441    0.001058201 
+  972          1003.09854   980.293     0.001028807 
+  946          999.01579    978.34605   0.001057082 
+  990          994.85265    976.40327   0.001010101 
+  934          990.79548    974.46462   0.001070664 
+  981          986.96738    972.53012   0.001019368 
+  917          983.35431    970.59974   0.001090513 
+  965          979.91276    968.67349   0.001036269 
+  988          976.59768    966.75135   0.001012146 
+  976          973.46309    964.83332   0.00102459 
+  960          970.51541    962.91939   0.001041667 
+  903          967.76047    961.00956   0.00110742 
+  930          965.16865    959.1038    0.001075269 
+  937          962.69492    957.20213   0.001067236 
+  949          960.31733    955.30453   0.001053741 
+  974          958.01975    953.41098   0.001026694 
+  893          955.78353    951.5215    0.001119821 
+  898          953.60059    949.63606   0.001113586 
+  896          951.4627     947.75466   0.001116071 
+  970          949.36326    945.8773    0.001030928 
+  936          947.29694    944.00396   0.001068376 
+  897          945.25946    942.13464   0.001114827 
+  890          943.24727    940.26933   0.001123596 
+  876          941.25773    938.40802   0.001141553 
+  887          939.28794    936.55071   0.001127396 
+  907          937.33615    934.69739   0.001102536 
+  903          935.40085    932.84805   0.00110742 
+  888          933.48043    931.00269   0.001126126 
+  907          931.57363    929.16129   0.001102536 
+  883          929.67966    927.32385   0.001132503 
+  912          927.79752    925.49036   0.001096491 
+  917          925.92658    923.66082   0.001090513 
+  910          924.06624    921.83522   0.001098901 
+  917          922.21601    920.01355   0.001090513 
+  885          920.37545    918.1958    0.001129944 
+  938          918.54424    916.38196   0.001066098 
+  884          916.72208    914.57204   0.001131222 
+  884          914.90875    912.76601   0.001131222 
+  897          913.10411    910.96389   0.001114827 
+  914          911.30798    909.16564   0.001094092 
+  913          909.52044    907.37128   0.00109529 
+  895          907.7412     905.58079   0.001117318 
+  933          905.97041    903.79417   0.001071811 
+  883          904.2081     902.01141   0.001132503 
+  963          902.45445    900.23249   0.001038422 
+  881          900.70949    898.45743   0.001135074 
+  843          898.97344    896.68619   0.00118624 
+  877          897.24658    894.91879   0.001140251 
+  860          895.52921    893.15521   0.001162791 
+  901          893.82172    891.39545   0.001109878 
+  916          892.12455    889.6395    0.001091703 
+  846          890.43828    887.88734   0.001182033 
+  866          888.76359    886.13898   0.001154734 
+  848          887.10137    884.39441   0.001179245 
+  859          885.45277    882.65362   0.001164144 
+  848          883.81915    880.91661   0.001179245 
+  888          882.20153    879.18336   0.001126126 
+  794          880.60136    877.45387   0.001259446 
+  821          879.02214    875.72813   0.001218027 
+  866          877.46448    874.00614   0.001154734 
+  936          875.93075    872.28788   0.001068376 
+  863          874.42495    870.57336   0.001158749 
+  847          872.94123    868.86256   0.001180638 
+  834          871.47725    867.15548   0.001199041 
+  865          870.03963    865.45211   0.001156069 
+  858          868.64326    863.75244   0.001165501 
+  854          867.29964    862.05647   0.00117096 
+  806          866.02224    860.36419   0.001240695 
+  828          864.91038    858.67559   0.001207729 
+  818          863.80252    856.99067   0.001222494 
+  833          862.80666    855.30942   0.00120048 
+  829          862.01024    853.63183   0.001206273 
+  847          861.33433    851.95789   0.001180638 
+  776          860.89333    850.28761   0.00128866 
+  842          860.77516    848.62096   0.001187648 
+  839          861.08628    846.95796   0.001191895 
+  833          862.02636    845.29857   0.00120048 
+  858          863.92059    843.64281   0.001165501 
+  895          867.39887    841.99067   0.001117318 
+  884          873.7969     840.34213   0.001131222 
+  887          885.9611     838.69719   0.001127396 
+  950          907.12481    837.05585   0.001052632 
+  904          934.48414    835.41809   0.001106195 
+  929          980.33724    833.78392   0.001076426 
+  1027         1039.92284   832.15332   0.00097371 
+  1144         1116.80968   830.52628   0.000874126 
+  1207         1230.35856   828.90281   0.0008285 
+  1377         1351.26969   827.28289   0.000726216 
+  1497         1414.82936   825.66651   0.000668003 
+  1343         1315.32352   824.05368   0.000744602 
+  1154         1188.82992   822.44438   0.000866551 
+  985          1049.10107   820.83861   0.001015228 
+  898          947.38793    819.23635   0.001113586 
+  868          895.69922    817.63762   0.001152074 
+  843          869.06793    816.04238   0.00118624 
+  827          853.40436    814.45065   0.00120919 
+  835          843.00025    812.86241   0.001197605 
+  842          835.4966     811.27766   0.001187648 
+  849          829.75613    809.69639   0.001177856 
+  819          825.13971    808.11859   0.001221001 
+  825          821.28692    806.54426   0.001212121 
+  843          817.9737     804.97339   0.00118624 
+  807          815.04601    803.40598   0.001239157 
+  808          812.40875    801.84201   0.001237624 
+  841          809.99407    800.28148   0.001189061 
+  762          807.75376    798.72439   0.001312336 
+  838          805.65334    797.17072   0.001193317 
+  847          803.66761    795.62048   0.001180638 
+  829          801.77787    794.07365   0.001206273 
+  806          799.96812    792.53023   0.001240695 
+  725          798.23255    790.99021   0.00137931 
+  827          796.55978    789.45359   0.00120919 
+  807          794.94785    787.92035   0.001239157 
+  775          793.39243    786.3905    0.001290323 
+  822          791.89096    784.86402   0.001216545 
+  748          790.44419    783.34092   0.001336898 
+  805          789.05285    781.82117   0.001242236 
+  812          787.72013    780.30479   0.001231527 
+  833          786.45014    778.79175   0.00120048 
+  812          785.25012    777.28206   0.001231527 
+  722          784.12854    775.7757    0.001385042 
+  790          783.09798    774.27268   0.001265823 
+  770          782.17447    772.77298   0.001298701 
+  712          781.37946    771.27659   0.001404494 
+  723          780.74196    769.78352   0.001383126 
+  728          780.30156    768.29376   0.001373626 
+  764          780.11309    766.80729   0.001308901 
+  772          780.25396    765.32412   0.001295337 
+  750          780.83718    763.84424   0.001333333 
+  766          782.0328     762.36763   0.001305483 
+  732          784.10808    760.8943    0.00136612 
+  764          787.5133     759.42423   0.001308901 
+  808          793.06912    757.95743   0.001237624 
+  812          802.33732    756.49388   0.001231527 
+  800          818.14234    755.03359   0.00125   
+  836          844.1744     753.57653   0.001196172 
+  920          878.5325     752.12271   0.001086957 
+  898          917.01301    750.67212   0.001113586 
+  1088         980.71866    749.22475   0.000919118 
+  1206         1069.59093   747.7806    0.000829187 
+  1341         1147.81589   746.33967   0.000745712 
+  1275         1216.86856   744.90193   0.000784314 
+  1125         1196.29008   743.4674    0.000888889 
+  1083         1107.21363   742.03606   0.000923361 
+  879          1012.72751   740.60791   0.001137656 
+  852          916.05683    739.18293   0.001173709 
+  804          850.48785    737.76113   0.001243781 
+  849          812.37877    736.3425    0.001177856 
+  752          789.74436    734.92703   0.001329787 
+  749          775.24688    733.51472   0.001335113 
+  751          765.19187    732.10556   0.001331558 
+  754          757.75855    730.69954   0.00132626 
+  712          751.98546    729.29666   0.001404494 
+  796          747.32045    727.8969    0.001256281 
+  722          743.42568    726.50028   0.001385042 
+  725          740.08363    725.10677   0.00137931 
+  744          737.14969    723.71638   0.001344086 
+  700          734.5251     722.3291    0.001428571 
+  715          732.13999    720.94491   0.001398601 
+  690          729.94432    719.56382   0.001449275 
+  700          727.90114    718.18582   0.001428571 
+  723          725.9847     716.8109    0.001383126 
+  740          724.17397    715.43906   0.001351351 
+  719          722.45483    714.07029   0.001390821 
+  716          720.81599    712.70459   0.001396648 
+  759          719.24974    711.34194   0.001317523 
+  757          717.75115    709.98235   0.001321004 
+  650          716.31758    708.62581   0.001538462 
+  719          714.94886    707.2723    0.001390821 
+  676          713.80132    705.92183   0.00147929 
+  767          712.57366    704.5744    0.001303781 
+  708          711.42778    703.22998   0.001412429 
+  708          710.45524    701.88858   0.001412429 
+  745          709.52455    700.55019   0.001342282 
+  680          708.74589    699.21481   0.001470588 
+  636          708.17274    697.88243   0.001572327 
+  699          707.8915     696.55304   0.001430615 
+  714          708.05611    695.22664   0.00140056 
+  727          708.95558    693.90322   0.001375516 
+  702          711.13598    692.58278   0.001424501 
+  714          715.46174    691.26531   0.00140056 
+  695          722.44084    689.9508    0.001438849 
+  741          730.71868    688.63926   0.001349528 
+  795          743.12813    687.33066   0.001257862 
+  800          762.99951    686.02501   0.00125   
+  848          782.03899    684.72231   0.001179245 
+  775          797.86322    683.42253   0.001290323 
+  817          797.16814    682.12569   0.00122399 
+  754          776.82231    680.83178   0.00132626 
+  721          755.69294    679.54078   0.001386963 
+  676          732.55473    678.25269   0.00147929 
+  687          715.31839    676.96751   0.001455604 
+  696          705.16982    675.68523   0.001436782 
+  704          699.36899    674.40584   0.001420455 
+  729          696.02926    673.12935   0.001371742 
+  672          694.23411    671.85574   0.001488095 
+  689          693.61923    670.585     0.001451379 
+  687          694.15705    669.31714   0.001455604 
+  689          696.07769    668.05215   0.001451379 
+  692          699.99905    666.79001   0.001445087 
+  749          707.19103    665.53073   0.001335113 
+  699          719.95646    664.27431   0.001430615 
+  748          740.98842    663.02072   0.001336898 
+  787          768.21156    661.76997   0.001270648 
+  789          802.70419    660.52206   0.001267427 
+  826          860.15242    659.27697   0.001210654 
+  874          925.39471    658.03471   0.001144165 
+  995          978.13578    656.79526   0.001005025 
+  991          998.6616     655.55862   0.001009082 
+  946          946.97354    654.32478   0.001057082 
+  858          885.25177    653.09375   0.001165501 
+  816          816.56123    651.86551   0.00122549 
+  718          757.48763    650.64005   0.001392758 
+  743          721.04141    649.41738   0.001345895 
+  624          699.82914    648.19748   0.001602564 
+  662          686.85813    646.98036   0.001510574 
+  613          678.30346    645.766     0.001631321 
+  629          672.27298    644.5544    0.001589825 
+  651          667.81772    643.34556   0.001536098 
+  691          664.42726    642.13946   0.001447178 
+  668          661.80964    640.93611   0.001497006 
+  648          659.79743    639.7355    0.00154321 
+  670          658.30305    638.53762   0.001492537 
+  644          657.29806    637.34246   0.001552795 
+  650          656.81009    636.15003   0.001538462 
+  622          656.93625    634.96032   0.001607717 
+  679          657.88568    633.77331   0.001472754 
+  677          660.07272    632.58901   0.001477105 
+  633          664.26489    631.40741   0.001579779 
+  688          671.61563    630.22851   0.001453488 
+  662          682.4608     629.05229   0.001510574 
+  719          696.10951    627.87876   0.001390821 
+  736          718.02212    626.70791   0.001358696 
+  827          748.04434    625.53973   0.00120919 
+  918          777.11947    624.37422   0.001089325 
+  963          802.19467    623.21136   0.001038422 
+  922          807.83119    622.05117   0.001084599 
+  895          816.88245    620.89363   0.001117318 
+  950          830.55891    619.73873   0.001052632 
+  1055         851.2677     618.58647   0.000947867 
+  1009         884.78362    617.43685   0.00099108 
+  1023         901.40115    616.28986   0.000977517 
+  886          906.97501    615.1455    0.001128668 
+  797          870.41836    614.00375   0.001254705 
+  765          815.3274     612.86462   0.00130719 
+  712          765.67435    611.7281    0.001404494 
+  709          718.26851    610.59418   0.001410437 
+  634          686.21773    609.46286   0.001577287 
+  624          667.52821    608.33413   0.001602564 
+  635          656.48057    607.20799   0.001574803 
+  617          649.49204    606.08443   0.001620746 
+  667          644.66016    604.96345   0.00149925 
+  601          640.94661    603.84504   0.001663894 
+  627          637.73325    602.7292    0.001594896 
+  631          634.63646    601.61592   0.001584786 
+  617          631.45429    600.50519   0.001620746 
+  613          628.13506    599.39702   0.001631321 
+  658          624.73124    598.2914    0.001519757 
+  654          621.3453     597.18831   0.001529052 
+  617          618.08218    596.08776   0.001620746 
+  604          615.01853    594.98974   0.001655629 
+  626          612.19327    593.89425   0.001597444 
+  627          609.61333    592.80127   0.001594896 
+  604          607.26519    591.71082   0.001655629 
+  594          605.13039    590.62287   0.001683502 
+  636          603.17375    589.53742   0.001572327 
+  548          601.37534    588.45448   0.001824818 
+  585          599.71395    587.37403   0.001709402 
+  609          598.17201    586.29607   0.001642036 
+  576          596.73822    585.2206    0.001736111 
+  565          595.39718    584.1476    0.001769912 
+  613          594.15427    583.07708   0.001631321 
+  567          592.9862     582.00903   0.001763668 
+  583          591.90222    580.94344   0.001715266 
+  590          590.90573    579.88031   0.001694915 
+  585          590.00436    578.81963   0.001709402 
+  598          589.21658    577.76141   0.001672241 
+  566          588.55464    576.70562   0.001766784 
+  566          588.05778    575.65228   0.001766784 
+  628          587.7901     574.60137   0.001592357 
+  562          587.82647    573.55289   0.001779359 
+  606          588.32251    572.50684   0.001650165 
+  604          589.57191    571.4632    0.001655629 
+  598          592.11767    570.42197   0.001672241 
+  576          596.89728    569.38316   0.001736111 
+  571          604.79324    568.34675   0.001751313 
+  627          615.07942    567.31274   0.001594896 
+  667          630.00413    566.28112   0.00149925 
+  625          652.4772     565.25189   0.0016    
+  664          672.46535    564.22505   0.001506024 
+  697          684.38121    563.20058   0.00143472 
+  650          675.30461    562.17849   0.001538462 
+  641          656.68098    561.15877   0.001560062 
+  610          638.66864    560.14142   0.001639344 
+  593          619.37805    559.12642   0.001686341 
+  589          607.42736    558.11378   0.001697793 
+  636          603.58493    557.10349   0.001572327 
+  584          602.69354    556.09554   0.001712329 
+  645          601.57601    555.08994   0.001550388 
+  615          596.26441    554.08667   0.001626016 
+  581          589.48367    553.08573   0.00172117 
+  607          583.04117    552.08711   0.001647446 
+  592          576.49819    551.09082   0.001689189 
+  600          571.72683    550.09684   0.001666667 
+  599          568.64825    549.10518   0.001669449 
+  651          566.60022    548.11582   0.001536098 
+  622          565.15623    547.12876   0.001607717 
+  637          564.09679    546.144     0.001569859 
+  649          563.31369    545.16153   0.001540832 
+  637          562.74788    544.18135   0.001569859 
+  692          562.36482    543.20345   0.001445087 
+  668          562.14719    542.22783   0.001497006 
+  709          562.05747    541.25448   0.001410437 
+  707          562.0637     540.2834    0.001414427 
+  653          562.13798    539.31458   0.001531394 
+  638          562.30202    538.34803   0.001567398 
+  631          562.60723    537.38372   0.001584786 
+  612          563.0784     536.42167   0.001633987 
+  592          563.75764    535.46186   0.001689189 
+  599          564.66634    534.50429   0.001669449 
+  593          565.79746    533.54896   0.001686341 
+  631          567.12753    532.59585   0.001584786 
+  614          568.63057    531.64497   0.001628664 
+  564          570.2996     530.69632   0.00177305 
+  635          572.18086    529.74988   0.001574803 
+  576          574.40625    528.80565   0.001736111 
+  608          577.22541    527.86363   0.001644737 
+  623          581.05223    526.92381   0.001605136 
+  589          586.56935    525.98619   0.001697793 
+  554          594.90798    525.05077   0.001805054 
+  607          607.71239    524.11753   0.001647446 
+  612          625.82036    523.18648   0.001633987 
+  633          649.23969    522.25761   0.001579779 
+  675          683.93049    521.33091   0.001481481 
+  767          725.34703    520.40638   0.001303781 
+  721          761.5576     519.48402   0.001386963 
+  768          782.6818     518.56382   0.001302083 
+  792          793.41134    517.64577   0.001262626 
+  832          822.40179    516.72988   0.001201923 
+  892          884.34169    515.81614   0.001121076 
+  1040         1023.68237   514.90454   0.000961538 
+  1239         1277.16285   513.99508   0.000807103 
+  1644         1574.21679   513.08775   0.000608273 
+  2279         2119.48931   512.18255   0.000438789 
+  3344         2919.67212   511.27948   0.000299043 
+  4497         3479.23391   510.37852   0.00022237 
+  4327         3557.34752   509.47969   0.000231107 
+  3250         2909.33341   508.58296   0.000307692 
+  2753         2445.73912   507.68834   0.00036324 
+  1927         1843.30141   506.79583   0.000518941 
+  1175         1272.13437   505.90541   0.000851064 
+  840          967.49086    505.01709   0.001190476 
+  729          815.22288    504.13085   0.001371742 
+  626          730.60051    503.2467    0.001597444 
+  633          677.9053     502.36463   0.001579779 
+  579          642.71932    501.48464   0.001727116 
+  590          618.06316    500.60672   0.001694915 
+  582          600.14409    499.73087   0.001718213 
+  559          586.76765    498.85707   0.001788909 
+  579          576.581      497.98534   0.001727116 
+  577          568.76245    497.11566   0.001733102 
+  548          562.71171    496.24803   0.001824818 
+  579          558.03342    495.38245   0.001727116 
+  569          554.39839    494.5189    0.001757469 
+  535          551.53673    493.6574    0.001869159 
+  581          549.22143    492.79792   0.00172117 
+  537          547.28514    491.94047   0.001862197 
+  529          545.64763    491.08505   0.001890359 
+  554          544.33007    490.23165   0.001805054 
+  542          543.45381    489.38026   0.001845018 
+  526          543.24236    488.53088   0.001901141 
+  558          544.05125    487.6835    0.001792115 
+  555          546.47987    486.83813   0.001801802 
+  524          551.65941    485.99476   0.001908397 
+  544          561.73559    485.15338   0.001838235 
+  614          580.41626    484.31399   0.001628664 
+  559          605.80339    483.47658   0.001788909 
+  672          641.27052    482.64115   0.001488095 
+  757          698.68764    481.8077    0.001321004 
+  743          749.59413    480.97622   0.001345895 
+  805          771.96576    480.14671   0.001242236 
+  828          741.99721    479.31917   0.001207729 
+  748          704.7978     478.49358   0.001336898 
+  689          670.07601    477.66995   0.001451379 
+  614          628.03991    476.84827   0.001628664 
+  597          603.13872    476.02853   0.001675042 
+  605          595.83095    475.21074   0.001652893 
+  637          601.03379    474.39488   0.001569859 
+  628          617.9912     473.58096   0.001592357 
+  631          650.63691    472.76897   0.001584786 
+  658          705.38207    471.95891   0.001519757 
+  755          776.01984    471.15076   0.001324503 
+  911          848.88238    470.34454   0.001097695 
+  1022         960.25712    469.54023   0.000978474 
+  1095         1068.90321   468.73782   0.000913242 
+  994          1054.09484   467.93732   0.001006036 
+  943          1019.81629   467.13873   0.001060445 
+  943          1025.69239   466.34202   0.001060445 
+  916          1042.68045   465.54722   0.001091703 
+  954          1118.48829   464.7543    0.001048218 
+  1141         1235.76939   463.96326   0.000876424 
+  1426         1438.47498   463.1741    0.000701262 
+  1980         1711.58443   462.38682   0.000505051 
+  2119         1752.33949   461.60142   0.000471921 
+  1962         1658.25358   460.81788   0.000509684 
+  1836         1605.42409   460.0362    0.000544662 
+  1505         1399.24841   459.25639   0.000664452 
+  1194         1173.78606   458.47843   0.000837521 
+  965          1033.77687   457.70232   0.001036269 
+  786          928.78003    456.92806   0.001272265 
+  792          864.55811    456.15564   0.001262626 
+  797          855.26819    455.38507   0.001254705 
+  878          867.84586    454.61633   0.001138952 
+  808          835.01849    453.84942   0.001237624 
+  807          797.9847     453.08434   0.001239157 
+  776          780.31663    452.32108   0.00128866 
+  797          761.37603    451.55964   0.001254705 
+  838          761.64821    450.80002   0.001193317 
+  820          783.44519    450.04221   0.001219512 
+  843          831.19727    449.28621   0.00118624 
+  830          907.27487    448.53201   0.001204819 
+  936          957.99917    447.77961   0.001068376 
+  1032         1003.99336   447.029     0.000968992 
+  1159         1128.24841   446.28019   0.000862813 
+  1441         1388.60758   445.53317   0.000693963 
+  1798         1871.43932   444.78793   0.000556174 
+  2761         2451.04509   444.04447   0.000362188 
+  4022         3630.64634   443.30279   0.000248633 
+  6130         5195.13163   442.56288   0.000163132 
+  7729         6130.59149   441.82474   0.000129383 
+  6273         5399.11645   441.08836   0.000159413 
+  4712         4278.79918   440.35374   0.000212224 
+  4124         3674.66139   439.62088   0.000242483 
+  2559         2489.5092    438.88978   0.000390778 
+  1357         1543.4987    438.16042   0.00073692 
+  953          1095.99825   437.43281   0.001049318 
+  827          882.34213    436.70694   0.00120919 
+  733          763.26048    435.9828    0.001364256 
+  662          688.17521    435.2604    0.001510574 
+  647          637.22437    434.53973   0.001545595 
+  581          600.8312     433.82079   0.00172117 
+  588          573.79147    433.10357   0.00170068 
+  576          553.05797    432.38806   0.001736111 
+  507          536.74269    431.67427   0.001972387 
+  544          523.62569    430.96219   0.001838235 
+  578          512.88497    430.25182   0.001730104 
+  522          503.95064    429.54316   0.001915709 
+  522          496.41778    428.83619   0.001915709 
+  496          489.99054    428.13091   0.002016129 
+  488          484.44914    427.42733   0.00204918 
+  523          479.62805    426.72544   0.001912046 
+  505          475.39962    426.02523   0.001980198 
+  499          471.66524    425.3267    0.002004008 
+  513          468.34727    424.62985   0.001949318 
+  481          465.38403    423.93467   0.002079002 
+  499          462.7262     423.24116   0.002004008 
+  500          460.33443    422.54932   0.002     
+  494          458.17667    421.85914   0.002024291 
+  505          456.22737    421.17062   0.001980198 
+  497          454.46572    420.48375   0.002012072 
+  511          452.8751     419.79853   0.001956947 
+  464          451.44262    419.11496   0.002155172 
+  451          450.15819    418.43303   0.002217295 
+  523          449.01453    417.75275   0.001912046 
+  454          448.00691    417.0741    0.002202643 
+  476          447.13259    416.39708   0.00210084 
+  467          446.39137    415.72169   0.002141328 
+  491          445.78527    415.04793   0.00203666 
+  440          445.31862    414.37578   0.002272727 
+  456          444.99828    413.70526   0.002192982 
+  441          444.83819    413.03635   0.002267574 
+  430          444.84322    412.36905   0.002325581 
+  427          445.0343     411.70336   0.00234192 
+  442          445.43288    411.03927   0.002262443 
+  454          446.06778    410.37678   0.002202643 
+  403          446.96833    409.71588   0.00248139 
+  433          448.1781     409.05658   0.002309469 
+  456          449.74814    408.39887   0.002192982 
+  432          451.74131    407.74275   0.002314815 
+  478          454.23465    407.0882    0.00209205 
+  438          457.32399    406.43524   0.002283105 
+  470          461.11421    405.78385   0.00212766 
+  462          465.7236     405.13403   0.002164502 
+  476          471.32032    404.48577   0.00210084 
+  467          478.02888    403.83909   0.002141328 
+  508          485.98003    403.19396   0.001968504 
+  568          495.22237    402.55039   0.001760563 
+  536          505.68562    401.90837   0.001865672 
+  568          517.12193    401.26791   0.001760563 
+  537          529.09213    400.62899   0.001862197 
+  563          541.0458     399.99161   0.001776199 
+  604          552.45106    399.35578   0.001655629 
+  587          562.88143    398.72147   0.001703578 
+  637          571.99945    398.08871   0.001569859 
+  707          579.55423    397.45747   0.001414427 
+  697          585.62097    396.82775   0.00143472 
+  753          591.16493    396.19956   0.001328021 
+  763          598.59228    395.57289   0.001310616 
+  703          610.64613    394.94773   0.001422475 
+  782          624.73799    394.32409   0.001278772 
+  780          642.68624    393.70195   0.001282051 
+  731          670.96621    393.08132   0.001367989 
+  648          674.75641    392.46219   0.00154321 
+  664          652.23992    391.84456   0.001506024 
+  660          640.74836    391.22842   0.001515152 
+  651          633.61113    390.61377   0.001536098 
+  632          609.76532    390.00061   0.001582278 
+  587          569.8615     389.38894   0.001703578 
+  545          540.85929    388.77875   0.001834862 
+  530          520.41483    388.17003   0.001886792 
+  493          497.58322    387.56279   0.002028398 
+  472          481.0574     386.95702   0.002118644 
+  502          474.17877    386.35272   0.001992032 
+  531          476.55253    385.74988   0.001883239 
+  474          488.37516    385.14851   0.002109705 
+  559          507.5535     384.54859   0.001788909 
+  634          535.34793    383.95012   0.001577287 
+  660          568.05258    383.35311   0.001515152 
+  638          584.12019    382.75754   0.001567398 
+  618          585.88689    382.16342   0.001618123 
+  522          567.61467    381.57074   0.001915709 
+  545          535.46758    380.97949   0.001834862 
+  425          506.85968    380.38968   0.002352941 
+  459          477.71312    379.80131   0.002178649 
+  424          451.58669    379.21436   0.002358491 
+  428          434.42479    378.62883   0.002336449 
+  421          423.8746     378.04473   0.002375297 
+  404          417.10203    377.46204   0.002475248 
+  388          412.44457    376.88077   0.00257732 
+  391          409.0502     376.30091   0.002557545 
+  400          406.47004    375.72245   0.0025    
+  395          404.46319    375.14541   0.002531646 
+  370          402.88375    374.56976   0.002702703 
+  362          401.64422    373.99551   0.002762431 
+  382          400.69041    373.42266   0.002617801 
+  399          399.98867    372.8512    0.002506266 
+  375          399.51787    372.28113   0.002666667 
+  412          399.26382    371.71244   0.002427184 
+  418          399.21645    371.14514   0.002392344 
+  424          399.37096    370.57921   0.002358491 
+  405          399.7361     370.01466   0.002469136 
+  378          400.34881    369.45149   0.002645503 
+  407          401.2946     368.88968   0.002457002 
+  357          402.73708    368.32924   0.00280112 
+  419          404.97823    367.77016   0.002386635 
+  418          408.58601    367.21245   0.002392344 
+  386          414.61928    366.65609   0.002590674 
+  434          424.84096    366.10108   0.002304147 
+  438          440.60414    365.54742   0.002283105 
+  435          458.86511    364.99512   0.002298851 
+  478          480.50269    364.44415   0.00209205 
+  490          503.74526    363.89453   0.002040816 
+  477          500.75642    363.34624   0.002096436 
+  480          482.668      362.79929   0.002083333 
+  442          472.20941    362.25368   0.002262443 
+  443          457.29925    361.70939   0.002257336 
+  428          437.74832    361.16642   0.002336449 
+  398          423.95363    360.62478   0.002512563 
+  380          416.25278    360.08446   0.002631579 
+  408          413.4263     359.54546   0.00245098 
+  423          412.71717    359.00776   0.002364066 
+  409          413.36898    358.47138   0.002444988 
+  400          415.89825    357.93631   0.0025    
+  402          415.7462     357.40254   0.002487562 
+  381          409.81647    356.87007   0.002624672 
+  402          404.98607    356.3389    0.002487562 
+  394          401.03413    355.80902   0.002538071 
+  411          395.51102    355.28043   0.00243309 
+  387          390.80436    354.75314   0.002583979 
+  347          387.72137    354.22713   0.002881844 
+  346          385.74452    353.7024    0.002890173 
+  363          384.421      353.17895   0.002754821 
+  356          383.49473    352.65678   0.002808989 
+  362          382.83343    352.13589   0.002762431 
+  356          382.36963    351.61626   0.002808989 
+  404          382.05877    351.0979    0.002475248 
+  383          381.88041    350.58081   0.002610966 
+  353          381.82081    350.06498   0.002832861 
+  407          381.87099    349.55041   0.002457002 
+  431          382.03983    349.03709   0.002320186 
+  389          382.32904    348.52503   0.002570694 
+  371          382.76445    348.01421   0.002695418 
+  384          383.38593    347.50465   0.002604167 
+  401          384.25033    346.99632   0.002493766 
+  391          385.37382    346.48924   0.002557545 
+  357          386.74106    345.9834    0.00280112 
+  379          388.52365    345.47879   0.002638522 
+  376          390.3576     344.97542   0.002659574 
+  393          392.06897    344.47327   0.002544529 
+  388          394.35471    343.97235   0.00257732 
+  413          396.89664    343.47265   0.002421308 
+  388          398.68916    342.97418   0.00257732 
+  393          399.96948    342.47692   0.002544529 
+  388          400.5296     341.98088   0.00257732 
+  426          401.03267    341.48605   0.002347418 
+  444          401.97505    340.99243   0.002252252 
+  411          403.04913    340.50001   0.00243309 
+  397          404.53287    340.0088    0.002518892 
+  432          406.73747    339.51879   0.002314815 
+  386          409.58316    339.02998   0.002590674 
+  425          412.97195    338.54236   0.002352941 
+  422          416.85582    338.05593   0.002369668 
+  426          421.21594    337.5707    0.002347418 
+  387          426.04944    337.08665   0.002583979 
+  451          431.36793    336.60378   0.002217295 
+  433          437.20899    336.12209   0.002309469 
+  394          443.65125    335.64158   0.002538071 
+  447          450.82008    335.16225   0.002237136 
+  420          458.87622    334.68409   0.002380952 
+  475          468.02505    334.2071    0.002105263 
+  454          478.50656    333.73127   0.002202643 
+  456          490.59923    333.25661   0.002192982 
+  474          504.62447    332.78311   0.002109705 
+  531          520.97366    332.31077   0.001883239 
+  472          540.14007    331.83958   0.002118644 
+  498          562.78558    331.36955   0.002008032 
+  569          589.8123     330.90067   0.001757469 
+  567          622.46117    330.43293   0.001763668 
+  561          662.44759    329.96634   0.001782531 
+  645          712.19674    329.50089   0.001550388 
+  668          775.20761    329.03658   0.001497006 
+  778          856.67559    328.5734    0.001285347 
+  915          964.66128    328.11136   0.001092896 
+  997          1112.16517   327.65045   0.001003009 
+  1359         1321.91115   327.19067   0.000735835 
+  1748         1636.50853   326.73201   0.000572082 
+  2327         2150.24935   326.27448   0.000429738 
+  3344         3092.70552   325.81807   0.000299043 
+  5028         4944.93858   325.36277   0.000198886 
+  8441         8007.48415   324.90859   0.000118469 
+  14217        12555.37508  324.45552   0.000070338 
+  22630        19457.33547  324.00356   0.000044189 
+  28130        23366.22754  323.5527    0.000035549 
+  20940        18911.80334  323.10295   0.000047755 
+  14846        15012.65473  322.6543    0.000067358 
+  14615        13876.65265  322.20675   0.000068423 
+  10894        10623.95542  321.76029   0.000091794 
+  5034         5997.35857   321.31493   0.000198649 
+  2650         3502.47472   320.87066   0.000377358 
+  1691         2348.10756   320.42748   0.000591366 
+  1353         1751.27752   319.98538   0.000739098 
+  1228         1394.79458   319.54436   0.000814332 
+  1068         1161.77201   319.10443   0.00093633 
+  966          1000.49517   318.66557   0.001035197 
+  896          884.16987    318.22778   0.001116071 
+  817          797.37324    317.79107   0.00122399 
+  767          730.71521    317.35543   0.001303781 
+  723          678.72901    316.92086   0.001383126 
+  658          637.67694    316.48735   0.001519757 
+  606          604.76493    316.0549    0.001650165 
+  595          578.27329    315.62351   0.001680672 
+  581          557.03832    315.19317   0.00172117 
+  548          540.12266    314.7639    0.001824818 
+  536          526.87807    314.33567   0.001865672 
+  573          516.87375    313.90849   0.001745201 
+  468          509.85806    313.48236   0.002136752 
+  516          505.65657    313.05727   0.001937984 
+  492          504.00739    312.63322   0.00203252 
+  457          504.85911    312.21021   0.002188184 
+  484          507.61164    311.78824   0.002066116 
+  502          511.62486    311.3673    0.001992032 
+  557          517.68824    310.9474    0.001795332 
+  511          525.88828    310.52852   0.001956947 
+  524          535.53881    310.11067   0.001908397 
+  554          546.80821    309.69384   0.001805054 
+  595          560.12002    309.27803   0.001680672 
+  586          575.65218    308.86324   0.001706485 
+  666          593.5064     308.44946   0.001501502 
+  600          613.74279    308.0367    0.001666667 
+  701          636.53084    307.62496   0.001426534 
+  754          661.9616     307.21422   0.00132626 
+  750          687.53244    306.80448   0.001333333 
+  787          710.10886    306.39575   0.001270648 
+  748          726.7447     305.98802   0.001336898 
+  758          718.86144    305.58129   0.001319261 
+  753          693.7036     305.17556   0.001328021 
+  688          669.22486    304.77082   0.001453488 
+  662          640.52925    304.36707   0.001510574 
+  653          603.17227    303.96431   0.001531394 
+  602          567.22997    303.56253   0.00166113 
+  560          536.05548    303.16174   0.001785714 
+  545          508.9827     302.76193   0.001834862 
+  512          485.2793     302.3631    0.001953125 
+  450          464.42968    301.96525   0.002222222 
+  513          446.52723    301.56837   0.001949318 
+  432          431.09273    301.17247   0.002314815 
+  430          417.72587    300.77753   0.002325581 
+  428          406.31316    300.38356   0.002336449 
+  392          396.49312    299.99056   0.00255102 
+  370          388.01041    299.59852   0.002702703 
+  386          380.64011    299.20743   0.002590674 
+  345          374.20475    298.81731   0.002898551 
+  376          368.55365    298.42814   0.002659574 
+  379          363.56688    298.03992   0.002638522 
+  368          359.13293    297.65266   0.002717391 
+  361          355.18502    297.26634   0.002770083 
+  363          351.64882    296.88097   0.002754821 
+  358          348.46574    296.49654   0.002793296 
+  366          345.5968     296.11305   0.00273224 
+  370          343.00151    295.7305    0.002702703 
+  352          340.64914    295.34889   0.002840909 
+  375          338.51481    294.96821   0.002666667 
+  341          336.57874    294.58846   0.002932551 
+  375          334.82545    294.20965   0.002666667 
+  332          333.24343    293.83176   0.003012048 
+  351          331.8256     293.45479   0.002849003 
+  327          330.57101    293.07875   0.003058104 
+  317          329.47719    292.70362   0.003154574 
+  325          328.55422    292.32942   0.003076923 
+  307          327.81789    291.95613   0.003257329 
+  355          327.29605    291.58375   0.002816901 
+  383          327.03041    291.21229   0.002610966 
+  311          327.09279    290.84173   0.003215434 
+  289          327.59948    290.47208   0.003460208 
+  369          328.75224    290.10334   0.002710027 
+  326          330.92456    289.7355    0.003067485 
+  355          334.83345    289.36855   0.002816901 
+  348          341.83359    289.00251   0.002873563 
+  403          354.02521    288.63735   0.00248139 
+  388          372.16666    288.2731    0.00257732 
+  403          392.84413    287.90973   0.00248139 
+  517          414.84378    287.54725   0.001934236 
+  445          420.23217    287.18566   0.002247191 
+  417          404.47186    286.82495   0.002398082 
+  445          392.09258    286.46512   0.002247191 
+  372          385.3305     286.10617   0.002688172 
+  375          370.56662    285.7481    0.002666667 
+  329          354.12729    285.39091   0.003039514 
+  312          343.85958    285.03459   0.003205128 
+  354          337.5829     284.67914   0.002824859 
+  376          333.77032    284.32455   0.002659574 
+  348          331.29991    283.97084   0.002873563 
+  333          330.05828    283.61798   0.003003003 
+  303          329.62298    283.26599   0.00330033 
+  359          330.11626    282.91486   0.002785515 
+  356          331.0462     282.56459   0.002808989 
+  323          331.91668    282.21517   0.003095975 
+  329          329.64442    281.86661   0.003039514 
+  319          325.49323    281.5189    0.003134796 
+  307          322.56837    281.17203   0.003257329 
+  314          320.1221     280.82602   0.003184713 
+  326          316.5742     280.48085   0.003067485 
+  319          313.36177    280.13652   0.003134796 
+  322          311.19047    279.79303   0.00310559 
+  341          309.77644    279.45038   0.002932551 
+  342          308.846      279.10856   0.002923977 
+  349          308.26821    278.76758   0.00286533 
+  314          307.99146    278.42743   0.003184713 
+  329          308.05225    278.08812   0.003039514 
+  364          308.57005    277.74962   0.002747253 
+  342          309.68378    277.41196   0.002923977 
+  309          311.35074    277.07512   0.003236246 
+  354          313.28158    276.7391    0.002824859 
+  341          314.89675    276.4039    0.002932551 
+  337          314.57201    276.06951   0.002967359 
+  334          313.66639    275.73595   0.002994012 
+  336          313.64993    275.40319   0.00297619 
+  322          313.8801     275.07125   0.00310559 
+  338          313.84226    274.74011   0.00295858 
+  310          314.70646    274.40978   0.003225806 
+  319          317.16635    274.08026   0.003134796 
+  333          321.69512    273.75154   0.003003003 
+  359          328.56187    273.42362   0.002785515 
+  408          338.41725    273.0965    0.00245098 
+  364          352.39576    272.77017   0.002747253 
+  382          369.61332    272.44464   0.002617801 
+  404          389.1731     272.11991   0.002475248 
+  408          412.69115    271.79596   0.00245098 
+  412          420.5733     271.4728    0.002427184 
+  427          400.20074    271.15043   0.00234192 
+  405          384.82127    270.82884   0.002469136 
+  412          380.7157     270.50804   0.002427184 
+  358          368.86976    270.18802   0.002793296 
+  397          351.92173    269.86877   0.002518892 
+  347          341.40702    269.5503    0.002881844 
+  334          335.85582    269.23261   0.002994012 
+  376          333.51024    268.91568   0.002659574 
+  351          333.33829    268.59953   0.002849003 
+  368          334.30046    268.28415   0.002717391 
+  319          336.04929    267.96953   0.003134796 
+  359          338.99046    267.65568   0.002785515 
+  342          343.35389    267.34259   0.002923977 
+  375          349.37178    267.03027   0.002666667 
+  385          357.64992    266.7187    0.002597403 
+  411          369.46645    266.40788   0.00243309 
+  421          388.18274    266.09783   0.002375297 
+  483          421.35208    265.78852   0.002070393 
+  459          476.0962     265.47997   0.002178649 
+  522          539.13905    265.17216   0.001915709 
+  650          615.21404    264.8651    0.001538462 
+  594          628.82105    264.55879   0.001683502 
+  587          574.86684    264.25322   0.001703578 
+  603          553.33274    263.94839   0.001658375 
+  580          563.94936    263.6443    0.001724138 
+  556          540.30978    263.34095   0.001798561 
+  570          509.53077    263.03834   0.001754386 
+  561          505.97579    262.73645   0.001782531 
+  599          524.57149    262.4353    0.001669449 
+  613          557.6306     262.13488   0.001631321 
+  589          600.02745    261.83519   0.001697793 
+  621          644.17312    261.53622   0.001610306 
+  652          679.46199    261.23798   0.001533742 
+  746          724.86685    260.94046   0.001340483 
+  815          794.83745    260.64366   0.001226994 
+  871          889.69505    260.34758   0.001148106 
+  1060         1017.95699   260.05222   0.000943396 
+  1336         1211.53474   259.75757   0.000748503 
+  1533         1516.26704   259.46363   0.000652316 
+  2155         2025.48582   259.17041   0.000464037 
+  3084         2980.51196   258.87789   0.000324254 
+  5033         4944.02898   258.58608   0.000198689 
+  8778         8552.2764    258.29498   0.000113921 
+  14362        12639.96244  258.00458   0.000069628 
+  20582        18081.85304  257.71488   0.000048586 
+  19072        17465.79661  257.42589   0.000052433 
+  12416        12396.83899  257.13759   0.000080541 
+  10777        10519.05767  256.84999   0.00009279 
+  11270        11076.83055  256.56308   0.000088731 
+  8154         8104.35777   256.27686   0.000122639 
+  4172         4504.17036   255.99134   0.000239693 
+  2172         2679.04912   255.70651   0.000460405 
+  1545         1830.03056   255.42236   0.000647249 
+  1162         1383.14088   255.1389    0.000860585 
+  945          1115.86836   254.85612   0.001058201 
+  838          944.71245    254.57403   0.001193317 
+  756          825.18966    254.29261   0.001322751 
+  649          730.2604     254.01187   0.001540832 
+  593          658.27864    253.73181   0.001686341 
+  591          607.88465    253.45243   0.001692047 
+  504          566.86665    253.17372   0.001984127 
+  487          525.11621    252.89568   0.002053388 
+  457          489.31732    252.61831   0.002188184 
+  429          462.57125    252.3416    0.002331002 
+  415          441.13804    252.06557   0.002409639 
+  406          421.99206    251.79019   0.002463054 
+  413          406.71525    251.51548   0.002421308 
+  387          396.24927    251.24144   0.002583979 
+  375          390.42216    250.96805   0.002666667 
+  363          386.50144    250.69531   0.002754821 
+  354          380.53822    250.42324   0.002824859 
+  346          373.94439    250.15182   0.002890173 
+  368          366.55551    249.88104   0.002717391 
+  332          360.06856    249.61093   0.003012048 
+  348          355.49432    249.34145   0.002873563 
+  359          353.0656     249.07263   0.002785515 
+  324          348.59544    248.80445   0.00308642 
+  321          340.01203    248.53692   0.003115265 
+  316          332.4479     248.27003   0.003164557 
+  300          327.89642    248.00377   0.003333333 
+  304          323.54923    247.73816   0.003289474 
+  341          317.53958    247.47318   0.002932551 
+  272          311.90338    247.20884   0.003676471 
+  313          307.37655    246.94514   0.003194888 
+  294          303.67656    246.68206   0.003401361 
+  279          300.52171    246.41961   0.003584229 
+  304          297.76318    246.1578    0.003289474 
+  286          295.33645    245.89661   0.003496503 
+  293          293.19115    245.63604   0.003412969 
+  267          291.28202    245.3761    0.003745318 
+  251          289.54481    245.11678   0.003984064 
+  285          287.91233    244.85808   0.003508772 
+  249          286.3303     244.6       0.004016064 
+  299          284.76497    244.34254   0.003344482 
+  286          283.20974    244.08569   0.003496503 
+  269          281.67324    243.82946   0.003717472 
+  268          280.17519    243.57384   0.003731343 
+  265          278.7233     243.31883   0.003773585 
+  281          277.32769    243.06443   0.003558719 
+  253          276.03562    242.81063   0.003952569 
+  265          274.87259    242.55744   0.003773585 
+  307          273.84164    242.30486   0.003257329 
+  274          272.94097    242.05287   0.003649635 
+  256          272.19629    241.80149   0.00390625 
+  244          271.62066    241.55071   0.004098361 
+  257          271.2295     241.30052   0.003891051 
+  233          271.0664     241.05093   0.004291845 
+  269          271.17434    240.80194   0.003717472 
+  287          271.44382    240.55354   0.003484321 
+  273          271.5699     240.30573   0.003663004 
+  273          271.90514    240.05851   0.003663004 
+  255          273.07831    239.81188   0.003921569 
+  275          274.91732    239.56583   0.003636364 
+  284          275.38483    239.32037   0.003521127 
+  281          273.80748    239.07549   0.003558719 
+  291          272.72849    238.8312    0.003436426 
+  251          272.96153    238.58748   0.003984064 
+  291          273.50021    238.34434   0.003436426 
+  275          274.20249    238.10179   0.003636364 
+  326          276.80567    237.8598    0.003067485 
+  340          283.06456    237.61839   0.002941176 
+  342          295.2611     237.37756   0.002923977 
+  334          313.96383    237.13729   0.002994012 
+  394          329.83689    236.8976    0.002538071 
+  402          324.99896    236.65847   0.002487562 
+  400          313.73964    236.41991   0.0025    
+  391          308.35715    236.18191   0.002557545 
+  389          305.35672    235.94448   0.002570694 
+  424          295.06694    235.70761   0.002358491 
+  381          283.08532    235.4713    0.002624672 
+  312          274.02687    235.23555   0.003205128 
+  362          268.17041    235.00035   0.002762431 
+  289          264.7817     234.76572   0.003460208 
+  302          263.01       234.53163   0.003311258 
+  270          262.45019    234.2981    0.003703704 
+  254          263.12322    234.06513   0.003937008 
+  279          265.12813    233.8327    0.003584229 
+  258          267.83952    233.60082   0.003875969 
+  268          270.36216    233.36948   0.003731343 
+  275          269.60429    233.1387    0.003636364 
+  282          267.42867    232.90845   0.003546099 
+  268          266.88156    232.67875   0.003731343 
+  276          267.48981    232.44959   0.003623188 
+  265          267.18224    232.22098   0.003773585 
+  290          266.7527     231.99289   0.003448276 
+  268          267.93306    231.76535   0.003731343 
+  266          271.10714    231.53834   0.003759398 
+  276          276.95528    231.31187   0.003623188 
+  300          287.50414    231.08592   0.003333333 
+  302          307.66676    230.86051   0.003311258 
+  327          346.27498    230.63563   0.003058104 
+  398          403.63082    230.41128   0.002512563 
+  464          467.35562    230.18745   0.002155172 
+  437          499.29404    229.96415   0.00228833 
+  370          450.62148    229.74137   0.002702703 
+  379          421.45381    229.51912   0.002638522 
+  411          417.53111    229.29739   0.00243309 
+  421          406.47441    229.07617   0.002375297 
+  344          359.11822    228.85548   0.002906977 
+  272          322.46819    228.6353    0.003676471 
+  297          300.89887    228.41564   0.003367003 
+  291          286.435      228.19649   0.003436426 
+  282          277.47528    227.97785   0.003546099 
+  266          272.19766    227.75973   0.003759398 
+  292          269.11756    227.54211   0.003424658 
+  275          267.38323    227.32501   0.003636364 
+  272          266.55601    227.10841   0.003676471 
+  291          266.42588    226.89231   0.003436426 
+  289          266.79737    226.67673   0.003460208 
+  281          267.22338    226.46164   0.003558719 
+  226          267.59332    226.24706   0.004424779 
+  272          268.3081     226.03297   0.003676471 
+  278          269.45221    225.81939   0.003597122 
+  253          270.81102    225.6063    0.003952569 
+  277          272.30298    225.39371   0.003610108 
+  266          274.12998    225.18162   0.003759398 
+  320          276.40765    224.97002   0.003125  
+  281          279.20717    224.75891   0.003558719 
+  290          282.66993    224.54829   0.003448276 
+  286          287.14364    224.33816   0.003496503 
+  304          293.25347    224.12852   0.003289474 
+  303          301.54826    223.91936   0.00330033 
+  305          310.27948    223.7107    0.003278689 
+  315          314.84565    223.50251   0.003174603 
+  342          318.14686    223.29481   0.002923977 
+  309          325.74591    223.08759   0.003236246 
+  322          339.49585    222.88085   0.00310559 
+  330          360.49918    222.67459   0.003030303 
+  395          390.5722     222.46881   0.002531646 
+  430          424.95486    222.26351   0.002325581 
+  420          447.23498    222.05868   0.002380952 
+  428          429.88559    221.85432   0.002336449 
+  426          421.2559     221.65043   0.002347418 
+  447          431.23883    221.44702   0.002237136 
+  415          446.22577    221.24408   0.002409639 
+  415          444.83598    221.0416    0.002409639 
+  421          447.70321    220.8396    0.002375297 
+  414          464.52933    220.63806   0.002415459 
+  503          493.18517    220.43698   0.001988072 
+  518          531.77241    220.23637   0.001930502 
+  629          580.44064    220.03622   0.001589825 
+  714          644.92389    219.83653   0.00140056 
+  800          733.4341     219.6373    0.00125   
+  901          856.97296    219.43853   0.001109878 
+  1030         1034.65362   219.24022   0.000970874 
+  1322         1305.65429   219.04236   0.00075643 
+  1868         1755.07067   218.84496   0.000535332 
+  2802         2594.79339   218.64801   0.000356888 
+  4572         4328.87545   218.45151   0.000218723 
+  8169         7635.58494   218.25547   0.000122414 
+  13383        11735.20032  218.05987   0.000074722 
+  17278        15637.94223  217.86472   0.000057877 
+  13923        12889.44733  217.67002   0.000071824 
+  8773         9034.53954   217.47577   0.000113986 
+  8055         8275.48192   217.28196   0.000124146 
+  9083         9036.88805   217.0886    0.000110096 
+  7459         7357.15424   216.89567   0.000134066 
+  3830         4204.85686   216.70319   0.000261097 
+  2082         2456.73393   216.51115   0.000480307 
+  1271         1638.49883   216.31955   0.000786782 
+  943          1217.64845   216.12838   0.001060445 
+  764          967.84991    215.93766   0.001308901 
+  640          804.91477    215.74736   0.0015625 
+  551          692.32343    215.5575    0.001814882 
+  520          611.35472    215.36808   0.001923077 
+  470          551.63744    215.17908   0.00212766 
+  410          507.25479    214.99052   0.002439024 
+  424          475.19735    214.80238   0.002358491 
+  412          454.94225    214.61468   0.002427184 
+  439          448.25564    214.4274    0.002277904 
+  375          454.66476    214.24055   0.002666667 
+  417          454.78114    214.05412   0.002398082 
+  345          434.73854    213.86811   0.002898551 
+  385          413.65907    213.68253   0.002597403 
+  387          405.17893    213.49736   0.002583979 
+  372          398.0105     213.31262   0.002688172 
+  360          375.76854    213.1283    0.002777778 
+  313          350.73962    212.94439   0.003194888 
+  346          332.56673    212.7609    0.002890173 
+  283          319.76357    212.57783   0.003533569 
+  309          307.19625    212.39517   0.003236246 
+  298          296.17796    212.21292   0.003355705 
+  294          287.95354    212.03109   0.003401361 
+  245          281.86574    211.84966   0.004081633 
+  286          277.19601    211.66865   0.003496503 
+  285          273.49433    211.48804   0.003508772 
+  271          270.49852    211.30784   0.003690037 
+  278          268.04563    211.12805   0.003597122 
+  286          266.01232    210.94866   0.003496503 
+  255          264.28886    210.76968   0.003921569 
+  246          262.76875    210.5911    0.004065041 
+  281          261.35831    210.41292   0.003558719 
+  266          259.99409    210.23515   0.003759398 
+  246          258.65564    210.05777   0.004065041 
+  256          257.36214    209.88079   0.00390625 
+  217          256.16114    209.70421   0.004608295 
+  231          255.12293    209.52802   0.004329004 
+  244          254.35202    209.35223   0.004098361 
+  242          254.02034    209.17683   0.004132231 
+  239          254.42467    209.00183   0.0041841 
+  245          256.04703    208.82722   0.004081633 
+  237          259.38146    208.653     0.004219409 
+  265          263.32225    208.47917   0.003773585 
+  235          263.2836     208.30572   0.004255319 
+  260          259.74412    208.13267   0.003846154 
+  245          257.21619    207.96      0.004081633 
+  246          255.99399    207.78772   0.004065041 
+  224          254.05771    207.61582   0.004464286 
+  228          250.68376    207.44431   0.004385965 
+  224          247.09524    207.27317   0.004464286 
+  205          244.27664    207.10242   0.004878049 
+  255          242.06345    206.93205   0.003921569 
+  221          240.46621    206.76206   0.004524887 
+  233          239.60613    206.59245   0.004291845 
+  234          239.03883    206.42321   0.004273504 
+  244          239.00561    206.25435   0.004098361 
+  212          239.63785    206.08586   0.004716981 
+  223          241.02718    205.91775   0.004484305 
+  222          242.75958    205.75001   0.004504505 
+  236          244.0638     205.58265   0.004237288 
+  217          245.50365    205.41565   0.004608295 
+  248          248.37616    205.24902   0.004032258 
+  274          253.01424    205.08277   0.003649635 
+  272          260.53103    204.91688   0.003676471 
+  287          274.56236    204.75135   0.003484321 
+  317          302.05533    204.5862    0.003154574 
+  353          346.28255    204.4214    0.002832861 
+  392          395.18577    204.25697   0.00255102 
+  447          419.69607    204.09291   0.002237136 
+  456          394.47698    203.9292    0.002192982 
+  355          383.90205    203.76586   0.002816901 
+  363          380.44995    203.60288   0.002754821 
+  362          371.42867    203.44025   0.002762431 
+  323          342.43129    203.27798   0.003095975 
+  302          315.56102    203.11607   0.003311258 
+  294          299.7172     202.95452   0.003401361 
+  258          286.23298    202.79331   0.003875969 
+  238          278.74444    202.63247   0.004201681 
+  276          278.85371    202.47197   0.003623188 
+  262          279.20076    202.31183   0.003816794 
+  274          272.80247    202.15204   0.003649635 
+  254          266.67532    201.9926    0.003937008 
+  270          262.94479    201.83351   0.003703704 
+  265          259.561      201.67476   0.003773585 
+  241          253.6357     201.51636   0.004149378 
+  231          247.03383    201.35831   0.004329004 
+  239          242.17854    201.2006    0.0041841 
+  226          237.98444    201.04324   0.004424779 
+  250          234.78589    200.88622   0.004     
+  229          232.2914     200.72954   0.004366812 
+  211          231.19825    200.57321   0.004739336 
+  219          230.69455    200.41721   0.00456621 
+  222          230.61841    200.26156   0.004504505 
+  221          230.64222    200.10624   0.004524887 
+  227          231.21744    199.95126   0.004405286 
+  219          231.8324     199.79661   0.00456621 
+  207          232.33638    199.6423    0.004830918 
+  232          233.04105    199.48833   0.004310345 
+  226          234.12104    199.33469   0.004424779 
+  232          235.57198    199.18138   0.004310345 
+  210          237.36417    199.02841   0.004761905 
+  222          239.83107    198.87576   0.004504505 
+  210          243.56408    198.72345   0.004761905 
+  224          249.07545    198.57146   0.004464286 
+  281          255.26889    198.4198    0.003558719 
+  233          257.6459     198.26847   0.004291845 
+  228          256.66499    198.11747   0.004385965 
+  229          257.17138    197.96679   0.004366812 
+  238          260.17777    197.81644   0.004201681 
+  244          263.66401    197.66641   0.004098361 
+  265          265.61626    197.5167    0.003773585 
+  268          267.9407     197.36732   0.003731343 
+  250          272.09427    197.21825   0.004     
+  263          278.30109    197.06951   0.003802281 
+  308          286.9051     196.92108   0.003246753 
+  293          298.83566    196.77298   0.003412969 
+  314          315.69238    196.62519   0.003184713 
+  301          338.34169    196.47771   0.003322259 
+  312          359.88596    196.33056   0.003205128 
+  350          368.12435    196.18372   0.002857143 
+  341          372.33588    196.03719   0.002932551 
+  408          383.54282    195.89097   0.00245098 
+  355          400.84902    195.74507   0.002816901 
+  358          415.85618    195.59948   0.002793296 
+  385          425.30392    195.4542    0.002597403 
+  420          435.25325    195.30923   0.002380952 
+  469          447.72515    195.16456   0.002132196 
+  499          462.22203    195.02021   0.002004008 
+  502          478.13006    194.87616   0.001992032 
+  529          494.86314    194.73242   0.001890359 
+  526          511.67979    194.58899   0.001901141 
+  541          527.75954    194.44585   0.001848429 
+  546          542.46305    194.30303   0.001831502 
+  561          555.71645    194.1605    0.001782531 
+  534          568.18306    194.01828   0.001872659 
+  549          580.91632    193.87636   0.001821494 
+  567          594.5995     193.73474   0.001763668 
+  580          608.15142    193.59341   0.001724138 
+  568          613.97611    193.45239   0.001760563 
+  604          611.69643    193.31166   0.001655629 
+  596          607.34846    193.17124   0.001677852 
+  567          600.81428    193.0311    0.001763668 
+  456          589.12138    192.89127   0.002192982 
+  513          568.95496    192.75173   0.001949318 
+  513          544.06286    192.61248   0.001949318 
+  465          517.47889    192.47352   0.002150538 
+  452          489.92112    192.33486   0.002212389 
+  410          462.00238    192.19649   0.002439024 
+  384          434.60319    192.0584    0.002604167 
+  378          408.6358     191.92061   0.002645503 
+  340          384.80489    191.78311   0.002941176 
+  386          363.48644    191.64589   0.002590674 
+  372          344.7674     191.50897   0.002688172 
+  319          328.54673    191.37233   0.003134796 
+  313          314.60438    191.23597   0.003194888 
+  287          302.71333    191.0999    0.003484321 
+  273          292.68883    190.96411   0.003663004 
+  269          284.36776    190.82861   0.003717472 
+  273          277.78425    190.69339   0.003663004 
+  257          273.18255    190.55845   0.003891051 
+  260          271.00068    190.42379   0.003846154 
+  295          270.98147    190.28942   0.003389831 
+  267          269.22259    190.15532   0.003745318 
+  283          262.45801    190.0215    0.003533569 
+  244          255.54717    189.88796   0.004098361 
+  253          251.44586    189.7547    0.003952569 
+  243          249.26693    189.62171   0.004115226 
+  239          245.87275    189.489     0.0041841 
+  242          240.90362    189.35656   0.004132231 
+  224          236.67613    189.2244    0.004464286 
+  205          233.67244    189.09251   0.004878049 
+  257          231.58014    188.96089   0.003891051 
+  231          230.12238    188.82955   0.004329004 
+  196          229.14739    188.69847   0.005102041 
+  239          228.57262    188.56767   0.0041841 
+  214          228.3508     188.43713   0.004672897 
+  231          228.44281    188.30687   0.004329004 
+  222          228.80363    188.17687   0.004504505 
+  259          229.37715    188.04714   0.003861004 
+  212          230.12668    187.91768   0.004716981 
+  222          231.0913     187.78848   0.004504505 
+  199          232.42463    187.65955   0.005025126 
+  213          234.10433    187.53089   0.004694836 
+  215          234.66085    187.40248   0.004651163 
+  234          232.43796    187.27434   0.004273504 
+  234          229.47797    187.14646   0.004273504 
+  221          227.44593    187.01885   0.004524887 
+  212          226.27183    186.89149   0.004716981 
+  207          224.82809    186.7644    0.004830918 
+  220          222.8595     186.63756   0.004545455 
+  222          221.69687    186.51098   0.004504505 
+  222          221.61851    186.38466   0.004504505 
+  221          221.09889    186.2586    0.004524887 
+  215          219.50628    186.1328    0.004651163 
+  207          218.8213     186.00725   0.004830918 
+  229          220.26652    185.88195   0.004366812 
+  227          223.9938     185.75692   0.004405286 
+  239          228.18131    185.63213   0.0041841 
+  211          228.90692    185.5076    0.004739336 
+  215          226.79445    185.38332   0.004651163 
+  226          224.8288     185.25929   0.004424779 
+  205          223.72775    185.13551   0.004878049 
+  236          224.42543    185.01198   0.004237288 
+  214          225.71366    184.88871   0.004672897 
+  222          227.83482    184.76568   0.004504505 
+  214          227.97439    184.6429    0.004672897 
+  216          223.29564    184.52037   0.00462963 
+  219          218.66726    184.39808   0.00456621 
+  225          216.91486    184.27604   0.004444444 
+  229          217.34835    184.15425   0.004366812 
+  224          217.24835    184.0327    0.004464286 
+  229          215.72619    183.9114    0.004366812 
+  238          215.06505    183.79033   0.004201681 
+  237          216.30552    183.66952   0.004219409 
+  255          219.8808     183.54894   0.003921569 
+  223          226.84351    183.42861   0.004484305 
+  277          239.54293    183.30852   0.003610108 
+  278          261.6266     183.18866   0.003597122 
+  316          298.13513    183.06905   0.003164557 
+  338          344.22478    182.94968   0.00295858 
+  345          343.56882    182.83054   0.002898551 
+  310          308.85619    182.71164   0.003225806 
+  303          287.03388    182.59298   0.00330033 
+  292          286.12777    182.47456   0.003424658 
+  291          294.54977    182.35637   0.003436426 
+  299          279.3248     182.23842   0.003344482 
+  287          255.61922    182.1207    0.003484321 
+  266          239.61695    182.00321   0.003759398 
+  239          231.91142    181.88596   0.0041841 
+  224          228.91293    181.76894   0.004464286 
+  235          225.7885     181.65216   0.004255319 
+  215          222.03231    181.5356    0.004651163 
+  233          218.88294    181.41927   0.004291845 
+  231          217.24459    181.30318   0.004329004 
+  231          216.74039    181.18731   0.004329004 
+  232          215.91458    181.07168   0.004310345 
+  261          215.2415     180.95627   0.003831418 
+  207          215.42725    180.84109   0.004830918 
+  224          216.3781     180.72614   0.004464286 
+  217          216.15247    180.61141   0.004608295 
+  214          214.6299     180.49691   0.004672897 
+  222          213.7829     180.38263   0.004504505 
+  200          214.07453    180.26858   0.005     
+  211          214.82328    180.15475   0.004739336 
+  199          214.73557    180.04115   0.005025126 
+  229          213.98601    179.92777   0.004366812 
+  189          213.43349    179.81461   0.005291005 
+  199          213.19274    179.70167   0.005025126 
+  212          213.1598     179.58895   0.004716981 
+  217          213.26809    179.47646   0.004608295 
+  207          213.50587    179.36418   0.004830918 
+  218          213.90069    179.25212   0.004587156 
+  183          214.51339    179.14028   0.005464481 
+  232          215.44303    179.02866   0.004310345 
+  228          216.85043    178.91726   0.004385965 
+  240          218.96697    178.80607   0.004166667 
+  228          221.91722    178.6951    0.004385965 
+  211          224.82907    178.58435   0.004739336 
+  235          225.99339    178.47381   0.004255319 
+  231          226.44633    178.36349   0.004329004 
+  221          227.30363    178.25338   0.004524887 
+  222          229.52521    178.14348   0.004504505 
+  218          231.84133    178.03379   0.004587156 
+  236          233.25721    177.92432   0.004237288 
+  257          234.33411    177.81506   0.003891051 
+  196          235.50018    177.70601   0.005102041 
+  236          237.2612     177.59717   0.004237288 
+  253          239.36019    177.48855   0.003952569 
+  233          241.80222    177.38013   0.004291845 
+  217          244.6429     177.27192   0.004608295 
+  247          247.97849    177.16392   0.004048583 
+  265          251.93116    177.05612   0.003773585 
+  267          256.64329    176.94853   0.003745318 
+  262          262.28116    176.84115   0.003816794 
+  246          269.03964    176.73398   0.004065041 
+  275          277.16466    176.62701   0.003636364 
+  318          286.99681    176.52025   0.003144654 
+  319          299.03813    176.41369   0.003134796 
+  326          314.07008    176.30734   0.003067485 
+  321          333.30426    176.20119   0.003115265 
+  358          358.3243     176.09524   0.002793296 
+  370          389.41766    175.98949   0.002702703 
+  400          421.6302     175.88395   0.0025    
+  474          453.93071    175.77861   0.002109705 
+  526          496.98654    175.67346   0.001901141 
+  531          558.99219    175.56852   0.001883239 
+  561          646.54955    175.46378   0.001782531 
+  694          768.61961    175.35924   0.001440922 
+  858          946.69363    175.25489   0.001165501 
+  1094         1230.0321    175.15075   0.000914077 
+  1521         1725.37358   175.0468    0.000657462 
+  2431         2714.57972   174.94305   0.000411353 
+  4201         4877.03373   174.8395    0.000238039 
+  7289         9045.01538   174.73614   0.000137193 
+  10359        12004.1711   174.63298   0.000096534 
+  10041        8490.45675   174.53001   0.000099592 
+  6358         5270.18367   174.42724   0.000157282 
+  4502         4536.06973   174.32466   0.000222124 
+  4823         5777.9129    174.22227   0.00020734 
+  5761         6700.46182   174.12008   0.000173581 
+  5140         4536.69508   174.01808   0.000194553 
+  3158         2556.74275   173.91627   0.000316656 
+  1699         1567.74884   173.81466   0.000588582 
+  1103         1092.53565   173.71323   0.000906618 
+  806          834.80136    173.612     0.001240695 
+  633          676.24517    173.51095   0.001579779 
+  538          570.61209    173.4101    0.001858736 
+  462          496.38647    173.30943   0.002164502 
+  413          442.12908    173.20896   0.002421308 
+  406          401.22341    173.10867   0.002463054 
+  363          369.63786    173.00857   0.002754821 
+  335          344.8048     172.90865   0.002985075 
+  314          325.04461    172.80892   0.003184713 
+  343          309.24153    172.70938   0.002915452 
+  303          296.6833     172.61003   0.00330033 
+  280          287.00226    172.51086   0.003571429 
+  301          280.20289    172.41187   0.003322259 
+  320          276.82197    172.31307   0.003125  
+  323          278.13822    172.21445   0.003095975 
+  309          285.88842    172.11602   0.003236246 
+  299          298.36659    172.01777   0.003344482 
+  277          301.377      171.9197    0.003610108 
+  245          287.88812    171.82181   0.004081633 
+  278          275.11303    171.7241    0.003597122 
+  276          272.23595    171.62658   0.003623188 
+  250          278.97848    171.52924   0.004     
+  297          288.98024    171.43207   0.003367003 
+  296          299.08666    171.33509   0.003378378 
+  309          311.29336    171.23828   0.003236246 
+  298          306.52853    171.14166   0.003355705 
+  257          282.58563    171.04521   0.003891051 
+  245          263.42478    170.94894   0.004081633 
+  305          256.76425    170.85284   0.003278689 
+  217          257.92769    170.75693   0.004608295 
+  236          253.04333    170.66119   0.004237288 
+  239          237.88309    170.56562   0.0041841 
+  214          223.55702    170.47023   0.004672897 
+  227          213.84297    170.37502   0.004405286 
+  189          207.53957    170.27998   0.005291005 
+  232          203.26466    170.18512   0.004310345 
+  225          200.16472    170.09043   0.004444444 
+  212          197.77694    169.99591   0.004716981 
+  203          195.85196    169.90157   0.004926108 
+  203          194.24977    169.80739   0.004926108 
+  200          192.88473    169.7134    0.005     
+  180          191.70154    169.61957   0.005555556 
+  195          190.66106    169.52591   0.005128205 
+  206          189.74039    169.43242   0.004854369 
+  221          188.91965    169.33911   0.004524887 
+  190          188.18548    169.24596   0.005263158 
+  225          187.52732    169.15299   0.004444444 
+  201          186.93994    169.06018   0.004975124 
+  208          186.41857    168.96754   0.004807692 
+  181          185.96075    168.87507   0.005524862 
+  168          185.56638    168.78277   0.005952381 
+  205          185.23771    168.69063   0.004878049 
+  192          184.98154    168.59866   0.005208333 
+  204          184.81067    168.50686   0.004901961 
+  192          184.74997    168.41523   0.005208333 
+  199          184.84173    168.32376   0.005025126 
+  203          185.1303     168.23245   0.004926108 
+  209          185.53042    168.14131   0.004784689 
+  206          185.64937    168.05034   0.004854369 
+  191          185.36684    167.95953   0.005235602 
+  187          185.09989    167.86888   0.005347594 
+  172          185.10708    167.77839   0.005813953 
+  201          185.37469    167.68807   0.004975124 
+  195          185.72138    167.59792   0.005128205 
+  178          186.04455    167.50792   0.005617978 
+  202          186.57779    167.41808   0.004950495 
+  191          187.56528    167.32841   0.005235602 
+  210          189.21448    167.2389    0.004761905 
+  179          191.86332    167.14955   0.005586592 
+  217          196.19645    167.06035   0.004608295 
+  202          203.51263    166.97132   0.004950495 
+  224          215.89645    166.88245   0.004464286 
+  220          234.84513    166.79374   0.004545455 
+  228          252.94162    166.70518   0.004385965 
+  226          250.87313    166.61678   0.004424779 
+  226          234.96886    166.52855   0.004424779 
+  244          224.38501    166.44046   0.004098361 
+  233          223.26763    166.35254   0.004291845 
+  202          227.37154    166.26477   0.004950495 
+  185          225.4444     166.17716   0.005405405 
+  195          215.89338    166.0897    0.005128205 
+  205          208.27974    166.0024    0.004878049 
+  184          205.27046    165.91526   0.005434783 
+  208          206.22143    165.82827   0.004807692 
+  198          210.22716    165.74143   0.005050505 
+  203          211.58879    165.65475   0.004926108 
+  214          206.47184    165.56822   0.004672897 
+  228          200.99631    165.48185   0.004385965 
+  211          198.54088    165.39563   0.004739336 
+  224          199.03871    165.30956   0.004464286 
+  238          199.92406    165.22364   0.004201681 
+  217          197.99972    165.13788   0.004608295 
+  191          195.58376    165.05227   0.005235602 
+  213          195.24751    164.9668    0.004694836 
+  199          197.36114    164.88149   0.005025126 
+  217          201.13506    164.79633   0.004608295 
+  202          204.59686    164.71132   0.004950495 
+  251          208.842      164.62646   0.003984064 
+  244          217.68116    164.54175   0.004098361 
+  246          232.70275    164.45719   0.004065041 
+  261          249.008      164.37277   0.003831418 
+  231          254.06336    164.28851   0.004329004 
+  240          246.53541    164.20439   0.004166667 
+  264          241.61879    164.12042   0.003787879 
+  238          247.37277    164.0366    0.004201681 
+  270          263.29687    163.95292   0.003703704 
+  257          281.60452    163.86939   0.003891051 
+  283          290.79664    163.78601   0.003533569 
+  280          294.15977    163.70277   0.003571429 
+  285          296.69329    163.61968   0.003508772 
+  278          302.64526    163.53674   0.003597122 
+  320          327.66172    163.45394   0.003125  
+  368          385.34467    163.37128   0.002717391 
+  412          495.93533    163.28877   0.002427184 
+  552          662.82197    163.2064    0.001811594 
+  608          730.36696    163.12418   0.001644737 
+  580          583.58386    163.0421    0.001724138 
+  496          453.64925    162.96016   0.002016129 
+  379          414.79699    162.87836   0.002638522 
+  393          449.21408    162.79671   0.002544529 
+  400          492.11484    162.7152    0.0025    
+  393          430.68897    162.63383   0.002544529 
+  344          340.29182    162.5526    0.002906977 
+  271          285.34283    162.47152   0.003690037 
+  263          256.30588    162.39057   0.003802281 
+  250          242.14037    162.30976   0.004     
+  228          237.58748    162.2291    0.004385965 
+  213          241.65492    162.14857   0.004694836 
+  257          257.83307    162.06818   0.003891051 
+  256          297.82759    161.98794   0.00390625 
+  357          378.91352    161.90783   0.00280112 
+  431          449.00462    161.82786   0.002320186 
+  383          388.51828    161.74803   0.002610966 
+  344          322.11312    161.66833   0.002906977 
+  340          310.46763    161.58878   0.002941176 
+  335          347.75836    161.50936   0.002985075 
+  403          407.91034    161.43007   0.00248139 
+  382          393.44168    161.35093   0.002617801 
+  342          322.12039    161.27192   0.002923977 
+  275          273.16297    161.19304   0.003636364 
+  233          253.04008    161.11431   0.004291845 
+  232          249.80909    161.0357    0.004310345 
+  227          246.07313    160.95724   0.004405286 
+  238          230.94658    160.87891   0.004201681 
+  193          213.4686     160.80071   0.005181347 
+  188          201.40148    160.72264   0.005319149 
+  170          194.36768    160.64472   0.005882353 
+  203          190.57675    160.56692   0.004926108 
+  174          188.60109    160.48926   0.005747126 
+  186          186.99143    160.41173   0.005376344 
+  174          185.42383    160.33433   0.005747126 
+  174          184.627      160.25707   0.005747126 
+  187          184.83158    160.17994   0.005347594 
+  207          185.99262    160.10294   0.004830918 
+  209          187.93873    160.02607   0.004784689 
+  203          190.69611    159.94933   0.004926108 
+  171          195.25209    159.87273   0.005847953 
+  204          203.13364    159.79625   0.004901961 
+  234          216.765      159.71991   0.004273504 
+  198          241.31416    159.64369   0.005050505 
+  247          279.64013    159.56761   0.004048583 
+  294          327.28821    159.49165   0.003401361 
+  286          345.12859    159.41583   0.003496503 
+  288          313.47185    159.34013   0.003472222 
+  288          278.0719     159.26457   0.003472222 
+  239          263.78047    159.18913   0.0041841 
+  239          268.21333    159.11382   0.0041841 
+  217          275.57932    159.03864   0.004608295 
+  234          260.9315     158.96358   0.004273504 
+  185          233.63019    158.88865   0.005405405 
+  217          212.34066    158.81385   0.004608295 
+  185          199.04564    158.73918   0.005405405 
+  180          191.00677    158.66464   0.005555556 
+  176          186.02008    158.59022   0.005681818 
+  194          182.80424    158.51592   0.005154639 
+  154          180.68319    158.44176   0.006493506 
+  177          179.29993    158.36771   0.005649718 
+  198          178.46075    158.2938    0.005050505 
+  196          178.06908    158.22001   0.005102041 
+  191          178.09868    158.14634   0.005235602 
+  157          178.58546    158.0728    0.006369427 
+  167          179.58483    157.99938   0.005988024 
+  180          180.86775    157.92609   0.005555556 
+  178          181.36139    157.85292   0.005617978 
+  182          180.64142    157.77987   0.005494505 
+  175          179.83981    157.70695   0.005714286 
+  202          179.52226    157.63415   0.004950495 
+  185          179.71244    157.56147   0.005405405 
+  187          180.13378    157.48892   0.005347594 
+  170          180.36782    157.41649   0.005882353 
+  196          180.86161    157.34418   0.005102041 
+  170          181.85383    157.27199   0.005882353 
+  219          181.8151     157.19993   0.00456621 
+  215          179.97825    157.12798   0.004651163 
+  207          178.16854    157.05616   0.004830918 
+  251          177.36074    156.98446   0.003984064 
+  247          177.55854    156.91287   0.004048583 
+  253          178.2441     156.84141   0.003952569 
+  273          178.55747    156.77007   0.003663004 
+  260          179.01884    156.69885   0.003846154 
+  285          180.53932    156.62775   0.003508772 
+  292          182.27248    156.55676   0.003424658 
+  300          182.49281    156.4859    0.003333333 
+  273          182.49825    156.41516   0.003663004 
+  254          184.18434    156.34453   0.003937008 
+  278          188.4191     156.27402   0.003597122 
+  261          196.24924    156.20363   0.003831418 
+  315          206.93239    156.13336   0.003174603 
+  252          213.67172    156.06321   0.003968254 
+  236          208.58807    155.99318   0.004237288 
+  229          199.25805    155.92326   0.004366812 
+  230          193.96208    155.85346   0.004347826 
+  232          193.88084    155.78377   0.004310345 
+  192          197.12845    155.7142    0.005208333 
+  205          198.23488    155.64475   0.004878049 
+  205          195.03266    155.57542   0.004878049 
+  184          191.34982    155.5062    0.005434783 
+  197          188.5072     155.4371    0.005076142 
+  212          187.07214    155.36811   0.004716981 
+  190          186.06981    155.29924   0.005263158 
+  199          185.45983    155.23048   0.005025126 
+  167          186.27463    155.16184   0.005988024 
+  188          188.42898    155.09331   0.005319149 
+  182          192.52502    155.0249    0.005494505 
+  193          199.69989    154.9566    0.005181347 
+  219          209.07081    154.88841   0.00456621 
+  191          214.06803    154.82034   0.005235602 
+  221          208.59409    154.75239   0.004524887 
+  223          200.81768    154.68454   0.004484305 
+  219          197.11942    154.61681   0.00456621 
+  231          197.88804    154.54919   0.004329004 
+  200          200.96336    154.48169   0.005     
+  221          201.04952    154.41429   0.004524887 
+  237          197.04083    154.34701   0.004219409 
+  220          193.45234    154.27985   0.004545455 
+  204          191.83379    154.21279   0.004901961 
+  180          191.8052     154.14585   0.005555556 
+  215          192.92294    154.07901   0.004651163 
+  226          194.99741    154.01229   0.004424779 
+  202          198.04661    153.94568   0.004950495 
+  227          202.12159    153.87918   0.004405286 
+  228          206.66819    153.81279   0.004385965 
+  234          210.35883    153.74651   0.004273504 
+  219          213.70554    153.68034   0.00456621 
+  191          218.17485    153.61429   0.005235602 
+  244          224.22363    153.54834   0.004098361 
+  279          231.84289    153.4825    0.003584229 
+  259          240.58303    153.41677   0.003861004 
+  277          249.9523     153.35115   0.003610108 
+  254          260.55513    153.28564   0.003937008 
+  289          272.94889    153.22024   0.003460208 
+  319          287.15496    153.15495   0.003134796 
+  314          303.069      153.08976   0.003184713 
+  344          320.71072    153.02468   0.002906977 
+  350          340.3476     152.95972   0.002857143 
+  355          361.6328     152.89486   0.002816901 
+  347          380.20038    152.8301    0.002881844 
+  399          389.77638    152.76546   0.002506266 
+  388          392.12982    152.70092   0.00257732 
+  380          393.87309    152.63649   0.002631579 
+  412          399.2892     152.57217   0.002427184 
+  427          401.71501    152.50795   0.00234192 
+  383          394.9582     152.44384   0.002610966 
+  351          382.60063    152.37984   0.002849003 
+  339          367.70099    152.31594   0.002949853 
+  318          352.93976    152.25215   0.003144654 
+  327          340.57817    152.18847   0.003058104 
+  300          326.94678    152.12489   0.003333333 
+  264          311.43781    152.06142   0.003787879 
+  304          296.82447    151.99805   0.003289474 
+  289          282.65903    151.93478   0.003460208 
+  268          269.63794    151.87163   0.003731343 
+  269          258.1014     151.80857   0.003717472 
+  237          247.91373    151.74562   0.004219409 
+  235          238.82669    151.68278   0.004255319 
+  212          230.56561    151.62004   0.004716981 
+  214          223.38867    151.55741   0.004672897 
+  255          217.10281    151.49487   0.003921569 
+  221          211.65748    151.43245   0.004524887 
+  240          206.98606    151.37012   0.004166667 
+  228          203.02331    151.3079    0.004385965 
+  209          199.70707    151.24578   0.004784689 
+  230          196.98233    151.18377   0.004347826 
+  226          194.80022    151.12186   0.004424779 
+  183          193.1829     151.06005   0.005464481 
+  205          192.26041    150.99834   0.004878049 
+  217          192.20785    150.93674   0.004608295 
+  196          192.9988     150.87524   0.005102041 
+  213          193.64766    150.81384   0.004694836 
+  196          193.38246    150.75254   0.005102041 
+  192          193.23064    150.69135   0.005208333 
+  216          193.65571    150.63025   0.00462963 
+  190          193.16511    150.56926   0.005263158 
+  209          192.15296    150.50837   0.004784689 
+  175          191.43479    150.44758   0.005714286 
+  229          190.9627     150.38689   0.004366812 
+  230          191.38261    150.3263    0.004347826 
+  226          192.38038    150.26582   0.004424779 
+  236          193.34075    150.20543   0.004237288 
+  221          194.91627    150.14514   0.004524887 
+  231          198.17516    150.08496   0.004329004 
+  225          204.10264    150.02487   0.004444444 
+  237          214.57347    149.96488   0.004219409 
+  240          233.33299    149.905     0.004166667 
+  285          266.01147    149.84521   0.003508772 
+  297          311.70902    149.78552   0.003367003 
+  312          333.872      149.72593   0.003205128 
+  353          305.57096    149.66644   0.002832861 
+  292          274.79367    149.60705   0.003424658 
+  291          266.11213    149.54776   0.003436426 
+  284          277.24854    149.48857   0.003521127 
+  267          293.33616    149.42947   0.003745318 
+  250          287.97727    149.37047   0.004     
+  299          259.19554    149.31158   0.003344482 
+  244          234.48531    149.25278   0.004098361 
+  242          221.73086    149.19407   0.004132231 
+  247          216.54145    149.13547   0.004048583 
+  211          211.65759    149.07696   0.004739336 
+  223          204.72549    149.01855   0.004484305 
+  206          199.18629    148.96024   0.004854369 
+  197          196.0628     148.90202   0.005076142 
+  188          194.26804    148.84391   0.005319149 
+  197          192.57539    148.78588   0.005076142 
+  196          191.20184    148.72796   0.005102041 
+  218          190.68713    148.67013   0.004587156 
+  226          191.13784    148.6124    0.004424779 
+  205          192.59209    148.55477   0.004878049 
+  241          195.02495    148.49723   0.004149378 
+  256          198.68504    148.43978   0.00390625 
+  210          205.02596    148.38244   0.004761905 
+  225          216.62192    148.32518   0.004444444 
+  270          237.20729    148.26803   0.003703704 
+  279          270.32238    148.21097   0.003584229 
+  313          314.40163    148.154     0.003194888 
+  295          328.84991    148.09713   0.003389831 
+  299          288.76413    148.04036   0.003344482 
+  307          254.89476    147.98368   0.003257329 
+  252          244.1274     147.92709   0.003968254 
+  298          251.18517    147.8706    0.003355705 
+  245          269.85437    147.81421   0.004081633 
+  287          276.99743    147.75791   0.003484321 
+  248          261.48621    147.7017    0.004032258 
+  275          251.61669    147.64559   0.003636364 
+  282          245.86575    147.58957   0.003546099 
+  234          234.01436    147.53364   0.004273504 
+  229          222.0949     147.47781   0.004366812 
+  203          215.79966    147.42207   0.004926108 
+  229          215.18962    147.36643   0.004366812 
+  215          218.39393    147.31088   0.004651163 
+  236          220.55921    147.25542   0.004237288 
+  217          218.16718    147.20005   0.004608295 
+  216          215.84699    147.14478   0.00462963 
+  249          218.08832    147.0896    0.004016064 
+  219          227.57125    147.03452   0.00456621 
+  248          246.40494    146.97952   0.004032258 
+  254          263.1963     146.92462   0.003937008 
+  246          252.97298    146.86981   0.004065041 
+  253          235.76197    146.8151    0.003952569 
+  245          227.94892    146.76047   0.004081633 
+  230          228.96927    146.70594   0.004347826 
+  228          237.28435    146.6515    0.004385965 
+  221          246.22289    146.59715   0.004524887 
+  231          242.44851    146.54289   0.004329004 
+  222          235.10979    146.48873   0.004504505 
+  274          232.46871    146.43465   0.003649635 
+  219          233.526      146.38067   0.00456621 
+  226          236.09318    146.32678   0.004424779 
+  253          239.08229    146.27298   0.003952569 
+  255          242.9937     146.21927   0.003921569 
+  239          248.06221    146.16565   0.0041841 
+  288          253.87681    146.11212   0.003472222 
+  245          260.20388    146.05868   0.004081633 
+  271          267.12684    146.00533   0.003690037 
+  267          274.7028     145.95207   0.003745318 
+  304          283.41626    145.89891   0.003289474 
+  310          293.55971    145.84583   0.003225806 
+  316          305.10292    145.79284   0.003164557 
+  331          318.15194    145.73994   0.003021148 
+  330          333.20861    145.68714   0.003030303 
+  358          350.7905     145.63442   0.002793296 
+  369          371.42066    145.58179   0.002710027 
+  376          395.81285    145.52925   0.002659574 
+  480          424.81286    145.4768    0.002083333 
+  480          458.64855    145.42444   0.002083333 
+  578          497.51757    145.37217   0.001730104 
+  633          544.18549    145.31999   0.001579779 
+  692          602.43513    145.26789   0.001445087 
+  684          676.21668    145.21589   0.001461988 
+  834          770.95436    145.16397   0.001199041 
+  873          894.53807    145.11214   0.001145475 
+  883          1059.16634   145.0604    0.001132503 
+  1154         1286.12083   145.00875   0.000866551 
+  1328         1612.36001   144.95719   0.000753012 
+  1817         2105.9224    144.90571   0.000550358 
+  2649         2907.32156   144.85433   0.000377501 
+  3993         4355.03792   144.80303   0.000250438 
+  6879         7282.15677   144.75182   0.00014537 
+  12069        13267.03295  144.70069   0.000082857 
+  19165        22345.87211  144.64966   0.000052178 
+  22144        23373.37515  144.59871   0.000045159 
+  16400        14879.03655  144.54785   0.000060976 
+  9751         9180.65335   144.49707   0.000102554 
+  7281         7341.59714   144.44639   0.000137344 
+  7853         8474.42497   144.39579   0.00012734 
+  9876         12065.83395  144.34527   0.000101256 
+  11375        13140.7022   144.29485   0.000087912 
+  8819         8645.69154   144.24451   0.000113392 
+  5201         4942.42183   144.19426   0.000192271 
+  2926         3037.33424   144.14409   0.000341763 
+  1758         2086.59132   144.09401   0.000568828 
+  1342         1563.57898   144.04402   0.000745156 
+  1042         1245.25478   143.99411   0.000959693 
+  890          1036.26437   143.94429   0.001123596 
+  771          879.63924    143.89456   0.001297017 
+  631          753.00392    143.84491   0.001584786 
+  642          656.39582    143.79535   0.001557632 
+  509          584.9137     143.74587   0.001964637 
+  479          531.9423     143.69648   0.002087683 
+  448          492.15402    143.64717   0.002232143 
+  390          456.21057    143.59795   0.002564103 
+  411          419.74978    143.54882   0.00243309 
+  345          388.14541    143.49977   0.002898551 
+  317          362.63027    143.4508    0.003154574 
+  342          341.82757    143.40192   0.002923977 
+  337          324.62395    143.35313   0.002967359 
+  305          309.89578    143.30442   0.003278689 
+  281          297.22176    143.2558    0.003558719 
+  277          286.20114    143.20726   0.003610108 
+  271          276.56263    143.1588    0.003690037 
+  278          268.08274    143.11043   0.003597122 
+  292          260.61441    143.06214   0.003424658 
+  243          254.03545    143.01394   0.004115226 
+  277          248.23786    142.96583   0.003610108 
+  256          243.15212    142.91779   0.00390625 
+  239          238.70794    142.86984   0.0041841 
+  225          234.85424    142.82198   0.004444444 
+  233          231.55181    142.7742    0.004291845 
+  218          228.77093    142.7265    0.004587156 
+  232          226.49539    142.67889   0.004310345 
+  227          224.74261    142.63136   0.004405286 
+  230          223.60498    142.58391   0.004347826 
+  239          223.32539    142.53655   0.0041841 
+  219          224.25725    142.48927   0.00456621 
+  225          225.77292    142.44207   0.004444444 
+  217          224.4714     142.39496   0.004608295 
+  205          221.08805    142.34793   0.004878049 
+  231          218.46524    142.30098   0.004329004 
+  211          216.87988    142.25412   0.004739336 
+  241          216.36345    142.20734   0.004149378 
+  238          216.71427    142.16064   0.004201681 
+  243          216.36294    142.11403   0.004115226 
+  233          214.48167    142.06749   0.004291845 
+  231          212.58894    142.02104   0.004329004 
+  216          211.08398    141.97468   0.00462963 
+  236          209.97244    141.92839   0.004237288 
+  195          209.24239    141.88219   0.005128205 
+  208          208.86436    141.83607   0.004807692 
+  216          208.78266    141.79003   0.00462963 
+  218          208.91367    141.74407   0.004587156 
+  228          209.1989     141.6982    0.004385965 
+  230          209.59887    141.6524    0.004347826 
+  221          210.07306    141.60669   0.004524887 
+  217          210.65695    141.56106   0.004608295 
+  244          211.50778    141.51552   0.004098361 
+  252          212.73415    141.47005   0.003968254 
+  244          213.46892    141.42467   0.004098361 
+  282          211.75834    141.37936   0.003546099 
+  231          208.40441    141.33414   0.004329004 
+  255          205.71935    141.289     0.003921569 
+  273          204.58362    141.24394   0.003663004 
+  279          205.12606    141.19896   0.003584229 
+  247          206.07144    141.15407   0.004048583 
+  241          203.78158    141.10925   0.004149378 
+  231          198.10565    141.06452   0.004329004 
+  235          192.7707     141.01986   0.004255319 
+  240          189.22961    140.97529   0.004166667 
+  222          187.40812    140.93079   0.004504505 
+  216          186.81742    140.88638   0.00462963 
+  212          186.17263    140.84205   0.004716981 
+  224          184.70454    140.7978    0.004464286 
+  201          183.74574    140.75363   0.004975124 
+  214          184.46176    140.70953   0.004672897 
+  188          187.48255    140.66552   0.005319149 
+  179          193.16017    140.62159   0.005586592 
+  195          199.64416    140.57774   0.005128205 
+  217          202.06183    140.53397   0.004608295 
+  182          201.36113    140.49028   0.005494505 
+  173          200.66679    140.44667   0.005780347 
+  189          197.63011    140.40314   0.005291005 
+  181          193.90601    140.35969   0.005524862 
+  209          192.60227    140.31631   0.004784689 
+  207          192.11477    140.27302   0.004830918 
+  199          190.58766    140.22981   0.005025126 
+  218          189.57635    140.18667   0.004587156 
+  186          188.57802    140.14362   0.005376344 
+  190          186.98067    140.10064   0.005263158 
+  191          186.60454    140.05775   0.005235602 
+  168          187.24199    140.01493   0.005952381 
+  224          186.39081    139.97219   0.004464286 
+  162          184.30828    139.92953   0.00617284 
+  184          183.12402    139.88695   0.005434783 
+  193          183.44685    139.84445   0.005181347 
+  178          185.19046    139.80203   0.005617978 
+  181          188.06753    139.75969   0.005524862 
+  168          191.08922    139.71742   0.005952381 
+  188          193.72403    139.67523   0.005319149 
+  196          197.24417    139.63312   0.005102041 
+  195          202.51826    139.59109   0.005128205 
+  196          209.40811    139.54914   0.005102041 
+  205          218.04565    139.50727   0.004878049 
+  212          229.15203    139.46547   0.004716981 
+  239          239.45831    139.42376   0.0041841 
+  248          242.49569    139.38212   0.004032258 
+  251          242.19369    139.34056   0.003984064 
+  229          245.77408    139.29907   0.004366812 
+  275          255.41148    139.25767   0.003636364 
+  296          270.93661    139.21634   0.003378378 
+  269          289.75874    139.17509   0.003717472 
+  271          308.22143    139.13392   0.003690037 
+  263          330.0501     139.09282   0.003802281 
+  336          364.81185    139.05181   0.00297619 
+  406          422.46812    139.01087   0.002463054 
+  519          518.3805     138.97001   0.001926782 
+  596          687.76899    138.92922   0.001677852 
+  973          1018.33492   138.88851   0.001027749 
+  1530         1692.87709   138.84788   0.000653595 
+  2411         2849.67707   138.80733   0.000414766 
+  2991         3476.87328   138.76685   0.000334336 
+  2647         2497.37293   138.72645   0.000377786 
+  1629         1555.76997   138.68613   0.000613874 
+  1141         1137.48478   138.64589   0.000876424 
+  1093         1101.89601   138.60572   0.000914913 
+  1251         1407.05086   138.56563   0.000799361 
+  1620         1907.85675   138.52561   0.000617284 
+  1598         1767.35463   138.48567   0.000625782 
+  1144         1146.56681   138.44581   0.000874126 
+  784          740.8004     138.40603   0.00127551 
+  496          535.87373    138.36632   0.002016129 
+  401          424.07404    138.32668   0.002493766 
+  332          354.21183    138.28713   0.003012048 
+  274          308.57699    138.24765   0.003649635 
+  274          278.78949    138.20824   0.003649635 
+  257          259.18259    138.16892   0.003891051 
+  233          246.32586    138.12966   0.004291845 
+  224          235.24438    138.09049   0.004464286 
+  215          223.16973    138.05139   0.004651163 
+  229          212.20177    138.01237   0.004366812 
+  190          203.4839     137.97342   0.005263158 
+  181          196.74863    137.93454   0.005524862 
+  198          191.76878    137.89575   0.005050505 
+  200          187.8056     137.85703   0.005     
+  206          184.81982    137.81838   0.004854369 
+  169          182.71589    137.77981   0.00591716 
+  201          181.55298    137.74132   0.004975124 
+  194          181.42185    137.7029    0.005154639 
+  183          181.97051    137.66455   0.005464481 
+  165          181.54586    137.62629   0.006060606 
+  169          179.26545    137.58809   0.00591716 
+  173          176.90448    137.54998   0.005780347 
+  181          175.62471    137.51193   0.005524862 
+  158          175.56172    137.47396   0.006329114 
+  181          176.66354    137.43607   0.005524862 
+  176          178.58278    137.39825   0.005681818 
+  189          180.54718    137.36051   0.005291005 
+  175          182.99165    137.32284   0.005714286 
+  202          187.52813    137.28525   0.004950495 
+  192          195.79886    137.24773   0.005208333 
+  203          210.6291     137.21028   0.004926108 
+  200          238.33509    137.17291   0.005     
+  258          291.4069     137.13562   0.003875969 
+  271          384.74382    137.0984    0.003690037 
+  336          483.09101    137.06125   0.00297619 
+  340          453.62015    137.02418   0.002941176 
+  323          351.49798    136.98718   0.003095975 
+  300          286.20084    136.95026   0.003333333 
+  252          263.45226    136.91341   0.003968254 
+  240          274.28058    136.87663   0.004166667 
+  275          313.05722    136.83993   0.003636364 
+  265          340.23693    136.80331   0.003773585 
+  265          298.87499    136.76675   0.003773585 
+  219          243.89382    136.73027   0.00456621 
+  218          210.1185     136.69387   0.004587156 
+  208          192.2432     136.65754   0.004807692 
+  206          182.56876    136.62128   0.004854369 
+  188          176.67574    136.58509   0.005319149 
+  217          173.01138    136.54898   0.004608295 
+  190          171.28791    136.51295   0.005263158 
+  231          171.57333    136.47698   0.004329004 
+  211          173.5439     136.44109   0.004739336 
+  188          174.94793    136.40528   0.005319149 
+  180          173.07509    136.36953   0.005555556 
+  209          169.97291    136.33386   0.004784689 
+  182          168.2752     136.29826   0.005494505 
+  159          168.52597    136.26274   0.006289308 
+  172          170.76415    136.22729   0.005813953 
+  196          174.89249    136.19191   0.005102041 
+  193          178.4916     136.15661   0.005181347 
+  185          177.37918    136.12138   0.005405405 
+  182          172.98118    136.08622   0.005494505 
+  196          169.71054    136.05113   0.005102041 
+  181          168.96594    136.01612   0.005524862 
+  182          170.68539    135.98118   0.005494505 
+  193          174.42429    135.94631   0.005181347 
+  204          177.25208    135.91151   0.004901961 
+  186          175.09557    135.87679   0.005376344 
+  199          170.3885     135.84214   0.005025126 
+  158          167.00398    135.80756   0.006329114 
+  153          165.68124    135.77306   0.006535948 
+  154          166.08944    135.73862   0.006493506 
+  174          167.42966    135.70426   0.005747126 
+  191          167.83349    135.66997   0.005235602 
+  168          166.47297    135.63576   0.005952381 
+  189          165.06461    135.60161   0.005291005 
+  176          164.66397    135.56754   0.005681818 
+  190          164.93624    135.53354   0.005263158 
+  176          164.99958    135.49961   0.005681818 
+  164          164.73744    135.46576   0.006097561 
+  175          164.50123    135.43197   0.005714286 
+  182          164.5776     135.39826   0.005494505 
+  198          165.14727    135.36462   0.005050505 
+  184          166.17265    135.33105   0.005434783 
+  173          167.39571    135.29755   0.005780347 
+  181          168.47149    135.26413   0.005524862 
+  184          169.57088    135.23077   0.005434783 
+  189          171.02533    135.19749   0.005291005 
+  175          172.96099    135.16428   0.005714286 
+  191          175.46278    135.13114   0.005235602 
+  153          178.65446    135.09807   0.006535948 
+  184          182.532      135.06507   0.005434783 
+  216          186.40618    135.03215   0.00462963 
+  184          189.31528    134.99929   0.005434783 
+  233          192.02814    134.96651   0.004291845 
+  219          195.70713    134.9338    0.00456621 
+  209          200.78121    134.90116   0.004784689 
+  227          207.52903    134.86859   0.004405286 
+  248          216.28284    134.83609   0.004032258 
+  276          227.0163     134.80366   0.003623188 
+  249          238.71555    134.7713    0.004016064 
+  262          249.40504    134.73901   0.003816794 
+  305          259.71839    134.70679   0.003278689 
+  276          273.52887    134.67465   0.003623188 
+  328          293.45107    134.64257   0.00304878 
+  362          321.42671    134.61057   0.002762431 
+  364          359.69834    134.57864   0.002747253 
+  379          409.25442    134.54677   0.002638522 
+  424          469.84619    134.51498   0.002358491 
+  492          552.08268    134.48326   0.00203252 
+  658          681.03062    134.4516    0.001519757 
+  884          899.4633     134.42002   0.001131222 
+  1284         1304.05555   134.38851   0.000778816 
+  2127         2113.47095   134.35707   0.000470146 
+  3472         3671.37311   134.32569   0.000288018 
+  4916         5637.48337   134.29439   0.000203417 
+  4764         5313.05187   134.26316   0.000209908 
+  3260         3372.65538   134.232     0.000306748 
+  2058         2147.43907   134.20091   0.000485909 
+  1660         1680.1068    134.16988   0.00060241 
+  1727         1745.02194   134.13893   0.000579039 
+  2088         2330.18876   134.10805   0.000478927 
+  2699         3171.47857   134.07724   0.000370508 
+  2445         2876.06588   134.04649   0.000408998 
+  1741         1822.61496   134.01582   0.000574383 
+  1069         1129.27158   133.98521   0.000935454 
+  689          774.20508    133.95468   0.001451379 
+  542          586.66579    133.92421   0.001845018 
+  419          475.35276    133.89382   0.002386635 
+  375          403.99254    133.86349   0.002666667 
+  322          354.68484    133.83323   0.00310559 
+  323          317.61332    133.80305   0.003095975 
+  292          289.62577    133.77293   0.003424658 
+  260          268.54936    133.74288   0.003846154 
+  252          252.23155    133.7129    0.003968254 
+  236          239.66293    133.68298   0.004237288 
+  246          230.22189    133.65314   0.004065041 
+  224          222.5015     133.62337   0.004464286 
+  217          215.41352    133.59366   0.004608295 
+  209          209.04497    133.56403   0.004784689 
+  197          203.22089    133.53446   0.005076142 
+  205          197.92768    133.50496   0.004878049 
+  191          193.08       133.47553   0.005235602 
+  183          188.97204    133.44617   0.005464481 
+  204          185.84243    133.41688   0.004901961 
+  206          183.58876    133.38765   0.004854369 
+  193          181.8464     133.3585    0.005181347 
+  166          180.25096    133.32941   0.006024096 
+  197          178.81887    133.30039   0.005076142 
+  193          177.42109    133.27144   0.005181347 
+  169          175.70092    133.24256   0.00591716 
+  186          173.6023     133.21374   0.005376344 
+  182          171.61635    133.185     0.005494505 
+  158          170.02574    133.15632   0.006329114 
+  201          168.83848    133.12771   0.004975124 
+  190          168.03298    133.09917   0.005263158 
+  164          167.55144    133.07069   0.006097561 
+  171          167.1853     133.04229   0.005847953 
+  164          166.22952    133.01395   0.006097561 
+  202          166.44901    132.98568   0.004950495 
+  160          167.55134    132.95748   0.00625   
+  181          169.37464    132.92934   0.005524862 
+  190          171.16117    132.90127   0.005263158 
+  195          173.48414    132.87327   0.005128205 
+  178          177.60338    132.84534   0.005617978 
+  177          181.97977    132.81748   0.005649718 
+  176          180.15151    132.78968   0.005681818 
+  189          174.54883    132.76195   0.005291005 
+  191          170.81182    132.73429   0.005235602 
+  174          169.50664    132.70669   0.005747126 
+  180          170.22962    132.67916   0.005555556 
+  157          173.17432    132.6517    0.006369427 
+  159          176.22393    132.62431   0.006289308 
+  175          174.68216    132.59698   0.005714286 
+  165          169.58237    132.56972   0.006060606 
+  162          165.35472    132.54253   0.00617284 
+  175          163.01056    132.5154    0.005714286 
+  172          162.12968    132.48835   0.005813953 
+  168          162.22585    132.46135   0.005952381 
+  167          162.59096    132.43443   0.005988024 
+  166          162.27248    132.40757   0.006024096 
+  172          161.39462    132.38078   0.005813953 
+  172          160.68589    132.35405   0.005813953 
+  181          160.37146    132.32739   0.005524862 
+  176          160.40243    132.3008    0.005681818 
+  190          160.73651    132.27428   0.005263158 
+  185          161.41539    132.24782   0.005405405 
+  174          162.58098    132.22142   0.005747126 
+  196          164.42853    132.1951    0.005102041 
+  159          166.92591    132.16884   0.006289308 
+  156          168.88836    132.14264   0.006410256 
+  186          168.63416    132.11652   0.005376344 
+  179          167.16546    132.09045   0.005586592 
+  151          166.28688    132.06446   0.006622517 
+  169          166.51427    132.03853   0.00591716 
+  175          167.89552    132.01267   0.005714286 
+  171          170.46739    131.98687   0.005847953 
+  168          173.97614    131.96114   0.005952381 
+  186          177.78841    131.93547   0.005376344 
+  164          182.11193    131.90987   0.006097561 
+  193          187.50596    131.88433   0.005181347 
+  188          195.20963    131.85887   0.005319149 
+  192          205.99601    131.83346   0.005208333 
+  209          214.09524    131.80812   0.004784689 
+  208          211.8137     131.78285   0.004807692 
+  203          204.21225    131.75764   0.004926108 
+  198          199.17946    131.7325    0.005050505 
+  215          198.33605    131.70743   0.004651163 
+  186          200.66226    131.68242   0.005376344 
+  200          205.61336    131.65747   0.005     
+  224          211.61178    131.63259   0.004464286 
+  189          214.83202    131.60777   0.005291005 
+  201          216.50544    131.58302   0.004975124 
+  227          221.41531    131.55834   0.004405286 
+  248          229.5408     131.53372   0.004032258 
+  245          234.1726     131.50916   0.004081633 
+  234          232.45074    131.48467   0.004273504 
+  249          231.02977    131.46025   0.004016064 
+  259          234.42923    131.43588   0.003861004 
+  281          243.87416    131.41159   0.003558719 
+  286          259.90215    131.38736   0.003496503 
+  280          280.83675    131.36319   0.003571429 
+  296          298.71596    131.33909   0.003378378 
+  326          309.47535    131.31505   0.003067485 
+  316          321.88558    131.29107   0.003164557 
+  342          339.48425    131.26716   0.002923977 
+  353          365.89269    131.24332   0.002832861 
+  412          404.98501    131.21954   0.002427184 
+  426          438.18286    131.19582   0.002347418 
+  418          461.88759    131.17217   0.002392344 
+  437          499.96392    131.14858   0.00228833 
+  563          565.4816     131.12506   0.001776199 
+  627          667.8553     131.1016    0.001594896 
+  770          824.34153    131.0782    0.001298701 
+  1079         1077.80763   131.05487   0.000926784 
+  1505         1517.36351   131.0316    0.000664452 
+  2270         2352.10966   131.0084    0.000440529 
+  4026         3993.74446   130.98525   0.000248385 
+  6022         6596.0769    130.96218   0.000166058 
+  7011         7667.8855    130.93916   0.000142633 
+  5463         5412.19743   130.91621   0.00018305 
+  3505         3313.73192   130.89333   0.000285307 
+  2423         2289.91961   130.8705    0.000412712 
+  2017         2005.73293   130.84774   0.000495786 
+  2315         2312.01016   130.82505   0.000431965 
+  3027         3259.09945   130.80241   0.00033036 
+  3674         4227.75542   130.77984   0.000272183 
+  3141         3495.33549   130.75734   0.00031837 
+  2162         2166.94927   130.73489   0.000462535 
+  1345         1348.35151   130.71251   0.000743494 
+  927          923.58034    130.6902    0.001078749 
+  687          695.93364    130.66794   0.001455604 
+  514          561.43656    130.64575   0.001945525 
+  426          474.84177    130.62362   0.002347418 
+  378          415.95609    130.60156   0.002645503 
+  361          374.57395    130.57955   0.002770083 
+  325          344.87227    130.55761   0.003076923 
+  312          323.08927    130.53574   0.003205128 
+  292          305.84775    130.51392   0.003424658 
+  306          290.2051     130.49217   0.003267974 
+  265          276.6047     130.47048   0.003773585 
+  307          266.25452    130.44885   0.003257329 
+  274          258.77394    130.42729   0.003649635 
+  264          253.04988    130.40578   0.003787879 
+  267          249.19635    130.38434   0.003745318 
+  238          248.01419    130.36296   0.004201681 
+  222          248.77469    130.34165   0.004504505 
+  227          248.58565    130.32039   0.004405286 
+  221          242.58907    130.2992    0.004524887 
+  211          231.95291    130.27807   0.004739336 
+  231          222.10401    130.257     0.004329004 
+  221          214.76921    130.236     0.004524887 
+  229          210.16048    130.21505   0.004366812 
+  217          208.25637    130.19417   0.004608295 
+  204          208.32571    130.17335   0.004901961 
+  208          207.8162     130.15259   0.004807692 
+  207          204.97503    130.13189   0.004830918 
+  231          202.60135    130.11125   0.004329004 
+  220          203.38115    130.09068   0.004545455 
+  253          207.79216    130.07017   0.003952569 
+  225          214.80934    130.04971   0.004444444 
+  210          221.82556    130.02932   0.004761905 
+  225          221.91152    130.00899   0.004444444 
+  248          213.78856    129.98872   0.004032258 
+  232          205.98938    129.96852   0.004310345 
+  227          203.09775    129.94837   0.004405286 
+  211          205.61521    129.92829   0.004739336 
+  233          212.96795    129.90826   0.004291845 
+  224          223.02697    129.8883    0.004464286 
+  202          228.99853    129.8684    0.004950495 
+  201          224.77145    129.84855   0.004975124 
+  221          216.85352    129.82877   0.004524887 
+  219          212.37174    129.80905   0.00456621 
+  203          213.07147    129.78939   0.004926108 
+  217          218.50725    129.76979   0.004608295 
+  213          226.43287    129.75026   0.004694836 
+  207          230.49632    129.73078   0.004830918 
+  187          226.51379    129.71136   0.005347594 
+  173          219.36664    129.692     0.005780347 
+  181          212.31601    129.67271   0.005524862 
+  193          204.90972    129.65347   0.005181347 
+  186          199.25533    129.63429   0.005376344 
+  184          196.54352    129.61517   0.005434783 
+  200          195.07442    129.59612   0.005     
+  164          192.04457    129.57712   0.006097561 
+  173          188.14188    129.55818   0.005780347 
+  173          185.49552    129.53931   0.005780347 
+  190          183.87057    129.52049   0.005263158 
+  214          183.59613    129.50173   0.004672897 
+  171          185.18927    129.48304   0.005847953 
+  208          186.25137    129.4644    0.004807692 
+  189          182.06674    129.44582   0.005291005 
+  165          173.79706    129.4273    0.006060606 
+  158          167.71943    129.40884   0.006329114 
+  167          165.1075     129.39044   0.005988024 
+  162          165.46356    129.3721    0.00617284 
+  182          168.12719    129.35382   0.005494505 
+  151          171.36301    129.3356    0.006622517 
+  166          172.86722    129.31743   0.006024096 
+  169          172.01888    129.29933   0.00591716 
+  183          172.57469    129.28128   0.005464481 
+  170          177.41575    129.2633    0.005882353 
+  150          183.91967    129.24537   0.006666667 
+  186          184.19178    129.2275    0.005376344 
+  145          176.52533    129.20969   0.006896552 
+  167          167.78919    129.19194   0.005988024 
+  160          161.57527    129.17425   0.00625   
+  175          158.48032    129.15662   0.005714286 
+  172          158.31667    129.13904   0.005813953 
+  151          160.44027    129.12152   0.006622517 
+  158          162.32301    129.10407   0.006329114 
+  156          160.10152    129.08667   0.006410256 
+  148          154.90529    129.06932   0.006756757 
+  162          150.23675    129.05204   0.00617284 
+  161          147.04803    129.03482   0.00621118 
+  156          145.04312    129.01765   0.006410256 
+  161          143.85374    129.00054   0.00621118 
+  136          143.26332    128.98349   0.007352941 
+  154          143.18915    128.9665    0.006493506 
+  125          143.63518    128.94956   0.008     
+  158          144.72734    128.93268   0.006329114 
+  147          146.62856    128.91586   0.006802721 
+  151          148.71763    128.8991    0.006622517 
+  157          148.93888    128.8824    0.006369427 
+  168          146.81779    128.86575   0.005952381 
+  168          144.46014    128.84916   0.005952381 
+  157          142.98949    128.83263   0.006369427 
+  135          142.40625    128.81616   0.007407407 
+  155          142.48344    128.79974   0.006451613 
+  148          143.05559    128.78338   0.006756757 
+  155          143.6589     128.76708   0.006451613 
+  179          143.29029    128.75083   0.005586592 
+  132          142.12198    128.73464   0.007575758 
+  150          141.17091    128.71851   0.006666667 
+  148          140.59829    128.70244   0.006756757 
+  129          139.97427    128.68642   0.007751938 
+  135          139.21227    128.67046   0.007407407 
+  161          138.56033    128.65456   0.00621118 
+  153          138.14482    128.63871   0.006535948 
+  154          137.96078    128.62292   0.006493506 
+  150          137.9773     128.60718   0.006666667 
+  151          138.15325    128.59151   0.006622517 
+  136          138.35873    128.57589   0.007352941 
+  145          138.44565    128.56032   0.006896552 
+  153          138.52509    128.54481   0.006535948 
+  149          138.78107    128.52936   0.006711409 
+  147          139.28177    128.51396   0.006802721 
+  140          140.01622    128.49862   0.007142857 
+  142          140.91205    128.48334   0.007042254 
+  148          142.0237     128.46811   0.006756757 
+  162          143.64287    128.45294   0.00617284 
+  167          146.31958    128.43782   0.005988024 
+  161          150.58061    128.42276   0.00621118 
+  163          156.45367    128.40776   0.006134969 
+  166          161.68962    128.39281   0.006024096 
+  182          162.60579    128.37792   0.005494505 
+  164          160.87661    128.36308   0.006097561 
+  163          160.26098    128.3483    0.006134969 
+  164          160.84441    128.33357   0.006097561 
+  151          160.55376    128.3189    0.006622517 
+  174          159.4334     128.30428   0.005747126 
+  159          159.37131    128.28972   0.006289308 
+  159          159.55309    128.27522   0.006289308 
+  152          158.20238    128.26077   0.006578947 
+  156          156.68885    128.24637   0.006410256 
+  150          156.77437    128.23203   0.006666667 
+  171          158.17015    128.21774   0.005847953 
+  168          159.7243     128.20351   0.005952381 
+  179          161.3354     128.18934   0.005586592 
+  133          162.48897    128.17522   0.007518797 
+  171          162.17436    128.16115   0.005847953 
+  167          162.17021    128.14714   0.005988024 
+  168          163.99272    128.13318   0.005952381 
+  160          165.89929    128.11928   0.00625   
+  164          165.39868    128.10543   0.006097561 
+  168          164.18284    128.09163   0.005952381 
+  142          164.58838    128.07789   0.007042254 
+  192          166.47565    128.06421   0.005208333 
+  180          169.4675     128.05057   0.005555556 
+  157          175.00219    128.037     0.006369427 
+  159          184.98552    128.02347   0.006289308 
+  229          201.1347     128.01      0.004366812 
+  251          227.12501    127.99658   0.003984064 
+  267          271.33882    127.98322   0.003745318 
+  250          333.88836    127.96991   0.004     
+  314          360.16168    127.95666   0.003184713 
+  270          311.42343    127.94346   0.003703704 
+  274          257.86464    127.93031   0.003649635 
+  232          230.08931    127.91721   0.004310345 
+  241          224.18155    127.90417   0.004149378 
+  205          235.65667    127.89118   0.004878049 
+  261          261.79487    127.87825   0.003831418 
+  265          292.66072    127.86537   0.003773585 
+  237          297.31119    127.85254   0.004219409 
+  242          263.58046    127.83976   0.004132231 
+  205          231.18929    127.82704   0.004878049 
+  225          215.67941    127.81437   0.004444444 
+  191          214.2861     127.80175   0.005235602 
+  240          222.53696    127.78919   0.004166667 
+  206          233.74705    127.77668   0.004854369 
+  204          242.56075    127.76422   0.004901961 
+  231          254.76047    127.75181   0.004329004 
+  280          284.94634    127.73946   0.003571429 
+  307          345.67433    127.72716   0.003257329 
+  350          414.62113    127.71491   0.002857143 
+  338          405.93773    127.70271   0.00295858 
+  299          338.49933    127.69057   0.003344482 
+  272          290.02319    127.67848   0.003676471 
+  262          271.42851    127.66644   0.003816794 
+  265          279.93576    127.65445   0.003773585 
+  263          318.86625    127.64251   0.003802281 
+  296          391.82968    127.63063   0.003378378 
+  296          457.12492    127.6188    0.003378378 
+  337          422.36201    127.60702   0.002967359 
+  278          331.79352    127.59529   0.003597122 
+  265          265.4833     127.58361   0.003773585 
+  217          230.3916     127.57198   0.004608295 
+  206          216.79033    127.56041   0.004854369 
+  218          219.07479    127.54889   0.004587156 
+  208          234.46676    127.53742   0.004807692 
+  208          247.92749    127.526     0.004807692 
+  219          232.03623    127.51463   0.00456621 
+  226          202.63368    127.50331   0.004424779 
+  167          181.28174    127.49204   0.005988024 
+  156          168.68313    127.48083   0.006410256 
+  171          161.46662    127.46966   0.005847953 
+  181          157.04696    127.45855   0.005524862 
+  157          153.94066    127.44748   0.006369427 
+  173          151.76747    127.43647   0.005780347 
+  201          150.50391    127.42551   0.004975124 
+  163          150.08541    127.4146    0.006134969 
+  163          150.48487    127.40374   0.006134969 
+  176          151.72577    127.39293   0.005681818 
+  185          153.6427     127.38217   0.005405405 
+  183          155.85735    127.37146   0.005464481 
+  178          158.7747     127.3608    0.005617978 
+  184          163.46483    127.35019   0.005434783 
+  186          170.30299    127.33963   0.005376344 
+  206          178.98792    127.32912   0.004854369 
+  198          187.89091    127.31866   0.005050505 
+  202          194.37094    127.30825   0.004950495 
+  199          201.48743    127.29789   0.005025126 
+  180          209.3361     127.28758   0.005555556 
+  195          206.47493    127.27732   0.005128205 
+  172          193.7733     127.26711   0.005813953 
+  180          183.63198    127.25695   0.005555556 
+  177          179.38256    127.24684   0.005649718 
+  187          179.24921    127.23678   0.005347594 
+  189          180.44735    127.22676   0.005291005 
+  168          183.21572    127.2168    0.005952381 
+  179          188.32405    127.20688   0.005586592 
+  162          189.87332    127.19702   0.00617284 
+  184          184.30769    127.1872    0.005434783 
+  191          177.80402    127.17744   0.005235602 
+  181          174.61182    127.16772   0.005524862 
+  174          175.36664    127.15805   0.005747126 
+  226          180.83864    127.14843   0.004424779 
+  212          193.61374    127.13885   0.004716981 
+  247          219.77128    127.12933   0.004048583 
+  326          270.326      127.11986   0.003067485 
+  405          350.56385    127.11043   0.002469136 
+  469          397.60686    127.10105   0.002132196 
+  370          338.59404    127.09172   0.002702703 
+  290          268.57054    127.08244   0.003448276 
+  250          230.27042    127.07321   0.004     
+  241          214.34627    127.06402   0.004149378 
+  276          214.41939    127.05488   0.003623188 
+  261          231.72628    127.04579   0.003831418 
+  318          270.68594    127.03675   0.003144654 
+  334          313.60281    127.02776   0.002994012 
+  301          307.84423    127.01881   0.003322259 
+  244          274.44636    127.00992   0.004098361 
+  215          243.06923    127.00107   0.004651163 
+  209          219.53324    126.99226   0.004784689 
+  190          205.50305    126.98351   0.005263158 
+  197          199.43336    126.9748    0.005076142 
+  205          201.05871    126.96614   0.004878049 
+  180          209.61052    126.95753   0.005555556 
+  203          218.9544     126.94896   0.004926108 
+  183          219.99041    126.94044   0.005464481 
+  217          212.91149    126.93197   0.004608295 
+  170          205.85584    126.92354   0.005882353 
+  198          202.08562    126.91517   0.005050505 
+  189          195.82913    126.90683   0.005291005 
+  186          187.33656    126.89855   0.005376344 
+  161          182.36426    126.89031   0.00621118 
+  164          180.51868    126.88212   0.006097561 
+  175          177.94279    126.87398   0.005714286 
+  191          174.89692    126.86588   0.005235602 
+  199          174.90799    126.85783   0.005025126 
+  185          179.17302    126.84982   0.005405405 
+  172          185.57772    126.84186   0.005813953 
+  195          192.35878    126.83395   0.005128205 
+  163          198.14638    126.82608   0.006134969 
+  184          195.473      126.81826   0.005434783 
+  145          184.22731    126.81049   0.006896552 
+  193          173.14726    126.80276   0.005181347 
+  152          165.88729    126.79507   0.006578947 
+  182          161.93531    126.78744   0.005494505 
+  151          160.80399    126.77985   0.006622517 
+  151          162.54238    126.7723    0.006622517 
+  161          165.99661    126.7648    0.00621118 
+  149          166.96798    126.75734   0.006711409 
+  163          162.4963     126.74994   0.006134969 
+  161          156.10523    126.74257   0.00621118 
+  143          151.01001    126.73525   0.006993007 
+  140          147.41544    126.72798   0.007142857 
+  143          144.76728    126.72075   0.006993007 
+  142          142.8311     126.71357   0.007042254 
+  153          141.47285    126.70643   0.006535948 
+  152          140.53692    126.69933   0.006578947 
+  148          139.9024     126.69229   0.006756757 
+  148          139.49465    126.68528   0.006756757 
+  125          139.2798     126.67832   0.008     
+  132          139.2531     126.67141   0.007575758 
+  163          139.43315    126.66454   0.006134969 
+  138          139.85915    126.65771   0.007246377 
+  147          140.56857    126.65093   0.006802721 
+  160          141.494      126.64419   0.00625   
+  161          142.39859    126.6375    0.00621118 
+  140          143.23683    126.63085   0.007142857 
+  165          144.34489    126.62425   0.006060606 
+  147          145.73685    126.61769   0.006802721 
+  166          146.61805    126.61117   0.006024096 
+  173          146.74047    126.6047    0.005780347 
+  141          147.16082    126.59827   0.007092199 
+  151          148.68869    126.59189   0.006622517 
+  137          151.49777    126.58554   0.00729927 
+  153          155.09466    126.57925   0.006535948 
+  161          157.70102    126.57299   0.00621118 
+  134          157.75235    126.56678   0.007462687 
+  150          156.66142    126.56062   0.006666667 
+  161          156.04017    126.55449   0.00621118 
+  140          156.3961     126.54841   0.007142857 
+  167          158.53012    126.54237   0.005988024 
+  135          162.50214    126.53638   0.007407407 
+  177          168.76005    126.53043   0.005649718 
+  171          176.86565    126.52452   0.005847953 
+  202          185.46784    126.51865   0.004950495 
+  200          193.28259    126.51283   0.005     
+  225          195.75795    126.50705   0.004444444 
+  177          189.95163    126.50132   0.005649718 
+  180          181.84698    126.49562   0.005555556 
+  173          176.08124    126.48997   0.005780347 
+  192          173.42022    126.48436   0.005208333 
+  172          173.36525    126.47879   0.005813953 
+  180          175.19914    126.47327   0.005555556 
+  149          178.42328    126.46779   0.006711409 
+  185          181.43388    126.46235   0.005405405 
+  167          180.8994     126.45695   0.005988024 
+  178          177.15919    126.45159   0.005617978 
+  182          173.5446     126.44628   0.005494505 
+  164          171.50611    126.44101   0.006097561 
+  183          171.02126    126.43578   0.005464481 
+  177          171.84729    126.43059   0.005649718 
+  159          173.87519    126.42544   0.006289308 
+  183          176.95937    126.42034   0.005464481 
+  180          180.33446    126.41527   0.005555556 
+  226          182.76209    126.41025   0.004424779 
+  187          184.66431    126.40527   0.005347594 
+  197          187.56043    126.40033   0.005076142 
+  189          192.0203     126.39543   0.005291005 
+  201          197.23533    126.39058   0.004975124 
+  183          201.02423    126.38576   0.005464481 
+  216          202.32387    126.38099   0.00462963 
+  189          202.99475    126.37625   0.005291005 
+  201          203.69234    126.37156   0.004975124 
+  212          203.57114    126.36691   0.004716981 
+  215          203.76094    126.3623    0.004651163 
+  211          205.75764    126.35773   0.004739336 
+  165          209.86884    126.3532    0.006060606 
+  186          215.2685     126.34871   0.005376344 
+  181          219.92283    126.34426   0.005524862 
+  201          222.74809    126.33985   0.004975124 
+  202          225.40218    126.33549   0.004950495 
+  220          228.95491    126.33116   0.004545455 
+  250          235.0767     126.32687   0.004     
+  248          250.00359    126.32263   0.004032258 
+  266          283.74496    126.31842   0.003759398 
+  358          348.72228    126.31425   0.002793296 
+  374          430.72211    126.31012   0.002673797 
+  410          428.71824    126.30604   0.002439024 
+  318          344.28756    126.30199   0.003144654 
+  263          277.27105    126.29798   0.003802281 
+  250          240.74974    126.29402   0.004     
+  214          223.75476    126.29009   0.004672897 
+  203          220.83669    126.2862    0.004926108 
+  267          232.84169    126.28235   0.003745318 
+  261          263.30633    126.27854   0.003831418 
+  261          294.66955    126.27477   0.003831418 
+  256          274.60154    126.27104   0.00390625 
+  236          228.59135    126.26735   0.004237288 
+  200          196.67612    126.2637    0.005     
+  168          178.73022    126.26008   0.005952381 
+  194          168.58712    126.25651   0.005154639 
+  174          162.42761    126.25297   0.005747126 
+  152          158.36982    126.24948   0.006578947 
+  160          155.44787    126.24602   0.00625   
+  164          153.12593    126.2426    0.006097561 
+  157          151.33401    126.23922   0.006369427 
+  161          150.16269    126.23588   0.00621118 
+  176          149.66753    126.23257   0.005681818 
+  157          149.94329    126.22931   0.006369427 
+  159          151.12816    126.22608   0.006289308 
+  156          153.07603    126.22289   0.006410256 
+  137          154.53557    126.21974   0.00729927 
+  156          153.79836    126.21663   0.006410256 
+  154          151.62845    126.21356   0.006493506 
+  142          149.6234     126.21052   0.007042254 
+  155          147.76114    126.20753   0.006451613 
+  151          146.01975    126.20457   0.006622517 
+  161          144.96468    126.20164   0.00621118 
+  165          144.78134    126.19876   0.006060606 
+  150          145.24159    126.19591   0.006666667 
+  153          145.55329    126.19311   0.006535948 
+  148          144.98363    126.19033   0.006756757 
+  139          144.10789    126.1876    0.007194245 
+  156          143.52241    126.18491   0.006410256 
+  142          142.97491    126.18225   0.007042254 
+  158          142.56738    126.17963   0.006329114 
+  160          142.86571    126.17704   0.00625   
+  120          144.0245     126.1745    0.008333333 
+  165          145.33987    126.17199   0.006060606 
+  165          145.31596    126.16951   0.006060606 
+  178          143.6916     126.16708   0.005617978 
+  150          141.71153    126.16468   0.006666667 
+  147          140.21543    126.16232   0.006802721 
+  145          139.28581    126.15999   0.006896552 
+  138          138.84779    126.15771   0.007246377 
+  161          138.92404    126.15546   0.00621118 
+  136          139.45914    126.15324   0.007352941 
+  133          140.03093    126.15106   0.007518797 
+  137          139.88476    126.14892   0.00729927 
+  124          138.96957    126.14682   0.008064516 
+  121          137.92646    126.14475   0.008264463 
+  141          137.16913    126.14272   0.007092199 
+  142          136.77169    126.14072   0.007042254 
+  132          136.69222    126.13876   0.007575758 
+  118          136.85892    126.13684   0.008474576 
+  140          137.07764    126.13495   0.007142857 
+  143          137.04227    126.1331    0.006993007 
+  151          136.76394    126.13128   0.006622517 
+  129          136.52418    126.1295    0.007751938 
+  148          136.45019    126.12776   0.006756757 
+  139          136.55959    126.12605   0.007194245 
+  133          136.85579    126.12438   0.007518797 
+  151          137.3565     126.12274   0.006622517 
+  150          138.06591    126.12114   0.006666667 
+  133          138.85939    126.11957   0.007518797 
+  144          139.43426    126.11804   0.006944444 
+  160          139.73995    126.11655   0.00625   
+  145          140.07757    126.11509   0.006896552 
+  134          140.62231    126.11367   0.007462687 
+  151          141.40218    126.11228   0.006622517 
+  152          142.37939    126.11092   0.006578947 
+  164          143.54328    126.1096    0.006097561 
+  151          145.01575    126.10832   0.006622517 
+  145          146.94952    126.10707   0.006896552 
+  163          149.52826    126.10586   0.006134969 
+  172          153.20089    126.10468   0.005813953 
+  165          159.00407    126.10353   0.006060606 
+  159          168.77627    126.10243   0.006289308 
+  194          185.21299    126.10135   0.005154639 
+  206          209.35122    126.10031   0.004854369 
+  198          228.32823    126.09931   0.005050505 
+  201          218.44321    126.09833   0.004975124 
+  162          194.63065    126.0974    0.00617284 
+  160          177.44869    126.0965    0.00625   
+  167          168.49939    126.09563   0.005988024 
+  177          165.38397    126.0948    0.005649718 
+  177          166.88701    126.094     0.005649718 
+  181          173.27978    126.09323   0.005524862 
+  178          184.93389    126.0925    0.005617978 
+  175          196.43007    126.0918    0.005714286 
+  175          195.57688    126.09114   0.005714286 
+  173          187.95821    126.09051   0.005780347 
+  177          183.29437    126.08992   0.005649718 
+  154          179.43561    126.08936   0.006493506 
+  161          174.05337    126.08883   0.00621118 
+  154          169.04035    126.08833   0.006493506 
+  178          165.2637     126.08787   0.005617978 
+  155          162.16941    126.08745   0.006451613 
+  161          160.24863    126.08706   0.00621118 
+  146          160.22444    126.0867    0.006849315 
+  167          162.2374     126.08637   0.005988024 
+  165          165.6231     126.08608   0.006060606 
+  169          168.06539    126.08582   0.00591716 
+  152          168.57289    126.08559   0.006578947 
+  189          169.34928    126.0854    0.005291005 
+  149          172.32321    126.08524   0.006711409 
+  158          177.08176    126.08512   0.006329114 
+  196          180.83759    126.08502   0.005102041 
+  177          180.74939    126.08496   0.005649718 
+  147          179.15543    126.08494   0.006802721 
+  190          179.14858    126.08494   0.005263158 
+  184          181.82697    126.08498   0.005434783 
+  199          190.09198    126.08505   0.005025126 
+  217          209.49613    126.08516   0.004608295 
+  265          247.01896    126.08529   0.003773585 
+  313          296.56779    126.08546   0.003194888 
+  308          304.8478     126.08567   0.003246753 
+  274          259.95116    126.0859    0.003649635 
+  209          219.02962    126.08617   0.004784689 
+  218          196.20679    126.08647   0.004587156 
+  225          185.98781    126.0868    0.004444444 
+  221          184.07066    126.08717   0.004524887 
+  200          189.11563    126.08756   0.005     
+  223          202.40601    126.08799   0.004484305 
+  219          223.11787    126.08846   0.00456621 
+  216          229.91721    126.08895   0.00462963 
+  188          206.59933    126.08948   0.005319149 
+  188          181.46906    126.09003   0.005319149 
+  158          166.38496    126.09063   0.006329114 
+  172          158.66616    126.09125   0.005813953 
+  165          154.97153    126.0919    0.006060606 
+  170          153.01719    126.09259   0.005882353 
+  143          151.64772    126.09331   0.006993007 
+  157          150.53357    126.09406   0.006369427 
+  130          149.38578    126.09484   0.007692308 
+  139          148.54509    126.09565   0.007194245 
+  167          148.74131    126.0965    0.005988024 
+  169          150.13952    126.09737   0.00591716 
+  143          152.24806    126.09828   0.006993007 
+  162          153.9077     126.09922   0.00617284 
+  163          154.29703    126.10019   0.006134969 
+  172          154.55568    126.1012    0.005813953 
+  152          156.53968    126.10223   0.006578947 
+  154          161.43611    126.1033    0.006493506 
+  177          169.77421    126.10439   0.005649718 
+  139          180.51295    126.10552   0.007194245 
+  164          190.02142    126.10668   0.006097561 
+  183          194.37205    126.10787   0.005464481 
+  147          190.59521    126.1091    0.006802721 
+  133          180.30681    126.11035   0.007518797 
+  176          169.74075    126.11163   0.005681818 
+  124          162.5601     126.11295   0.008064516 
+  152          159.25859    126.1143    0.006578947 
+  146          159.38887    126.11567   0.006849315 
+  172          162.12076    126.11708   0.005813953 
+  161          165.53317    126.11852   0.00621118 
+  144          167.14946    126.11999   0.006944444 
+  128          165.26287    126.12149   0.0078125 
+  130          159.83408    126.12302   0.007692308 
+  154          153.60936    126.12459   0.006493506 
+  170          148.7511     126.12618   0.005882353 
+  138          145.51391    126.1278    0.007246377 
+  150          143.48559    126.12946   0.006666667 
+  148          142.2717     126.13114   0.006756757 
+  162          141.60709    126.13286   0.00617284 
+  142          141.25316    126.13461   0.007042254 
+  121          140.97995    126.13638   0.008264463 
+  156          140.75759    126.13819   0.006410256 
+  143          140.73234    126.14003   0.006993007 
+  146          141.03532    126.1419    0.006849315 
+  157          141.74951    126.14379   0.006369427 
+  157          142.97765    126.14572   0.006369427 
+  153          144.88248    126.14768   0.006535948 
+  136          147.64588    126.14967   0.007352941 
+  135          151.11785    126.15169   0.007407407 
+  164          154.22199    126.15374   0.006097561 
+  156          155.80053    126.15582   0.006410256 
+  142          156.4102     126.15793   0.007042254 
+  147          157.02414    126.16007   0.006802721 
+  141          157.14425    126.16224   0.007092199 
+  158          156.67214    126.16444   0.006329114 
+  166          157.01958    126.16667   0.006024096 
+  156          159.33625    126.16893   0.006410256 
+  172          164.33748    126.17123   0.005813953 
+  148          172.86193    126.17355   0.006756757 
+  196          186.46863    126.1759    0.005102041 
+  193          208.39057    126.17828   0.005181347 
+  208          239.63039    126.18069   0.004807692 
+  240          261.61441    126.18313   0.004166667 
+  183          248.75401    126.1856    0.005464481 
+  205          222.58379    126.1881    0.004878049 
+  187          202.67821    126.19062   0.005347594 
+  187          188.43473    126.19318   0.005347594 
+  178          178.99802    126.19577   0.005617978 
+  171          175.20866    126.19839   0.005847953 
+  164          177.7627     126.20104   0.006097561 
+  195          187.34985    126.20372   0.005128205 
+  186          200.52607    126.20642   0.005376344 
+  190          202.60071    126.20916   0.005263158 
+  180          190.33739    126.21193   0.005555556 
+  162          177.77124    126.21472   0.00617284 
+  155          168.44469    126.21755   0.006451613 
+  141          161.1695     126.2204    0.007092199 
+  163          155.85771    126.22329   0.006134969 
+  160          152.36894    126.2262    0.00625   
+  145          150.23159    126.22914   0.006896552 
+  155          149.01494    126.23212   0.006451613 
+  156          148.44845    126.23512   0.006410256 
+  137          148.3389     126.23815   0.00729927 
+  152          148.53904    126.24121   0.006578947 
+  155          148.98028    126.2443    0.006451613 
+  136          149.57013    126.24742   0.007352941 
+  173          150.3957     126.25057   0.005780347 
+  158          151.49012    126.25375   0.006329114 
+  159          152.88573    126.25696   0.006289308 
+  178          154.65205    126.26019   0.005617978 
+  160          156.88728    126.26346   0.00625   
+  147          159.72816    126.26675   0.006802721 
+  177          163.2774     126.27008   0.005649718 
+  163          167.34426    126.27343   0.006134969 
+  178          171.28935    126.27681   0.005617978 
+  210          175.06626    126.28023   0.004761905 
+  183          179.61505    126.28367   0.005464481 
+  175          185.67282    126.28714   0.005714286 
+  190          193.48095    126.29064   0.005263158 
+  225          203.76832    126.29417   0.004444444 
+  225          218.04154    126.29772   0.004444444 
+  238          238.38257    126.30131   0.004201681 
+  240          267.80322    126.30493   0.004166667 
+  295          311.03268    126.30857   0.003389831 
+  388          377.79597    126.31224   0.00257732 
+  514          491.99554    126.31595   0.001945525 
+  684          699.99445    126.31968   0.001461988 
+  1036         1061.12852   126.32344   0.000965251 
+  1357         1508.29881   126.32723   0.00073692 
+  1324         1558.58419   126.33105   0.000755287 
+  981          1141.00958   126.3349    0.001019368 
+  753          768.54772    126.33878   0.001328021 
+  548          558.44318    126.34268   0.001824818 
+  464          457.89375    126.34662   0.002155172 
+  410          425.03565    126.35058   0.002439024 
+  452          448.25743    126.35458   0.002212389 
+  571          540.86704    126.3586    0.001751313 
+  737          722.58713    126.36265   0.001356852 
+  825          912.79156    126.36673   0.001212121 
+  751          850.48828    126.37084   0.001331558 
+  625          618.27053    126.37498   0.0016    
+  410          442.17447    126.37915   0.002439024 
+  346          340.97341    126.38334   0.002890173 
+  255          283.14397    126.38757   0.003921569 
+  241          247.51361    126.39182   0.004149378 
+  204          223.90383    126.39611   0.004901961 
+  220          207.27987    126.40042   0.004545455 
+  188          195.4368     126.40476   0.005319149 
+  211          186.83815    126.40913   0.004739336 
+  183          180.25341    126.41353   0.005464481 
+  184          175.48915    126.41796   0.005434783 
+  181          172.31747    126.42242   0.005524862 
+  156          169.54498    126.42691   0.006410256 
+  171          166.00158    126.43142   0.005847953 
+  169          162.06174    126.43597   0.00591716 
+  171          158.35958    126.44054   0.005847953 
+  159          155.03789    126.44515   0.006289308 
+  157          152.31614    126.44978   0.006369427 
+  167          150.2587     126.45444   0.005988024 
+  149          148.77278    126.45913   0.006711409 
+  139          147.75592    126.46385   0.007194245 
+  145          147.07522    126.4686    0.006896552 
+  149          146.48885    126.47338   0.006711409 
+  166          145.85456    126.47818   0.006024096 
+  158          145.33148    126.48302   0.006329114 
+  146          145.0903     126.48788   0.006849315 
+  181          145.13934    126.49278   0.005524862 
+  142          145.36666    126.4977    0.007042254 
+  162          145.62728    126.50266   0.00617284 
+  169          145.87044    126.50764   0.00591716 
+  153          146.1335     126.51265   0.006535948 
+  141          146.37635    126.51769   0.007092199 
+  151          146.67841    126.52276   0.006622517 
+  162          147.29345    126.52786   0.00617284 
+  147          148.42241    126.53299   0.006802721 
+  143          150.24469    126.53815   0.006993007 
+  182          153.0173     126.54333   0.005494505 
+  169          157.15257    126.54855   0.00591716 
+  177          163.32406    126.5538    0.005649718 
+  161          172.61651    126.55907   0.00621118 
+  149          186.84807    126.56438   0.006711409 
+  167          207.28253    126.56971   0.005988024 
+  189          226.63948    126.57508   0.005291005 
+  217          226.59439    126.58047   0.004608295 
+  181          209.75701    126.58589   0.005524862 
+  171          192.04681    126.59135   0.005847953 
+  171          178.97564    126.59683   0.005847953 
+  162          171.21949    126.60234   0.00617284 
+  174          168.11173    126.60788   0.005747126 
+  178          168.99383    126.61345   0.005617978 
+  179          173.98922    126.61905   0.005586592 
+  159          183.41218    126.62468   0.006289308 
+  161          193.55421    126.63034   0.00621118 
+  171          195.36266    126.63603   0.005847953 
+  189          190.40473    126.64175   0.005291005 
+  182          186.77636    126.6475    0.005494505 
+  187          185.86215    126.65328   0.005347594 
+  167          183.71395    126.65909   0.005988024 
+  149          177.06967    126.66493   0.006711409 
+  190          168.8001     126.6708    0.005263158 
+  169          162.33963    126.6767    0.00591716 
+  143          158.4416     126.68263   0.006993007 
+  152          156.70864    126.68859   0.006578947 
+  150          156.70111    126.69458   0.006666667 
+  178          158.38943    126.7006    0.005617978 
+  178          161.97469    126.70665   0.005617978 
+  166          167.00546    126.71273   0.006024096 
+  167          171.56998    126.71884   0.005988024 
+  173          174.18572    126.72498   0.005780347 
+  169          175.90138    126.73116   0.00591716 
+  155          177.14038    126.73736   0.006451613 
+  184          175.94272    126.74359   0.005434783 
+  171          171.45515    126.74985   0.005847953 
+  153          166.50683    126.75615   0.006535948 
+  170          163.4577     126.76247   0.005882353 
+  157          162.49548    126.76882   0.006369427 
+  156          162.43042    126.77521   0.006410256 
+  167          162.17804    126.78163   0.005988024 
+  182          162.21799    126.78807   0.005494505 
+  164          163.14234    126.79455   0.006097561 
+  168          164.41468    126.80106   0.005952381 
+  182          164.71107    126.8076    0.005494505 
+  156          163.30957    126.81417   0.006410256 
+  150          161.50988    126.82077   0.006666667 
+  202          160.65075    126.8274    0.004950495 
+  155          160.92389    126.83406   0.006451613 
+  172          161.77627    126.84076   0.005813953 
+  164          162.57451    126.84749   0.006097561 
+  199          163.47366    126.85424   0.005025126 
+  173          164.9503     126.86103   0.005780347 
+  211          167.2181     126.86785   0.004739336 
+  171          170.34819    126.8747    0.005847953 
+  178          174.43818    126.88159   0.005617978 
+  182          179.66089    126.8885    0.005494505 
+  191          186.28022    126.89545   0.005235602 
+  202          194.61262    126.90242   0.004950495 
+  217          204.83906    126.90943   0.004608295 
+  210          217.01731    126.91647   0.004761905 
+  225          231.95766    126.92355   0.004444444 
+  279          251.8188     126.93065   0.003584229 
+  317          279.57686    126.93779   0.003154574 
+  357          319.54738    126.94496   0.00280112 
+  412          379.24448    126.95216   0.002427184 
+  516          473.06124    126.95939   0.001937984 
+  681          629.16708    126.96666   0.001468429 
+  1020         899.3255     126.97396   0.000980392 
+  1452         1358.5339    126.98129   0.000688705 
+  1984         1976.46284   126.98865   0.000504032 
+  2024         2206.65684   126.99605   0.000494071 
+  1590         1709.50927   127.00348   0.000628931 
+  1166         1145.98185   127.01094   0.000857633 
+  793          799.838      127.01843   0.001261034 
+  624          621.04029    127.02596   0.001602564 
+  637          543.88226    127.03352   0.001569859 
+  592          537.68177    127.04111   0.001689189 
+  684          603.37762    127.04873   0.001461988 
+  812          766.18673    127.05639   0.001231527 
+  1008         1038.65092   127.06408   0.000992063 
+  1063         1237.30604   127.07181   0.000940734 
+  923          1059.49398   127.07957   0.001083424 
+  699          742.59002    127.08736   0.001430615 
+  515          521.40727    127.09518   0.001941748 
+  431          393.90855    127.10304   0.002320186 
+  301          321.06117    127.11093   0.003322259 
+  289          276.89496    127.11886   0.003460208 
+  250          247.67233    127.12682   0.004     
+  235          226.70782    127.13482   0.004255319 
+  211          211.12784    127.14284   0.004739336 
+  210          199.48138    127.15091   0.004761905 
+  204          190.71409    127.159     0.004901961 
+  202          184.05832    127.16713   0.004950495 
+  178          179.00508    127.1753    0.005617978 
+  168          175.24873    127.1835    0.005952381 
+  174          172.63319    127.19173   0.005747126 
+  181          171.0549     127.2       0.005524862 
+  167          170.3291     127.2083    0.005988024 
+  163          170.23368    127.21664   0.006134969 
+  182          170.55537    127.22502   0.005494505 
+  174          170.34608    127.23342   0.005747126 
+  206          168.47367    127.24187   0.004854369 
+  185          165.71211    127.25035   0.005405405 
+  172          163.48963    127.25886   0.005813953 
+  186          162.13716    127.26741   0.005376344 
+  156          161.21722    127.27599   0.006410256 
+  147          160.56389    127.28461   0.006802721 
+  184          160.61661    127.29327   0.005434783 
+  184          161.81001    127.30196   0.005434783 
+  133          164.33089    127.31069   0.007518797 
+  152          167.91179    127.31945   0.006578947 
+  168          171.73262    127.32825   0.005952381 
+  173          176.09969    127.33709   0.005780347 
+  180          183.73956    127.34596   0.005555556 
+  217          198.12711    127.35487   0.004608295 
+  165          221.82309    127.36382   0.006060606 
+  233          249.7164     127.3728    0.004291845 
+  217          257.41286    127.38182   0.004608295 
+  199          235.55321    127.39088   0.005025126 
+  222          210.63773    127.39997   0.004504505 
+  183          195.86354    127.4091    0.005464481 
+  200          190.52355    127.41827   0.005     
+  190          192.29061    127.42747   0.005263158 
+  192          200.15927    127.43671   0.005208333 
+  202          210.99785    127.44599   0.004950495 
+  187          217.33355    127.45531   0.005347594 
+  211          220.79903    127.46467   0.004739336 
+  184          222.834      127.47406   0.005434783 
+  200          213.01062    127.48349   0.005     
+  177          196.09656    127.49296   0.005649718 
+  192          182.53536    127.50247   0.005208333 
+  168          174.01748    127.51201   0.005952381 
+  166          169.80686    127.5216    0.006024096 
+  177          169.17909    127.53122   0.005649718 
+  168          171.05429    127.54088   0.005952381 
+  175          171.74588    127.55059   0.005714286 
+  140          167.88182    127.56033   0.007142857 
+  170          162.76657    127.5701    0.005882353 
+  166          159.50582    127.57992   0.006024096 
+  164          158.32121    127.58978   0.006097561 
+  189          158.46588    127.59968   0.005291005 
+  156          159.15525    127.60962   0.006410256 
+  192          160.11166    127.61959   0.005208333 
+  157          161.10653    127.62961   0.006369427 
+  133          161.50598    127.63967   0.007518797 
+  171          161.53838    127.64977   0.005847953 
+  160          161.52076    127.65991   0.00625   
+  170          160.69502    127.67009   0.005882353 
+  172          158.64999    127.6803    0.005813953 
+  182          156.51212    127.69057   0.005494505 
+  168          155.22418    127.70087   0.005952381 
+  164          154.93125    127.71121   0.006097561 
+  160          155.39405    127.72159   0.00625   
+  173          156.3135     127.73202   0.005780347 
+  178          157.30581    127.74248   0.005617978 
+  155          158.06199    127.75299   0.006451613 
+  186          158.84116    127.76354   0.005376344 
+  160          159.71466    127.77414   0.00625   
+  179          160.24376    127.78477   0.005586592 
+  178          160.3958     127.79545   0.005617978 
+  154          160.57889    127.80617   0.006493506 
+  181          160.75966    127.81693   0.005524862 
+  174          160.96411    127.82773   0.005747126 
+  180          161.47153    127.83858   0.005555556 
+  218          162.43476    127.84947   0.004587156 
+  204          163.87266    127.86041   0.004901961 
+  209          165.76767    127.87138   0.004784689 
+  196          168.11921    127.8824    0.005102041 
+  208          170.96214    127.89347   0.004807692 
+  216          174.35363    127.90458   0.00462963 
+  231          178.32971    127.91573   0.004329004 
+  223          182.84314    127.92693   0.004484305 
+  195          187.88733    127.93817   0.005128205 
+  213          193.73484    127.94945   0.004694836 
+  229          200.81851    127.96078   0.004366812 
+  233          209.6039     127.97216   0.004291845 
+  213          220.65649    127.98358   0.004694836 
+  258          234.82935    127.99505   0.003875969 
+  234          253.48673    128.00656   0.004273504 
+  296          278.85445    128.01812   0.003378378 
+  324          314.48486    128.02972   0.00308642 
+  352          365.06452    128.04137   0.002840909 
+  417          432.04873    128.05306   0.002398082 
+  506          503.62816    128.0648    0.001976285 
+  572          578.02898    128.07659   0.001748252 
+  732          698.38527    128.08842   0.00136612 
+  952          925.25896    128.10031   0.00105042 
+  1543         1340.55543   128.11223   0.000648088 
+  2181         2034.67344   128.12421   0.000458505 
+  2804         2847.27048   128.13623   0.000356633 
+  2669         2941.63929   128.1483    0.000374672 
+  2046         2196.83411   128.16042   0.000488759 
+  1428         1490.55496   128.17259   0.00070028 
+  1100         1071.36979   128.1848    0.000909091 
+  871          851.11394    128.19706   0.001148106 
+  766          746.5014     128.20938   0.001305483 
+  745          732.40957    128.22174   0.001342282 
+  841          814.35737    128.23415   0.001189061 
+  1014         1010.35381   128.2466    0.000986193 
+  1373         1331.80069   128.25911   0.000728332 
+  1541         1671.26374   128.27167   0.000648929 
+  1404         1613.87739   128.28427   0.000712251 
+  1079         1188.63921   128.29693   0.000926784 
+  817          818.16762    128.30964   0.00122399 
+  592          591.19828    128.3224    0.001689189 
+  467          461.35224    128.3352    0.002141328 
+  394          386.99768    128.34806   0.002538071 
+  353          344.93829    128.36097   0.002832861 
+  317          323.02006    128.37393   0.003154574 
+  304          308.64226    128.38694   0.003289474 
+  294          287.12554    128.40001   0.003401361 
+  244          261.8162     128.41312   0.004098361 
+  253          242.3602     128.42629   0.003952569 
+  222          230.21935    128.43951   0.004504505 
+  231          223.79097    128.45278   0.004329004 
+  221          220.85103    128.46611   0.004524887 
+  185          218.00475    128.47949   0.005405405 
+  202          212.44814    128.49292   0.004950495 
+  191          205.44961    128.5064    0.005235602 
+  200          199.29183    128.51994   0.005     
+  189          193.95904    128.53353   0.005291005 
+  199          188.90636    128.54718   0.005025126 
+  166          184.69392    128.56088   0.006024096 
+  183          182.00377    128.57463   0.005464481 
+  183          181.0688     128.58844   0.005464481 
+  173          181.87943    128.6023    0.005780347 
+  184          184.04134    128.61622   0.005434783 
+  206          186.1874     128.6302    0.004854369 
+  156          186.62224    128.64423   0.006410256 
+  164          185.20142    128.65831   0.006097561 
+  178          183.07972    128.67246   0.005617978 
+  183          181.31291    128.68665   0.005464481 
+  202          180.24888    128.70091   0.004950495 
+  166          179.73836    128.71522   0.006024096 
+  183          179.38403    128.72959   0.005464481 
+  170          179.73476    128.74402   0.005882353 
+  172          181.80779    128.7585    0.005813953 
+  168          185.20271    128.77304   0.005952381 
+  154          187.41738    128.78764   0.006493506 
+  158          186.09847    128.8023    0.006329114 
+  174          181.70678    128.81702   0.005747126 
+  190          176.56501    128.83179   0.005263158 
+  169          172.61871    128.84663   0.00591716 
+  160          170.40149    128.86152   0.00625   
+  167          169.47078    128.87647   0.005988024 
+  181          169.15778    128.89149   0.005524862 
+  162          169.44805    128.90656   0.00617284 
+  190          170.84216    128.92169   0.005263158 
+  186          173.34753    128.93689   0.005376344 
+  170          175.98392    128.95214   0.005882353 
+  158          177.57926    128.96746   0.006329114 
+  171          177.77793    128.98283   0.005847953 
+  159          176.08895    128.99827   0.006289308 
+  164          172.16722    129.01377   0.006097561 
+  148          167.39693    129.02934   0.006756757 
+  137          163.36603    129.04496   0.00729927 
+  193          160.54083    129.06065   0.005181347 
+  159          158.7859     129.0764    0.006289308 
+  131          157.91553    129.09222   0.007633588 
+  163          157.84377    129.1081    0.006134969 
+  160          158.60374    129.12404   0.00625   
+  152          160.28497    129.14004   0.006578947 
+  159          162.79335    129.15611   0.006289308 
+  154          165.44083    129.17225   0.006493506 
+  167          167.11825    129.18845   0.005988024 
+  171          167.11998    129.20471   0.005847953 
+  165          165.55884    129.22105   0.006060606 
+  160          163.79658    129.23744   0.00625   
+  154          163.29892    129.25391   0.006493506 
+  165          164.6791     129.27043   0.006060606 
+  179          167.76098    129.28703   0.005586592 
+  178          171.11479    129.30369   0.005617978 
+  159          172.07406    129.32042   0.006289308 
+  150          169.77648    129.33722   0.006666667 
+  169          166.42184    129.35409   0.00591716 
+  174          163.94895    129.37102   0.005747126 
+  160          162.49387    129.38802   0.00625   
+  183          161.38916    129.40509   0.005464481 
+  166          160.64767    129.42223   0.006024096 
+  138          160.89053    129.43944   0.007246377 
+  178          162.54991    129.45672   0.005617978 
+  197          165.72131    129.47407   0.005076142 
+  167          169.85732    129.49149   0.005988024 
+  176          173.27849    129.50898   0.005681818 
+  187          174.4955     129.52654   0.005347594 
+  180          174.06788    129.54418   0.005555556 
+  182          172.79851    129.56188   0.005494505 
+  192          170.89878    129.57966   0.005208333 
+  183          169.18838    129.5975    0.005464481 
+  175          168.41541    129.61542   0.005714286 
+  183          168.73262    129.63342   0.005464481 
+  207          170.07332    129.65148   0.004830918 
+  193          172.45257    129.66963   0.005181347 
+  185          175.72892    129.68784   0.005405405 
+  173          179.41385    129.70613   0.005780347 
+  161          183.14691    129.72449   0.00621118 
+  228          187.18345    129.74293   0.004385965 
+  223          191.99491    129.76144   0.004484305 
+  207          197.8483     129.78003   0.004830918 
+  236          205.44118    129.79869   0.004237288 
+  219          215.81575    129.81743   0.00456621 
+  257          229.91013    129.83625   0.003891051 
+  240          248.78199    129.85514   0.004166667 
+  326          273.71401    129.87411   0.003067485 
+  319          307.16213    129.89316   0.003134796 
+  411          356.3153     129.91229   0.00243309 
+  484          436.35794    129.93149   0.002066116 
+  643          574.10623    129.95077   0.00155521 
+  973          811.1715     129.97013   0.001027749 
+  1249         1176.53575   129.98958   0.000800641 
+  1395         1517.81417   130.0091    0.000716846 
+  1306         1440.99643   130.0287    0.000765697 
+  1057         1062.18127   130.04838   0.000946074 
+  792          747.33934    130.06814   0.001262626 
+  607          560.56041    130.08798   0.001647446 
+  528          461.81226    130.10791   0.001893939 
+  431          417.63551    130.12791   0.002320186 
+  425          413.63301    130.148     0.002352941 
+  536          450.09176    130.16817   0.001865672 
+  570          535.22259    130.18842   0.001754386 
+  673          674.24914    130.20876   0.001485884 
+  805          846.76374    130.22918   0.001242236 
+  756          909.38559    130.24968   0.001322751 
+  664          749.30881    130.27027   0.001506024 
+  604          546.37866    130.29095   0.001655629 
+  400          407.81079    130.3117    0.0025    
+  356          325.79589    130.33255   0.002808989 
+  314          278.11569    130.35348   0.003184713 
+  251          250.45319    130.37449   0.003984064 
+  253          235.52396    130.3956    0.003952569 
+  232          229.32387    130.41679   0.004310345 
+  227          225.94569    130.43806   0.004405286 
+  227          216.8022     130.45943   0.004405286 
+  197          203.09223    130.48088   0.005076142 
+  209          191.72741    130.50242   0.004784689 
+  200          184.26313    130.52405   0.005     
+  200          179.222      130.54577   0.005     
+  175          174.50708    130.56758   0.005714286 
+  153          169.55089    130.58948   0.006535948 
+  175          165.10045    130.61147   0.005714286 
+  177          161.56648    130.63356   0.005649718 
+  197          158.91086    130.65573   0.005076142 
+  183          156.96572    130.67799   0.005464481 
+  167          155.57323    130.70035   0.005988024 
+  144          154.64271    130.7228    0.006944444 
+  174          154.19786    130.74534   0.005747126 
+  160          154.32468    130.76798   0.00625   
+  160          154.9638     130.79071   0.00625   
+  155          155.61698    130.81353   0.006451613 
+  169          155.60431    130.83645   0.00591716 
+  126          154.85213    130.85947   0.007936508 
+  153          153.77463    130.88258   0.006535948 
+  175          152.84453    130.90578   0.005714286 
+  156          152.31081    130.92908   0.006410256 
+  160          152.3209     130.95248   0.00625   
+  144          152.98695    130.97598   0.006944444 
+  178          154.21243    130.99957   0.005617978 
+  150          155.47522    131.02326   0.006666667 
+  168          155.72037    131.04706   0.005952381 
+  150          154.55708    131.07094   0.006666667 
+  155          152.92396    131.09493   0.006451613 
+  133          151.60631    131.11902   0.007518797 
+  139          150.68533    131.14321   0.007194245 
+  146          150.13873    131.1675    0.006849315 
+  163          150.06135    131.19189   0.006134969 
+  155          150.55689    131.21639   0.006451613 
+  162          151.7824     131.24098   0.00617284 
+  156          153.92357    131.26568   0.006410256 
+  152          157.06368    131.29048   0.006578947 
+  149          160.99033    131.31538   0.006711409 
+  147          164.82769    131.34039   0.006802721 
+  123          166.95703    131.3655    0.008130081 
+  170          165.83333    131.39072   0.005882353 
+  180          162.20618    131.41604   0.005555556 
+  149          158.48682    131.44147   0.006711409 
+  152          156.11786    131.467     0.006578947 
+  160          155.46084    131.49264   0.00625   
+  162          156.51744    131.51839   0.00617284 
+  154          158.90225    131.54425   0.006493506 
+  139          161.00571    131.57021   0.007194245 
+  155          161.00337    131.59628   0.006451613 
+  157          160.21416    131.62247   0.006369427 
+  163          160.41724    131.64876   0.006134969 
+  177          161.11935    131.67516   0.005649718 
+  159          160.90111    131.70167   0.006289308 
+  156          159.3447     131.72829   0.006410256 
+  149          157.13817    131.75503   0.006711409 
+  143          155.18348    131.78187   0.006993007 
+  159          153.96009    131.80883   0.006289308 
+  163          153.54781    131.8359    0.006134969 
+  154          153.68795    131.86309   0.006493506 
+  147          153.48118    131.89039   0.006802721 
+  128          152.16437    131.9178    0.0078125 
+  152          150.57995    131.94533   0.006578947 
+  153          149.67681    131.97297   0.006535948 
+  132          149.60416    132.00073   0.007575758 
+  153          150.14943    132.02861   0.006535948 
+  151          150.98964    132.0566    0.006622517 
+  146          152.05309    132.08471   0.006849315 
+  162          153.70224    132.11294   0.00617284 
+  150          156.24262    132.14129   0.006666667 
+  173          159.47044    132.16976   0.005780347 
+  175          162.2073     132.19834   0.005714286 
+  165          162.92223    132.22705   0.006060606 
+  141          161.40178    132.25587   0.007092199 
+  168          158.31816    132.28482   0.005952381 
+  192          154.65088    132.31389   0.005208333 
+  166          151.47761    132.34308   0.006024096 
+  175          149.2558     132.3724    0.005714286 
+  140          147.96654    132.40183   0.007142857 
+  147          147.4995     132.4314    0.006802721 
+  136          147.78843    132.46108   0.007352941 
+  147          148.80346    132.49089   0.006802721 
+  158          150.3669     132.52083   0.006329114 
+  160          151.87649    132.55089   0.00625   
+  142          152.55133    132.58108   0.007042254 
+  140          152.25414    132.61139   0.007142857 
+  160          151.32035    132.64184   0.00625   
+  156          150.2601     132.67241   0.006410256 
+  159          149.62615    132.70311   0.006289308 
+  161          149.5911     132.73394   0.00621118 
+  160          149.90805    132.76489   0.00625   
+  127          150.09199    132.79598   0.007874016 
+  144          149.99712    132.8272    0.006944444 
+  165          149.98885    132.85855   0.006060606 
+  156          150.29667    132.89004   0.006410256 
+  144          150.96838    132.92165   0.006944444 
+  136          152.0351     132.9534    0.007352941 
+  158          153.41237    132.98529   0.006329114 
+  160          154.93491    133.0173    0.00625   
+  153          155.89983    133.04946   0.006535948 
+  149          155.31954    133.08174   0.006711409 
+  152          153.49826    133.11417   0.006578947 
+  143          151.57186    133.14673   0.006993007 
+  149          150.00981    133.17942   0.006711409 
+  160          148.79667    133.21226   0.00625   
+  148          147.99773    133.24523   0.006756757 
+  153          147.637      133.27835   0.006535948 
+  156          147.65677    133.3116    0.006410256 
+  165          148.02678    133.34499   0.006060606 
+  162          148.68517    133.37852   0.00617284 
+  149          149.56144    133.4122    0.006711409 
+  167          150.39198    133.44602   0.005988024 
+  174          150.68481    133.47998   0.005747126 
+  142          150.50474    133.51408   0.007042254 
+  128          150.47246    133.54832   0.0078125 
+  188          150.80088    133.58271   0.005319149 
+  147          150.99511    133.61725   0.006802721 
+  137          150.51026    133.65193   0.00729927 
+  182          149.4615     133.68676   0.005494505 
+  157          148.28214    133.72173   0.006369427 
+  157          147.31757    133.75686   0.006369427 
+  147          146.7617     133.79213   0.006802721 
+  144          146.66898    133.82754   0.006944444 
+  160          147.03684    133.86311   0.00625   
+  149          147.66919    133.89883   0.006711409 
+  183          148.82131    133.9347    0.005464481 
+  163          150.14501    133.97072   0.006134969 
+  133          151.41085    134.00689   0.007518797 
+  167          152.34863    134.04322   0.005988024 
+  157          152.87296    134.07969   0.006369427 
+  139          153.11101    134.11633   0.007194245 
+  149          152.91753    134.15311   0.006711409 
+  167          152.0005     134.19005   0.005988024 
+  149          150.64485    134.22715   0.006711409 
+  162          149.41371    134.2644    0.00617284 
+  140          148.53864    134.30181   0.007142857 
+  141          148.27041    134.33938   0.007092199 
+  140          148.46466    134.37711   0.007142857 
+  145          148.98493    134.41499   0.006896552 
+  155          149.69228    134.45304   0.006451613 
+  137          150.53094    134.49124   0.00729927 
+  143          151.60109    134.52961   0.006993007 
+  130          152.84146    134.56814   0.007692308 
+  145          153.598      134.60683   0.006896552 
+  143          153.09637    134.64568   0.006993007 
+  145          151.58395    134.6847    0.006896552 
+  121          149.92147    134.72388   0.008264463 
+  129          148.60233    134.76323   0.007751938 
+  139          147.94766    134.80274   0.007194245 
+  143          147.46458    134.84242   0.006993007 
+  150          147.29981    134.88227   0.006666667 
+  166          147.39596    134.92228   0.006024096 
+  166          147.71064    134.96247   0.006024096 
+  170          148.21939    135.00282   0.005882353 
+  155          148.83285    135.04334   0.006451613 
+  127          149.33408    135.08404   0.007874016 
+  161          149.46103    135.1249    0.00621118 
+  149          149.24713    135.16594   0.006711409 
+  167          149.02138    135.20715   0.005988024 
+  159          148.98953    135.24853   0.006289308 
+  137          149.0506     135.29009   0.00729927 
+  157          149.14634    135.33182   0.006369427 
+  147          149.43889    135.37372   0.006802721 
+  151          150.05942    135.41581   0.006622517 
+  144          151.19018    135.45807   0.006944444 
+  143          152.66415    135.50051   0.006993007 
+  155          154.57488    135.54313   0.006451613 
+  172          156.60745    135.58592   0.005813953 
+  168          158.03425    135.6289    0.005952381 
+  142          158.29295    135.67206   0.007042254 
+  137          157.85185    135.71539   0.00729927 
+  157          157.6319     135.75892   0.006369427 
+  164          158.12888    135.80262   0.006097561 
+  157          159.4015     135.84651   0.006369427 
+  194          161.30129    135.89058   0.005154639 
+  162          163.33573    135.93484   0.00617284 
+  172          164.95317    135.97928   0.005813953 
+  163          166.44932    136.02391   0.006134969 
+  156          168.71036    136.06873   0.006410256 
+  145          171.57227    136.11373   0.006896552 
+  173          172.85745    136.15893   0.005780347 
+  170          171.00517    136.20431   0.005882353 
+  173          167.74196    136.24989   0.005780347 
+  150          165.01688    136.29565   0.006666667 
+  148          163.41801    136.34161   0.006756757 
+  179          162.88374    136.38776   0.005586592 
+  184          163.2453     136.43411   0.005434783 
+  178          164.25436    136.48065   0.005617978 
+  172          165.51471    136.52738   0.005813953 
+  185          166.7598     136.57431   0.005405405 
+  178          168.10368    136.62144   0.005617978 
+  165          169.62943    136.66876   0.006060606 
+  170          170.90767    136.71628   0.005882353 
+  185          171.12641    136.76401   0.005405405 
+  176          170.51623    136.81193   0.005681818 
+  198          170.29916    136.86005   0.005050505 
+  173          171.09267    136.90837   0.005780347 
+  193          172.95576    136.9569    0.005181347 
+  172          175.72133    137.00563   0.005813953 
+  183          178.81057    137.05456   0.005464481 
+  206          181.10563    137.1037    0.004854369 
+  176          182.02148    137.15304   0.005681818 
+  193          182.36048    137.20259   0.005181347 
+  198          183.08918    137.25235   0.005050505 
+  189          184.54012    137.30232   0.005291005 
+  190          186.82737    137.35249   0.005263158 
+  201          190.13043    137.40288   0.004975124 
+  215          194.63458    137.45347   0.004651163 
+  217          200.44183    137.50428   0.004608295 
+  202          207.39649    137.55529   0.004950495 
+  209          214.94315    137.60652   0.004784689 
+  238          222.66304    137.65797   0.004201681 
+  235          230.87471    137.70963   0.004255319 
+  242          240.14939    137.7615    0.004132231 
+  258          251.37881    137.8136    0.003875969 
+  275          266.06368    137.8659    0.003636364 
+  283          285.98036    137.91843   0.003533569 
+  310          313.31759    137.97118   0.003225806 
+  363          351.44597    138.02414   0.002754821 
+  421          406.20235    138.07733   0.002375297 
+  553          488.24574    138.13074   0.001808318 
+  676          617.23505    138.18437   0.00147929 
+  977          827.54564    138.23822   0.001023541 
+  1280         1169.90597   138.2923    0.00078125 
+  1763         1672.34364   138.3466    0.000567215 
+  2060         2144.91318   138.40113   0.000485437 
+  1952         2101.8354    138.45589   0.000512295 
+  1559         1606.2488    138.51087   0.000641437 
+  1187         1135.76699   138.56608   0.00084246 
+  880          830.32348    138.62152   0.001136364 
+  673          652.44941    138.67719   0.001485884 
+  658          554.67132    138.7331    0.001519757 
+  588          508.03684    138.78923   0.00170068 
+  599          500.03975    138.8456    0.001669449 
+  630          530.96732    138.9022    0.001587302 
+  731          612.94436    138.95904   0.001367989 
+  871          768.25248    139.01611   0.001148106 
+  1035         1006.60624   139.07342   0.000966184 
+  1132         1222.19664   139.13097   0.000883392 
+  1061         1172.81705   139.18876   0.000942507 
+  857          910.7647     139.24678   0.001166861 
+  689          670.12242    139.30505   0.001451379 
+  536          511.93801    139.36355   0.001865672 
+  464          415.29428    139.4223    0.002155172 
+  371          355.73503    139.48129   0.002695418 
+  304          317.50139    139.54053   0.003289474 
+  323          291.75097    139.60001   0.003095975 
+  281          273.64123    139.65974   0.003558719 
+  266          260.39177    139.71971   0.003759398 
+  231          250.23642    139.77994   0.004329004 
+  281          242.12963    139.84041   0.003558719 
+  236          235.58916    139.90113   0.004237288 
+  241          230.31963    139.9621    0.004149378 
+  231          226.0176     140.02332   0.004329004 
+  233          222.39172    140.0848    0.004291845 
+  190          219.08423    140.14653   0.005263158 
+  228          215.60043    140.20851   0.004385965 
+  214          211.77219    140.27075   0.004672897 
+  205          207.89499    140.33324   0.004878049 
+  220          204.50594    140.396     0.004545455 
+  223          201.63715    140.45901   0.004484305 
+  238          199.25484    140.52228   0.004201681 
+  205          197.28394    140.58581   0.004878049 
+  191          195.65611    140.6496    0.005235602 
+  180          194.32048    140.71366   0.005555556 
+  181          193.23168    140.77798   0.005524862 
+  189          192.34015    140.84256   0.005291005 
+  198          191.59527    140.90741   0.005050505 
+  169          190.90817    140.97252   0.00591716 
+  199          190.09491    141.03791   0.005025126 
+  206          189.04393    141.10356   0.004854369 
+  217          188.04832    141.16948   0.004608295 
+  174          187.30563    141.23567   0.005747126 
+  187          186.90293    141.30213   0.005347594 
+  157          186.83018    141.36886   0.006369427 
+  171          187.03247    141.43587   0.005847953 
+  193          187.42736    141.50315   0.005181347 
+  179          187.93895    141.57071   0.005586592 
+  179          188.53766    141.63854   0.005586592 
+  167          189.21825    141.70665   0.005988024 
+  209          189.97743    141.77505   0.004784689 
+  175          190.83032    141.84371   0.005714286 
+  193          191.82033    141.91267   0.005181347 
+  198          193.02916    141.9819    0.005050505 
+  210          194.5908     142.05141   0.004761905 
+  190          196.70569    142.12121   0.005263158 
+  189          199.64133    142.1913    0.005291005 
+  201          203.6565     142.26166   0.004975124 
+  226          208.62139    142.33232   0.004424779 
+  224          213.21236    142.40327   0.004464286 
+  208          215.27154    142.4745    0.004807692 
+  196          214.83135    142.54602   0.005102041 
+  210          213.9309     142.61784   0.004761905 
+  210          213.13558    142.68995   0.004761905 
+  195          211.3144     142.76235   0.005128205 
+  189          207.77963    142.83504   0.005291005 
+  178          203.30464    142.90803   0.005617978 
+  198          199.10046    142.98132   0.005050505 
+  187          195.81599    143.05491   0.005347594 
+  225          193.6142     143.12879   0.004444444 
+  205          192.49982    143.20298   0.004878049 
+  215          192.37505    143.27746   0.004651163 
+  240          192.73724    143.35225   0.004166667 
+  213          192.46963    143.42734   0.004694836 
+  196          191.003      143.50274   0.005102041 
+  204          189.17645    143.57844   0.004901961 
+  204          187.64479    143.65444   0.004901961 
+  204          186.03826    143.73076   0.004901961 
+  207          183.76043    143.80738   0.004830918 
+  196          180.86134    143.88432   0.005102041 
+  191          177.88132    143.96156   0.005235602 
+  175          175.26602    144.03912   0.005714286 
+  198          173.18604    144.11699   0.005050505 
+  187          171.62988    144.19517   0.005347594 
+  196          170.48501    144.27367   0.005102041 
+  184          169.55486    144.35249   0.005434783 
+  174          168.67042    144.43163   0.005747126 
+  199          167.88428    144.51108   0.005025126 
+  175          167.40152    144.59086   0.005714286 
+  201          167.39109    144.67095   0.004975124 
+  189          167.9457     144.75137   0.005291005 
+  166          169.03481    144.83211   0.006024096 
+  183          170.29375    144.91318   0.005464481 
+  164          170.8612     144.99457   0.006097561 
+  175          170.04308    145.07629   0.005714286 
+  180          168.25828    145.15834   0.005555556 
+  174          166.43661    145.24072   0.005747126 
+  184          165.07237    145.32343   0.005434783 
+  178          164.2083     145.40647   0.005617978 
+  213          163.70269    145.48985   0.004694836 
+  175          163.43448    145.57356   0.005714286 
+  172          163.35997    145.6576    0.005813953 
+  175          163.44072    145.74198   0.005714286 
+  152          163.68398    145.8267    0.006578947 
+  171          164.17914    145.91176   0.005847953 
+  171          164.95083    145.99716   0.005847953 
+  174          165.76816    146.0829    0.005747126 
+  175          166.19463    146.16898   0.005714286 
+  205          166.10198    146.2554    0.004878049 
+  168          165.88481    146.34218   0.005952381 
+  177          165.96961    146.42929   0.005649718 
+  165          166.55834    146.51676   0.006060606 
+  177          167.74348    146.60458   0.005649718 
+  181          169.63048    146.69274   0.005524862 
+  193          172.39636    146.78126   0.005181347 
+  174          176.34514    146.87013   0.005747126 
+  181          182.04561    146.95935   0.005524862 
+  187          190.5896     147.04893   0.005347594 
+  222          203.89302    147.13886   0.004504505 
+  229          224.65917    147.22915   0.004366812 
+  252          254.511      147.3198    0.003968254 
+  288          285.77186    147.41081   0.003472222 
+  268          292.86726    147.50219   0.003731343 
+  265          267.89018    147.59392   0.003773585 
+  225          237.7271     147.68602   0.004444444 
+  222          217.08799    147.77848   0.004504505 
+  205          205.92186    147.87132   0.004878049 
+  198          201.7031     147.96451   0.005050505 
+  223          202.91437    148.05808   0.004484305 
+  219          209.33735    148.15202   0.00456621 
+  236          221.85156    148.24633   0.004237288 
+  196          242.0081     148.34101   0.005102041 
+  246          270.42516    148.43607   0.004065041 
+  257          300.79889    148.5315    0.003891051 
+  283          316.68821    148.62731   0.003533569 
+  269          310.39213    148.7235    0.003717472 
+  265          285.44009    148.82006   0.003773585 
+  245          252.47592    148.91701   0.004081633 
+  248          225.64399    149.01434   0.004032258 
+  216          208.15748    149.11205   0.00462963 
+  198          197.78051    149.21015   0.005050505 
+  215          192.26316    149.30863   0.004651163 
+  164          190.32378    149.40751   0.006097561 
+  198          191.50661    149.50677   0.005050505 
+  179          195.90121    149.60642   0.005586592 
+  249          203.74191    149.70646   0.004016064 
+  209          214.31959    149.80689   0.004784689 
+  233          222.79345    149.90772   0.004291845 
+  200          220.85131    150.00894   0.005     
+  183          209.61451    150.11057   0.005464481 
+  191          197.61244    150.21258   0.005235602 
+  193          188.46511    150.315     0.005181347 
+  209          181.90679    150.41782   0.004784689 
+  164          177.21004    150.52105   0.006097561 
+  157          173.91469    150.62467   0.006369427 
+  168          171.67553    150.7287    0.005952381 
+  188          170.21586    150.83314   0.005319149 
+  165          169.33669    150.93799   0.006060606 
+  157          168.88806    151.04324   0.006369427 
+  141          168.7353     151.14891   0.007092199 
+  136          168.75956    151.25498   0.007352941 
+  162          168.87397    151.36147   0.00617284 
+  162          169.03572    151.46838   0.00617284 
+  153          169.26841    151.5757    0.006535948 
+  160          169.60515    151.68344   0.00625   
+  152          169.9901     151.7916    0.006578947 
+  176          170.36638    151.90018   0.005681818 
+  159          170.81003    152.00918   0.006289308 
+  144          171.42502    152.1186    0.006944444 
+  173          172.11968    152.22845   0.005780347 
+  160          172.48765    152.33873   0.00625   
+  167          172.16248    152.44943   0.005988024 
+  164          171.32558    152.56056   0.006097561 
+  176          170.43195    152.67213   0.005681818 
+  165          169.7029     152.78412   0.006060606 
+  158          169.10659    152.89655   0.006329114 
+  149          168.59695    153.00941   0.006711409 
+  155          168.22394    153.12271   0.006451613 
+  155          168.05934    153.23645   0.006451613 
+  153          168.13929    153.35063   0.006535948 
+  158          168.47531    153.46525   0.006329114 
+  155          169.06288    153.58031   0.006451613 
+  149          169.8643     153.69581   0.006711409 
+  148          170.71022    153.81176   0.006756757 
+  153          171.20154    153.92815   0.006535948 
+  141          170.96304    154.045     0.007092199 
+  168          170.11189    154.16229   0.005952381 
+  165          169.11009    154.28004   0.006060606 
+  146          168.25909    154.39823   0.006849315 
+  152          167.60076    154.51689   0.006578947 
+  167          167.09135    154.63599   0.005988024 
+  178          166.70567    154.75556   0.005617978 
+  158          166.42561    154.87558   0.006329114 
+  153          166.24261    154.99606   0.006535948 
+  162          166.17319    155.11701   0.00617284 
+  186          166.23092    155.23842   0.005376344 
+  161          166.40954    155.36029   0.00621118 
+  178          166.66316    155.48263   0.005617978 
+  189          166.89363    155.60544   0.005291005 
+  148          166.99714    155.72872   0.006756757 
+  167          166.97061    155.85247   0.005988024 
+  157          166.92225    155.97669   0.006369427 
+  163          166.9535     156.10138   0.006134969 
+  156          167.10027    156.22655   0.006410256 
+  171          167.34755    156.3522    0.005847953 
+  167          167.63846    156.47833   0.005988024 
+  160          167.9023     156.60493   0.00625   
+  180          168.12574    156.73202   0.005555556 
+  187          168.3624     156.8596    0.005347594 
+  143          168.667      156.98765   0.006993007 
+  154          169.05982    157.1162    0.006493506 
+  152          169.53774    157.24523   0.006578947 
+  159          170.08974    157.37475   0.006289308 
+  156          170.70499    157.50477   0.006410256 
+  156          171.36364    157.63528   0.006410256 
+  165          172.03349    157.76628   0.006060606 
+  134          172.72835    157.89778   0.007462687 
+  150          173.52936    158.02977   0.006666667 
+  182          174.52816    158.16227   0.005494505 
+  177          175.79381    158.29526   0.005649718 
+  154          177.37563    158.42876   0.006493506 
+  177          179.29289    158.56277   0.005649718 
+  166          181.4247     158.69728   0.006024096 
+  182          183.31516    158.83229   0.005494505 
+  172          184.30532    158.96782   0.005813953 
+  160          184.24264    159.10386   0.00625   
+  182          183.72987    159.24041   0.005494505 
+  188          183.42336    159.37748   0.005319149 
+  158          183.60943    159.51506   0.006329114 
+  191          184.33914    159.65315   0.005235602 
+  184          185.59628    159.79177   0.005434783 
+  190          187.31706    159.93091   0.005263158 
+  173          189.2866     160.07057   0.005780347 
+  178          191.22409    160.21076   0.005617978 
+  180          193.07253    160.35147   0.005555556 
+  194          194.9498     160.49271   0.005154639 
+  156          196.96816    160.63448   0.006410256 
+  155          199.31897    160.77677   0.006451613 
+  193          202.15374    160.91961   0.005181347 
+  194          205.51467    161.06297   0.005154639 
+  216          209.5782     161.20688   0.00462963 
+  169          214.49782    161.35132   0.00591716 
+  192          219.20794    161.4963    0.005208333 
+  225          221.43512    161.64182   0.004444444 
+  214          221.99704    161.78788   0.004672897 
+  232          224.62403    161.93449   0.004310345 
+  214          232.05183    162.08165   0.004672897 
+  245          246.41022    162.22935   0.004081633 
+  258          270.64481    162.3776    0.003875969 
+  286          307.48363    162.52641   0.003496503 
+  347          350.30949    162.67577   0.002881844 
+  354          368.82479    162.82568   0.002824859 
+  310          342.58975    162.97615   0.003225806 
+  271          300.75871    163.12718   0.003690037 
+  256          268.45778    163.27877   0.00390625 
+  229          248.62481    163.43092   0.004366812 
+  264          237.65854    163.58364   0.003787879 
+  220          231.42926    163.73692   0.004545455 
+  213          226.89566    163.89077   0.004694836 
+  199          223.69848    164.04519   0.005025126 
+  211          222.58111    164.20018   0.004739336 
+  221          224.35752    164.35574   0.004524887 
+  282          230.38403    164.51188   0.003546099 
+  250          242.43935    164.66859   0.004     
+  253          261.20468    164.82588   0.003952569 
+  279          280.0456     164.98375   0.003584229 
+  256          281.63263    165.14221   0.00390625 
+  241          263.78826    165.30125   0.004149378 
+  230          243.51531    165.46087   0.004347826 
+  223          228.74176    165.62108   0.004484305 
+  214          218.74354    165.78188   0.004672897 
+  191          211.67158    165.94327   0.005235602 
+  209          206.59496    166.10525   0.004784689 
+  186          203.04271    166.26783   0.005376344 
+  187          200.50259    166.43101   0.005347594 
+  196          198.50664    166.59478   0.005102041 
+  174          196.84426    166.75916   0.005747126 
+  191          195.46647    166.92413   0.005235602 
+  202          194.37501    167.08971   0.004950495 
+  181          193.64879    167.2559    0.005524862 
+  185          193.3782     167.42269   0.005405405 
+  186          193.54942    167.5901    0.005376344 
+  187          194.0115     167.75811   0.005347594 
+  159          194.49885    167.92674   0.006289308 
+  193          194.7379     168.09598   0.005181347 
+  187          194.61239    168.26584   0.005347594 
+  202          194.23915    168.43632   0.004950495 
+  211          193.82407    168.60743   0.004739336 
+  196          193.40616    168.77915   0.005102041 
+  181          192.94332    168.9515    0.005524862 
+  176          192.52469    169.12447   0.005681818 
+  172          192.25236    169.29808   0.005813953 
+  199          192.11911    169.47231   0.005025126 
+  199          192.12535    169.64718   0.005025126 
+  189          192.33897    169.82268   0.005291005 
+  190          192.79642    169.99882   0.005263158 
+  198          193.40354    170.1756    0.005050505 
+  207          193.93798    170.35301   0.004830918 
+  213          194.24088    170.53107   0.004694836 
+  186          194.41337    170.70978   0.005376344 
+  172          194.69302    170.88913   0.005813953 
+  180          195.22958    171.06912   0.005555556 
+  215          196.02732    171.24977   0.004651163 
+  207          196.98531    171.43107   0.004830918 
+  186          197.86003    171.61303   0.005376344 
+  162          198.72629    171.79564   0.00617284 
+  191          199.27786    171.9789    0.005235602 
+  192          199.49334    172.16283   0.005208333 
+  197          199.61365    172.34742   0.005076142 
+  204          199.89339    172.53268   0.004901961 
+  207          200.43637    172.7186    0.004830918 
+  182          201.21168    172.90519   0.005494505 
+  194          202.12106    173.09244   0.005154639 
+  203          203.10538    173.28037   0.004926108 
+  216          204.22049    173.46898   0.00462963 
+  220          205.5725     173.65826   0.004545455 
+  218          207.24875    173.84822   0.004587156 
+  198          209.26448    174.03886   0.005050505 
+  189          211.80367    174.23018   0.005291005 
+  201          214.85293    174.42218   0.004975124 
+  200          218.34119    174.61488   0.005     
+  225          221.96179    174.80826   0.004444444 
+  200          225.14001    175.00233   0.005     
+  227          227.32134    175.19709   0.004405286 
+  231          228.58654    175.39255   0.004329004 
+  229          229.58121    175.5887    0.004366812 
+  203          230.63075    175.78556   0.004926108 
+  207          231.43154    175.98311   0.004830918 
+  238          231.66627    176.18137   0.004201681 
+  204          231.52077    176.38033   0.004901961 
+  216          231.40893    176.58      0.00462963 
+  207          231.61505    176.78038   0.004830918 
+  232          232.28353    176.98147   0.004310345 
+  196          233.48717    177.18327   0.005102041 
+  221          235.25591    177.38579   0.004524887 
+  235          237.57797    177.58903   0.004255319 
+  217          240.35307    177.79299   0.004608295 
+  234          243.30295    177.99766   0.004273504 
+  228          246.05257    178.20307   0.004385965 
+  227          248.5223     178.4092    0.004405286 
+  265          251.06206    178.61605   0.003773585 
+  236          253.9987     178.82364   0.004237288 
+  256          257.33025    179.03196   0.00390625 
+  288          260.93368    179.24102   0.003472222 
+  263          264.9442     179.45081   0.003802281 
+  264          269.87423    179.66134   0.003787879 
+  278          276.61013    179.87261   0.003597122 
+  323          286.22462    180.08463   0.003095975 
+  342          299.13343    180.29739   0.002923977 
+  341          312.76639    180.5109    0.002932551 
+  351          319.94554    180.72516   0.002849003 
+  325          316.85154    180.94017   0.003076923 
+  330          309.5561     181.15594   0.003030303 
+  353          304.14599    181.37247   0.002832861 
+  310          302.01304    181.58975   0.003225806 
+  370          302.58721    181.80779   0.002702703 
+  364          305.26639    182.0266    0.002747253 
+  301          309.75278    182.24617   0.003322259 
+  326          315.89275    182.46651   0.003067485 
+  355          323.60322    182.68762   0.002816901 
+  383          332.92653    182.90951   0.002610966 
+  339          344.14616    183.13216   0.002949853 
+  387          357.8135     183.3556    0.002583979 
+  354          374.49323    183.57981   0.002824859 
+  380          393.97778    183.80481   0.002631579 
+  418          413.90327    184.03058   0.002392344 
+  458          431.27407    184.25715   0.002183406 
+  447          447.79263    184.4845    0.002237136 
+  483          467.9873     184.71264   0.002070393 
+  520          494.5011     184.94158   0.001923077 
+  572          528.53293    185.17131   0.001748252 
+  620          571.42365    185.40183   0.001612903 
+  672          625.71938    185.63316   0.001488095 
+  740          695.66901    185.86529   0.001351351 
+  849          786.80858    186.09822   0.001177856 
+  986          904.8369     186.33196   0.001014199 
+  1133         1056.89611   186.56651   0.000882613 
+  1432         1260.94414   186.80187   0.000698324 
+  1757         1554.69986   187.03804   0.000569152 
+  2415         2000.30696   187.27503   0.000414079 
+  3178         2692.35726   187.51284   0.000314663 
+  4527         3753.98438   187.75147   0.000220897 
+  6169         5234.92876   187.99092   0.000162101 
+  7239         6713.60529   188.23119   0.000138141 
+  7124         7034.62349   188.4723    0.000140371 
+  5910         5858.12641   188.71423   0.000169205 
+  4809         4305.70346   188.957     0.000207943 
+  3583         3105.96955   189.2006    0.000279096 
+  2808         2318.11472   189.44503   0.000356125 
+  2295         1826.67654   189.69031   0.00043573 
+  1967         1528.28178   189.93643   0.000508388 
+  1748         1355.63788   190.18339   0.000572082 
+  1590         1271.27894   190.4312    0.000628931 
+  1539         1262.07303   190.67986   0.000649773 
+  1626         1335.26782   190.92937   0.000615006 
+  1821         1516.88078   191.17973   0.000549149 
+  2192         1853.56213   191.43095   0.000456204 
+  2815         2401.91786   191.68303   0.00035524 
+  3454         3145.40076   191.93597   0.000289519 
+  3858         3753.04641   192.18977   0.000259202 
+  3702         3643.14533   192.44444   0.000270124 
+  3076         2908.35955   192.69998   0.000325098 
+  2425         2137.24689   192.95639   0.000412371 
+  1817         1573.23391   193.21367   0.000550358 
+  1436         1200.41729   193.47183   0.000696379 
+  1150         957.10431    193.73086   0.000869565 
+  980          794.86821    193.99078   0.001020408 
+  834          682.57061    194.25158   0.001199041 
+  712          601.35195    194.51327   0.001404494 
+  666          540.04679    194.77584   0.001501502 
+  544          492.20645    195.03931   0.001838235 
+  530          454.21779    195.30366   0.001886792 
+  462          423.89653    195.56892   0.002164502 
+  433          399.66856    195.83507   0.002309469 
+  430          380.33992    196.10212   0.002325581 
+  393          364.95011    196.37008   0.002544529 
+  377          352.65524    196.63894   0.00265252 
+  339          342.5804     196.90871   0.002949853 
+  328          333.97628    197.17939   0.00304878 
+  310          326.59818    197.45098   0.003225806 
+  329          320.61915    197.72349   0.003039514 
+  332          316.02224    197.99692   0.003012048 
+  306          311.96679    198.27127   0.003267974 
+  292          307.02419    198.54655   0.003424658 
+  303          300.72269    198.82274   0.00330033 
+  288          293.89456    199.09987   0.003472222 
+  269          287.41408    199.37793   0.003717472 
+  293          281.76179    199.65692   0.003412969 
+  298          277.16907    199.93685   0.003355705 
+  276          273.64209    200.21772   0.003623188 
+  291          271.06008    200.49953   0.003436426 
+  263          269.34638    200.78229   0.003802281 
+  291          268.47952    201.06599   0.003436426 
+  240          268.35103    201.35064   0.004166667 
+  257          268.79898    201.63624   0.003891051 
+  268          269.8587     201.9228    0.003731343 
+  259          271.90293    202.21032   0.003861004 
+  284          275.49399    202.49879   0.003521127 
+  247          281.00548    202.78823   0.004048583 
+  235          288.54133    203.07863   0.004255319 
+  274          298.03446    203.37      0.003649635 
+  277          307.10566    203.66234   0.003610108 
+  312          308.92022    203.95566   0.003205128 
+  276          299.92416    204.24995   0.003623188 
+  256          286.21789    204.54522   0.00390625 
+  239          274.21233    204.84147   0.0041841 
+  219          265.64415    205.1387    0.00456621 
+  247          260.11519    205.43693   0.004048583 
+  249          256.94989    205.73614   0.004016064 
+  252          255.6822     206.03634   0.003968254 
+  243          256.05345    206.33754   0.004115226 
+  222          257.98672    206.63973   0.004504505 
+  232          261.63682    206.94293   0.004310345 
+  244          267.46916    207.24712   0.004098361 
+  224          276.32971    207.55233   0.004464286 
+  253          289.4164     207.85854   0.003952569 
+#--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--#
+
+# start Validation Reply Form
+vrf_PLAT741_NEW5minmill_phase_1 # for all atoms in 1_quartz
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+vrf_PLAT741_NEW5minmill_phase_3 # for all atoms in 3_pyrrhotite
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+vrf_PLAT741_NEW5minmill_phase_4 # for all atoms in 4_rutile
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+vrf_PLAT741_NEW5minmill_phase_2 # for all atoms in 2_albite
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT155_NEW5minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT141_NEW5minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT142_NEW5minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT143_NEW5minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT144_NEW5minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT145_NEW5minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT146_NEW5minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT151_NEW5minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+# end Validation Reply Form

--- a/data/hamish/vb5042sup9.cif
+++ b/data/hamish/vb5042sup9.cif
@@ -1,0 +1,6669 @@
+
+data_NEW10minmill_publ
+_audit_creation_method  "created in GSAS-II"
+_audit_creation_date  2021-08-04T18:46
+_audit_author_name  "McDougall, Hamish"
+_audit_update_record
+   "2021-08-04T18:46  Initial software-generated CIF"
+_pd_block_id  2021-08-04T18:46|NEW10minmill|McDougallHamish|Overall
+# GSAS-II edited template follows Publication_Template
+#=============================================================================
+# this information describes the project, paper etc. for the CIF             #
+# Acta Cryst. Section C papers and editorial correspondence is generated     #
+# from the information in this section                                       #
+#                                                                            #
+#   (from)   CIF submission form for Rietveld refinements (Acta Cryst. C)    #
+#                                                 Version 14 December 1998   #
+#=============================================================================
+# 1. SUBMISSION DETAILS
+
+_publ_contact_author_name             "Suzanne Neville; Vanessa Peterson; Christophe Didier"   # Name of author for correspondence
+_publ_contact_author_address             # Address of author for correspondence
+; ?
+;
+_publ_contact_author_email           "s.neville@unsw.edu.au; vanessa.peterson@ansto.gov.au; drchristophedidier@gmail.com"
+_publ_contact_author_fax             ?
+_publ_contact_author_phone           ?
+
+_publ_contact_letter
+; ?
+;
+   
+_publ_requested_journal              ?
+_publ_requested_coeditor_name        ?
+_publ_requested_category             ?   # Acta C: one of CI/CM/CO/FI/FM/FO
+
+#==============================================================================
+
+# 2. PROCESSING SUMMARY (IUCr Office Use Only)
+
+_journal_data_validation_number      ?
+
+_journal_date_recd_electronic        ?
+_journal_date_to_coeditor            ?
+_journal_date_from_coeditor          ?
+_journal_date_accepted               ?
+_journal_date_printers_first         ?
+_journal_date_printers_final         ?
+_journal_date_proofs_out             ?
+_journal_date_proofs_in              ?
+_journal_coeditor_name               ?
+_journal_coeditor_code               ?
+_journal_coeditor_notes
+; ?
+;
+_journal_techeditor_code             ?
+_journal_techeditor_notes
+; ?
+;
+_journal_coden_ASTM                  ?
+_journal_name_full                   ?
+_journal_year                        ?
+_journal_volume                      ?
+_journal_issue                       ?
+_journal_page_first                  ?
+_journal_page_last                   ?
+_journal_paper_category              ?
+_journal_suppl_publ_number           ?
+_journal_suppl_publ_pages            ?
+
+#==============================================================================
+
+# 3. TITLE AND AUTHOR LIST
+
+_publ_section_title
+; ?
+;
+_publ_section_title_footnote
+; ?
+;         
+ 
+# The loop structure below should contain the names and addresses of all 
+# authors, in the required order of publication. Repeat as necessary.
+
+loop_
+	_publ_author_name
+        _publ_author_footnote
+	_publ_author_address
+ ?                                   #<--'Last name, first name' 
+; ?
+;
+; ?
+;
+
+#==============================================================================
+
+# 4. TEXT
+
+_publ_section_synopsis
+;  ?
+;
+_publ_section_abstract                         
+; ?
+;          
+_publ_section_comment                          
+; ?
+;
+_publ_section_exptl_prep      # Details of the preparation of the sample(s)
+                              # should be given here. 
+; ?
+;
+_publ_section_exptl_refinement                  
+; ?
+;
+_publ_section_references
+; ?
+;
+_publ_section_figure_captions
+; ?
+;
+_publ_section_acknowledgements
+; ?
+;
+
+#=============================================================================
+# 5. OVERALL REFINEMENT & COMPUTING DETAILS
+
+_refine_special_details
+; ?
+;
+_pd_proc_ls_special_details
+; ?
+;
+
+# The following items are used to identify the programs used.
+_computing_molecular_graphics     ?
+_computing_publication_material   ?
+
+_refine_ls_weighting_scheme       ?        
+_refine_ls_weighting_details      ?
+_refine_ls_hydrogen_treatment     ?        
+_refine_ls_extinction_method      ?        
+_refine_ls_extinction_coef        ?         
+_refine_ls_number_constraints     ?        
+
+_refine_ls_restrained_S_all       ?        
+_refine_ls_restrained_S_obs       ?
+
+#==============================================================================
+# 6. SAMPLE PREPARATION DATA
+
+# (In the unusual case where multiple samples are used in a single
+#  Rietveld study, this information should be moved into the phase
+#  blocks)
+
+# The following three fields describe the preparation of the material.
+# The cooling rate is in K/min.  The pressure at which the sample was  
+# prepared is in kPa.  The temperature of preparation is in K.
+               
+_pd_prep_cool_rate                N/A        
+_pd_prep_pressure                 101.3        
+_pd_prep_temperature              298         
+
+_pd_char_colour                   ?       # use ICDD colour descriptions
+
+data_NEW10minmill_overall
+_pd_proc_info_datetime  2021-08-04T18:46
+_pd_calc_method  "Rietveld Refinement"
+_computing_structure_refinement
+   "GSAS-II (Toby & Von Dreele, J. Appl. Cryst. 46, 544-549, 2013)"
+_refine_ls_number_parameters  30
+_refine_ls_goodness_of_fit_all  2.138
+_refine_ls_shift/su_max  0.1571
+
+# OVERALL WEIGHTED R-FACTOR
+_refine_ls_wR_factor_obs  0.08569
+_refine_ls_matrix_type  full
+# POINTERS TO PHASE AND HISTOGRAM BLOCKS
+loop_   _pd_phase_block_id
+  2021-08-04T18:46|NEW10minmill|phase_0|McDougallHamish
+  2021-08-04T18:46|NEW10minmill|phase_2|McDougallHamish
+  2021-08-04T18:46|NEW10minmill|phase_4|McDougallHamish
+  2021-08-04T18:46|NEW10minmill|phase_1|McDougallHamish
+  2021-08-04T18:46|NEW10minmill|phase_3|McDougallHamish
+_pd_block_diffractogram_id
+;
+2021-08-04T18:46|NEW10minmill|McDougallHamish|PANalytical,Co-EmpyreanII_hist_0
+;
+
+data_NEW10minmill_phase_0
+# Information for phase 0
+_pd_block_id  2021-08-04T18:46|NEW10minmill|phase_0|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for FeS2 follows
+_pd_phase_name  FeS2
+_cell_length_a  5.419877(30)
+_cell_length_b  5.419877(30)
+_cell_length_c  5.419877(30)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  90
+_cell_volume  159.2093(27)
+_exptl_crystal_density_diffrn  5.0050
+_symmetry_cell_setting  cubic
+_symmetry_space_group_name_H-M  "P a -3"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  z,x,y
+     3  y,z,x
+     4  1/2+x,y,1/2-z
+     5  1/2-z,1/2+x,y
+     6  y,1/2-z,1/2+x
+     7  -z,1/2+x,1/2-y
+     8  1/2-y,-z,1/2+x
+     9  1/2+y,1/2-z,-x
+    10  -x,1/2+y,1/2-z
+    11  1/2-z,-x,1/2+y
+    12  1/2+x,1/2-y,-z
+    13  -x,-y,-z
+    14  -z,-x,-y
+    15  -y,-z,-x
+    16  1/2-x,-y,1/2+z
+    17  1/2+z,1/2-x,-y
+    18  -y,1/2+z,1/2-x
+    19  z,1/2-x,1/2+y
+    20  1/2+y,z,1/2-x
+    21  1/2-y,1/2+z,x
+    22  x,1/2-y,1/2+z
+    23  1/2+z,x,1/2-y
+    24  1/2-x,1/2+y,z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Fe1    Fe   0.00000     0.00000     0.00000     1.000      Uiso 0.00873(29) 4   
+S2     S    0.38482(10) 0.38482     0.38482     1.000      Uiso 0.00867(31) 8   
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Fe   4      11.7695    7.3573     3.5222     2.3045     4.7611     0.3072     15.3535    76.8805    1.0369     0.945
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S    8      6.9053     5.2034     1.4379     1.5863     1.4679     22.2151    0.2536     56.172     0.8669     0.2847
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Fe S2"
+_chemical_formula_weight  119.97
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Fe1    S2     2.26483(15)   1_555    4_455 yes
+  Fe1    S2     2.26483(15)   1_555    5_545 yes
+  Fe1    S2     2.26483(15)   1_555    6_554 yes
+  Fe1    S2     2.26483(15)   1_555    7_545 yes
+  Fe1    S2     2.26483(15)   1_555    8_554 yes
+  Fe1    S2     2.2648(5)    1_555    9_455 yes
+  S2     Fe1    2.26483(15)   1_555    4_555 yes
+  S2     Fe1    2.26483(15)   1_555    5_555 yes
+  S2     Fe1    2.2648(5)    1_555    6_555 yes
+  S2     S2     2.1625(6)    1_555   13_666 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.1814(11), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW10minmill_phase_2
+# Information for phase 2
+_pd_block_id  2021-08-04T18:46|NEW10minmill|phase_2|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for NaAlSi3O8 follows
+_pd_phase_name  NaAlSi3O8
+_cell_length_a  8.137
+_cell_length_b  12.785
+_cell_length_c  7.1583
+_cell_angle_alpha  94.26
+_cell_angle_beta   116.6
+_cell_angle_gamma  87.71
+_cell_volume  664.008
+_exptl_crystal_density_diffrn  2.6230
+_symmetry_cell_setting  triclinic
+_symmetry_space_group_name_H-M  "C -1"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -x,-y,-z
+     3  1/2+x,1/2+y,z
+     4  1/2-x,1/2-y,-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Al1    Al3+ 0.00887     0.16846     0.20805     1.000      Uani 0.007      4   
+Si1    Si4+ 0.00375     0.82051     0.23737     1.000      Uani 0.006      4   
+Si2    Si4+ 0.69162     0.11021     0.31466     1.000      Uani 0.006      4   
+Si3    Si4+ 0.68129     0.88190     0.36076     1.000      Uani 0.006      4   
+Na1    Na1+ 0.26799     0.98865     0.14650     1.000      Uani 0.031      4   
+O1     O2-  0.00490     0.13103     0.96660     1.000      Uani 0.012      4   
+O2     O2-  0.59176     0.99756     0.28040     1.000      Uani 0.008      4   
+O3     O2-  0.81230     0.10966     0.19010     1.000      Uani 0.014      4   
+O4     O2-  0.82000     0.85101     0.25870     1.000      Uani 0.018      4   
+O5     O2-  0.01288     0.30238     0.27060     1.000      Uani 0.011      4   
+O6     O2-  0.02329     0.69368     0.22910     1.000      Uani 0.011      4   
+O7     O2-  0.20780     0.10896     0.38900     1.000      Uani 0.011      4   
+O8     O2-  0.18400     0.86817     0.43620     1.000      Uani 0.012      4   
+
+loop_
+   _atom_site_aniso_label
+   _atom_site_aniso_U_11
+   _atom_site_aniso_U_22
+   _atom_site_aniso_U_33
+   _atom_site_aniso_U_12
+   _atom_site_aniso_U_13
+   _atom_site_aniso_U_23
+Al1    0.0074      0.0068      0.0061      -0.0009     0.0031      0.0004      
+Si1    0.0068      0.0065      0.0055      0.0011      0.0030      0.0008      
+Si2    0.0061      0.0055      0.0073      -0.0002     0.0025      0.0004      
+Si3    0.0060      0.0055      0.0074      0.0006      0.0028      0.0009      
+Na1    0.0136      0.0471      0.0315      -0.0050     0.0084      -0.0219     
+O1     0.0164      0.0122      0.0074      -0.0002     0.0067      0.0014      
+O2     0.0074      0.0056      0.0119      0.0003      0.0033      0.0020      
+O3     0.0117      0.0130      0.0162      -0.0040     0.0093      -0.0017     
+O4     0.0134      0.0179      0.0216      0.0046      0.0129      0.0020      
+O5     0.0103      0.0076      0.0150      -0.0020     0.0052      -0.0009     
+O6     0.0101      0.0071      0.0145      0.0022      0.0034      0.0012      
+O7     0.0120      0.0129      0.0080      0.0024      0.0013      0.0015      
+O8     0.0140      0.0140      0.0084      -0.0026     -0.0002     -0.0006     
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Al   4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Na   4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  O    32     ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si   12     ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Al Na O8 Si3"
+_chemical_formula_weight  262.22
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Al1    O1     1.74519      1_555    1_554 yes
+  Al1    O3     1.7429       1_555    1_455 yes
+  Al1    O5     1.73509      1_555    1_555 yes
+  Al1    O7     1.74556      1_555    1_555 yes
+  Si1    O1     1.59985      1_555    2_566 yes
+  Si1    O4     1.59997      1_555    1_455 yes
+  Si1    O6     1.62225      1_555    1_555 yes
+  Si1    O8     1.61907      1_555    1_555 yes
+  Si2    O2     1.63011      1_555    1_545 yes
+  Si2    O3     1.59435      1_555    1_555 yes
+  Si2    O6     1.61836      1_555    3_545 yes
+  Si2    O8     1.6168       1_555    2_666 yes
+  Si3    O2     1.64718      1_555    1_555 yes
+  Si3    O4     1.61975      1_555    1_555 yes
+  Si3    O5     1.59682      1_555    3_555 yes
+  Si3    O7     1.60203      1_555    2_666 yes
+  Na1    O1     2.66887      1_555    1_564 yes
+  Na1    O1     2.53079      1_555    2_566 yes
+  Na1    O2     2.3704       1_555    1_555 yes
+  Na1    O3     2.45321      1_555    2_665 yes
+  Na1    O7     2.43384      1_555    1_565 yes
+  O1     Al1    1.74519      1_555    1_556 yes
+  O1     Si1    1.59985      1_555    2_566 yes
+  O1     Na1    2.66887      1_555    1_546 yes
+  O1     Na1    2.53079      1_555    2_566 yes
+  O2     Si2    1.63011      1_555    1_565 yes
+  O2     Si3    1.64718      1_555    1_555 yes
+  O2     Na1    2.3704       1_555    1_555 yes
+  O3     Al1    1.7429       1_555    1_655 yes
+  O3     Si2    1.59435      1_555    1_555 yes
+  O3     Na1    2.45321      1_555    2_665 yes
+  O4     Si1    1.59997      1_555    1_655 yes
+  O4     Si3    1.61975      1_555    1_555 yes
+  O5     Al1    1.73509      1_555    1_555 yes
+  O5     Si3    1.59682      1_555    3_445 yes
+  O6     Si1    1.62225      1_555    1_555 yes
+  O6     Si2    1.61836      1_555    3_455 yes
+  O7     Al1    1.74556      1_555    1_555 yes
+  O7     Si3    1.60203      1_555    2_666 yes
+  O7     Na1    2.43384      1_555    1_545 yes
+  O8     Si1    1.61907      1_555    1_555 yes
+  O8     Si2    1.6168       1_555    2_666 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Al1    O3     102.836       1_554  1_555    1_455 yes
+  O1     Al1    O5     116.047       1_554  1_555    1_555 yes
+  O3     Al1    O5     112.215       1_455  1_555    1_555 yes
+  O1     Al1    O7     104.004       1_554  1_555    1_555 yes
+  O3     Al1    O7     111.151       1_455  1_555    1_555 yes
+  O5     Al1    O7     110.14        1_555  1_555    1_555 yes
+  O1     Si1    O4     109.433       2_566  1_555    1_455 yes
+  O1     Si1    O6     112.47        2_566  1_555    1_555 yes
+  O4     Si1    O6     108.187       1_455  1_555    1_555 yes
+  O1     Si1    O8     107.176       2_566  1_555    1_555 yes
+  O4     Si1    O8     111.446       1_455  1_555    1_555 yes
+  O6     Si1    O8     108.16        1_555  1_555    1_555 yes
+  O2     Si2    O3     111.144       1_545  1_555    1_555 yes
+  O2     Si2    O6     104.24        1_545  1_555    3_545 yes
+  O3     Si2    O6     112.114       1_555  1_555    3_545 yes
+  O2     Si2    O8     106.97        1_545  1_555    2_666 yes
+  O3     Si2    O8     111.591       1_555  1_555    2_666 yes
+  O6     Si2    O8     110.422       3_545  1_555    2_666 yes
+  O2     Si3    O4     107.269       1_555  1_555    1_555 yes
+  O2     Si3    O5     105.914       1_555  1_555    3_555 yes
+  O4     Si3    O5     110.224       1_555  1_555    3_555 yes
+  O2     Si3    O7     108.565       1_555  1_555    2_666 yes
+  O4     Si3    O7     110.208       1_555  1_555    2_666 yes
+  O5     Si3    O7     114.328       3_555  1_555    2_666 yes
+  Al1    O1     Si1    141.397       1_556  1_555    2_566 yes
+  Si2    O2     Si3    130.019       1_565  1_555    1_555 yes
+  Si2    O2     Na1    120.351       1_565  1_555    1_555 yes
+  Si3    O2     Na1    108.811       1_555  1_555    1_555 yes
+  Al1    O3     Si2    139.461       1_655  1_555    1_555 yes
+  Si1    O4     Si3    161.151       1_655  1_555    1_555 yes
+  Al1    O5     Si3    129.689       1_555  1_555    3_445 yes
+  Si1    O6     Si2    135.676       1_555  1_555    3_455 yes
+  Al1    O7     Si3    133.943       1_555  1_555    2_666 yes
+  Si1    O8     Si2    151.747       1_555  1_555    2_666 yes
+_pd_proc_ls_pref_orient_corr  none
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.099(8), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW10minmill_phase_4
+# Information for phase 4
+_pd_block_id  2021-08-04T18:46|NEW10minmill|phase_4|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for Pyrrhotite 4M follows
+_pd_phase_name  "Pyrrhotite 4M"
+_cell_length_a  11.95(4)
+_cell_length_b  6.850(5)
+_cell_length_c  12.84(5)
+_cell_angle_alpha  90
+_cell_angle_beta   117.23(8)
+_cell_angle_gamma  90
+_cell_volume  934.4(6)
+_exptl_crystal_density_diffrn  4.6021
+_symmetry_cell_setting  monoclinic
+_symmetry_space_group_name_H-M  "C 2/c"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -x,y,1/2-z
+     3  -x,-y,-z
+     4  x,-y,1/2+z
+     5  1/2+x,1/2+y,z
+     6  1/2-x,1/2+y,1/2-z
+     7  1/2-x,1/2-y,-z
+     8  1/2+x,1/2-y,1/2+z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+S1     S    0.01800     0.38330     0.11960     1.000      Uiso 0.010      8   
+S2     S    0.02910     0.11420     0.63900     1.000      Uiso 0.010      8   
+Fe3    Fe   0.10860     0.10250     0.49980     1.000      Uiso 0.010      8   
+S4     S    0.23410     0.13550     0.38260     1.000      Uiso 0.010      8   
+Fe5    Fe   0.24180     0.36600     0.24680     1.000      Uiso 0.010      8   
+S6     S    0.26790     0.13400     0.12360     1.000      Uiso 0.010      8   
+Fe7    Fe   0.38720     0.15000     0.01260     1.000      Uiso 0.010      8   
+Fe8    Fe   0.00000     0.14720     0.25000     1.000      Uiso 0.010      4   
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  Fe   28     11.7695    7.3573     3.5222     2.3045     4.7611     0.3072     15.3535    76.8805    1.0369     0.945
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S    32     6.9053     5.2034     1.4379     1.5863     1.4679     22.2151    0.2536     56.172     0.8669     0.2847
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  4
+_chemical_formula_sum  "Fe7 S8"
+_chemical_formula_weight  647.41
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  S1     Fe3    2.49323      1_555    2_555 yes
+  S1     Fe5    2.41557      1_555    1_555 yes
+  S1     Fe7    2.38804      1_555    5_455 yes
+  S1     Fe7    2.44444      1_555    7_555 yes
+  S1     Fe8    2.40722      1_555    1_555 yes
+  S2     Fe3    2.37832      1_555    1_555 yes
+  S2     Fe3    2.3245       1_555    3_556 yes
+  S2     Fe5    2.44705      1_555    7_556 yes
+  S2     Fe7    2.36633      1_555    8_456 yes
+  S2     Fe8    2.41078      1_555    3_556 yes
+  Fe3    S1     2.49323      1_555    2_555 yes
+  Fe3    S2     2.37832      1_555    1_555 yes
+  Fe3    S2     2.3245       1_555    3_556 yes
+  Fe3    S6     2.45057      1_555    4_556 yes
+  S4     Fe5    2.38508      1_555    1_555 yes
+  Fe5    S1     2.41557      1_555    1_555 yes
+  Fe5    S2     2.44705      1_555    7_556 yes
+  Fe5    S4     2.38508      1_555    1_555 yes
+  Fe5    S6     2.36147      1_555    1_555 yes
+  S6     Fe3    2.45057      1_555    4_555 yes
+  S6     Fe5    2.36147      1_555    1_555 yes
+  S6     Fe7    2.43592      1_555    1_555 yes
+  S6     Fe7    2.39083      1_555    7_555 yes
+  Fe7    S1     2.38804      1_555    5_545 yes
+  Fe7    S1     2.44444      1_555    7_555 yes
+  Fe7    S2     2.36633      1_555    8_555 yes
+  Fe7    S6     2.43592      1_555    1_555 yes
+  Fe7    S6     2.39083      1_555    7_555 yes
+  Fe8    S1     2.40722      1_555    1_555 yes
+  Fe8    S1     2.40722      1_555    2_555 yes
+  Fe8    S2     2.41078      1_555    3_556 yes
+  Fe8    S2     2.41078      1_555    4_555 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.0294(29), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW10minmill_phase_1
+# Information for phase 1
+_pd_block_id  2021-08-04T18:46|NEW10minmill|phase_1|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for SiO2 follows
+_pd_phase_name  SiO2
+_cell_length_a  4.9161(5)
+_cell_length_b  4.9161(5)
+_cell_length_c  5.4064(5)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  120
+_cell_volume  113.159(11)
+_exptl_crystal_density_diffrn  2.6451
+_symmetry_cell_setting  trigonal
+_symmetry_space_group_name_H-M  "P 32 2 1"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  -y,x-y,2/3+z
+     3  y-x,-x,1/3+z
+     4  y,x,-z
+     5  -x,y-x,2/3-z
+     6  x-y,-y,1/3-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Si1    Si4+ 0.47000     0.00000     0.66670     1.000      Uani 0.006      3   
+O1     O2-  0.41460     0.26780     0.78543     1.000      Uani 0.011      6   
+
+loop_
+   _atom_site_aniso_label
+   _atom_site_aniso_U_11
+   _atom_site_aniso_U_22
+   _atom_site_aniso_U_33
+   _atom_site_aniso_U_12
+   _atom_site_aniso_U_13
+   _atom_site_aniso_U_23
+Si1    0.0073      0.0059      0.0053      0.0029      0.0003      0.0006      
+O1     0.0120      0.0105      0.0118      0.0065      -0.0029     -0.0040     
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  O    6      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si   3      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  3
+_chemical_formula_sum  "O2 Si"
+_chemical_formula_weight  60.08
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Si1    O1     1.60564      1_555    1_555 yes
+  Si1    O1     1.61191      1_555    2_654 yes
+  Si1    O1     1.61165      1_555    5_656 yes
+  Si1    O1     1.60578      1_555    6_556 yes
+  O1     Si1    1.60564      1_555    1_555 yes
+  O1     Si1    1.61191      1_555    3_665 yes
+  O1     Si1    1.61165      1_555    5_666 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Si1    O1     110.253       1_555  1_555    2_654 yes
+  O1     Si1    O1     108.751       1_555  1_555    5_656 yes
+  O1     Si1    O1     109.68        2_654  1_555    5_656 yes
+  O1     Si1    O1     109.159       1_555  1_555    6_556 yes
+  O1     Si1    O1     108.731       2_654  1_555    6_556 yes
+  O1     Si1    O1     110.259       5_656  1_555    6_556 yes
+  Si1    O1     Si1    143.831       1_555  1_555    3_665 yes
+  Si1    O1     Si1    143.835       1_555  1_555    5_666 yes
+  Si1    O1     Si1    0.009         3_665  1_555    5_666 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.151(8), 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW10minmill_phase_3
+# Information for phase 3
+_pd_block_id  2021-08-04T18:46|NEW10minmill|phase_3|McDougallHamish
+# GSAS-II edited template follows Phase_Template
+#==============================================================================
+# 7. CHEMICAL, STRUCTURAL AND CRYSTAL DATA
+
+_pd_char_particle_morphology      ?
+
+_chemical_name_systematic
+; ?
+;
+_chemical_name_common             ?
+_chemical_formula_moiety          ?        
+_chemical_formula_structural      ?        
+_chemical_formula_analytical      ?
+_chemical_melting_point           ?
+_chemical_compound_source         ?       # for minerals and 
+                                          # natural products
+_symmetry_space_group_name_Hall   ?
+
+_exptl_crystal_F_000               ?
+_exptl_crystal_density_meas        ?
+_exptl_crystal_density_method      ?
+
+_cell_measurement_temperature     300        
+
+_cell_special_details
+; ?
+;
+
+_geom_special_details             ?
+
+# The following item identifies the program(s) used (if appropriate).
+_computing_structure_solution     ?        
+
+#==============================================================================
+
+# 8. Phase information from GSAS-II
+
+
+
+# phase info for TiO2 follows
+_pd_phase_name  TiO2
+_cell_length_a  4.5991(7)
+_cell_length_b  4.5991(7)
+_cell_length_c  2.9603(7)
+_cell_angle_alpha  90
+_cell_angle_beta   90
+_cell_angle_gamma  90
+_cell_volume  62.617(16)
+_exptl_crystal_density_diffrn  4.2376
+_symmetry_cell_setting  tetragonal
+_symmetry_space_group_name_H-M  "P 42/m n m"
+loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+     1  x,y,z
+     2  1/2-y,1/2+x,1/2+z
+     3  -x,-y,z
+     4  1/2+y,1/2-x,1/2+z
+     5  1/2-x,1/2+y,1/2+z
+     6  -y,-x,z
+     7  1/2+x,1/2-y,1/2+z
+     8  y,x,z
+     9  -x,-y,-z
+    10  1/2+y,1/2-x,1/2-z
+    11  x,y,-z
+    12  1/2-y,1/2+x,1/2-z
+    13  1/2+x,1/2-y,1/2-z
+    14  y,x,-z
+    15  1/2-x,1/2+y,1/2-z
+    16  -y,-x,-z
+
+# ATOMIC COORDINATES AND DISPLACEMENT PARAMETERS
+loop_ 
+   _atom_site_label
+   _atom_site_type_symbol
+   _atom_site_fract_x
+   _atom_site_fract_y
+   _atom_site_fract_z
+   _atom_site_occupancy
+   _atom_site_adp_type
+   _atom_site_U_iso_or_equiv
+   _atom_site_symmetry_multiplicity
+Ti1    Ti4+ 0.00000     0.00000     0.00000     1.000      Uani 0.006      2   
+O1     O2-  0.30493     0.30493     0.00000     1.000      Uani 0.006      4   
+
+loop_
+   _atom_site_aniso_label
+   _atom_site_aniso_U_11
+   _atom_site_aniso_U_22
+   _atom_site_aniso_U_33
+   _atom_site_aniso_U_12
+   _atom_site_aniso_U_13
+   _atom_site_aniso_U_23
+Ti1    0.0070      0.0070      0.0047      -0.0002     0.0000      0.0000      
+O1     0.0060      0.0060      0.0045      -0.0019     0.0000      0.0000      
+
+loop_  _atom_type_symbol _atom_type_number_in_cell
+        _atom_type_scat_Cromer_Mann_a1 _atom_type_scat_Cromer_Mann_a2 _atom_type_scat_Cromer_Mann_a3
+        _atom_type_scat_Cromer_Mann_a4 _atom_type_scat_Cromer_Mann_b1 _atom_type_scat_Cromer_Mann_b2
+        _atom_type_scat_Cromer_Mann_b3 _atom_type_scat_Cromer_Mann_b4 _atom_type_scat_Cromer_Mann_c
+        _atom_type_scat_length_neutron _atom_type_scat_source
+  O    4      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Ti   2      ?          ?          ?          ?          ?          ?          ?          ?          ?          ?
+      https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+# Note that Z affects _cell_formula_sum and _weight
+_cell_formula_units_Z  2
+_chemical_formula_sum  "O2 Ti"
+_chemical_formula_weight  79.9
+
+# MOLECULAR GEOMETRY
+loop_
+   _geom_bond_atom_site_label_1
+   _geom_bond_atom_site_label_2
+   _geom_bond_distance
+   _geom_bond_site_symmetry_1
+   _geom_bond_site_symmetry_2
+   _geom_bond_publ_flag
+  Ti1    O1     1.98331      1_555    1_555 yes
+  Ti1    O1     1.94953      1_555    2_544 yes
+  Ti1    O1     1.94953      1_555    2_545 yes
+  Ti1    O1     1.98331      1_555    3_555 yes
+  Ti1    O1     1.94953      1_555    4_454 yes
+  Ti1    O1     1.94953      1_555    4_455 yes
+  O1     Ti1    1.98331      1_555    1_555 yes
+  O1     Ti1    1.94953      1_555    2_554 yes
+  O1     Ti1    1.94953      1_555    2_555 yes
+
+loop_
+   _geom_angle_atom_site_label_1
+   _geom_angle_atom_site_label_2
+   _geom_angle_atom_site_label_3
+   _geom_angle
+   _geom_angle_site_symmetry_1
+   _geom_angle_site_symmetry_2
+   _geom_angle_site_symmetry_3
+   _geom_angle_publ_flag
+  O1     Ti1    O1     90            1_555  1_555    2_544 yes
+  O1     Ti1    O1     90            1_555  1_555    2_545 yes
+  O1     Ti1    O1     98.795        2_544  1_555    2_545 yes
+  O1     Ti1    O1     180           1_555  1_555    3_555 yes
+  O1     Ti1    O1     90            2_544  1_555    3_555 yes
+  O1     Ti1    O1     90            2_545  1_555    3_555 yes
+  O1     Ti1    O1     90            1_555  1_555    4_454 yes
+  O1     Ti1    O1     81.205        2_544  1_555    4_454 yes
+  O1     Ti1    O1     180           2_545  1_555    4_454 yes
+  O1     Ti1    O1     90            3_555  1_555    4_454 yes
+  O1     Ti1    O1     90            1_555  1_555    4_455 yes
+  O1     Ti1    O1     180           2_544  1_555    4_455 yes
+  O1     Ti1    O1     81.205        2_545  1_555    4_455 yes
+  O1     Ti1    O1     90            3_555  1_555    4_455 yes
+  O1     Ti1    O1     98.795        4_454  1_555    4_455 yes
+  Ti1    O1     Ti1    130.602       1_555  1_555    2_554 yes
+  Ti1    O1     Ti1    130.602       1_555  1_555    2_555 yes
+  Ti1    O1     Ti1    98.795        2_554  1_555    2_555 yes
+_pd_proc_ls_pref_orient_corr
+   "March-Dollase correction coef. = 1.000 axis = [0, 0, 1]"
+_pd_proc_ls_profile_function
+;
+  Crystallite size in microns with "isotropic" model:
+  parameters: Size, G/L mix
+    0.200, 1.000, 
+  Microstrain, "isotropic" model (10^6^ * delta Q/Q)
+    parameters: Mustrain, G/L mix
+    0.000, 1.000, 
+
+;
+
+data_NEW10minmill_pwd_0
+_pd_proc_ls_profile_function
+;
+Finger-Cox-Jephcoat function parameters U, V, W, X, Y, SH/L:
+  peak variance(Gauss) = Utan(Th)^2^+Vtan(Th)+W:
+  peak HW(Lorentz) = X/cos(Th)+Ytan(Th); SH/L = S/L+H/L
+  U, V, W in (centideg)^2^, X & Y in centideg
+    0.000, 0.000, 1.089, 0.882, 1.689, 0.058, 
+;
+# Information for histogram 0: PWDR BAT3_10min_milla_30mm_MonicaHamish_Ruoming_step size 0_10_min_mill_a.xrdml Scan 1
+_pd_block_id
+;
+2021-08-04T18:46|NEW10minmill|McDougallHamish|PANalytical,Co-EmpyreanII_hist_0
+;
+# GSAS-II edited template follows Instrument_Template
+#==============================================================================
+# 9. INSTRUMENT CHARACTERIZATION
+
+_exptl_special_details
+; ?
+;
+
+# if regions of the data are excluded, the reason(s) are supplied here:
+_pd_proc_info_excluded_regions
+; ?
+;
+
+# The following item is used to identify the equipment used to record 
+# the powder pattern when the diffractogram was measured at a laboratory 
+# other than the authors' home institution, e.g. when neutron or synchrotron
+# radiation is used.
+
+_pd_instr_location
+; ?
+;
+_pd_calibration_special_details           # description of the method used
+                                          # to calibrate the instrument
+; ?
+;
+
+_diffrn_source                    Co-Ka       
+_diffrn_source_target             Co
+_diffrn_source_type               Graded_Flat
+_diffrn_measurement_device_type   Panalytical_Reflection_Transmission       
+_diffrn_detector                  PIXcel1D       
+_diffrn_detector_type             Empyrean_II       # make or model of detector
+
+_pd_meas_scan_method              ?       # options are 'step', 'cont',
+                                          # 'tof', 'fixed' or
+                                          # 'disp' (= dispersive)
+_pd_meas_special_details
+;  ?
+;
+
+# The following two items identify the program(s) used (if appropriate).
+_computing_data_collection        ?        
+_computing_data_reduction         ?                   
+
+# Describe any processing performed on the data, prior to refinement.
+# For example: a manual Lp correction or a precomputed absorption correction
+_pd_proc_info_data_reduction      ?
+
+# The following item is used for angular dispersive measurements only.
+
+_diffrn_radiation_monochromator   ?        
+
+# The following items are used to define the size of the instrument.
+# Not all distances are appropriate for all instrument types.
+
+_pd_instr_dist_src/mono           ?
+_pd_instr_dist_mono/spec          ?
+_pd_instr_dist_src/spec           ?
+_pd_instr_dist_spec/anal          ?
+_pd_instr_dist_anal/detc          ?
+_pd_instr_dist_spec/detc          ?
+
+# 10. Specimen size and mounting information
+
+# The next three fields give the specimen dimensions in mm.  The equatorial 
+# plane contains the incident and diffracted beam.
+
+_pd_spec_size_axial               ?       # perpendicular to 
+                                          # equatorial plane
+
+_pd_spec_size_equat               ?       # parallel to 
+                                          # scattering vector 
+                                          # in transmission
+
+_pd_spec_size_thick               ?       # parallel to 
+                                          # scattering vector 
+                                          # in reflection
+
+_pd_spec_mounting                         # This field should be
+                                          # used to give details of the 
+                                          # container.
+; ?
+;
+
+_pd_spec_mount_mode               ?       # options are 'reflection' 
+                                          # or 'transmission'
+    
+_pd_spec_shape                    ?       # options are 'cylinder' 
+                                          # 'flat_sheet' or 'irregular'
+
+
+loop_
+     _atom_type_symbol
+     _atom_type_scat_dispersion_real
+     _atom_type_scat_dispersion_imag
+     _atom_type_scat_dispersion_source
+  Al        0.255   0.328   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Fe       -3.332   0.490   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Na        0.167   0.167   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  O         0.063   0.044   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  S         0.371   0.733   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Si        0.298   0.438   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+  Ti       -0.063   2.321   https://subversion.xray.aps.anl.gov/pyGSAS/trunk/atmdata.py
+
+_diffrn_radiation_type  K\a~1,2~
+loop_
+   _diffrn_radiation_wavelength
+   _diffrn_radiation_wavelength_wt
+   _diffrn_radiation_wavelength_id
+  1.78892         1.0             1     
+  1.79278         0.5000          2     
+
+# PHASE TABLE
+loop_
+   _pd_phase_id
+   _pd_phase_block_id
+   _pd_phase_mass_%
+  0  2021-08-04T18:46|NEW10minmill|phase_0|McDougallHamish  0.8323(26)
+  2  2021-08-04T18:46|NEW10minmill|phase_2|McDougallHamish  0.0800(23)
+  4  2021-08-04T18:46|NEW10minmill|phase_4|McDougallHamish  0.0310(13)
+  1  2021-08-04T18:46|NEW10minmill|phase_1|McDougallHamish  0.0496(8)
+  3  2021-08-04T18:46|NEW10minmill|phase_3|McDougallHamish  0.0071(4)
+loop_
+   _gsas_proc_phase_R_F_factor
+   _gsas_proc_phase_R_Fsqd_factor
+   _gsas_proc_phase_id
+   _gsas_proc_phase_block_id
+    0.02834  0.05852  0  2021-08-04T18:46|NEW10minmill|phase_0|McDougallHamish
+    0.07538  0.14790  2  2021-08-04T18:46|NEW10minmill|phase_2|McDougallHamish
+    0.06852  0.10954  4  2021-08-04T18:46|NEW10minmill|phase_4|McDougallHamish
+    0.05761  0.12259  1  2021-08-04T18:46|NEW10minmill|phase_1|McDougallHamish
+    0.06165  0.16172  3  2021-08-04T18:46|NEW10minmill|phase_3|McDougallHamish
+_pd_proc_ls_prof_R_factor     0.06725
+_pd_proc_ls_prof_wR_factor    0.08569
+_gsas_proc_ls_prof_R_B_factor   0.07918
+_gsas_proc_ls_prof_wR_B_factor  0.09806
+_pd_proc_ls_prof_wR_expected  0.04024
+_diffrn_radiation_probe  x-ray
+_diffrn_radiation_polarisn_ratio  0.7000
+_pd_proc_ls_background_function
+;
+Background function: "chebyschev-1" function with 7 terms:
+    433.0(13), -482.0(20), 358.5(19), -178.2(17), 94.3(16), -31.7(12), 
+    13.8(11), 
+;
+_diffrn_ambient_temperature  300
+_diffrn_ambient_pressure  100
+
+# STRUCTURE FACTOR TABLE
+loop_
+   _pd_refln_phase_id
+   _refln_index_h
+   _refln_index_k
+   _refln_index_l
+   _refln_F_squared_meas
+   _refln_F_squared_calc
+   _refln_phase_calc
+   _refln_d_spacing
+   _gsas_i100_meas
+  0  1    1    1    957.3089   866.0114   0.0     3.12917  25.11  
+  0  2    0    0    6573.2864  6225.3214  -0.0    2.70994  95.61  
+  0  2    1    0    3501.4339  3351.6775  0.0     2.42384  80.45  
+  0  2    1    1    1747.0066  1704.1977  -180.0  2.21266  66.17  
+  0  2    2    0    3092.7766  3271.1756  -0.0    1.91622  43.23  
+  0  2    2    1    38.6663    36.3198    -0.0    1.80663  0.96   
+  0  3    1    1    4948.6024  5166.5587  -0.0    1.63415  100.00 
+  0  2    2    2    2067.6059  2295.3306  0.0     1.56458  12.81  
+  0  3    0    2    2880.4590  2977.3091  -0.0    1.50320  24.87  
+  0  3    1    2    557.3370   584.3306   0.0     1.44852  9.02   
+  0  3    2    1    1522.8167  1596.5714  180.0   1.44852  24.65  
+  0  4    0    0    357.8304   371.7594   -180.0  1.35497  1.30   
+  0  3    2    2    32.5548    38.0617    -0.0    1.31451  0.46   
+  0  4    1    0    83.8591    98.0445    -0.0    1.31451  0.59   
+  0  4    1    1    51.1878    53.0339    180.0   1.27748  0.69   
+  0  3    3    1    533.8767   544.7040   -0.0    1.24341  7.04   
+  0  4    0    2    865.9177   860.6685   0.0     1.21192  5.60   
+  0  4    2    0    865.9177   860.6685   0.0     1.21192  5.60   
+  0  4    1    2    1.3251     1.2882     -0.0    1.18271  0.02   
+  0  4    2    1    1358.1702  1320.3279  -180.0  1.18271  17.36  
+  0  3    3    2    708.0283   673.2342   0.0     1.15552  9.00   
+  0  4    2    2    1041.0094  978.3322   0.0     1.10633  13.35  
+  0  4    3    0    113.7057   116.2068   -0.0    1.08398  0.74   
+  0  4    1    3    52.6491    63.2817    -180.0  1.06293  0.70   
+  0  4    3    1    19.2691    23.1605    0.0     1.06293  0.26   
+  0  3    3    3    1663.3884  1503.3697  -0.0    1.04306  7.61   
+  0  5    1    1    3383.0613  3057.6092  -0.0    1.04306  46.43  
+  1  1    0    0    241.5298   242.5263   180.0   4.25750  0.32   
+  1  1    0    1    703.8523   634.5057   120.0   3.34486  0.56   
+  1  1    0    -1   1674.4384  1509.4657  -120.0  3.34486  1.34   
+  1  1    1    0    364.7797   343.8874   -155.6  2.45807  0.15   
+  1  1    0    2    311.7914   298.8540   -120.0  2.28207  0.11   
+  1  1    0    -2   89.9353    86.2036    -60.0   2.28207  0.03   
+  1  1    1    1    95.9351    96.0668    82.9    2.23765  0.07   
+  1  2    0    0    303.0328   308.9202   0.0     2.12875  0.09   
+  1  2    0    -1   94.2269    77.2271    60.0    1.98074  0.03   
+  1  2    0    1    225.8169   185.0766   -60.0   1.98074  0.06   
+  1  1    1    2    518.8016   602.9051   9.8     1.81862  0.23   
+  1  0    0    3    100.3009   94.4436    0.0     1.80214  0.01   
+  1  2    0    2    92.1995    82.0960    60.0    1.67243  0.02   
+  1  2    0    -2   409.1152   364.2832   120.0   1.67243  0.08   
+  1  1    0    -3   220.6864   203.8693   180.0   1.65958  0.04   
+  1  1    0    3    2.7998     2.5864     0.0     1.65958  0.00   
+  1  2    1    0    15.3401    14.6469    -38.9   1.60919  0.01   
+  1  2    1    -1   328.6250   356.4111   95.9    1.54232  0.11   
+  1  2    1    1    282.8355   306.7501   -109.6  1.54232  0.09   
+  1  1    1    3    146.8409   142.5897   117.5   1.45338  0.04   
+  1  3    0    0    86.2773    76.3720    -180.0  1.41917  0.01   
+  1  2    1    -2   343.6953   413.8536   -123.3  1.38273  0.09   
+  1  2    1    2    106.7141   128.4976   143.4   1.38273  0.03   
+  1  2    0    -3   257.0681   292.6770   -0.0    1.37544  0.03   
+  1  2    0    3    905.1559   1030.5376  0.0     1.37544  0.12   
+  1  3    0    -1   713.8452   815.9930   -120.0  1.37266  0.09   
+  1  3    0    1    0.8893     1.0166     -60.0   1.37266  0.00   
+  1  1    0    -4   107.6269   120.2849   -120.0  1.28824  0.01   
+  1  1    0    4    354.7659   396.4901   120.0   1.28824  0.04   
+  1  3    0    -2   179.2909   208.3599   120.0   1.25653  0.02   
+  1  3    0    2    408.7313   475.0001   -120.0  1.25653  0.05   
+  1  2    2    0    272.7680   371.1277   -16.5   1.22904  0.03   
+  1  2    1    -3   68.6240    71.0196    179.1   1.20031  0.02   
+  1  2    1    3    291.2964   301.4652   -134.8  1.20031  0.07   
+  1  2    2    1    110.0497   105.6117   88.6    1.19846  0.03   
+  1  1    1    4    361.6511   334.2134   -14.4   1.18436  0.08   
+  1  3    1    0    384.9357   361.6377   121.4   1.18082  0.09   
+  1  3    1    -1   216.7459   189.9626   -18.5   1.15362  0.05   
+  1  3    1    1    72.3475    63.4075    16.4    1.15362  0.02   
+  1  2    0    4    66.7066    70.6901    120.0   1.14104  0.01   
+  1  2    0    -4   1.3909     1.4739     -120.0  1.14104  0.00   
+  1  2    2    2    3.1506     3.3523     -9.9    1.11882  0.00   
+  1  3    0    -3   7.0174     6.6897     -0.0    1.11495  0.00   
+  1  3    0    3    65.8134    62.7403    -180.0  1.11495  0.01   
+  1  3    1    -2   281.0886   304.4208   -8.9    1.08209  0.06   
+  1  3    1    2    114.8445   124.3773   59.1    1.08209  0.03   
+  1  4    0    0    121.4439   168.2186   0.0     1.06438  0.01   
+  1  1    0    -5   406.3863   346.3251   120.0   1.04801  0.05   
+  1  1    0    5    152.4573   129.9251   -120.0  1.04801  0.02   
+  1  4    0    -1   36.5478    31.4136    60.0    1.04433  0.00   
+  1  4    0    1    337.1343   289.7739   120.0   1.04433  0.04   
+  1  2    1    -4   8.3831     10.8635    51.2    1.03496  0.00   
+  1  2    1    4    185.9177   240.9267   -129.5  1.03496  0.05   
+  2  0    0    1    2728.4582  685.7541   180.0   6.38786  0.04   
+  2  0    2    0    1470.4505  396.3962   180.0   6.37466  0.02   
+  2  1    1    0    746.0457   238.2363   -0.0    6.33955  0.01   
+  2  1    -1   0    820.9501   287.4879   -0.0    6.29869  0.01   
+  2  1    1    -1   780.5624   406.2352   180.0   5.91009  0.01   
+  2  1    -1   -1   1019.2111  415.6378   -180.0  5.58552  0.01   
+  2  0    2    -1   11.3192    16.5792    0.0     4.66174  0.00   
+  2  0    2    1    2.2892     1.8371     180.0   4.37623  0.00   
+  2  2    0    -1   20485.8978 21037.4763 -0.0    4.02732  0.10   
+  2  1    -1   1    2714.0614  3767.3897  -0.0    3.85265  0.01   
+  2  1    1    1    9298.2745  10390.3834 0.0     3.77565  0.05   
+  2  1    3    0    7838.9204  5886.9121  180.0   3.68167  0.03   
+  2  1    3    -1   5848.3851  4505.3267  0.0     3.66562  0.02   
+  2  1    -3   0    12994.1672 11675.3013 180.0   3.65766  0.05   
+  2  2    0    0    2.2840     2.5781     0.0     3.63776  0.00   
+  2  1    1    -2   6232.2242  4328.5159  0.0     3.50520  0.03   
+  2  2    2    -1   3241.4443  1650.0035  180.0   3.48122  0.01   
+  2  1    -3   -1   58.6800    12.1276    0.0     3.43616  0.00   
+  2  1    -1   -2   6704.6566  5251.4578  0.0     3.37264  0.03   
+  2  2    -2   -1   349.5192   364.8637   0.0     3.33313  0.00   
+  2  2    0    -2   28157.0918 26655.4799 -180.0  3.21484  0.09   
+  2  0    0    2    38714.0270 37071.8044 -180.0  3.19393  0.14   
+  2  0    4    0    25961.2348 25362.8195 180.0   3.18733  0.08   
+  2  2    2    0    14800.3173 13873.6743 180.0   3.16977  0.05   
+  2  2    -2   0    15540.7312 14946.6082 -180.0  3.14934  0.05   
+  2  1    -3   1    13776.4918 11175.2497 -180.0  2.96418  0.04   
+  2  2    2    -2   8257.1640  7187.5067  0.0     2.95504  0.02   
+  2  0    2    -2   5231.9929  5310.5610  0.0     2.93060  0.01   
+  2  0    4    -1   7738.0372  8585.7945  0.0     2.92677  0.02   
+  2  1    3    1    5877.1164  6897.0276  180.0   2.86133  0.02   
+  2  1    3    -2   1484.7763  1923.0466  -0.0    2.83885  0.00   
+  2  2    -2   -2   165.1786   183.4547   -0.0    2.79276  0.00   
+  2  0    2    2    172.1154   191.6414   0.0     2.78600  0.00   
+  2  0    4    1    348.2305   387.5360   -0.0    2.78271  0.00   
+  2  2    0    1    112.0671   109.5836   -0.0    2.68712  0.00   
+  2  3    1    -1   428.8453   431.0071   -180.0  2.66293  0.00   
+  2  1    -3   -2   6544.7215  6171.6319  -0.0    2.63839  0.01   
+  2  3    -1   -1   36.8745    33.5476    -180.0  2.62530  0.00   
+  2  2    4    -1   15179.0312 12550.4891 -180.0  2.55995  0.03   
+  2  3    1    -2   2467.8044  1812.0722  180.0   2.53704  0.00   
+  2  1    -1   2    809.4548   667.2869   180.0   2.51139  0.00   
+  2  2    -2   1    1978.8942  1686.7859  -180.0  2.49495  0.00   
+  2  3    -1   -2   549.3332   451.5613   180.0   2.48043  0.00   
+  2  1    1    2    121.6361   110.2849   180.0   2.46610  0.00   
+  2  2    2    1    1451.2447  1367.0046  -180.0  2.45771  0.00   
+  2  2    -4   -1   10729.8051 10453.7459 -180.0  2.44277  0.02   
+  2  1    5    -1   4267.1260  4093.1663  -0.0    2.42941  0.01   
+  2  1    5    0    57.8824    64.0884    180.0   2.41202  0.00   
+  2  2    4    0    3554.2764  3944.1458  -0.0    2.40628  0.01   
+  2  1    -5   0    1981.7339  2230.8323  180.0   2.40074  0.00   
+  2  2    -4   0    1834.1331  2079.3222  -0.0    2.38844  0.00   
+  2  3    1    0    1401.9970  1565.2946  -0.0    2.38575  0.00   
+  2  3    -1   0    1832.0243  2090.0863  -0.0    2.37918  0.00   
+  2  2    0    -3   7.1906     7.3701     180.0   2.35133  0.00   
+  2  2    4    -2   2.7902     2.9331     0.0     2.34729  0.00   
+  2  1    1    -3   96.2721    110.8373   -0.0    2.33656  0.00   
+  2  0    4    -2   855.2353   884.3144   -180.0  2.33087  0.00   
+  2  3    3    -1   16027.9410 9809.7794  180.0   2.31766  0.02   
+  2  1    -5   -1   1738.6554  1044.9800  0.0     2.31526  0.00   
+  2  1    -1   -3   2456.0590  2291.2470  -0.0    2.27750  0.00   
+  2  2    2    -3   203.2989   155.6865   -0.0    2.26146  0.00   
+  2  3    3    -2   19.9691    15.9172    0.0     2.25070  0.00   
+  2  3    -3   -1   3088.8065  2703.2457  -180.0  2.24518  0.00   
+  2  1    -3   2    867.7598   824.7896   -0.0    2.22556  0.00   
+  2  0    4    2    1755.9692  2085.0250  0.0     2.18812  0.00   
+  2  2    -4   -2   1204.9352  1431.8638  0.0     2.18799  0.00   
+  2  1    -5   1    3488.3190  4194.8986  180.0   2.18493  0.00   
+  2  2    -2   -3   1302.1450  1851.4932  0.0     2.15451  0.00   
+  2  1    5    -2   255.2295   312.7232   -180.0  2.15169  0.00   
+  2  3    1    -3   163.0051   204.6119   0.0     2.13824  0.00   
+  2  3    -3   -2   418.2222   512.1941   180.0   2.13724  0.00   
+  2  1    3    2    159.3835   174.4523   -180.0  2.13433  0.00   
+  2  0    0    3    442.9583   454.6548   -0.0    2.12929  0.00   
+  2  0    6    0    11295.3045 11042.6256 -0.0    2.12489  0.01   
+  2  1    3    -3   704.2241   674.2906   -180.0  2.11876  0.00   
+  2  1    5    1    4845.7666  4734.7647  180.0   2.11595  0.01   
+  2  3    3    0    1434.5089  1496.6439  -180.0  2.11318  0.00   
+  2  3    -3   0    123.6486   182.7827   -180.0  2.09956  0.00   
+  2  3    -1   -3   1867.0032  2416.5634  0.0     2.08973  0.00   
+  2  2    -4   1    7395.2816  8370.0925  180.0   2.07604  0.01   
+  2  0    2    -3   269.9065   286.8930   -180.0  2.05903  0.00   
+  2  0    6    -1   77.2142    83.9001    -0.0    2.05549  0.00   
+  2  2    4    1    2178.0633  2723.1302  180.0   2.03350  0.00   
+  2  4    0    -2   982.6450   1673.8545  -0.0    2.01366  0.00   
+  2  1    -5   -2   663.9899   976.2191   -0.0    2.00557  0.00   
+  2  4    0    -1   2630.6892  3207.5402  -0.0    2.00025  0.00   
+  2  2    0    2    785.8725   914.6787   0.0     1.99827  0.00   
+  2  1    -3   -3   1963.9638  2006.9284  -0.0    1.99351  0.00   
+  2  0    2    3    1569.5152  1320.4879  0.0     1.98235  0.00   
+  2  0    6    1    6028.1264  4760.1395  0.0     1.97919  0.01   
+  2  3    -1   1    2421.6210  1778.1424  0.0     1.97162  0.00   
+  2  3    3    -3   1007.0330  747.2487   -180.0  1.97003  0.00   
+  2  3    1    1    921.8715   1049.8991  0.0     1.96352  0.00   
+  2  2    4    -3   182.1304   210.6125   -180.0  1.96339  0.00   
+  2  4    2    -2   1198.8315  1505.1300  0.0     1.94723  0.00   
+  2  2    -2   2    4024.5684  4434.5615  -0.0    1.92633  0.00   
+  2  4    2    -1   176.7810   195.3738   0.0     1.92397  0.00   
+  2  2    6    -1   23.8191    25.7092    -0.0    1.91781  0.00   
+  2  4    -2   -2   13853.4574 14612.2943 -0.0    1.89414  0.01   
+  2  4    -2   -1   78.3639    83.9894    180.0   1.89341  0.00   
+  2  3    5    -1   2988.4043  3253.1319  -180.0  1.88804  0.00   
+  2  2    2    2    10268.8974 11147.4650 -0.0    1.88782  0.01   
+  2  3    -3   -3   190.1407   242.1347   -0.0    1.86184  0.00   
+  2  3    5    -2   115.6597   151.7748   -180.0  1.86122  0.00   
+  2  4    0    -3   13474.9796 17227.6438 -180.0  1.84958  0.01   
+  2  2    -6   -1   548.4216   630.1904   -180.0  1.84310  0.00   
+  2  1    -5   2    28.7318    32.7906    -180.0  1.84286  0.00   
+  2  2    6    0    5574.6151  5973.8074  -0.0    1.84084  0.01   
+  2  2    6    -2   3154.5639  2234.4122  -180.0  1.83281  0.00   
+  2  1    -1   3    2908.5277  2403.8627  -180.0  1.82957  0.00   
+  2  2    -6   0    12829.9633 11170.3478 0.0     1.82883  0.01   
+  2  2    -4   -3   387.8937   351.5785   -0.0    1.82817  0.00   
+  2  0    4    -3   6450.3436  6600.1943  180.0   1.82454  0.01   
+  2  3    -5   -1   509.7582   547.0575   -180.0  1.82305  0.00   
+  2  0    6    -2   8725.2500  9376.7847  -180.0  1.82300  0.01   
+  2  4    0    0    14539.6429 16544.7345 -0.0    1.81888  0.01   
+  2  3    -3   1    1253.9980  1388.1619  -0.0    1.81269  0.00   
+  2  4    2    -3   1791.7262  1698.2109  -0.0    1.80678  0.00   
+  2  1    1    3    14079.0635 13204.6231 -180.0  1.80269  0.02   
+  2  3    3    1    493.5937   659.8672   -0.0    1.79396  0.00   
+  2  1    5    -3   28.4024    36.9138    180.0   1.79152  0.00   
+  2  1    7    -1   335.7249   370.2527   -180.0  1.78554  0.00   
+  2  2    0    -4   26907.2175 29304.7955 0.0     1.78457  0.03   
+  2  1    7    0    1465.8184  1186.7943  -0.0    1.76994  0.00   
+  2  3    5    0    482.7464   192.4714   -180.0  1.76391  0.00   
+  2  1    -7   0    4801.4245  1861.7091  0.0     1.76369  0.00   
+  2  1    5    2    5044.5830  1478.1411  -180.0  1.75728  0.00   
+  2  3    -5   -2   836.2188   292.8600   -180.0  1.75539  0.00   
+  2  2    2    -4   10946.1981 5374.4235  180.0   1.75260  0.01   
+  2  4    2    0    6564.9267  3240.2714  180.0   1.75255  0.01   
+  2  3    -5   0    1.1450     0.6787     -180.0  1.75073  0.00   
+  2  4    -2   -3   2051.6269  1498.9920  -180.0  1.74735  0.00   
+  2  4    -2   0    2000.5557  1478.3757  -180.0  1.74562  0.00   
+  2  4    4    -2   14494.0553 11156.5991 -180.0  1.74061  0.01   
+  2  3    1    -4   14.7950    11.6942    0.0     1.73791  0.00   
+  2  1    1    -4   1236.4780  931.5858   180.0   1.73044  0.00   
+  2  0    4    3    1665.8620  1649.4123  180.0   1.72108  0.00   
+  2  1    -7   -1   549.8733   544.5769   -0.0    1.72100  0.00   
+  2  2    -4   2    5163.3512  5111.9528  -180.0  1.72066  0.00   
+  2  0    6    2    4099.4098  4043.0244  180.0   1.71979  0.00   
+  2  2    -6   -2   5820.0222  5843.5104  180.0   1.71808  0.00   
+  2  1    -3   3    3845.4278  3889.7621  0.0     1.71755  0.00   
+  2  4    4    -1   3380.0768  3425.3612  -0.0    1.71605  0.00   
+  2  3    -1   -4   31.2977    26.3196    -0.0    1.70384  0.00   
+  2  3    5    -3   2303.1762  1781.5059  180.0   1.70048  0.00   
+  2  1    -1   -4   1529.1314  1087.2281  180.0   1.69839  0.00   
+  2  2    -2   -4   8317.6259  6607.2640  -0.0    1.68632  0.01   
+  2  2    -6   1    144.6685   111.8094   180.0   1.68403  0.00   
+  2  1    -7   1    1409.5518  1037.6002  0.0     1.67991  0.00   
+  2  1    7    -2   3502.5476  3014.1863  0.0     1.67337  0.00   
+  2  4    -4   -1   3606.6975  3113.5342  -0.0    1.67328  0.00   
+  2  1    -5   -3   353.2151   322.6770   -180.0  1.66739  0.00   
+  2  2    4    2    7610.4468  6980.1241  -180.0  1.66673  0.01   
+  2  4    -4   -2   3263.2166  2996.9232  -180.0  1.66656  0.00   
+  2  1    3    3    638.5733   605.4945   0.0     1.65314  0.00   
+  2  3    3    -4   491.4550   474.5918   180.0   1.65084  0.00   
+  2  2    6    1    15.6312    15.0623    180.0   1.64996  0.00   
+  2  4    4    -3   87.2732    81.5092    0.0     1.64497  0.00   
+  2  1    3    -4   1339.7952  1267.0308  -180.0  1.64299  0.00   
+  2  2    6    -3   423.3684   438.3802   0.0     1.63845  0.00   
+  2  1    7    1    924.0563   959.6711   0.0     1.63566  0.00   
+  2  5    1    -2   64.8779    62.3555    -180.0  1.62122  0.00   
+  2  2    4    -4   7.0483     6.6299     0.0     1.60885  0.00   
+  2  3    -1   2    255.4569   237.1891   -180.0  1.60779  0.00   
+  2  4    0    -4   27.6864    25.5451    0.0     1.60742  0.00   
+  2  5    -1   -2   118.5864   104.4782   -0.0    1.60481  0.00   
+  2  3    1    2    5.3465     3.3755     -180.0  1.59704  0.00   
+  2  0    0    4    2725.6513  1719.5025  -0.0    1.59697  0.00   
+  2  0    8    0    6424.7810  4104.7411  -0.0    1.59366  0.00   
+  2  3    -5   -3   8668.2991  7048.0684  -180.0  1.58673  0.01   
+  2  4    2    -4   6845.8106  5767.4424  -180.0  1.58523  0.00   
+  2  4    4    0    95.1519    80.5872    180.0   1.58489  0.00   
+  2  3    -5   1    3741.4032  3541.7994  0.0     1.57987  0.00   
+  2  1    -7   -2   106.6445   106.0592   180.0   1.57566  0.00   
+  2  4    -4   0    975.3462   972.7791   180.0   1.57467  0.00   
+  2  4    0    1    1306.4929  1313.3627  0.0     1.57405  0.00   
+  2  0    2    -4   6798.6378  6835.8768  -180.0  1.57267  0.01   
+  2  5    1    -1   1835.0121  1838.8969  0.0     1.57223  0.00   
+  2  5    1    -3   4.4523     4.5305     0.0     1.57056  0.00   
+  2  0    8    -1   4901.8943  5105.5113  -180.0  1.56971  0.00   
+  2  3    -3   -4   205.6999   222.0271   -180.0  1.56739  0.00   
+  2  1    -3   -4   1071.2148  1168.3240  -180.0  1.56437  0.00   
+  2  5    -1   -1   3256.0103  3532.8589  -0.0    1.56314  0.00   
+  2  3    5    1    6116.0553  6630.5027  -0.0    1.55930  0.00   
+  2  2    0    3    1626.3148  1763.6711  -180.0  1.55911  0.00   
+  2  4    -4   -3   616.9240   668.2938   0.0     1.55805  0.00   
+  2  0    6    -3   50.4984    50.4752    180.0   1.55391  0.00   
+  2  5    -1   -3   3303.9720  3177.9812  180.0   1.54983  0.00   
+  2  5    3    -2   1928.4693  1684.3120  0.0     1.53962  0.00   
+  2  3    7    -1   368.3741   255.3064   -0.0    1.53554  0.00   
+  2  4    -2   -4   6107.2320  4566.3850  180.0   1.53333  0.00   
+  2  4    -2   1    466.9575   360.2122   -0.0    1.53138  0.00   
+  2  2    -2   3    4744.8683  3884.5431  0.0     1.52972  0.00   
+  2  1    -5   3    150.0359   114.2358   180.0   1.52775  0.00   
+  2  0    2    4    2673.5828  1999.2534  180.0   1.52655  0.00   
+  2  3    7    -2   1897.5777  1417.6951  180.0   1.52649  0.00   
+  2  4    2    1    74.6423    55.0425    -0.0    1.52494  0.00   
+  2  0    8    1    72.9013    53.4117    0.0     1.52385  0.00   
+  2  3    -3   2    974.8984   713.5252   0.0     1.52351  0.00   
+  2  2    -6   -3   1383.7282  972.3599   180.0   1.52111  0.00   
+  2  1    -7   2    2780.8590  2092.8268  180.0   1.51406  0.00   
+  2  2    -4   -4   4038.7782  3475.0688  -180.0  1.51008  0.00   
+  2  2    8    -1   9215.6762  8932.7653  0.0     1.50687  0.01   
+  2  5    3    -3   11077.3338 11216.4371 -0.0    1.50125  0.01   
+  2  2    2    3    259.2061   261.4234   0.0     1.49966  0.00   
+  2  5    -3   -2   1286.8236  1283.3165  0.0     1.49852  0.00   
+  2  4    6    -2   1654.6707  1643.4734  -180.0  1.49804  0.00   
+  2  3    3    2    2941.2324  2828.3266  0.0     1.49651  0.00   
+  2  5    3    -1   1598.5622  1375.8687  180.0   1.49230  0.00   
+  2  1    7    -3   1158.4425  963.7100   -0.0    1.49138  0.00   
+  2  3    5    -4   1241.2761  976.7543   0.0     1.48741  0.00   
+  2  3    -7   -1   5.4519     4.1505     -180.0  1.48641  0.00   
+  2  2    -6   2    2969.5256  2225.9899  -180.0  1.48209  0.00   
+  2  1    5    -4   717.6713   569.2303   -0.0    1.48061  0.00   
+  2  4    4    -4   1160.9565  936.8644   -0.0    1.47752  0.00   
+  2  4    6    -1   3008.5009  2425.3077  -0.0    1.47727  0.00   
+  2  2    8    -2   2460.8108  2036.6290  -0.0    1.46947  0.00   
+  2  5    -3   -1   2703.5149  2250.7625  180.0   1.46932  0.00   
+  2  0    4    -4   1978.5686  1799.2981  0.0     1.46530  0.00   
+  2  2    8    0    18605.7911 17372.8918 180.0   1.46378  0.01   
+  2  0    8    -2   2859.5612  2670.5014  0.0     1.46338  0.00   
+  2  3    7    0    1470.8122  1344.4772  -0.0    1.46164  0.00   
+  2  0    6    3    11128.6952 9727.2084  -180.0  1.45874  0.01   
+  2  2    -8   -1   320.1597   277.6153   0.0     1.45806  0.00   
+  2  2    -8   0    16688.9818 14971.6548 -180.0  1.45572  0.01   
+  2  1    5    3    87.8023    84.4701    0.0     1.45352  0.00   
+  2  3    -7   0    1873.9911  1874.7884  -0.0    1.45113  0.00   
+  2  5    -3   -3   3872.0183  3973.0050  -0.0    1.44873  0.00   
+  2  1    7    2    331.9477   339.6716   180.0   1.44736  0.00   
+  2  5    1    0    458.6674   468.7582   0.0     1.44694  0.00   
+  2  5    -1   0    282.6789   282.6566   0.0     1.44450  0.00   
+  2  3    -7   -2   409.2104   407.5222   -180.0  1.44435  0.00   
+  2  5    1    -4   377.7103   376.0669   -0.0    1.44434  0.00   
+  2  4    6    -3   5241.1739  4799.2632  180.0   1.44037  0.00   
+  2  3    7    -3   2301.9844  2066.9126  0.0     1.43858  0.00   
+  2  4    -6   -1   15659.0859 13974.0377 -0.0    1.43651  0.01   
+  2  1    -1   4    2022.2647  1747.7612  -0.0    1.43156  0.00   
+  2  2    6    2    15964.0944 14127.5120 -180.0  1.43067  0.01   
+  2  4    -6   -2   11844.1337 11494.7453 -180.0  1.42772  0.01   
+  2  3    1    -5   54.9594    54.5453    0.0     1.42498  0.00   
+  2  2    -4   3    9374.6947  9304.7725  -0.0    1.42492  0.01   
+  2  5    -1   -4   6389.2400  6191.0063  0.0     1.42367  0.00   
+  2  2    0    -5   593.5681   530.6717   -0.0    1.41970  0.00   
+  2  2    6    -4   4615.2929  4109.1661  -0.0    1.41942  0.00   
+  2  4    -4   1    2697.6455  2328.2327  -180.0  1.41643  0.00   
+  2  1    1    4    11301.8165 9765.5200  -0.0    1.41417  0.01   
+  2  2    2    -5   146.5649   102.1798   180.0   1.40774  0.00   
+  2  4    4    1    6489.3720  4251.1055  -180.0  1.40628  0.00   
+  2  1    9    -1   501.9493   313.3806   180.0   1.40427  0.00   
+  2  3    -1   -5   970.6387   559.2035   180.0   1.40173  0.00   
+  2  5    5    -2   147.9292   121.8591   180.0   1.39689  0.00   
+  2  4    -4   -4   398.5706   333.7965   -180.0  1.39638  0.00   
+  2  5    3    -4   13071.4934 10290.7248 -180.0  1.39407  0.01   
+  2  0    4    4    738.8869   603.2489   180.0   1.39300  0.00   
+  2  1    9    0    7071.6988  6061.3448  -180.0  1.39244  0.00   
+  2  0    8    2    917.3023   841.8614   -0.0    1.39135  0.00   
+  2  1    -7   -3   9.2757     8.6161     0.0     1.39082  0.00   
+  2  2    -8   -2   420.2243   389.1003   0.0     1.38958  0.00   
+  2  1    -9   0    5291.1320  5032.6219  -180.0  1.38852  0.00   
+  2  3    -5   -4   741.1265   712.8918   180.0   1.38828  0.00   
+  2  1    -5   -4   12.2345    12.2841    -0.0    1.38705  0.00   
+  2  4    6    0    6829.9552  6881.9956  0.0     1.38694  0.00   
+  2  2    -8   1    2262.6272  2583.5813  -0.0    1.38353  0.00   
+  2  3    -5   2    96.4709    107.7060   180.0   1.38139  0.00   
+  2  1    -3   4    10372.8561 11498.8556 180.0   1.38001  0.01   
+  2  3    3    -5   543.4759   601.2645   -0.0    1.37984  0.00   
+  2  5    3    0    1866.3011  2064.1961  180.0   1.37983  0.00   
+  2  2    4    3    7057.7669  7682.9819  -0.0    1.37735  0.00   
+  2  4    -6   0    2658.1277  2929.6322  0.0     1.37669  0.00   
+  2  5    -3   0    1665.4571  1846.9850  -180.0  1.37349  0.00   
+  2  4    0    -5   8897.2031  9852.1453  -0.0    1.37263  0.01   
+  2  5    5    -3   931.3923   1000.1841  -0.0    1.37203  0.00   
+  2  1    1    -5   59.0399    51.8333    180.0   1.36876  0.00   
+  2  2    8    -3   1094.2697  897.0709   0.0     1.36740  0.00   
+  2  2    -2   -5   967.1109   890.9937   -180.0  1.36475  0.00   
+  2  1    -9   -1   2429.4585  2521.2414  180.0   1.36346  0.00   
+  2  4    2    -5   10265.0113 11335.5971 180.0   1.36264  0.01   
+  2  2    8    1    3372.2291  3611.9875  -180.0  1.35827  0.00   
+  2  5    5    -1   843.3860   870.4892   -180.0  1.35737  0.00   
+  2  4    -6   -3   3842.3274  4126.3352  180.0   1.35385  0.00   
+  2  3    -7   1    522.8480   576.4772   0.0     1.35312  0.00   
+  2  1    9    -2   13401.0100 16147.0686 0.0     1.35152  0.01   
+  2  6    0    -2   13967.6645 16981.3924 180.0   1.35133  0.01   
+  2  1    -9   1    2978.9377  3741.5161  -0.0    1.35032  0.00   
+  2  1    -1   -5   8897.8997  10683.9602 -0.0    1.34891  0.01   
+  2  3    5    2    178.2792   209.3398   0.0     1.34817  0.00   
+  2  5    -5   -2   506.9120   568.7530   180.0   1.34647  0.00   
+  2  4    0    2    19704.6055 20266.7951 180.0   1.34356  0.01   
+  2  6    0    -3   464.0101   424.9852   0.0     1.34244  0.00   
+  2  3    -7   -3   1104.4908  987.1236   180.0   1.34218  0.00   
+  2  5    -3   -4   22.3736    19.4544    -0.0    1.34037  0.00   
+  2  3    7    1    515.8733   545.2034   0.0     1.33504  0.00   
+  2  1    3    4    273.9717   303.9072   180.0   1.33473  0.00   
+  2  2    4    -5   1885.9692  2138.1647  -0.0    1.33359  0.00   
+  2  6    2    -2   6573.1690  7470.5514  0.0     1.33146  0.00   
+  2  3    -1   3    454.1816   551.6386   -0.0    1.32984  0.00   
+  2  5    -5   -1   2547.8006  3077.6343  -180.0  1.32879  0.00   
+  2  1    -7   3    680.9266   845.5145   -180.0  1.32789  0.00   
+  2  1    3    -5   10436.3651 12956.3684 180.0   1.32785  0.01   
+  2  4    6    -4   987.2156   1219.1637  0.0     1.32754  0.00   
+  2  6    2    -3   4.8739     6.0091     -0.0    1.32656  0.00   
+  2  4    -2   -5   2588.2682  3146.4347  0.0     1.32203  0.00   
+  2  1    9    1    857.1138   1105.1306  -0.0    1.32057  0.00   
+  2  4    -2   2    1720.6005  2255.4357  0.0     1.32028  0.00   
+  2  3    1    3    2454.2645  3237.6008  0.0     1.32015  0.00   
+  2  2    -6   -4   86.1665    114.0134   0.0     1.31919  0.00   
+  2  3    -3   -5   1648.0979  2179.7868  180.0   1.31918  0.00   
+  2  0    6    -4   2974.3976  3685.3963  0.0     1.31717  0.00   
+  2  0    8    -3   3755.8890  4546.6333  -0.0    1.31636  0.00   
+  2  6    -2   -2   299.1850   330.6363   180.0   1.31265  0.00   
+  2  4    2    2    496.8308   505.4413   0.0     1.30914  0.00   
+  2  5    -5   -3   6502.1225  6208.9517  0.0     1.30653  0.00   
+  2  3    7    -4   12.0896    11.5530    -180.0  1.30602  0.00   
+  2  6    0    -1   783.4058   635.2341   -0.0    1.30261  0.00   
+  2  6    -2   -3   5944.1177  4797.6968  0.0     1.30107  0.00   
+  2  1    7    -4   1016.4060  816.7390   180.0   1.30069  0.00   
+  2  4    4    -5   958.3726   839.8412   -180.0  1.29576  0.00   
+  2  5    -1   1    633.2490   560.8179   -180.0  1.29287  0.00   
+  2  5    5    -4   113.1973   102.0732   -0.0    1.29210  0.00   
+  2  5    1    1    233.5428   213.0414   180.0   1.29128  0.00   
+  2  5    1    -5   1219.7573  1297.0866  -180.0  1.28850  0.00   
+  2  1    -9   -2   6962.4103  7594.2794  0.0     1.28440  0.00   
+  2  3    -3   3    3499.5624  3821.2749  180.0   1.28422  0.00   
+  2  2    -6   3    88.1406    97.9036    -0.0    1.28363  0.00   
+  2  3    5    -5   2729.7962  3037.5557  -0.0    1.28334  0.00   
+  2  6    2    -1   2310.1126  2446.8719  180.0   1.28151  0.00   
+  2  4    8    -2   14249.5295 16043.2073 -0.0    1.27998  0.01   
+  2  6    0    -4   4121.9175  4642.8182  0.0     1.27913  0.00   
+  2  1    -5   4    0.2476     0.2762     -0.0    1.27885  0.00   
+  2  0    0    5    1430.3546  1504.7953  0.0     1.27757  0.00   
+  2  2    -8   -3   928.7562   969.8153   0.0     1.27578  0.00   
+  2  1    -3   -5   1583.3759  1649.0848  -180.0  1.27554  0.00   
+  2  0    10   0    5412.0383  5612.4673  -0.0    1.27493  0.00   
+  2  3    9    -1   546.8058   567.6734   180.0   1.27318  0.00   
+  2  3    9    -2   199.8194   209.3409   0.0     1.27118  0.00   
+  2  6    -2   -1   571.7704   604.9530   -180.0  1.27102  0.00   
+  2  5    -1   -5   3029.1933  3287.3648  -0.0    1.27057  0.00   
+  2  4    -6   1    1976.1596  2157.0193  180.0   1.27033  0.00   
+  2  2    0    4    5012.2439  5970.9564  -0.0    1.26862  0.00   
+  2  6    2    -4   2198.5146  2642.8907  -180.0  1.26852  0.00   
+  2  0    2    -5   3381.0127  4140.6925  180.0   1.26818  0.00   
+  2  2    -8   2    12787.6023 15669.9235 0.0     1.26800  0.01   
+  2  5    5    0    1258.4550  1539.1640  -0.0    1.26791  0.00   
+  2  0    10   -1   584.1900   722.1628   -180.0  1.26570  0.00   
+  2  4    8    -1   100.2674   116.1733   180.0   1.26381  0.00   
+  2  2    -4   -5   30.8877    34.2839    180.0   1.26302  0.00   
+  2  1    -9   2    375.3115   407.6104   0.0     1.26267  0.00   
+  2  6    4    -2   3726.6066  4060.9393  -0.0    1.26012  0.00   
+  2  1    7    3    1300.3511  1423.0605  -180.0  1.25993  0.00   
+  2  5    -5   0    1139.8766  1251.7915  -0.0    1.25974  0.00   
+  2  4    6    1    32.1003    35.4122    180.0   1.25938  0.00   
+  2  6    4    -3   5224.7139  5742.7030  -180.0  1.25904  0.00   
+  2  3    3    3    31.7114    34.1056    0.0     1.25855  0.00   
+  2  2    -2   4    2454.1125  2630.4316  180.0   1.25569  0.00   
+  2  5    3    -5   7443.3585  7849.9862  180.0   1.25548  0.00   
+  2  1    9    -3   488.8869   446.4585   -180.0  1.25310  0.00   
+  2  4    -4   2    3004.1030  2913.1494  0.0     1.24747  0.00   
+  2  4    8    -3   1630.5818  1591.0184  -180.0  1.24643  0.00   
+  2  5    -3   1    157.0945   154.1169   -180.0  1.24419  0.00   
+  2  4    -6   -4   4444.3706  4649.8078  0.0     1.24074  0.00   
+  2  1    5    -5   19.9463    20.8490    -0.0    1.24058  0.00   
+  2  6    -2   -4   112.1528   116.0421   -0.0    1.24022  0.00   
+  2  5    3    1    846.0507   865.0651   -180.0  1.23993  0.00   
+  2  0    6    4    4352.4183  4402.8269  -0.0    1.23960  0.00   
+  2  0    8    3    2487.7025  2523.8232  0.0     1.23892  0.00   
+  2  5    7    -2   48.0469    48.4702    -180.0  1.23815  0.00   
+  2  0    2    5    6.2974     6.1649     -0.0    1.23770  0.00   
+  2  3    -9   -1   2087.5529  1878.7146  -180.0  1.23697  0.00   
+  2  0    10   1    80.3162    69.0195    180.0   1.23540  0.00   
+  2  2    8    -4   0.7849     0.6712     -0.0    1.23509  0.00   
+  2  2    2    4    221.1096   202.3679   180.0   1.23305  0.00   
+  2  2    10   -1   733.6316   674.5837   -0.0    1.23266  0.00   
+  2  2    6    3    641.8009   591.5126   -0.0    1.23202  0.00   
+  2  4    -8   -1   1337.7484  1660.8265  180.0   1.22975  0.00   
+  2  4    4    2    5586.5375  7216.8110  -0.0    1.22886  0.00   
+  2  6    -4   -2   5765.5285  7429.0559  0.0     1.22874  0.00   
+  2  4    -4   -5   4722.1336  5935.8119  180.0   1.22833  0.00   
+  2  3    9    0    169.3717   207.1256   180.0   1.22722  0.00   
+  2  2    8    2    15714.1791 16367.8700 -0.0    1.22501  0.01   
+  2  3    -7   2    4.2615     4.4310     -180.0  1.22493  0.00   
+  2  5    7    -3   725.5900   701.3947   180.0   1.22357  0.00   
+  2  5    -5   -4   554.1466   527.2945   -180.0  1.22255  0.00   
+  2  2    6    -5   97.2630    93.3157    -0.0    1.22244  0.00   
+  2  3    9    -3   3947.1429  3989.5508  -0.0    1.22187  0.00   
+  2  4    -8   -2   15296.6998 15576.6760 0.0     1.22139  0.01   
+  2  1    5    4    3308.8409  2923.6151  -180.0  1.22003  0.00   
+  2  3    -9   0    71.6467    63.1939    -0.0    1.21922  0.00   
+  2  6    -4   -3   1.9347     1.6171     -180.0  1.21643  0.00   
+  2  6    4    -1   11.0781    10.2523    180.0   1.21473  0.00   
+  2  2    10   -2   3448.9749  3195.8904  -180.0  1.21471  0.00   
+  2  3    -7   -4   10.0663    9.5153     0.0     1.21279  0.00   
+  2  6    0    0    13778.5293 13100.2263 0.0     1.21259  0.01   
+  2  1    9    2    1840.2120  1749.7864  0.0     1.21259  0.00   
+  2  0    4    -5   54.0561    51.4047    -180.0  1.21258  0.00   
+  2  1    -7   -4   707.6090   673.8718   0.0     1.21254  0.00   
+  2  6    4    -4   204.9296   199.9465   0.0     1.21185  0.00   
+  2  0    10   -2   2483.9633  2393.1814  180.0   1.21068  0.00   
+  2  3    -9   -2   2.5317     2.4088     0.0     1.20966  0.00   
+  2  5    7    -1   1008.9761  919.5910   -0.0    1.20764  0.00   
+  2  5    -3   -5   1835.1936  1669.4106  -180.0  1.20756  0.00   
+  2  2    10   0    13.5745    11.8619    180.0   1.20601  0.00   
+  2  3    -5   -5   5822.7251  5223.5291  -0.0    1.20426  0.00   
+  2  4    8    0    2123.5994  2036.1638  -180.0  1.20314  0.00   
+  2  2    -10  0    1214.3296  1234.3417  180.0   1.20037  0.00   
+  2  2    -10  -1   1962.3207  1881.5821  0.0     1.19900  0.00   
+  2  2    -4   4    0.0045     0.0043     180.0   1.19841  0.00   
+  2  3    -5   3    5427.1992  5149.8089  -180.0  1.19827  0.00   
+  2  6    -4   -1   4365.3486  4013.4094  180.0   1.19705  0.00   
+  2  4    -8   0    2035.9869  1701.7086  -180.0  1.19422  0.00   
+  2  4    6    -5   6476.0238  5356.2972  -0.0    1.19366  0.00   
+  2  6    2    0    8007.4798  6359.8747  -180.0  1.19287  0.00   
+  2  3    1    -6   217.8042   172.0799   180.0   1.19278  0.00   
+  2  3    7    2    269.2895   210.6961   180.0   1.19262  0.00   
+  2  6    -2   0    2617.4167  1825.4606  -180.0  1.18959  0.00   
+  2  5    -7   -2   335.8528   235.2689   -180.0  1.18926  0.00   
+  2  5    5    -5   687.9022   652.0282   -0.0    1.18202  0.00   
+  2  6    0    -5   1984.5861  1859.8386  -0.0    1.18139  0.00   
+  2  5    -7   -1   1265.6058  1170.6276  -0.0    1.17956  0.00   
+  2  3    -1   -6   11486.7218 10651.6340 0.0     1.17652  0.01   
+  2  1    -9   -3   3678.0668  3479.3329  -0.0    1.17569  0.00   
+  2  4    0    -6   734.0877   694.8770   -180.0  1.17567  0.00   
+  2  6    2    -5   727.2542   690.4314   180.0   1.17553  0.00   
+  2  4    8    -4   5203.6228  5262.2410  180.0   1.17365  0.00   
+  2  1    -1   5    43.7163    44.3347    0.0     1.17349  0.00   
+  2  2    0    -6   3130.6605  3262.2227  -180.0  1.17258  0.00   
+  2  4    2    -6   750.2345   785.7923   0.0     1.17185  0.00   
+  2  4    -8   -3   486.3248   512.5086   -0.0    1.17167  0.00   
+  2  1    -5   -5   5071.3531  5414.4867  -180.0  1.17131  0.00   
+  2  3    3    -6   3080.3984  3178.6335  180.0   1.16840  0.00   
+  2  5    7    -4   5764.3448  5932.4007  0.0     1.16833  0.00   
+  2  2    2    -6   432.8493   444.4424   0.0     1.16828  0.00   
+  2  0    8    -4   6809.7159  6734.2463  -180.0  1.16544  0.00   
+  2  3    5    3    9590.7137  9033.3981  -180.0  1.16397  0.01   
+  2  6    -4   -4   1435.1663  1331.0105  -180.0  1.16381  0.00   
+  2  3    7    -5   1278.9599  1180.8749  180.0   1.16377  0.00   
+  2  3    -9   1    30.9311    24.5109    -0.0    1.16177  0.00   
+  2  1    1    5    2579.6366  1984.2370  0.0     1.16142  0.00   
+  2  2    -10  1    533.5763   408.7012   -180.0  1.16134  0.00   
+  2  0    4    5    4831.4313  3674.6390  -180.0  1.16082  0.00   
+  2  6    6    -3   737.7383   572.9928   0.0     1.16041  0.00   
+  2  5    -5   1    10.3817    8.2052     180.0   1.16017  0.00   
+  2  7    1    -3   408.3755   326.8856   180.0   1.15995  0.00   
+  2  2    4    4    417.2425   334.7388   180.0   1.15990  0.00   
+  2  0    10   2    2399.6828  1953.1670  -180.0  1.15916  0.00   
+  2  5    -7   -3   17.0768    13.9221    0.0     1.15905  0.00   
+  2  6    6    -2   1296.9719  1062.5954  180.0   1.15883  0.00   
+  2  2    -10  -2   1064.0216  927.1428   -180.0  1.15763  0.00   
+  2  2    10   -3   522.5174   456.9863   180.0   1.15752  0.00   
+  2  1    -7   4    8902.8579  7894.1741  -0.0    1.15699  0.00   
+  2  1    11   -1   188.9460   172.4013   -0.0    1.15488  0.00   
+  2  5    5    1    16.3175    14.5872    180.0   1.15443  0.00   
+  2  4    0    3    439.9200   372.8509   -0.0    1.15214  0.00   
+  2  7    -1   -3   245.1872   190.7937   -0.0    1.15103  0.00   
+  2  1    -9   3    505.2015   390.2848   -180.0  1.15086  0.00   
+  2  7    1    -2   523.1740   417.6649   180.0   1.14957  0.00   
+  2  6    -2   -5   4.2472     3.3422     180.0   1.14818  0.00   
+  2  2    -8   -4   1469.6216  1241.1393  -0.0    1.14713  0.00   
+  2  3    9    1    991.1431   840.9132   -180.0  1.14703  0.00   
+  2  1    -3   5    153.8722   131.0137   -0.0    1.14691  0.00   
+  2  4    -6   2    1028.9338  884.2580   -180.0  1.14653  0.00   
+  2  1    11   0    742.7516   673.8595   0.0     1.14593  0.00   
+  2  3    -9   -3   7368.9357  6842.7549  -0.0    1.14539  0.00   
+  2  1    -11  0    59.8109    56.5171    180.0   1.14326  0.00   
+  2  7    -1   -2   272.4329   258.5173   180.0   1.14319  0.00   
+  2  2    10   1    2202.8514  2221.3310  -180.0  1.14260  0.00   
+  2  2    -6   -5   8154.0878  8280.7099  -0.0    1.14253  0.00   
+  2  5    -1   2    0.2454     0.2523     -180.0  1.14237  0.00   
+  2  4    -2   -6   153.1306   159.9954   -0.0    1.14109  0.00   
+  2  5    7    0    1519.9342  1584.2307  0.0     1.14103  0.00   
+  2  3    9    -4   3439.2555  3452.1120  -180.0  1.13977  0.00   
+  2  4    -2   3    671.6890   675.3480   180.0   1.13965  0.00   
+  2  2    -8   3    932.0397   940.5804   180.0   1.13923  0.00   
+  2  5    1    2    151.4686   151.0052   180.0   1.13897  0.00   
+  2  2    -2   -6   469.0669   457.5743   180.0   1.13875  0.00   
+  2  5    1    -6   92.9398    92.8501    180.0   1.13644  0.00   
+  2  6    4    0    10012.6347 9886.1889  -180.0  1.13618  0.00   
+  2  1    9    -4   6640.3893  6387.1239  180.0   1.13575  0.00   
+  2  7    1    -4   116.0235   104.3489   0.0     1.13318  0.00   
+  2  5    -7   0    649.7717   561.3250   0.0     1.13270  0.00   
+  2  6    4    -5   4161.0031  3560.8356  -0.0    1.13225  0.00   
+  2  7    3    -3   1994.3849  1752.7599  180.0   1.13164  0.00   
+  2  1    7    -5   2078.4363  1876.4532  -0.0    1.13113  0.00   
+  2  4    4    -6   80.7413    74.0198    180.0   1.13073  0.00   
+  2  6    -4   0    9837.6381  8996.3605  -180.0  1.13052  0.00   
+  2  1    1    -6   13.9585    12.7255    180.0   1.13041  0.00   
+  2  4    2    3    29.5572    26.9687    0.0     1.12798  0.00   
+  2  1    11   -2   3728.2633  4054.5939  -180.0  1.12721  0.00   
+  2  2    4    -6   555.2957   617.9103   -180.0  1.12706  0.00   
+  2  1    -11  -1   71.8389    80.5660    180.0   1.12692  0.00   
+  2  0    6    -5   739.9295   825.3110   -0.0    1.12677  0.00   
+  2  0    10   -3   24.0012    25.1309    180.0   1.12560  0.00   
+  2  6    6    -4   1020.2757  1116.6065  -0.0    1.12535  0.00   
+  2  4    -8   1    1194.4685  1428.0735  -0.0    1.12500  0.00   
+  2  4    6    2    408.8594   491.6513   180.0   1.12497  0.00   
+  2  3    -3   -6   1985.2449  2679.1058  0.0     1.12421  0.00   
+  2  1    -11  1    397.3238   520.4388   180.0   1.12385  0.00   
+  2  3    -1   4    54.2633    62.3074    180.0   1.12290  0.00   
+  2  7    -1   -4   299.6530   340.7362   180.0   1.12266  0.00   
+  2  6    -6   -2   5.1779     5.8815     -0.0    1.12259  0.00   
+  2  5    -1   -6   3154.8180  3679.1020  -180.0  1.12188  0.00   
+  2  6    6    -1   16.6529    18.5196    -180.0  1.12105  0.00   
+  2  7    3    -2   441.9040   466.2613   -180.0  1.11981  0.00   
+  2  5    -5   -5   3271.7477  3254.1700  180.0   1.11710  0.00   
+  2  1    -1   -6   1574.3996  1573.1101  -180.0  1.11699  0.00   
+  2  4    -6   -5   12.3229    12.1624    -180.0  1.11621  0.00   
+  2  5    3    -6   3720.2381  3572.8767  0.0     1.11574  0.00   
+  2  3    1    4    597.6515   557.2568   180.0   1.11489  0.00   
+  2  4    8    1    3256.8702  3030.2470  -0.0    1.11486  0.00   
+  2  1    3    5    243.9117   208.8946   -180.0  1.11404  0.00   
+  2  2    -6   4    2045.9922  1626.0861  -0.0    1.11278  0.00   
+  2  6    -6   -3   11140.1930 9170.8262  180.0   1.11104  0.01   
+  2  5    -3   2    28.2221    23.9804    -180.0  1.11049  0.00   
+  2  3    5    -6   88.2040    75.3696    -0.0    1.11017  0.00   
+  2  1    3    -6   4292.6830  3749.4968  0.0     1.10915  0.00   
+  2  7    3    -4   967.7274   851.8273   -0.0    1.10885  0.00   
+  2  7    -3   -3   9.0521     8.0510     -0.0    1.10731  0.00   
+  2  7    1    -1   603.6012   540.2195   -180.0  1.10485  0.00   
+  2  6    0    1    3162.3881  2851.2916  180.0   1.10441  0.00   
+  2  1    11   1    390.9620   353.4958   0.0     1.10278  0.00   
+  2  7    -3   -2   8.5621     7.6618     -0.0    1.10240  0.00   
+  2  4    10   -2   320.7294   293.9448   -180.0  1.10139  0.00   
+  2  7    -1   -1   607.6533   560.8360   -180.0  1.10125  0.00   
+  2  5    3    2    99.9324    92.4856    -180.0  1.10119  0.00   
+  2  2    8    -5   3959.6259  3728.5603  180.0   1.10077  0.00   
+  2  6    -6   -1   6.5779     6.2337     0.0     1.10033  0.00   
+  2  5    -7   -4   138.1564   136.6182   0.0     1.09716  0.00   
+  2  3    -3   4    146.0121   143.6453   -0.0    1.09706  0.00   
+  2  1    7    4    60.0531    57.0295    -0.0    1.09661  0.00   
+  2  0    8    4    3134.8643  2959.2417  180.0   1.09406  0.00   
+  2  4    -8   -4   3929.5051  3685.4545  -180.0  1.09399  0.00   
+  2  4    -4   3    2368.1696  2186.7268  180.0   1.09385  0.00   
+  2  3    -7   3    1966.2739  1814.2931  0.0     1.09384  0.00   
+  2  1    9    3    334.5495   308.2223   180.0   1.09383  0.00   
+  2  2    -10  2    4.1600     3.3265     -0.0    1.09247  0.00   
+  2  2    8    3    482.3432   379.8198   0.0     1.09126  0.00   
+  2  5    9    -2   2241.8698  1582.6840  -0.0    1.09021  0.00   
+  2  4    10   -1   2.2790     1.7369     -180.0  1.08903  0.00   
+  2  6    -2   1    1.9942     1.5406     -180.0  1.08894  0.00   
+  2  1    -5   5    7196.2432  5646.2565  0.0     1.08884  0.00   
+  2  6    2    1    297.4073   245.3481   -0.0    1.08745  0.00   
+  2  2    -10  -3   752.9845   617.4947   180.0   1.08733  0.00   
+  2  5    7    -5   111.3689   91.0318    -180.0  1.08704  0.00   
+  2  6    -4   -5   453.8071   422.0173   180.0   1.08477  0.00   
+  2  3    -7   -5   3027.2473  3180.2930  0.0     1.08232  0.00   
+  2  5    9    -3   34.9487    37.0056    -180.0  1.08217  0.00   
+  2  4    10   -3   467.5741   496.5346   180.0   1.08176  0.00   
+  2  4    8    -5   383.7132   416.8216   0.0     1.08002  0.00   
+  2  7    -3   -4   438.0826   475.9937   -180.0  1.08002  0.00   
+  2  3    11   -2   1075.8131  1209.7235  180.0   1.07973  0.00   
+  2  3    -9   2    1002.6541  1162.0253  -0.0    1.07952  0.00   
+  2  1    -11  -2   421.7291   505.5742   -0.0    1.07909  0.00   
+  2  3    11   -1   2113.5759  2531.9784  -180.0  1.07901  0.00   
+  2  4    -4   -6   51.7723    79.4879    0.0     1.07725  0.00   
+  2  7    3    -1   250.9733   517.9063   0.0     1.07642  0.00   
+  2  7    1    -5   11.8443    25.2106    -0.0    1.07626  0.00   
+  2  5    -3   -6   639.3992   1371.1187  180.0   1.07586  0.00   
+  2  2    10   -4   1327.8547  2842.5457  0.0     1.07584  0.00   
+  2  2    -4   -6   89.9786    186.5753   0.0     1.07568  0.00   
+  2  3    3    4    324.6236   560.4316   180.0   1.07511  0.00   
+  2  1    -11  2    387.6898   558.2780   -180.0  1.07370  0.00   
+  2  7    5    -3   650.5039   928.6481   180.0   1.07351  0.00   
+  2  4    4    3    575.4928   818.8776   180.0   1.07348  0.00   
+  2  1    -3   -6   122.2456   135.6225   180.0   1.07233  0.00   
+  2  6    0    -6   3.5778     4.1780     -180.0  1.07161  0.00   
+  2  1    11   -3   393.4458   540.3856   180.0   1.07008  0.00   
+  2  6    2    -6   64.1906    107.8329   0.0     1.06912  0.00   
+  2  6    -6   -4   311.2178   552.9788   0.0     1.06862  0.00   
+  2  5    9    -1   525.9255   1026.4794  0.0     1.06732  0.00   
+  2  2    6    4    2148.3049  4143.5979  0.0     1.06716  0.00   
+  2  7    -3   -1   105.9362   173.9010   0.0     1.06652  0.00   
+  2  2    0    5    1304.1458  1937.9253  0.0     1.06580  0.00   
+  2  0    6    5    242.2022   358.8678   0.0     1.06561  0.00   
+  2  7    -1   -5   2222.2550  3288.8085  0.0     1.06535  0.00   
+  2  5    5    -6   302.9866   447.2840   -180.0  1.06509  0.00   
+  2  0    0    6    37.4394    53.4823    180.0   1.06464  0.00   
+  2  0    10   3    2298.2154  3276.3246  0.0     1.06463  0.00   
+  2  4    6    -6   25.3180    31.3322    -180.0  1.06282  0.00   
+  2  6    6    -5   346.6380   434.3157   -0.0    1.06260  0.00   
+  2  0    12   0    89.1131    112.6819   180.0   1.06244  0.00   
+  2  4    -10  -1   851.3820   1132.6677  180.0   1.06171  0.00   
+  2  7    5    -2   3352.6358  4496.3914  -180.0  1.06153  0.00   
+  2  0    2    -6   552.3301   748.1993   0.0     1.06104  0.00   
+  2  5    -7   1    718.8066   969.1237   180.0   1.06052  0.00   
+  2  1    -9   -4   1285.7262  1706.8793  -180.0  1.06015  0.00   
+  2  2    -2   5    2502.7631  3313.4198  -180.0  1.05994  0.00   
+  2  3    -9   -4   10.3246    13.6703    -180.0  1.05993  0.00   
+  2  2    6    -6   208.1139   288.6216   -180.0  1.05938  0.00   
+  2  0    12   -1   899.8288   1340.4500  -0.0    1.05892  0.00   
+  2  1    -7   -5   5.0451     7.5059     -180.0  1.05860  0.00   
+  2  1    5    -6   31.8951    47.4061    -180.0  1.05858  0.00   
+  2  2    10   2    910.2155   1237.1699  -0.0    1.05797  0.00   
+  2  3    7    3    9.9735     12.9031    -180.0  1.05758  0.00   
+  2  7    3    -5   1741.7264  2239.1302  -180.0  1.05718  0.00   
+  2  6    6    0    332.7920   461.7745   -0.0    1.05659  0.00   
+  2  7    5    -4   1531.7242  2051.4003  0.0     1.05581  0.00   
+  2  4    -10  -2   2442.1392  3145.7849  0.0     1.05450  0.00   
+  2  5    7    1    28.7929    37.2884    180.0   1.05440  0.00   
+  2  6    8    -3   7539.3493  8866.7538  -0.0    1.05196  0.00   
+  2  3    -11  -1   222.8550   261.5320   -0.0    1.05193  0.00   
+  2  5    -5   2    4946.1203  5387.0808  -180.0  1.05131  0.00   
+  2  3    9    2    811.2607   862.2832   -0.0    1.05108  0.00   
+  2  3    11   -3   643.1948   673.7850   180.0   1.05082  0.00   
+  2  6    -6   0    501.0021   488.9045   -0.0    1.04978  0.00   
+  2  6    8    -2   368.8696   331.3808   0.0     1.04899  0.00   
+  2  3    11   0    458.9451   407.0557   -0.0    1.04881  0.00   
+  2  3    -5   -6   1400.6854  1235.7557  -180.0  1.04872  0.00   
+  2  4    10   0    72.1617    61.4161    -0.0    1.04771  0.00   
+  2  5    -9   -2   2632.2108  2208.3085  -0.0    1.04729  0.00   
+  2  5    9    -4   258.7651   228.7958   -180.0  1.04516  0.00   
+  2  6    -2   -6   1473.0384  1293.5044  -0.0    1.04487  0.00   
+  2  6    -4   1    3600.5931  3160.5795  -0.0    1.04485  0.00   
+  2  3    -5   4    2636.4263  2301.6767  -0.0    1.04377  0.00   
+  2  3    9    -5   2047.7344  1817.7670  180.0   1.04328  0.00   
+  2  1    5    5    1824.9895  1623.2967  -0.0    1.04294  0.00   
+  2  3    -11  0    1573.1234  1387.3612  0.0     1.04270  0.00   
+  2  2    2    5    299.8405   264.3036   0.0     1.04269  0.00   
+  2  5    -9   -1   72.1183    62.5557    0.0     1.04240  0.00   
+  2  6    4    1    1187.5434  1021.8291  -0.0    1.04223  0.00   
+  2  4    -10  0    625.3891   554.7785   -0.0    1.04034  0.00   
+  2  2    12   -1   4351.6606  3828.0670  -180.0  1.03971  0.00   
+  2  0    2    6    1696.2466  1492.8101  0.0     1.03949  0.00   
+  2  7    -5   -3   3994.1738  3517.5593  180.0   1.03943  0.00   
+  2  5    5    2    4591.3950  4324.4718  -180.0  1.03825  0.00   
+  2  4    -8   2    307.9346   298.1823   -0.0    1.03802  0.00   
+  2  6    4    -6   1286.3949  1251.2761  -180.0  1.03798  0.00   
+  2  0    12   1    331.1611   335.8693   -0.0    1.03750  0.00   
+  2  7    -5   -2   1443.9420  1492.9651  -180.0  1.03709  0.00   
+  2  7    1    0    1205.0828  1264.8986  -0.0    1.03656  0.00   
+  2  1    -9   4    2.4913     2.8086     180.0   1.03594  0.00   
+  2  1    11   2    1471.9509  1702.3367  180.0   1.03580  0.00   
+  2  7    -1   0    1471.0620  1823.6465  -0.0    1.03529  0.00   
+  2  4    10   -4   7.2586     9.1218     0.0     1.03486  0.00   
+  2  3    -11  -2   1120.4034  1522.0493  -180.0  1.03326  0.00   
+  3  1    1    0    1445.1945  1272.1351  -0.0    3.25208  0.03   
+  3  1    0    1    545.1091   492.3054   -0.0    2.48925  0.01   
+  3  2    0    0    128.0343   149.2770   -0.0    2.29957  0.00   
+  3  1    1    1    314.5256   374.9846   180.0   2.18917  0.01   
+  3  2    1    0    140.6268   152.8499   0.0     2.05680  0.00   
+  3  2    1    1    1008.6240  880.3927   -0.0    1.68912  0.02   
+  3  2    2    0    1085.7816  1143.4700  -0.0    1.62604  0.01   
+  3  0    0    2    1766.4198  1418.0349  -0.0    1.48017  0.00   
+  3  3    1    0    377.0293   356.8641   -0.0    1.45437  0.00   
+  3  2    2    1    28.0615    28.2488    180.0   1.42520  0.00   
+  3  3    0    1    822.7128   1055.5915  -0.0    1.36133  0.01   
+  3  1    1    2    421.1132   541.6489   -0.0    1.34719  0.00   
+  3  3    1    1    35.3680    32.7655    0.0     1.30535  0.00   
+  3  3    2    0    14.4759    15.0323    180.0   1.27557  0.00   
+  3  2    0    2    150.7319   145.3457   -0.0    1.24463  0.00   
+  3  2    1    2    40.2784    42.1744    0.0     1.20141  0.00   
+  3  3    2    1    143.3821   154.5305   -0.0    1.17145  0.00   
+  3  4    0    0    522.2409   422.3425   -0.0    1.14978  0.00   
+  3  4    1    0    83.3697    78.7307    180.0   1.11545  0.00   
+  3  2    2    2    547.1205   562.7841   -0.0    1.09458  0.00   
+  3  3    3    0    577.0749   592.5639   -0.0    1.08403  0.00   
+  3  4    1    1    315.4361   271.8264   -0.0    1.04381  0.00   
+  3  3    1    2    213.7352   220.8812   -0.0    1.03740  0.00   
+  4  1    1    0    9128.6784  5228.4628  0.0     5.75712  0.00   
+  4  1    1    -1   2489.6354  1404.0285  0.0     5.74499  0.00   
+  4  0    0    2    12804.2604 6637.1207  0.0     5.70850  0.00   
+  4  2    0    0    1992.6110  778.0303   180.0   5.31188  0.00   
+  4  2    0    -2   27682.5647 11512.4620 0.0     5.27405  0.00   
+  4  1    1    1    9925.3893  5910.4373  -180.0  4.69390  0.00   
+  4  1    1    -2   732.1413   470.7689   -180.0  4.67424  0.00   
+  4  1    1    2    1914.2781  1807.7940  -180.0  3.62866  0.00   
+  4  1    1    -3   6736.1090  6212.2295  180.0   3.61352  0.00   
+  4  0    2    0    5789.6904  1735.5337  180.0   3.42507  0.00   
+  4  3    1    -1   2712.8574  1015.8549  -0.0    3.40815  0.00   
+  4  3    1    -2   7721.9704  3189.7832  180.0   3.40061  0.00   
+  4  0    2    1    6173.8167  4999.9766  -0.0    3.28063  0.00   
+  4  2    0    2    13660.1410 11595.1621 -0.0    3.22237  0.00   
+  4  2    0    -4   5521.8370  5001.5029  180.0   3.19707  0.00   
+  4  3    1    0    2443.3635  2138.6790  0.0     3.14576  0.00   
+  4  3    1    -3   3203.1214  2676.9485  180.0   3.12805  0.00   
+  4  4    0    -2   115900.9301 81005.2590 -180.0  2.98678  0.01   
+  4  2    2    -1   101547.1273 74974.4061 -0.0    2.97131  0.01   
+  4  0    2    2    830.6658   792.0140   0.0     2.93698  0.00   
+  4  2    2    0    1236.7570  1807.4000  0.0     2.87856  0.00   
+  4  2    2    -2   386.0973   528.8583   -0.0    2.87249  0.00   
+  4  1    1    3    1963.8211  2485.3846  -0.0    2.86476  0.00   
+  4  1    1    -4   4758.3003  5800.7943  -0.0    2.85432  0.00   
+  4  0    0    4    8476.0596  10332.6990 -0.0    2.85425  0.00   
+  4  3    1    1    3581.4873  3755.5610  -180.0  2.75914  0.00   
+  4  3    1    -4   3020.2864  3264.9087  -0.0    2.73926  0.00   
+  4  4    0    0    74244.6955 71155.6385 0.0     2.65594  0.00   
+  4  2    2    1    143517.9841 132877.6779 0.0     2.64033  0.01   
+  4  2    2    -3   73214.9489 66210.9067 -180.0  2.63099  0.01   
+  4  4    0    -4   153253.4403 140757.4165 180.0   2.63703  0.01   
+  4  0    2    3    18334.2351 14168.9224 180.0   2.54585  0.00   
+  4  3    1    2    8854.2024  9780.7432  -180.0  2.37688  0.00   
+  4  3    1    -5   5570.7563  5864.9894  -0.0    2.35910  0.00   
+  4  2    2    2    137.9518   143.7218   -180.0  2.34695  0.00   
+  4  2    2    -4   861.5124   880.9787   180.0   2.33712  0.00   
+  4  1    1    4    2903.3916  2966.0204  -0.0    2.33701  0.00   
+  4  1    1    -5   325.3178   299.8592   -0.0    2.32972  0.00   
+  4  4    2    -2   1651.7191  1407.7572  -0.0    2.25109  0.00   
+  4  5    1    -2   2424.5227  2126.1968  180.0   2.24699  0.00   
+  4  5    1    -3   596.8589   539.9195   180.0   2.24338  0.00   
+  4  1    3    0    54.5260    52.3498    0.0     2.23240  0.00   
+  4  1    3    -1   4342.8992  4174.3249  -0.0    2.23169  0.00   
+  4  4    2    -1   898.7583   918.3342   0.0     2.21132  0.00   
+  4  4    2    -3   12450.2349 13297.0101 -0.0    2.20583  0.00   
+  4  0    2    4    842.5338   966.5437   180.0   2.19269  0.00   
+  4  5    1    -1   8768.7065  11536.3543 -0.0    2.16794  0.00   
+  4  1    3    1    815.5133   1029.6032  -0.0    2.15229  0.00   
+  4  1    3    -2   8856.2156  10946.2520 0.0     2.15038  0.00   
+  4  5    1    -4   529.0446   710.8684   -180.0  2.15826  0.00   
+  4  2    0    4    1401.0999  1633.1560  0.0     2.13910  0.00   
+  4  2    0    -6   6866.0285  7213.4493  0.0     2.12673  0.00   
+  4  4    2    0    558.4607   728.4469   -180.0  2.09885  0.00   
+  4  4    2    -4   444.3896   548.6870   -180.0  2.08948  0.00   
+  4  4    0    2    260148.0829 286221.3519 180.0   2.07255  0.01   
+  4  2    2    3    273843.3029 292718.2813 0.0     2.06286  0.01   
+  4  2    2    -5   270625.8406 297005.3196 0.0     2.05396  0.01   
+  4  4    0    -6   276278.6946 302633.0236 -180.0  2.05462  0.01   
+  4  3    1    3    975.2244   1082.3187  -180.0  2.04981  0.00   
+  4  3    1    -6   128.2978   154.8230   -0.0    2.03514  0.00   
+  4  5    1    0    603.0531   772.1001   180.0   2.02937  0.00   
+  4  1    3    2    9886.0867  13994.1542 -0.0    2.01442  0.00   
+  4  1    3    -3   873.8303   1236.4908  -0.0    2.01182  0.00   
+  4  5    1    -5   10137.2531 14176.1263 -0.0    2.01618  0.00   
+  4  3    3    -1   8339.4428  7013.3013  -0.0    1.97420  0.00   
+  4  3    3    -2   221.8669   187.8868   0.0     1.97272  0.00   
+  4  1    1    5    4115.7780  4617.6850  180.0   1.96234  0.00   
+  4  6    0    -2   942.3072   972.9793   180.0   1.96447  0.00   
+  4  1    1    -6   1204.9561  1562.3504  -0.0    1.95706  0.00   
+  4  6    0    -4   13735.5597 17299.1482 -180.0  1.95870  0.00   
+  4  4    2    1    17427.0027 20968.4796 -0.0    1.94310  0.00   
+  4  4    2    -5   62.5134    70.9491    180.0   1.93197  0.00   
+  4  3    3    0    9082.7309  9823.0333  180.0   1.91904  0.00   
+  4  3    3    -3   2603.7756  2765.6462  -0.0    1.91500  0.00   
+  4  0    0    6    1633.2883  1708.2631  -0.0    1.90283  0.00   
+  4  0    2    5    86.7522    90.1411    -180.0  1.89990  0.00   
+  4  5    1    1    2207.6882  2505.3220  -180.0  1.86271  0.00   
+  4  1    3    3    2899.8899  3418.2280  0.0     1.84952  0.00   
+  4  1    3    -4   444.1345   508.0697   -180.0  1.84670  0.00   
+  4  5    1    -6   2485.0239  2902.7977  -180.0  1.84845  0.00   
+  4  3    3    1    3168.1456  3292.1807  -0.0    1.82016  0.00   
+  4  3    3    -4   14342.7956 15058.0591 -180.0  1.81442  0.00   
+  4  2    2    4    1910.5318  2005.1019  180.0   1.81433  0.00   
+  4  2    2    -6   112.2930   110.8992   -0.0    1.80676  0.00   
+  4  3    1    4    1131.2568  1172.6193  -0.0    1.78363  0.00   
+  4  4    2    2    699.6815   570.2454   -0.0    1.77318  0.00   
+  4  3    1    -7   947.5682   721.9792   -180.0  1.77181  0.00   
+  4  6    0    0    46485.8725 33194.4176 180.0   1.77063  0.00   
+  4  4    2    -6   2871.8180  1199.0522  -0.0    1.76192  0.00   
+  4  6    0    -6   5.1808     2.0490     0.0     1.75802  0.00   
+  4  6    2    -3   410044.3791 370366.9259 -180.0  1.72143  0.01   
+  4  0    4    0    374081.6825 347791.6477 -180.0  1.71254  0.01   
+  4  6    2    -2   468.5920   389.9210   -0.0    1.70408  0.00   
+  4  6    2    -4   2008.0235  1561.2658  180.0   1.70030  0.00   
+  4  0    4    1    4469.4463  3249.6100  -0.0    1.69359  0.00   
+  4  3    3    2    4925.3188  3596.7315  -0.0    1.69640  0.00   
+  4  3    3    -5   13852.7499 10523.7647 0.0     1.68990  0.00   
+  4  5    1    2    3516.6756  2571.5632  -180.0  1.69286  0.00   
+  4  1    1    6    952.7344   742.5307   -0.0    1.68641  0.00   
+  4  1    3    4    57.7915    44.8547    -0.0    1.68172  0.00   
+  4  1    1    -7   16026.6820 12441.2647 -180.0  1.68245  0.00   
+  4  1    3    -5   5956.7052  4675.3950  0.0     1.67900  0.00   
+  4  5    1    -7   339.4493   266.2206   -180.0  1.67911  0.00   
+  4  0    2    6    1105.8384  1004.1391  0.0     1.66337  0.00   
+  4  2    4    -1   3001.4483  2834.0739  180.0   1.64622  0.00   
+  4  6    2    -1   922.4756   866.7397   -180.0  1.65156  0.00   
+  4  7    1    -3   38.0035    35.5775    180.0   1.65277  0.00   
+  4  5    3    -2   356.6922   336.5635   -180.0  1.64723  0.00   
+  4  7    1    -4   593.8642   558.9717   -0.0    1.65076  0.00   
+  4  5    3    -3   1304.2560  1232.2503  -180.0  1.64580  0.00   
+  4  0    4    2    626.2335   609.5389   -180.0  1.64031  0.00   
+  4  6    2    -5   534.0940   505.9447   -180.0  1.64471  0.00   
+  4  2    4    0    747.0026   751.1044   -0.0    1.62992  0.00   
+  4  2    4    -2   4430.2368  4447.2782  180.0   1.62882  0.00   
+  4  7    1    -2   3745.8528  3580.8228  180.0   1.62109  0.00   
+  4  5    3    -1   1041.9147  966.2701   0.0     1.61531  0.00   
+  4  7    1    -5   990.8818   919.2802   -0.0    1.61541  0.00   
+  4  5    3    -4   4211.4813  3833.4911  -180.0  1.61130  0.00   
+  4  4    0    4    70876.1011 64474.9733 180.0   1.61119  0.00   
+  4  4    2    3    30.7814    27.4115    180.0   1.60834  0.00   
+  4  2    2    5    43467.4006 37144.1292 -180.0  1.60557  0.00   
+  4  2    2    -7   90552.7949 66556.6160 0.0     1.59927  0.00   
+  4  4    2    -7   3603.9987  2584.1012  -0.0    1.59783  0.00   
+  4  4    0    -8   51036.6642 36994.7586 0.0     1.59853  0.00   
+  4  2    4    1    2205.2976  1918.9270  0.0     1.58277  0.00   
+  4  2    4    -3   2076.5124  1870.9134  0.0     1.58075  0.00   
+  4  2    0    6    30429.6441 28946.2323 -0.0    1.57689  0.00   
+  4  6    2    0    323.2359   317.6512   -0.0    1.57288  0.00   
+  4  2    0    -8   4954.2088  4984.3398  -180.0  1.56994  0.00   
+  4  3    1    5    1722.6614  1741.4129  180.0   1.56939  0.00   
+  4  3    3    3    466.7870   484.1839   0.0     1.56463  0.00   
+  4  0    4    3    2798.4708  2908.7315  -0.0    1.56170  0.00   
+  4  6    2    -6   1202.3310  1248.6458  -180.0  1.56402  0.00   
+  4  3    3    -6   1457.3058  1491.8604  -180.0  1.55808  0.00   
+  4  3    1    -8   1799.7269  1861.7114  0.0     1.55987  0.00   
+  4  7    1    -1   1971.2694  2047.1082  -0.0    1.56112  0.00   
+  4  5    3    0    3761.1199  3761.4033  180.0   1.55549  0.00   
+  4  7    1    -6   3890.9881  3796.1172  -180.0  1.55270  0.00   
+  4  5    3    -5   1463.1709  1406.9215  0.0     1.54952  0.00   
+  4  5    1    3    1014.7453  789.2030   0.0     1.53388  0.00   
+  4  1    3    5    9.7542     7.4029     -180.0  1.52468  0.00   
+  4  1    3    -6   1542.1807  1154.4884  0.0     1.52220  0.00   
+  4  5    1    -8   7.1668     5.3441     0.0     1.52138  0.00   
+  4  2    4    2    5205.0947  4241.8442  180.0   1.51224  0.00   
+  4  2    4    -4   2874.2760  2480.9162  -0.0    1.50960  0.00   
+  4  6    0    2    9893.4961  8951.5408  -180.0  1.50724  0.00   
+  4  6    0    -8   4937.9505  4397.8587  -180.0  1.49431  0.00   
+  4  8    0    -4   23010.5720 20190.1236 0.0     1.49339  0.00   
+  4  4    4    -2   25770.2788 20429.5329 -0.0    1.48565  0.00   
+  4  7    1    0    661.4892   523.9364   0.0     1.48175  0.00   
+  4  6    2    1    629.5996   508.4966   180.0   1.47901  0.00   
+  4  5    3    1    1796.5286  1469.8281  180.0   1.47651  0.00   
+  4  4    4    -1   218.1899   180.2923   180.0   1.47405  0.00   
+  4  1    1    7    11096.9431 9091.7882  -0.0    1.47619  0.00   
+  4  4    4    -3   2004.3397  1667.5953  180.0   1.47242  0.00   
+  4  1    1    -8   8929.9046  7407.8451  0.0     1.47312  0.00   
+  4  0    2    7    3010.4320  2503.1732  180.0   1.47256  0.00   
+  4  0    4    4    674.6009   576.6663   180.0   1.46849  0.00   
+  4  5    3    -6   0.2121     0.1797     -180.0  1.46938  0.00   
+  4  7    1    -7   278.8980   232.7336   -180.0  1.47169  0.00   
+  4  6    2    -7   1280.3266  1086.5341  180.0   1.46921  0.00   
+  4  4    2    4    345.4153   309.4549   -180.0  1.45793  0.00   
+  4  4    2    -8   310.4517   302.9912   -180.0  1.44854  0.00   
+  4  8    0    -2   53660.3013 52418.6929 0.0     1.44786  0.00   
+  4  4    4    0    44225.7417 40355.6835 -180.0  1.43928  0.00   
+  4  8    0    -6   42382.1986 39586.7446 -180.0  1.44170  0.00   
+  4  4    4    -4   60508.4853 54046.6468 0.0     1.43625  0.00   
+  4  3    3    4    5171.9435  4617.7330  -180.0  1.43618  0.00   
+  4  2    2    6    0.9149     0.8092     -180.0  1.43238  0.00   
+  4  3    3    -7   1605.1130  1448.2500  0.0     1.42999  0.00   
+  4  2    4    3    2901.9263  2692.4789  180.0   1.42752  0.00   
+  4  2    2    -8   1957.8431  1821.8495  -0.0    1.42716  0.00   
+  4  2    4    -5   1785.5625  1667.9730  180.0   1.42456  0.00   
+  4  0    0    8    287014.8855 267147.3687 -0.0    1.42712  0.00   
+  4  3    1    6    1205.9120  941.1628   180.0   1.39613  0.00   
+  4  5    1    4    877.2063   767.3314   0.0     1.39151  0.00   
+  4  7    1    1    58.5203    50.2466    -180.0  1.39219  0.00   
+  4  3    1    -9   755.0799   710.0031   -0.0    1.38839  0.00   
+  4  4    4    1    3651.2395  3619.1298  -0.0    1.38597  0.00   
+  4  5    3    2    461.7766   442.8188   -180.0  1.38751  0.00   
+  4  1    3    6    3048.6420  3147.4132  0.0     1.38395  0.00   
+  4  4    4    -5   1157.7908  1222.2903  0.0     1.38191  0.00   
+  4  1    3    -7   459.7754   485.6927   -180.0  1.38176  0.00   
+  4  5    3    -7   1016.7987  1075.6125  180.0   1.37991  0.00   
+  4  7    1    -8   219.2787   231.8332   0.0     1.38148  0.00   
+  4  5    1    -9   2997.3601  3171.8690  -0.0    1.38047  0.00   
+  4  6    2    2    241.8435   255.7408   -180.0  1.37957  0.00   
+  4  0    4    5    373.9936   361.1264   -180.0  1.37003  0.00   
+  4  6    2    -8   2.9711     2.8407     0.0     1.36963  0.00   
+  4  8    2    -4   786.8169   740.6559   180.0   1.36893  0.00   
+  4  7    3    -3   3358.1565  3200.0066  -180.0  1.36518  0.00   
+  4  7    3    -4   469.3100   462.7448   -180.0  1.36404  0.00   
+  4  1    5    0    4131.2840  4351.0671  -180.0  1.35878  0.00   
+  4  1    5    -1   54.2354    57.0734    -0.0    1.35862  0.00   
+  4  8    2    -3   1820.1168  1927.1422  180.0   1.36047  0.00   
+  4  8    2    -5   13526.6243 14183.9959 180.0   1.35791  0.00   
+  4  7    3    -2   6452.1116  6976.2993  0.0     1.34716  0.00   
+  4  1    5    1    8086.9402  7402.6017  0.0     1.34008  0.00   
+  4  7    3    -5   2404.5967  2392.5313  180.0   1.34389  0.00   
+  4  1    5    -2   3062.5207  2788.2936  180.0   1.33962  0.00   
+  4  2    4    4    220.3162   204.5003   -180.0  1.33688  0.00   
+  4  2    4    -6   4092.5543  4268.4903  180.0   1.33385  0.00   
+  4  8    2    -2   183.4218   192.6758   0.0     1.33360  0.00   
+  4  8    2    -6   101.1281   116.9837   0.0     1.32879  0.00   
+  4  8    0    0    108968.8833 127051.3804 0.0     1.32797  0.00   
+  4  4    2    5    10862.8611 12829.1260 0.0     1.32490  0.00   
+  4  4    4    2    94397.3452 113690.7835 0.0     1.32017  0.00   
+  4  0    2    8    312.8474   368.7877   180.0   1.31734  0.00   
+  4  4    4    -6   105506.2960 120494.6069 0.0     1.31549  0.00   
+  4  3    3    5    1061.3404  1245.3080  -0.0    1.31705  0.00   
+  4  4    2    -9   4744.2058  5532.0571  180.0   1.31667  0.00   
+  4  8    0    -8   116655.2115 139611.9415 -0.0    1.31851  0.00   
+  4  3    3    -8   6726.3533  7100.1131  180.0   1.31140  0.00   
+  4  7    3    -1   964.6970   1033.0922  180.0   1.31215  0.00   
+  4  1    1    8    148.9111   157.0219   180.0   1.31135  0.00   
+  4  1    1    -9   714.1159   716.4331   180.0   1.30891  0.00   
+  4  1    5    2    1905.5753  1729.2451  180.0   1.30476  0.00   
+  4  1    5    -3   8176.5032  7288.3669  -0.0    1.30405  0.00   
+  4  7    3    -6   7828.3295  7547.9716  -0.0    1.30714  0.00   
+  4  6    4    -3   2774.6686  2354.5174  -0.0    1.29838  0.00   
+  4  9    1    -4   987.0625   843.6936   0.0     1.30173  0.00   
+  4  9    1    -5   304.2378   257.7171   0.0     1.30047  0.00   
+  4  7    1    2    4706.8683  3981.9309  -180.0  1.29994  0.00   
+  4  3    5    -1   676.9404   620.3632   0.0     1.29364  0.00   
+  4  3    5    -2   2371.6085  2183.5705  -0.0    1.29322  0.00   
+  4  5    3    3    381.1509   335.5434   180.0   1.29585  0.00   
+  4  6    4    -2   26.7536    25.5439    0.0     1.29089  0.00   
+  4  4    0    6    19822.4122 18520.1244 180.0   1.29206  0.00   
+  4  6    4    -4   7150.3954  7133.9568  -0.0    1.28925  0.00   
+  4  8    2    -1   9467.0460  8943.5192  180.0   1.29141  0.00   
+  4  5    3    -8   3394.8434  3486.9853  180.0   1.28828  0.00   
+  4  7    1    -9   133.7577   133.2810   180.0   1.28929  0.00   
+  4  2    2    7    15884.2623 16158.5560 -0.0    1.28861  0.00   
+  4  2    2    -9   18439.2320 19800.7206 0.0     1.28427  0.00   
+  4  8    2    -7   400.8236   430.5740   -180.0  1.28487  0.00   
+  4  9    1    -3   5176.4797  5527.0781  180.0   1.28635  0.00   
+  4  4    0    -10  19329.0443 20726.7458 -180.0  1.28335  0.00   
+  4  3    5    0    676.8855   719.1866   -0.0    1.27774  0.00   
+  4  9    1    -6   174.8220   187.2211   -0.0    1.28270  0.00   
+  4  6    2    3    0.3587     0.3842     180.0   1.28136  0.00   
+  4  3    5    -3   5714.0534  6024.5361  -0.0    1.27654  0.00   
+  4  0    4    6    112.5220   118.4775   180.0   1.27292  0.00   
+  4  6    2    -9   438.8112   466.1247   180.0   1.27181  0.00   
+  4  6    4    -1   425.0715   481.2657   -180.0  1.26760  0.00   
+  4  6    4    -5   515.6020   581.1244   -180.0  1.26450  0.00   
+  4  5    1    5    4061.4295  4621.6594  180.0   1.26672  0.00   
+  4  6    0    4    6416.2911  7286.7428  180.0   1.26717  0.00   
+  4  7    3    0    718.2313   803.5252   180.0   1.26395  0.00   
+  4  1    3    7    7831.0377  8423.0771  -0.0    1.26050  0.00   
+  4  1    5    3    33.7190    35.0520    180.0   1.25659  0.00   
+  4  1    3    -8   2916.9855  3097.1421  180.0   1.25859  0.00   
+  4  1    5    -4   3031.7796  3091.9628  180.0   1.25570  0.00   
+  4  7    3    -7   2301.1744  2425.0787  180.0   1.25769  0.00   
+  4  5    1    -10  6742.6041  7062.5162  -180.0  1.25711  0.00   
+  4  6    0    -10  113.6023   117.7110   180.0   1.25641  0.00   
+  4  3    1    7    1638.6181  1614.1267  -0.0    1.25452  0.00   
+  4  9    1    -2   353.1193   362.9584   0.0     1.25602  0.00   
+  4  3    5    1    8759.8908  8322.4019  0.0     1.24726  0.00   
+  4  4    4    3    17.4982    16.4792    0.0     1.24775  0.00   
+  4  9    1    -7   9639.3777  8763.1983  -180.0  1.25037  0.00   
+  4  3    5    -4   1121.8694  1089.7337  -0.0    1.24541  0.00   
+  4  3    1    -10  3201.8244  2992.0824  180.0   1.24815  0.00   
+  4  2    4    5    1196.3550  1149.9417  0.0     1.24645  0.00   
+  4  2    4    -7   801.6947   790.0395   0.0     1.24350  0.00   
+  4  4    4    -7   6606.7777  6538.6159  -0.0    1.24282  0.00   
+  4  2    0    8    28.2975    27.9622    -0.0    1.24308  0.00   
+  4  2    0    -10  2055.9856  2007.7264  180.0   1.23870  0.00   
+  4  8    2    0    759.2592   734.2240   180.0   1.23816  0.00   
+  4  6    4    0    13693.5060 14141.6746 -0.0    1.23097  0.00   
+  4  8    2    -8   596.1880   629.3241   180.0   1.23049  0.00   
+  4  6    4    -6   119.2449   129.6186   -180.0  1.22671  0.00   
+  4  9    1    -1   2958.3506  2745.9583  -0.0    1.21378  0.00   
+  4  3    3    6    908.3705   849.8323   0.0     1.20955  0.00   
+  4  4    2    6    443.3330   412.4297   -0.0    1.20890  0.00   
+  4  7    1    3    77.9209    73.1605    180.0   1.21007  0.00   
+  4  3    5    2    4109.9574  3736.5604  0.0     1.20520  0.00   
+  4  5    3    4    8289.8739  7537.7747  -180.0  1.20654  0.00   
+  4  7    3    1    3003.7748  2740.0570  180.0   1.20699  0.00   
+  4  3    5    -5   52.0871    48.8417    180.0   1.20286  0.00   
+  4  3    3    -9   1034.0269  946.2084   -0.0    1.20451  0.00   
+  4  9    1    -8   2559.4239  2328.9959  0.0     1.20666  0.00   
+  4  1    5    4    4155.0056  3928.7774  180.0   1.19990  0.00   
+  4  4    2    -10  174.7876   165.9924   -0.0    1.20176  0.00   
+  4  1    5    -5   702.5259   654.8785   0.0     1.19891  0.00   
+  4  7    3    -8   5.7570     5.4486     0.0     1.19998  0.00   
+  4  5    3    -9   320.7146   300.8907   180.0   1.19933  0.00   
+  4  7    1    -10  8798.2912  8320.4071  -180.0  1.19992  0.00   
+  4  0    2    9    351.2159   269.6312   -0.0    1.18958  0.00   
+  4  5    5    -2   3749.6524  3018.8319  -0.0    1.18718  0.00   
+  4  5    5    -3   0.1205     0.0988     -0.0    1.18665  0.00   
+  4  6    2    4    344.7362   268.2247   180.0   1.18844  0.00   
+  4  10   0    -4   8869.0904  6819.2609  0.0     1.18930  0.00   
+  4  10   0    -6   13822.3987 11137.7777 0.0     1.18716  0.00   
+  4  6    4    1    1494.9994  1319.5472  0.0     1.18438  0.00   
+  4  0    4    7    310.8062   286.2756   180.0   1.18106  0.00   
+  4  6    4    -7   1934.1463  1785.8753  0.0     1.17933  0.00   
+  4  6    2    -10  2.3936     2.2097     -0.0    1.17955  0.00   
+  4  1    1    9    132.7397   122.6246   -0.0    1.17893  0.00   
+  4  8    0    2    33885.3584 31276.2536 180.0   1.17978  0.00   
+  4  5    5    -1   7616.8233  7302.4121  -180.0  1.17507  0.00   
+  4  1    1    -10  818.3015   763.7273   180.0   1.17695  0.00   
+  4  8    2    1    6315.1042  5843.7913  -180.0  1.17825  0.00   
+  4  5    5    -4   5634.3911  5548.7125  -0.0    1.17352  0.00   
+  4  4    4    4    34267.6264 33769.7454 0.0     1.17348  0.00   
+  4  4    4    -8   28874.6144 28593.8022 -180.0  1.16856  0.00   
+  4  8    2    -9   8380.7512  8436.7352  180.0   1.16999  0.00   
+  4  8    0    -10  38128.4827 38342.1586 0.0     1.16986  0.00   
+  4  2    2    8    101.4315   100.3601   0.0     1.16850  0.00   
+  4  2    2    -10  599.4159   560.5897   -0.0    1.16486  0.00   
+  4  2    4    6    16428.1110 13774.5927 180.0   1.16003  0.00   
+  4  9    1    0    197.5194   176.0223   180.0   1.16327  0.00   
+  4  2    4    -8   2770.5492  2415.0044  0.0     1.15725  0.00   
+  4  3    5    3    3536.2625  3127.0405  0.0     1.15512  0.00   
+  4  5    1    6    58.7741    50.3624    0.0     1.15831  0.00   
+  4  3    5    -6   60.0295    51.3916    -0.0    1.15247  0.00   
+  4  9    1    -9   640.9013   566.9119   180.0   1.15523  0.00   
+  4  1    3    8    3188.9985  2763.3932  0.0     1.15316  0.00   
+  4  5    5    0    7932.1594  6651.7754  -0.0    1.15142  0.00   
+  4  1    3    -9   1.5906     1.3357     -0.0    1.15150  0.00   
+  4  5    5    -5   10207.4742 8491.3154  -180.0  1.14900  0.00   
+  4  5    1    -11  1831.3863  1516.7746  0.0     1.14998  0.00   
+  4  9    3    -4   488.9981   427.6756   0.0     1.14660  0.00   
+  4  0    6    0    2656.9018  2596.7689  -0.0    1.14169  0.00   
+  4  9    3    -5   72.5045    64.9913    -0.0    1.14574  0.00   
+  4  7    3    2    5420.8601  4904.6864  -0.0    1.14538  0.00   
+  4  0    0    10   435.0181   425.1377   -0.0    1.14170  0.00   
+  4  1    5    5    5215.0127  5032.6543  -0.0    1.13876  0.00   
+  4  10   0    -2   16702.1437 16048.9180 0.0     1.14271  0.00   
+  4  1    5    -6   5534.5308  5298.3291  180.0   1.13772  0.00   
+  4  0    6    1    1720.9161  1640.4659  180.0   1.13603  0.00   
+  4  7    3    -9   4869.2042  4668.9703  180.0   1.13807  0.00   
+  4  3    1    8    71.6696    68.5695    180.0   1.13731  0.00   
+  4  10   0    -8   1520.0199  1454.1480  0.0     1.13704  0.00   
+  4  9    3    -3   1498.0645  1428.2991  -180.0  1.13605  0.00   
+  4  9    3    -6   2008.4396  1858.4252  -0.0    1.13354  0.00   
+  4  3    1    -11  33.9158    30.9874    0.0     1.13200  0.00   
+  4  6    4    2    3086.8673  2826.0255  0.0     1.13144  0.00   
+  4  6    4    -8   1999.0600  2097.1131  -0.0    1.12594  0.00   
+  4  10   2    -5   6530.0536  6296.0544  0.0     1.12806  0.00   
+  4  8    4    -4   3907.3778  4159.2534  -180.0  1.12554  0.00   
+  4  2    6    -1   3288.8793  3528.7487  180.0   1.12139  0.00   
+  4  7    1    4    4627.8450  4938.2570  -0.0    1.12548  0.00   
+  4  0    6    2    1335.8073  1369.0916  -180.0  1.11952  0.00   
+  4  5    3    5    1799.8836  1971.6886  -180.0  1.12246  0.00   
+  4  10   2    -4   8.1430     9.0469     180.0   1.12349  0.00   
+  4  8    4    -3   3137.8845  3320.7972  -180.0  1.12083  0.00   
+  4  10   2    -6   159.7478   172.5207   180.0   1.12169  0.00   
+  4  5    5    1    714.9889   709.4788   0.0     1.11827  0.00   
+  4  8    4    -5   1009.3648  1031.3589  180.0   1.11940  0.00   
+  4  2    6    0    5564.8110  5302.4095  180.0   1.11620  0.00   
+  4  2    6    -2   1048.0605  989.3398   180.0   1.11585  0.00   
+  4  5    5    -6   2703.3793  2497.8759  0.0     1.11516  0.00   
+  4  5    3    -10  1696.5576  1597.4314  -0.0    1.11576  0.00   
+  4  7    1    -11  2200.1881  2088.6950  180.0   1.11605  0.00   
+  4  3    3    7    8097.9583  7166.8557  0.0     1.11394  0.00   
+  4  9    3    -2   2201.0807  2022.5437  0.0     1.11500  0.00   
+  4  8    2    2    129.6846   121.0275   0.0     1.11546  0.00   
+  4  9    3    -7   2045.3960  1753.7287  -180.0  1.11104  0.00   
+  4  3    3    -10  301.6702   264.2274   -0.0    1.10948  0.00   
+  4  4    2    7    10441.5622 9279.0283  0.0     1.10827  0.00   
+  4  8    2    -10  40.7380    36.6373    0.0     1.10706  0.00   
+  4  10   2    -3   39666.6109 35203.8950 -180.0  1.10839  0.00   
+  4  9    1    1    4285.4780  3819.0095  -180.0  1.10800  0.00   
+  4  8    4    -2   32353.5063 29359.0716 -180.0  1.10566  0.00   
+  4  2    6    1    29630.2048 27548.7335 -180.0  1.10070  0.00   
+  4  10   2    -7   38518.1260 35019.9858 0.0     1.10493  0.00   
+  4  8    4    -6   32947.7953 30140.2855 0.0     1.10291  0.00   
+  4  2    6    -3   31876.8690 29812.9759 0.0     1.10002  0.00   
+  4  4    2    -11  2371.1926  2176.8388  -0.0    1.10207  0.00   
+  4  3    5    4    75.2132    70.1032    0.0     1.10044  0.00   
+  4  6    2    5    144651.7086 132384.6544 -180.0  1.10275  0.00   
+  4  4    4    5    2899.6600  2696.4068  180.0   1.10069  0.00   
+  4  3    5    -7   3090.3647  2930.0044  0.0     1.09764  0.00   
+  4  9    1    -10  299.2514   280.9621   0.0     1.09951  0.00   
+  4  0    4    8    142449.2053 133831.5365 -180.0  1.09634  0.00   
+  4  4    4    -9   143.1173   133.9399   0.0     1.09596  0.00   
+  4  0    6    3    3825.0154  3383.4803  -0.0    1.09354  0.00   
+  4  6    2    -11  163554.2439 150074.4912 -180.0  1.09463  0.00   
+  4  9    3    -1   1202.4520  1115.8683  0.0     1.08513  0.00   
+  4  0    2    10   133.8629   134.1910   0.0     1.08311  0.00   
+  4  10   2    -2   906.0236   881.0436   -0.0    1.08397  0.00   
+  4  7    3    3    5865.8317  6001.5072  180.0   1.08247  0.00   
+  4  8    4    -1   6.1625     6.5265     0.0     1.08126  0.00   
+  4  2    4    7    125.4053   143.4288   180.0   1.07961  0.00   
+  4  9    3    -8   15.2170    16.9772    180.0   1.08004  0.00   
+  4  5    5    2    4140.9410  5297.2246  0.0     1.07807  0.00   
+  4  2    6    2    323.2789   477.4907   0.0     1.07614  0.00   
+  4  2    4    -9   930.7274   1302.5665  -180.0  1.07706  0.00   
+  4  1    5    6    5113.1081  7480.0027  180.0   1.07640  0.00   
+  4  2    6    -4   2154.1690  3152.1404  -0.0    1.07519  0.00   
+  4  10   2    -8   256.2336   302.3912   0.0     1.07913  0.00   
+  4  8    4    -7   652.6506   885.6814   -0.0    1.07741  0.00   
+  4  1    5    -7   7581.4231  11163.8819 0.0     1.07537  0.00   
+  4  5    5    -7   11.6789    16.5190    0.0     1.07450  0.00   
+  4  6    4    3    1032.1858  1518.5743  -180.0  1.07534  0.00   
+  4  7    3    -10  8395.1274  12283.0876 0.0     1.07519  0.00   
+  4  6    0    6    637.5403   883.9233   180.0   1.07412  0.00   
+  4  6    4    -9   569.7002   817.4912   -180.0  1.06968  0.00   
+  4  1    1    10   1901.4964  2604.5605  -180.0  1.07040  0.00   
+  4  11   1    -5   122.4768   157.5132   180.0   1.07195  0.00   
+  4  11   1    -6   4.3285     5.7138     -180.0  1.07109  0.00   
+  4  4    6    -2   1652.9119  2477.8101  -180.0  1.06644  0.00   
+  4  1    1    -11  27.6406    41.8604    0.0     1.06876  0.00   
+  4  7    5    -3   854.8732   1328.1334  -180.0  1.06750  0.00   
+  4  4    0    8    16294.9201 23578.4335 -0.0    1.06955  0.00   
+  4  7    5    -4   109.7113   168.2003   180.0   1.06696  0.00   
+  4  2    2    9    15774.2190 24417.3666 -0.0    1.06728  0.00   
+  4  6    0    -12  2034.8553  2941.5303  -180.0  1.06569  0.00   
+  4  4    6    -1   1.5233     1.9888     -0.0    1.06212  0.00   
+  4  2    2    -11  15574.8506 21036.3619 -180.0  1.06419  0.00   
+  4  4    6    -3   2144.1174  2812.7886  180.0   1.06151  0.00   
+  4  4    0    -12  21559.3116 28331.7840 -180.0  1.06336  0.00   
+  4  5    1    7    2409.3555  3272.1719  0.0     1.06432  0.00   
+  4  0    6    4    1255.9575  1663.7702  0.0     1.06003  0.00   
+  4  11   1    -4   3896.3173  5133.1272  0.0     1.06347  0.00   
+  4  1    3    9    1216.9658  1612.3386  0.0     1.06002  0.00   
+  4  10   0    0    632.7592   825.0864   0.0     1.06238  0.00   
+  4  7    5    -2   1.2224     1.6286     -0.0    1.05882  0.00   
+  4  11   1    -7   50.4587    66.4677    -180.0  1.06095  0.00   
+  4  1    3    -10  1774.2534  2360.0175  0.0     1.05858  0.00   
+  4  7    5    -5   2976.3672  3876.7540  -180.0  1.05723  0.00   
+  4  5    1    -12  1615.0140  2099.8839  -180.0  1.05709  0.00   
+  4  10   0    -10  3748.4911  4674.1789  0.0     1.05481  0.00   
+  4  4    6    0    1672.2974  1584.3551  0.0     1.04889  0.00   
+  4  8    2    3    19399.3368 22612.1590 180.0   1.05269  0.00   
+  4  10   2    -1   51443.9639 58101.4525 0.0     1.05205  0.00   
+  4  4    6    -4   1280.3590  1165.1403  0.0     1.04771  0.00   
+  4  8    4    0    63884.2630 62147.7315 -180.0  1.04942  0.00   
+  4  9    1    2    125.7824   133.0663   -0.0    1.05090  0.00   
+  4  9    3    0    2523.5000  2360.3626  0.0     1.04859  0.00   
+  4  2    6    3    62092.9033 55650.4545 -180.0  1.04431  0.00   
+  4  7    1    5    1131.9766  1026.1966  0.0     1.04753  0.00   
+  4  2    6    -5   62452.2373 55960.4729 -180.0  1.04315  0.00   
+  4  3    5    5    4058.0467  3636.4681  -0.0    1.04401  0.00   
+  4  10   2    -9   75205.9438 67449.0195 0.0     1.04616  0.00   
+  4  8    4    -8   75341.5573 67560.0505 -180.0  1.04474  0.00   
+  4  5    3    6    1562.9276  1401.9183  -180.0  1.04495  0.00   
+  4  8    2    -11  5.4357     4.8725     0.0     1.04445  0.00   
+  4  11   1    -3   30.7925    27.6167    180.0   1.04628  0.00   
+  4  3    5    -8   423.9296   381.1962   -0.0    1.04119  0.00   
+  4  7    5    -1   5180.9113  4645.3933  -180.0  1.04156  0.00   
+  4  9    3    -9   551.2049   493.5891   -180.0  1.04268  0.00   
+  4  9    1    -11  5542.0828  4960.4562  180.0   1.04235  0.00   
+  4  11   1    -8   5983.6366  5355.4548  0.0     1.04229  0.00   
+  4  7    5    -6   22.0759    20.5743    180.0   1.03905  0.00   
+  4  5    3    -11  177.6638   166.8139   -0.0    1.03882  0.00   
+  4  7    1    -12  604.2498   565.4922   -180.0  1.03892  0.00   
+  4  3    1    9    1060.4359  986.9071   -180.0  1.03910  0.00   
+_reflns_number_total  1184
+_reflns_d_resolution_low    6.388
+_reflns_d_resolution_high   1.033
+
+# POWDER DATA TABLE
+_pd_meas_2theta_range_min  10.01313
+_pd_meas_2theta_range_max  119.99238
+_pd_meas_2theta_range_inc  0.02626
+_pd_proc_2theta_range_min  9.98829
+_pd_proc_2theta_range_max  119.96754
+_pd_proc_2theta_range_inc  0.02626
+_pd_proc_number_of_points  4189
+
+loop_
+   _pd_meas_intensity_total
+   _pd_calc_intensity_total
+   _pd_proc_intensity_bkg_calc
+   _pd_proc_ls_weight
+  2719         0            0           0         
+  2601         0            0           0         
+  2618         0            0           0         
+  2547         0            0           0         
+  2601         0            0           0         
+  2669         0            0           0         
+  2581         0            0           0         
+  2630         0            0           0         
+  2688         0            0           0         
+  2591         0            0           0         
+  2594         0            0           0         
+  2528         0            0           0         
+  2588         0            0           0         
+  2581         0            0           0         
+  2587         0            0           0         
+  2552         0            0           0         
+  2624         0            0           0         
+  2552         0            0           0         
+  2582         0            0           0         
+  2548         0            0           0         
+  2583         0            0           0         
+  2546         0            0           0         
+  2559         0            0           0         
+  2580         0            0           0         
+  2515         0            0           0         
+  2439         0            0           0         
+  2504         0            0           0         
+  2548         0            0           0         
+  2547         0            0           0         
+  2519         0            0           0         
+  2546         0            0           0         
+  2402         0            0           0         
+  2474         0            0           0         
+  2388         0            0           0         
+  2439         0            0           0         
+  2490         0            0           0         
+  2469         0            0           0         
+  2482         0            0           0         
+  2473         0            0           0         
+  2443         0            0           0         
+  2547         0            0           0         
+  2429         0            0           0         
+  2402         0            0           0         
+  2429         0            0           0         
+  2394         0            0           0         
+  2367         0            0           0         
+  2432         0            0           0         
+  2385         0            0           0         
+  2416         0            0           0         
+  2420         0            0           0         
+  2328         0            0           0         
+  2372         0            0           0         
+  2367         0            0           0         
+  2411         0            0           0         
+  2468         0            0           0         
+  2240         0            0           0         
+  2404         0            0           0         
+  2348         0            0           0         
+  2324         0            0           0         
+  2311         0            0           0         
+  2387         0            0           0         
+  2271         0            0           0         
+  2309         0            0           0         
+  2319         0            0           0         
+  2378         0            0           0         
+  2354         0            0           0         
+  2292         0            0           0         
+  2303         0            0           0         
+  2149         0            0           0         
+  2253         0            0           0         
+  2277         0            0           0         
+  2201         0            0           0         
+  2311         0            0           0         
+  2247         0            0           0         
+  2210         0            0           0         
+  2191         0            0           0         
+  2297         0            0           0         
+  2298         0            0           0         
+  2214         0            0           0         
+  2292         0            0           0         
+  2215         0            0           0         
+  2259         0            0           0         
+  2168         0            0           0         
+  2188         0            0           0         
+  2160         0            0           0         
+  2213         0            0           0         
+  2272         0            0           0         
+  2221         0            0           0         
+  2130         0            0           0         
+  2064         0            0           0         
+  2054         0            0           0         
+  2118         0            0           0         
+  2128         0            0           0         
+  2153         0            0           0         
+  2173         0            0           0         
+  2157         0            0           0         
+  2140         0            0           0         
+  2120         0            0           0         
+  2163         0            0           0         
+  2124         0            0           0         
+  2151         0            0           0         
+  2119         0            0           0         
+  2121         0            0           0         
+  1980         0            0           0         
+  2130         0            0           0         
+  2191         0            0           0         
+  2039         0            0           0         
+  2089         0            0           0         
+  2117         0            0           0         
+  2002         0            0           0         
+  2036         0            0           0         
+  2074         0            0           0         
+  2043         0            0           0         
+  2089         0            0           0         
+  2017         0            0           0         
+  2021         0            0           0         
+  1975         0            0           0         
+  2132         0            0           0         
+  2025         0            0           0         
+  2040         0            0           0         
+  2046         0            0           0         
+  1919         0            0           0         
+  2020         0            0           0         
+  1923         0            0           0         
+  1998         0            0           0         
+  2033         0            0           0         
+  1968         0            0           0         
+  1984         0            0           0         
+  2031         0            0           0         
+  1967         0            0           0         
+  1975         0            0           0         
+  1969         0            0           0         
+  1919         0            0           0         
+  1962         0            0           0         
+  1952         0            0           0         
+  1974         0            0           0         
+  1917         0            0           0         
+  1934         0            0           0         
+  1963         0            0           0         
+  1862         0            0           0         
+  1900         0            0           0         
+  1924         0            0           0         
+  1840         0            0           0         
+  1888         0            0           0         
+  1867         0            0           0         
+  1894         0            0           0         
+  1796         0            0           0         
+  1841         0            0           0         
+  1915         0            0           0         
+  1890         0            0           0         
+  1858         0            0           0         
+  1841         0            0           0         
+  1926         0            0           0         
+  1871         0            0           0         
+  1859         0            0           0         
+  1887         0            0           0         
+  1807         0            0           0         
+  1707         0            0           0         
+  1834         0            0           0         
+  1790         0            0           0         
+  1794         0            0           0         
+  1832         0            0           0         
+  1823         0            0           0         
+  1763         0            0           0         
+  1830         0            0           0         
+  1883         0            0           0         
+  1798         0            0           0         
+  1774         0            0           0         
+  1828         0            0           0         
+  1785         0            0           0         
+  1747         0            0           0         
+  1791         0            0           0         
+  1747         0            0           0         
+  1820         0            0           0         
+  1717         0            0           0         
+  1673         0            0           0         
+  1678         0            0           0         
+  1858         0            0           0         
+  1733         0            0           0         
+  1747         0            0           0         
+  1732         0            0           0         
+  1626         0            0           0         
+  1681         0            0           0         
+  1802         0            0           0         
+  1681         0            0           0         
+  1749         0            0           0         
+  1747         0            0           0         
+  1772         0            0           0         
+  1778         0            0           0         
+  1673         0            0           0         
+  1643         0            0           0         
+  1698         0            0           0         
+  1654         0            0           0         
+  1613         0            0           0         
+  1689         0            0           0         
+  1643         0            0           0         
+  1667         0            0           0         
+  1680         1592.44858   1591.59227  0.000595238 
+  1652         1589.32475   1588.42927  0.000605327 
+  1721         1586.21081   1585.27263  0.000581058 
+  1680         1583.10705   1582.12234  0.000595238 
+  1657         1580.01408   1578.9784   0.0006035 
+  1691         1576.93253   1575.84079  0.000591366 
+  1648         1573.86316   1572.7095   0.000606796 
+  1607         1570.80687   1569.58453  0.000622278 
+  1604         1567.76479   1566.46585  0.000623441 
+  1623         1564.73842   1563.35346  0.000616143 
+  1672         1561.72918   1560.24736  0.000598086 
+  1641         1558.73934   1557.14752  0.000609385 
+  1608         1555.77171   1554.05393  0.000621891 
+  1633         1552.82966   1550.9666   0.00061237 
+  1556         1549.9179    1547.8855   0.000642674 
+  1579         1547.04265   1544.81063  0.000633312 
+  1572         1544.2125    1541.74197  0.000636132 
+  1607         1541.43966   1538.67952  0.000622278 
+  1620         1538.74225   1535.62326  0.000617284 
+  1562         1536.14854   1532.57318  0.000640205 
+  1591         1533.70494   1529.52928  0.000628536 
+  1592         1531.48862   1526.49153  0.000628141 
+  1611         1529.62152   1523.45994  0.000620732 
+  1585         1528.24961   1520.43449  0.000630915 
+  1516         1527.35735   1517.41517  0.000659631 
+  1570         1526.6317    1514.40198  0.000636943 
+  1631         1526.14345   1511.39489  0.000613121 
+  1553         1526.59062   1508.39389  0.000643915 
+  1532         1528.70439   1505.39899  0.000652742 
+  1624         1531.70235   1502.41017  0.000615764 
+  1582         1534.65947   1499.42741  0.000632111 
+  1566         1538.71425   1496.45071  0.00063857 
+  1614         1545.03927   1493.48006  0.000619579 
+  1602         1551.71715   1490.51544  0.00062422 
+  1639         1555.25205   1487.55685  0.000610128 
+  1595         1551.83265   1484.60428  0.000626959 
+  1637         1542.10558   1481.65771  0.000610874 
+  1610         1529.92362   1478.71713  0.000621118 
+  1529         1518.7673    1475.78254  0.000654022 
+  1553         1509.66913   1472.85393  0.000643915 
+  1537         1502.05901   1469.93127  0.000650618 
+  1484         1495.61511   1467.01457  0.000673854 
+  1451         1489.90393   1464.10382  0.00068918 
+  1469         1484.31181   1461.199    0.000680735 
+  1511         1477.68613   1458.3001   0.000661813 
+  1518         1470.52173   1455.40711  0.000658762 
+  1449         1463.87892   1452.52003  0.000690131 
+  1472         1458.3342    1449.63884  0.000679348 
+  1459         1453.71159   1446.76353  0.000685401 
+  1522         1449.68515   1443.89409  0.00065703 
+  1402         1446.02629   1441.03051  0.000713267 
+  1426         1442.60014   1438.17279  0.000701262 
+  1417         1439.32946   1435.3209   0.000705716 
+  1481         1436.1688    1432.47485  0.000675219 
+  1476         1433.08993   1429.63462  0.000677507 
+  1478         1430.07592   1426.8002   0.00067659 
+  1445         1427.11145   1423.97158  0.000692042 
+  1462         1424.18934   1421.14875  0.000683995 
+  1418         1421.30426   1418.33171  0.000705219 
+  1468         1418.45051   1415.52043  0.000681199 
+  1398         1415.62586   1412.71491  0.000715308 
+  1453         1412.8284    1409.91515  0.000688231 
+  1369         1410.057     1407.12112  0.00073046 
+  1392         1407.31662   1404.33283  0.000718391 
+  1389         1404.59697   1401.55026  0.000719942 
+  1405         1401.90726   1398.77339  0.000711744 
+  1371         1399.24384   1396.00223  0.000729395 
+  1380         1396.61534   1393.23676  0.000724638 
+  1387         1394.02123   1390.47697  0.000720981 
+  1435         1391.47562   1387.72285  0.000696864 
+  1418         1388.98222   1384.97439  0.000705219 
+  1411         1386.5671    1382.23159  0.000708717 
+  1382         1384.25803   1379.49442  0.000723589 
+  1409         1382.10393   1376.76289  0.000709723 
+  1370         1380.14778   1374.03698  0.000729927 
+  1354         1378.34336   1371.31667  0.000738552 
+  1446         1376.59707   1368.60198  0.000691563 
+  1413         1375.08426   1365.89287  0.000707714 
+  1435         1374.08509   1363.18935  0.000696864 
+  1336         1373.51226   1360.49139  0.000748503 
+  1373         1372.95234   1357.79901  0.000728332 
+  1386         1372.7635    1355.11217  0.000721501 
+  1359         1373.21606   1352.43088  0.000735835 
+  1426         1373.48691   1349.75512  0.000701262 
+  1373         1372.5321    1347.08488  0.000728332 
+  1370         1369.08897   1344.42016  0.000729927 
+  1306         1363.89822   1341.76095  0.000765697 
+  1349         1358.64372   1339.10723  0.00074129 
+  1340         1354.51179   1336.45899  0.000746269 
+  1289         1351.65526   1333.81623  0.000775795 
+  1355         1349.78026   1331.17893  0.000738007 
+  1325         1348.64394   1328.54709  0.000754717 
+  1288         1348.1116    1325.9207   0.000776398 
+  1360         1348.07285   1323.29975  0.000735294 
+  1324         1348.42525   1320.68422  0.000755287 
+  1348         1348.99981   1318.07411  0.00074184 
+  1317         1349.52793   1315.46941  0.000759301 
+  1297         1349.68203   1312.8701   0.00077101 
+  1301         1349.13839   1310.27619  0.00076864 
+  1336         1347.68552   1307.68765  0.000748503 
+  1347         1345.28823   1305.10449  0.00074239 
+  1338         1342.06152   1302.52669  0.000747384 
+  1302         1338.17656   1299.95423  0.000768049 
+  1247         1333.77566   1297.38712  0.000801925 
+  1364         1328.95427   1294.82534  0.000733138 
+  1383         1323.80132   1292.26889  0.000723066 
+  1253         1318.44125   1289.71775  0.000798085 
+  1314         1313.03433   1287.17191  0.000761035 
+  1259         1307.74279   1284.63136  0.000794281 
+  1348         1302.69554   1282.0961   0.00074184 
+  1269         1297.97507   1279.56612  0.000788022 
+  1295         1293.6272    1277.0414   0.000772201 
+  1303         1289.68086   1274.52194  0.00076746 
+  1206         1286.15955   1272.00773  0.000829187 
+  1313         1283.04013   1269.49875  0.000761615 
+  1219         1280.19867   1266.99501  0.000820345 
+  1294         1277.66617   1264.49648  0.000772798 
+  1273         1275.6712    1262.00317  0.000785546 
+  1377         1274.22506   1259.51505  0.000726216 
+  1175         1272.95787   1257.03213  0.000851064 
+  1353         1272.06127   1254.55439  0.000739098 
+  1230         1271.68484   1252.08182  0.000813008 
+  1286         1271.02888   1249.61442  0.000777605 
+  1320         1269.01324   1247.15217  0.000757576 
+  1253         1264.48288   1244.69507  0.000798085 
+  1226         1258.38571   1242.24311  0.000815661 
+  1290         1252.22139   1239.79627  0.000775194 
+  1190         1246.98182   1237.35455  0.000840336 
+  1246         1242.71775   1234.91794  0.000802568 
+  1243         1239.12198   1232.48643  0.000804505 
+  1202         1235.92614   1230.06001  0.000831947 
+  1241         1232.97657   1227.63867  0.000805802 
+  1239         1230.18582   1225.2224   0.000807103 
+  1245         1227.505     1222.8112   0.000803213 
+  1255         1224.90567   1220.40505  0.000796813 
+  1265         1222.3706    1218.00394  0.000790514 
+  1240         1219.88903   1215.60788  0.000806452 
+  1341         1217.45431   1213.21683  0.000745712 
+  1312         1215.06256   1210.83081  0.000762195 
+  1370         1212.71187   1208.4498   0.000729927 
+  1266         1210.40197   1206.07379  0.000789889 
+  1316         1208.13392   1203.70276  0.000759878 
+  1204         1205.91011   1201.33672  0.000830565 
+  1215         1203.73422   1198.97566  0.000823045 
+  1222         1201.61139   1196.61955  0.000818331 
+  1127         1199.54836   1194.26841  0.000887311 
+  1202         1197.55369   1191.9222   0.000831947 
+  1204         1195.63804   1189.58094  0.000830565 
+  1183         1193.81435   1187.2446   0.000845309 
+  1173         1192.09791   1184.91319  0.000852515 
+  1153         1190.50618   1182.58668  0.000867303 
+  1143         1189.05793   1180.26508  0.000874891 
+  1196         1187.77151   1177.94837  0.00083612 
+  1161         1186.66233   1175.63654  0.000861326 
+  1168         1185.73893   1173.32959  0.000856164 
+  1126         1184.99838   1171.0275   0.000888099 
+  1122         1184.41976   1168.73028  0.000891266 
+  1209         1183.95161   1166.4379   0.00082713 
+  1136         1183.49376   1164.15036  0.000880282 
+  1162         1182.88119   1161.86765  0.000860585 
+  1146         1181.89097   1159.58977  0.0008726 
+  1197         1180.29392   1157.3167   0.000835422 
+  1164         1177.93971   1155.04843  0.000859107 
+  1061         1174.82523   1152.78496  0.000942507 
+  1146         1171.09779   1150.52628  0.0008726 
+  1136         1166.99186   1148.27237  0.000880282 
+  1113         1162.74619   1146.02324  0.000898473 
+  1178         1158.54529   1143.77887  0.000848896 
+  1106         1154.5019    1141.53925  0.000904159 
+  1117         1150.66736   1139.30438  0.000895255 
+  1158         1147.05174   1137.07424  0.000863558 
+  1089         1143.64245   1134.84882  0.000918274 
+  1156         1140.41696   1132.62813  0.000865052 
+  1103         1137.35003   1130.41215  0.000906618 
+  1130         1134.41762   1128.20086  0.000884956 
+  1083         1131.60097   1125.99427  0.000923361 
+  1125         1128.87665   1123.79237  0.000888889 
+  1108         1126.23329   1121.59513  0.000902527 
+  1140         1123.65575   1119.40257  0.000877193 
+  1131         1121.13497   1117.21466  0.000884173 
+  1103         1118.66251   1115.03141  0.000906618 
+  1076         1116.23146   1112.85279  0.000929368 
+  1124         1113.83616   1110.67881  0.00088968 
+  1119         1111.47279   1108.50945  0.000893655 
+  1123         1109.13584   1106.34471  0.000890472 
+  1132         1106.82339   1104.18458  0.000883392 
+  1098         1104.53194   1102.02904  0.000910747 
+  1140         1102.25972   1099.8781   0.000877193 
+  1115         1100.00485   1097.73173  0.000896861 
+  1117         1097.76577   1095.58994  0.000895255 
+  1116         1095.54115   1093.45272  0.000896057 
+  1141         1093.32985   1091.32005  0.000876424 
+  1120         1091.13092   1089.19193  0.000892857 
+  1191         1088.94351   1087.06835  0.000839631 
+  1120         1086.76692   1084.94931  0.000892857 
+  1190         1084.60054   1082.83478  0.000840336 
+  1158         1082.44383   1080.72477  0.000863558 
+  1191         1080.29633   1078.61927  0.000839631 
+  1129         1078.15765   1076.51827  0.00088574 
+  1128         1076.02743   1074.42176  0.000886525 
+  1088         1073.90539   1072.32972  0.000919118 
+  1051         1071.79126   1070.24217  0.000951475 
+  1083         1069.68481   1068.15907  0.000923361 
+  1054         1067.58587   1066.08044  0.000948767 
+  1063         1065.49427   1064.00625  0.000940734 
+  1035         1063.40987   1061.93651  0.000966184 
+  1030         1061.33257   1059.87119  0.000970874 
+  969          1059.26228   1057.8103   0.001031992 
+  1040         1057.19892   1055.75383  0.000961538 
+  1076         1055.14245   1053.70177  0.000929368 
+  1031         1053.09285   1051.6541   0.000969932 
+  1067         1051.0501    1049.61083  0.000937207 
+  985          1049.01422   1047.57194  0.001015228 
+  1005         1046.98524   1045.53742  0.000995025 
+  994          1044.96321   1043.50727  0.001006036 
+  939          1042.94821   1041.48148  0.001064963 
+  993          1040.94033   1039.46004  0.001007049 
+  1039         1038.93971   1037.44295  0.000962464 
+  1002         1036.94649   1035.43019  0.000998004 
+  965          1034.96085   1033.42175  0.001036269 
+  1017         1032.98602   1031.41764  0.000983284 
+  1033         1031.01627   1029.41783  0.000968054 
+  1029         1029.0549    1027.42233  0.000971817 
+  912          1027.10376   1025.43112  0.001096491 
+  1036         1025.16027   1023.4442   0.000965251 
+  1004         1023.22643   1021.46156  0.000996016 
+  971          1021.3028    1019.48319  0.001029866 
+  1026         1019.39006   1017.50908  0.000974659 
+  1032         1017.48901   1015.53923  0.000968992 
+  984          1015.60058   1013.57362  0.00101626 
+  931          1013.72588   1011.61225  0.001074114 
+  1035         1011.86621   1009.65511  0.000966184 
+  1009         1010.02343   1007.70219  0.00099108 
+  1022         1008.19879   1005.75349  0.000978474 
+  981          1006.39483   1003.809    0.001019368 
+  952          1004.6144    1001.86871  0.00105042 
+  1058         1002.86058   999.9326    0.00094518 
+  963          1001.13727   998.00068   0.001038422 
+  945          999.44924    996.07294   0.001058201 
+  1013         997.80247    994.14936   0.000987167 
+  1022         996.20419    992.22995   0.000978474 
+  999          994.66312    990.31469   0.001001001 
+  967          993.18997    988.40357   0.001034126 
+  1030         991.79771    986.49658   0.000970874 
+  944          990.50164    984.59373   0.001059322 
+  1021         989.31985    982.695     0.000979432 
+  1002         988.27189    980.80038   0.000998004 
+  1015         987.37803    978.90986   0.000985222 
+  994          986.6553     977.02345   0.001006036 
+  952          986.11072    975.14112   0.00105042 
+  967          985.72908    973.26288   0.001034126 
+  914          985.458      971.38871   0.001094092 
+  961          985.19172    969.51861   0.001040583 
+  900          984.7672     967.65257   0.001111111 
+  954          983.98862    965.79058   0.001048218 
+  971          982.6833     963.93263   0.001029866 
+  913          980.76515    962.07872   0.00109529 
+  942          978.26392    960.22884   0.001061571 
+  908          975.30556    958.38298   0.001101322 
+  928          972.07396    956.54113   0.001077586 
+  1007         968.75087    954.70329   0.000993049 
+  903          965.46337    952.86945   0.00110742 
+  882          962.27583    951.03959   0.001133787 
+  948          959.22632    949.21372   0.001054852 
+  922          956.28658    947.39183   0.001084599 
+  895          953.44125    945.57391   0.001117318 
+  863          950.71607    943.75994   0.001158749 
+  916          948.11915    941.94993   0.001091703 
+  867          945.65674    940.14386   0.001153403 
+  917          943.31306    938.34173   0.001090513 
+  908          941.06503    936.54354   0.001101322 
+  857          938.89356    934.74926   0.001166861 
+  947          936.78425    932.9589    0.001055966 
+  917          934.72626    931.17245   0.001090513 
+  879          932.71129    929.3899    0.001137656 
+  846          930.73282    927.61124   0.001182033 
+  865          928.78563    925.83647   0.001156069 
+  869          926.86553    924.06558   0.001150748 
+  908          924.96913    922.29855   0.001101322 
+  874          923.09362    920.5354    0.001144165 
+  887          921.24938    918.77609   0.001127396 
+  881          919.40926    917.02064   0.001135074 
+  908          917.59058    915.26903   0.001101322 
+  906          915.77943    913.52125   0.001103753 
+  880          913.981      911.7773    0.001136364 
+  919          912.19436    910.03717   0.001088139 
+  854          910.41872    908.30085   0.00117096 
+  872          908.65343    906.56833   0.001146789 
+  911          906.91781    904.83961   0.001097695 
+  932          905.17178    903.11469   0.001072961 
+  846          903.43471    901.39354   0.001182033 
+  902          901.72732    899.67617   0.001108647 
+  869          900.00741    897.96257   0.001150748 
+  946          898.30121    896.25273   0.001057082 
+  926          896.59757    894.54665   0.001079914 
+  965          894.90184    892.84431   0.001036269 
+  962          893.21398    891.14571   0.001039501 
+  1025         891.53395    889.45085   0.00097561 
+  955          889.86799    887.75971   0.00104712 
+  951          888.20372    886.07228   0.001051525 
+  909          886.54743    884.38857   0.00110011 
+  835          884.90236    882.70856   0.001197605 
+  827          883.33659    881.03225   0.00120919 
+  836          881.70568    879.35963   0.001196172 
+  901          880.08354    877.69069   0.001109878 
+  822          878.50765    876.02542   0.001216545 
+  881          876.91072    874.36383   0.001135074 
+  899          875.31738    872.70589   0.001112347 
+  889          873.73456    871.05161   0.001124859 
+  866          872.16613    869.40097   0.001154734 
+  853          870.60653    867.75398   0.001172333 
+  842          869.05998    866.11061   0.001187648 
+  808          867.52772    864.47088   0.001237624 
+  822          866.01096    862.83476   0.001216545 
+  834          864.51069    861.20225   0.001199041 
+  804          863.02899    859.57335   0.001243781 
+  798          861.56883    857.94804   0.001253133 
+  859          860.1317     856.32633   0.001164144 
+  817          858.71824    854.7082    0.00122399 
+  815          857.33049    853.09365   0.001226994 
+  826          855.96743    851.48266   0.001210654 
+  878          854.63484    849.87524   0.001138952 
+  783          853.34287    848.27138   0.001277139 
+  847          852.1014     846.67106   0.001180638 
+  818          850.92224    845.07429   0.001222494 
+  865          849.8176     843.48105   0.001156069 
+  841          848.80245    841.89134   0.001189061 
+  829          847.8972     840.30515   0.001206273 
+  791          847.12952    838.72247   0.001264223 
+  827          846.53769    837.1433    0.00120919 
+  774          846.17581    835.56764   0.00129199 
+  821          846.12221    833.99546   0.001218027 
+  815          846.49387    832.42678   0.001226994 
+  847          847.47502    830.86157   0.001180638 
+  832          849.37517    829.29984   0.001201923 
+  820          852.76923    827.74157   0.001219512 
+  872          858.81807    826.18677   0.001146789 
+  853          869.75919    824.63542   0.001172333 
+  889          888.46271    823.08751   0.001124859 
+  905          912.61606    821.54304   0.001104972 
+  958          945.06006    820.00201   0.001043841 
+  978          1000.25031   818.4644    0.001022495 
+  1020         1060.43121   816.93021   0.000980392 
+  1206         1142.45973   815.39944   0.000829187 
+  1244         1235.89372   813.87207   0.000803859 
+  1342         1269.56444   812.3481    0.000745156 
+  1243         1208.09977   810.82752   0.000804505 
+  1140         1109.68261   809.31033   0.000877193 
+  1001         1005.27201   807.79652   0.000999001 
+  861          924.70929    806.28608   0.00116144 
+  801          879.64432    804.779     0.001248439 
+  780          854.86674    803.27529   0.001282051 
+  793          839.9498     801.77492   0.001261034 
+  806          829.99179    800.27791   0.001240695 
+  752          822.79218    798.78423   0.001329787 
+  727          817.27293    797.29388   0.001375516 
+  785          812.84379    795.80687   0.001273885 
+  838          809.15456    794.32317   0.001193317 
+  758          805.987      792.84278   0.001319261 
+  797          803.19975    791.3657    0.001254705 
+  798          800.69745    789.89193   0.001253133 
+  764          798.41421    788.42144   0.001308901 
+  796          796.30374    786.95424   0.001256281 
+  821          794.33251    785.49032   0.001218027 
+  766          792.47645    784.02968   0.001305483 
+  735          790.71703    782.5723    0.001360544 
+  739          789.04138    781.11819   0.00135318 
+  725          787.43992    779.66732   0.00137931 
+  732          785.90594    778.21971   0.00136612 
+  733          784.43508    776.77534   0.001364256 
+  755          783.03262    775.3342    0.001324503 
+  704          781.6815     773.89629   0.001420455 
+  739          780.3947     772.46161   0.00135318 
+  736          779.16644    771.03014   0.001358696 
+  729          778.00496    769.60188   0.001371742 
+  762          776.9163     768.17682   0.001312336 
+  739          775.90884    766.75496   0.00135318 
+  708          774.99389    765.33629   0.001412429 
+  760          774.1862     763.9208    0.001315789 
+  730          773.50534    762.50849   0.001369863 
+  742          772.97713    761.09935   0.001347709 
+  781          772.63574    759.69338   0.00128041 
+  738          772.52749    758.29056   0.001355014 
+  723          772.71573    756.8909    0.001383126 
+  750          773.28871    755.49438   0.001333333 
+  745          774.37321    754.10101   0.001342282 
+  787          776.15654    752.71076   0.001270648 
+  782          778.93077    751.32364   0.001278772 
+  816          783.15145    749.93965   0.00122549 
+  803          789.59709    748.55877   0.00124533 
+  763          799.56479    747.18099   0.001310616 
+  832          815.09896    745.80632   0.001201923 
+  851          838.61569    744.43475   0.001175088 
+  842          870.1497     743.06626   0.001187648 
+  955          908.38317    741.70086   0.00104712 
+  1005         961.54505    740.33853   0.000995025 
+  1126         1030.99891   738.97927   0.000888099 
+  1217         1097.51258   737.62308   0.000821693 
+  1261         1147.77617   736.26995   0.000793021 
+  1085         1147.03417   734.91987   0.000921659 
+  996          1088.28658   733.57284   0.001004016 
+  872          1011.63789   732.22885   0.001146789 
+  736          931.26771    730.88789   0.001358696 
+  811          867.17504    729.54996   0.001233046 
+  750          824.59141    728.21505   0.001333333 
+  760          797.28477    726.88316   0.001315789 
+  745          779.24009    725.55427   0.001342282 
+  790          766.69717    724.22839   0.001265823 
+  763          757.51155    722.90551   0.001310616 
+  763          750.62816    721.58562   0.001310616 
+  806          745.02172    720.26871   0.001240695 
+  787          740.41548    718.95478   0.001270648 
+  720          736.60963    717.64383   0.001388889 
+  785          733.25624    716.33584   0.001273885 
+  691          730.3056     715.03082   0.001447178 
+  685          727.66648    713.72874   0.001459854 
+  785          725.27319    712.42962   0.001273885 
+  734          723.07714    711.13344   0.001362398 
+  669          721.04276    709.8402    0.001494768 
+  761          719.14325    708.54989   0.00131406 
+  725          717.35844    707.26251   0.00137931 
+  707          715.67339    705.97804   0.001414427 
+  685          714.07715    704.69649   0.001459854 
+  662          712.56203    703.41785   0.001510574 
+  703          711.12338    702.1421    0.001422475 
+  671          709.75928    700.86925   0.001490313 
+  683          708.47059    699.5993    0.001464129 
+  669          707.26148    698.33222   0.001494768 
+  619          706.13986    697.06803   0.001615509 
+  691          705.11894    695.8067    0.001447178 
+  691          704.21925    694.54824   0.001447178 
+  692          703.47217    693.29265   0.001445087 
+  668          702.92663    692.0399    0.001497006 
+  645          702.66136    690.79001   0.001550388 
+  655          702.80777    689.54295   0.001526718 
+  703          703.59329    688.29874   0.001422475 
+  672          705.40686    687.05735   0.001488095 
+  696          708.86372    685.8188    0.001436782 
+  734          714.62273    684.58306   0.001362398 
+  676          722.233      683.35013   0.00147929 
+  775          729.71038    682.12001   0.001290323 
+  716          738.7403     680.8927    0.001396648 
+  779          751.55527    679.66818   0.001283697 
+  734          761.90655    678.44645   0.001362398 
+  725          759.59109    677.22751   0.00137931 
+  705          748.96159    676.01134   0.00141844 
+  652          734.6817     674.79795   0.001533742 
+  744          718.9953     673.58733   0.001344086 
+  696          706.83787    672.37947   0.001436782 
+  648          698.91276    671.17436   0.00154321 
+  653          693.96175    669.97201   0.001531394 
+  677          690.92622    668.7724    0.001477105 
+  623          689.20402    667.57553   0.001605136 
+  626          688.52661    666.38139   0.001597444 
+  661          688.86162    665.18999   0.001512859 
+  686          690.38569    664.0013    0.001457726 
+  700          693.5383     662.81533   0.001428571 
+  679          699.1598     661.63208   0.001472754 
+  646          708.68577    660.45153   0.001547988 
+  711          724.07416    659.27367   0.00140647 
+  682          745.85348    658.09852   0.001466276 
+  739          769.31022    656.92605   0.00135318 
+  803          794.06184    655.75626   0.00124533 
+  845          828.8777     654.58915   0.001183432 
+  848          864.24045    653.42472   0.001179245 
+  909          869.40782    652.26295   0.00110011 
+  872          845.12404    651.10384   0.001146789 
+  819          810.5751     649.94739   0.001221001 
+  743          768.32745    648.79359   0.001345895 
+  700          731.81827    647.64243   0.001428571 
+  679          706.99189    646.49391   0.001472754 
+  656          691.07542    645.34802   0.00152439 
+  706          680.67226    644.20477   0.001416431 
+  694          673.56659    643.06413   0.001440922 
+  648          668.48767    641.92611   0.00154321 
+  643          664.72815    640.79071   0.00155521 
+  661          661.89002    639.65791   0.001512859 
+  656          659.74564    638.52771   0.00152439 
+  623          658.16821    637.4001    0.001605136 
+  640          657.09762    636.27509   0.0015625 
+  675          656.52842    635.15266   0.001481481 
+  647          656.50885    634.03281   0.001545595 
+  642          657.15601    632.91553   0.001557632 
+  675          658.69664    631.80082   0.001481481 
+  667          661.52058    630.68867   0.00149925 
+  667          666.30419    629.57908   0.00149925 
+  658          674.06334    628.47205   0.001519757 
+  682          685.6927     627.36756   0.001466276 
+  689          700.14599    626.26561   0.001451379 
+  760          716.20587    625.16619   0.001315789 
+  791          738.44255    624.06931   0.001264223 
+  837          766.69271    622.97496   0.001194743 
+  898          788.24314    621.88312   0.001113586 
+  874          799.14144    620.7938    0.001144165 
+  924          811.13691    619.70699   0.001082251 
+  938          826.8728     618.62268   0.001066098 
+  1005         843.82779    617.54087   0.000995025 
+  1043         860.93089    616.46155   0.000958773 
+  991          879.55652    615.38473   0.001009082 
+  881          881.25851    614.31038   0.001135074 
+  824          849.61011    613.23852   0.001213592 
+  744          808.35624    612.16913   0.001344086 
+  675          764.13801    611.1022    0.001481481 
+  665          722.27326    610.03774   0.001503759 
+  668          691.89225    608.97573   0.001497006 
+  636          672.18279    607.91618   0.001572327 
+  678          659.42753    606.85907   0.001474926 
+  639          650.82929    605.80441   0.001564945 
+  623          644.67774    604.75218   0.001605136 
+  649          639.95294    603.70238   0.001540832 
+  661          636.03253    602.65501   0.001512859 
+  617          632.52761    601.61006   0.001620746 
+  627          629.21329    600.56752   0.001594896 
+  590          625.98874    599.5274    0.001694915 
+  636          622.83882    598.48968   0.001572327 
+  633          619.79521    597.45436   0.001579779 
+  640          616.90313    596.42144   0.0015625 
+  620          614.19821    595.39091   0.001612903 
+  593          611.69752    594.36276   0.001686341 
+  572          609.40062    593.33699   0.001748252 
+  613          607.29499    592.3136    0.001631321 
+  559          605.36221    591.29258   0.001788909 
+  587          603.58247    590.27392   0.001703578 
+  625          601.93689    589.25762   0.0016    
+  572          600.40903    588.24368   0.001748252 
+  591          598.9853     587.23208   0.001692047 
+  571          597.65497    586.22284   0.001751313 
+  610          596.41013    585.21593   0.001639344 
+  586          595.24565    584.21135   0.001706485 
+  649          594.15858    583.20911   0.001540832 
+  571          593.15014    582.20919   0.001751313 
+  593          592.22412    581.21159   0.001686341 
+  586          591.38792    580.21631   0.001706485 
+  596          590.65465    579.22333   0.001677852 
+  577          590.0448     578.23266   0.001733102 
+  636          589.58984    577.24429   0.001572327 
+  564          589.33868    576.25822   0.00177305 
+  580          589.36974    575.27443   0.001724138 
+  611          589.81308    574.29293   0.001636661 
+  579          590.89238    573.31371   0.001727116 
+  597          592.98887    572.33677   0.001675042 
+  590          596.71343    571.3621    0.001694915 
+  567          602.78913    570.38969   0.001763668 
+  599          611.05665    569.41954   0.001669449 
+  623          619.87473    568.45165   0.001605136 
+  662          630.61563    567.48601   0.001510574 
+  697          644.15589    566.52262   0.00143472 
+  680          651.02026    565.56147   0.001470588 
+  685          645.44592    564.60255   0.001459854 
+  663          636.25194    563.64587   0.001508296 
+  664          625.30428    562.69141   0.001506024 
+  612          613.99803    561.73918   0.001633987 
+  626          606.08215    560.78916   0.001597444 
+  611          602.43668    559.84136   0.001636661 
+  634          602.04226    558.89576   0.001577287 
+  669          600.65345    557.95237   0.001494768 
+  615          596.06937    557.01117   0.001626016 
+  569          590.85677    556.07217   0.001757469 
+  599          585.19356    555.13535   0.001669449 
+  638          579.50828    554.20072   0.001567398 
+  582          575.09944    553.26827   0.001718213 
+  656          572.01238    552.33799   0.00152439 
+  635          569.84142    551.40989   0.001574803 
+  698          568.26196    550.48395   0.001432665 
+  625          567.07474    549.56016   0.0016    
+  677          566.17026    548.63854   0.001477105 
+  632          565.48665    547.71906   0.001582278 
+  651          564.98518    546.80173   0.001536098 
+  697          564.64579    545.88655   0.00143472 
+  712          564.46008    544.9735    0.001404494 
+  701          564.39968    544.06258   0.001426534 
+  644          564.4363     543.15379   0.001552795 
+  620          564.58566    542.24712   0.001612903 
+  637          564.85918    541.34257   0.001569859 
+  599          565.26641    540.44014   0.001669449 
+  610          565.83303    539.53981   0.001639344 
+  587          566.57699    538.64159   0.001703578 
+  636          567.50664    537.74547   0.001572327 
+  604          568.62533    536.85144   0.001655629 
+  640          569.9376     535.9595    0.0015625 
+  628          571.4626     535.06965   0.001592357 
+  647          573.2536     534.18189   0.001545595 
+  710          575.4228     533.29619   0.001408451 
+  680          578.16598    532.41258   0.001470588 
+  634          581.79769    531.53102   0.001577287 
+  612          586.80787    530.65154   0.001633987 
+  621          593.94773    529.77411   0.001610306 
+  596          604.27684    528.89873   0.001677852 
+  620          618.70007    528.02541   0.001612903 
+  636          636.44029    527.15413   0.001572327 
+  689          657.08989    526.28489   0.001451379 
+  677          684.00738    525.41769   0.001477105 
+  722          712.43193    524.55252   0.001385042 
+  808          731.93361    523.68938   0.001237624 
+  745          752.39443    522.82826   0.001342282 
+  826          787.88649    521.96915   0.001210654 
+  891          851.38722    521.11207   0.001122334 
+  1033         973.51422    520.25699   0.000968054 
+  1196         1178.02717   519.40392   0.00083612 
+  1511         1436.07352   518.55284   0.000661813 
+  1973         1856.95665   517.70377   0.000506842 
+  2599         2435.6123    516.85668   0.000384763 
+  3189         2856.7904    516.01159   0.000313578 
+  3376         2927.15764   515.16847   0.000296209 
+  2815         2505.88817   514.32734   0.00035524 
+  2164         2118.10683   513.48818   0.000462107 
+  1674         1663.53824   512.65099   0.000597372 
+  1147         1220.86564   511.81576   0.00087184 
+  803          956.96054    510.9825    0.00124533 
+  661          814.04756    510.15119   0.001512859 
+  634          732.15042    509.32184   0.001577287 
+  621          680.7695     508.49443   0.001610306 
+  584          646.21936    507.66897   0.001712329 
+  602          621.84251    506.84544   0.00166113 
+  580          604.67871    506.02385   0.001724138 
+  571          591.28245    505.2042    0.001751313 
+  534          581.00496    504.38647   0.001872659 
+  564          573.3373     503.57066   0.00177305 
+  537          567.06407    502.75677   0.001862197 
+  588          562.1316     501.94479   0.00170068 
+  572          558.26471    501.13473   0.001748252 
+  573          555.25468    500.32656   0.001745201 
+  565          552.93139    499.5203    0.001769912 
+  562          551.1538     498.71594   0.001779359 
+  585          549.81275    497.91347   0.001709402 
+  594          548.85288    497.11288   0.001683502 
+  545          548.29329    496.31419   0.001834862 
+  585          548.24986    495.51737   0.001709402 
+  538          548.9655     494.72242   0.001858736 
+  589          550.89197    493.92935   0.001697793 
+  533          554.95363    493.13815   0.001876173 
+  621          563.29822    492.3488    0.001610306 
+  571          580.25624    491.56132   0.001751313 
+  580          607.86354    490.77569   0.001724138 
+  652          639.71702    489.99191   0.001533742 
+  722          705.57492    489.20998   0.001385042 
+  806          783.07722    488.42989   0.001240695 
+  876          833.26545    487.65164   0.001141553 
+  876          805.57052    486.87523   0.001141553 
+  777          747.3764     486.10064   0.001287001 
+  738          714.17232    485.32788   0.001355014 
+  679          656.02772    484.55694   0.001472754 
+  670          616.37197    483.78782   0.001492537 
+  636          603.58162    483.02051   0.001572327 
+  630          606.22414    482.25501   0.001587302 
+  686          619.817      481.49131   0.001457726 
+  723          645.2532     480.72942   0.001383126 
+  704          685.19092    479.96933   0.001420455 
+  763          737.45823    479.21102   0.001310616 
+  814          795.82017    478.45451   0.001228501 
+  987          868.17508    477.69978   0.001013171 
+  956          938.44355    476.94683   0.001046025 
+  917          954.05425    476.19566   0.001090513 
+  887          937.7923     475.44626   0.001127396 
+  881          932.59207    474.69863   0.001135074 
+  812          936.32039    473.95277   0.001231527 
+  901          965.41522    473.20867   0.001109878 
+  990          1027.74788   472.46632   0.001010101 
+  1180         1129.69787   471.72573   0.000847458 
+  1340         1259.1437    470.98688   0.000746269 
+  1458         1324.50232   470.24978   0.000685871 
+  1493         1317.67068   469.51442   0.000669792 
+  1273         1295.05572   468.7808    0.000785546 
+  1154         1207.38823   468.04891   0.000866551 
+  995          1083.99389   467.31875   0.001005025 
+  920          987.79449    466.59032   0.001086957 
+  852          912.95042    465.86361   0.001173709 
+  835          861.21721    465.13861   0.001197605 
+  845          841.79307    464.41533   0.001183432 
+  888          841.00054    463.69375   0.001126126 
+  872          825.86443    462.97389   0.001146789 
+  847          802.30818    462.25572   0.001180638 
+  839          788.41477    461.53925   0.001191895 
+  826          780.25253    460.82448   0.001210654 
+  772          784.46752    460.1114    0.001295337 
+  799          806.72143    459.4       0.001251564 
+  909          848.98236    458.69028   0.00110011 
+  899          911.66997    457.98225   0.001112347 
+  874          974.16761    457.27589   0.001144165 
+  1012         1042.44734   456.5712    0.000988142 
+  1185         1171.94788   455.86817   0.000843882 
+  1438         1427.93083   455.16681   0.00069541 
+  1875         1888.88393   454.46711   0.000533333 
+  2538         2489.1574    453.76906   0.000394011 
+  3905         3518.28921   453.07267   0.000256082 
+  5742         4979.6256    452.37792   0.000174155 
+  7202         5923.39883   451.68482   0.00013885 
+  5982         5570.09768   450.99336   0.000167168 
+  4635         4509.41468   450.30354   0.00021575 
+  3996         3814.92911   449.61535   0.00025025 
+  2730         2777.3062    448.92878   0.0003663 
+  1595         1788.48883   448.24385   0.000626959 
+  1152         1257.61081   447.56053   0.000868056 
+  947          990.2659     446.87883   0.001055966 
+  826          841.82523    446.19875   0.001210654 
+  738          749.27409    445.52028   0.001355014 
+  720          686.8539     444.84341   0.001388889 
+  692          642.49016    444.16815   0.001445087 
+  644          609.68211    443.49448   0.001552795 
+  578          584.63649    442.82241   0.001730104 
+  596          565.01461    442.15194   0.001677852 
+  541          549.30414    441.48305   0.001848429 
+  565          536.4907     440.81575   0.001769912 
+  580          525.8736     440.15002   0.001724138 
+  583          516.95489    439.48588   0.001715266 
+  642          509.37152    438.82331   0.001557632 
+  576          502.85498    438.1623    0.001736111 
+  590          497.2027     437.50287   0.001694915 
+  585          492.25885    436.84499   0.001709402 
+  629          487.90278    436.18868   0.001589825 
+  586          484.03983    435.53392   0.001706485 
+  578          480.59445    434.88071   0.001730104 
+  593          477.50643    434.22906   0.001686341 
+  599          474.72837    433.57894   0.001669449 
+  600          472.2185     432.93037   0.001666667 
+  600          469.94596    432.28333   0.001666667 
+  561          467.88441    431.63783   0.001782531 
+  578          466.01376    430.99386   0.001730104 
+  512          464.31461    430.35141   0.001953125 
+  504          462.77412    429.71049   0.001984127 
+  504          461.3815     429.07109   0.001984127 
+  517          460.12881    428.4332    0.001934236 
+  488          459.00954    427.79683   0.00204918 
+  450          458.0204     427.16196   0.002222222 
+  494          457.15999    426.5286    0.002024291 
+  408          456.42885    425.89675   0.00245098 
+  474          455.8304     425.26639   0.002109705 
+  461          455.36902    424.63752   0.002169197 
+  404          455.05353    424.01015   0.002475248 
+  462          454.89414    423.38427   0.002164502 
+  479          454.90588    422.75986   0.002087683 
+  456          455.10681    422.13695   0.002192982 
+  451          455.52063    421.5155    0.002217295 
+  436          456.17638    420.89553   0.002293578 
+  450          457.10879    420.27704   0.002222222 
+  481          458.36199    419.66001   0.002079002 
+  452          459.98794    419.04444   0.002212389 
+  437          462.04872    418.43033   0.00228833 
+  496          464.61445    417.81768   0.002016129 
+  491          467.76204    417.20648   0.00203666 
+  475          471.56856    416.59674   0.002105263 
+  495          476.09747    415.98844   0.002020202 
+  514          481.37639    415.38158   0.001945525 
+  492          487.36913    414.77616   0.00203252 
+  548          493.94543    414.17218   0.001824818 
+  594          500.87581    413.56963   0.001683502 
+  582          507.87805    412.96851   0.001718213 
+  605          514.71156    412.36882   0.001652893 
+  559          521.2802     411.77055   0.001788909 
+  578          527.6689     411.1737    0.001730104 
+  630          534.09462    410.57826   0.001587302 
+  612          540.85131    409.98424   0.001633987 
+  618          548.28359    409.39163   0.001618123 
+  647          556.97546    408.80042   0.001545595 
+  703          567.9339     408.21061   0.001422475 
+  681          582.0788     407.62221   0.001468429 
+  705          598.27769    407.0352    0.00141844 
+  731          616.03489    406.44958   0.001367989 
+  689          636.16227    405.86536   0.001451379 
+  673          644.98676    405.28252   0.001485884 
+  609          636.21584    404.70106   0.001642036 
+  628          626.14068    404.12098   0.001592357 
+  598          617.42557    403.54228   0.001672241 
+  599          600.28289    402.96495   0.001669449 
+  621          573.01631    402.38899   0.001610306 
+  600          547.655      401.8144    0.001666667 
+  578          528.08407    401.24117   0.001730104 
+  532          509.72583    400.6693    0.001879699 
+  509          495.11827    400.09878   0.001964637 
+  479          487.34435    399.52962   0.002087683 
+  457          486.73886    398.96181   0.002188184 
+  489          493.16814    398.39535   0.00204499 
+  526          505.83031    397.83023   0.001901141 
+  551          524.04688    397.26645   0.001814882 
+  581          544.97819    396.70401   0.00172117 
+  564          559.79067    396.14291   0.00177305 
+  597          564.54012    395.58313   0.001675042 
+  552          555.40581    395.02468   0.001811594 
+  505          534.58306    394.46756   0.001980198 
+  491          512.29282    393.91176   0.00203666 
+  419          489.81461    393.35727   0.002386635 
+  423          468.29138    392.80411   0.002364066 
+  416          451.913      392.25225   0.002403846 
+  432          440.79035    391.7017    0.002314815 
+  429          433.27923    391.15246   0.002331002 
+  391          428.03237    390.60452   0.002557545 
+  389          424.20658    390.05788   0.002570694 
+  418          421.31172    389.51254   0.002392344 
+  404          419.06104    388.96849   0.002475248 
+  427          417.28314    388.42573   0.00234192 
+  403          415.8722     387.88426   0.00248139 
+  395          414.76159    387.34407   0.002531646 
+  382          413.90975    386.80516   0.002617801 
+  404          413.29209    386.26753   0.002475248 
+  382          412.8958     385.73117   0.002617801 
+  406          412.71673    385.19608   0.002463054 
+  392          412.75863    384.66227   0.00255102 
+  399          413.03534    384.12972   0.002506266 
+  401          414.16609    383.59843   0.002493766 
+  362          415.04197    383.0684    0.002762431 
+  372          416.36507    382.53963   0.002688172 
+  394          418.34677    382.01211   0.002538071 
+  404          421.64947    381.48584   0.002475248 
+  433          426.29759    380.96081   0.002309469 
+  423          433.45278    380.43704   0.002364066 
+  434          443.68417    379.9145    0.002304147 
+  438          455.95507    379.3932    0.002283105 
+  491          469.43145    378.87314   0.00203666 
+  446          482.22612    378.3543    0.002242152 
+  502          484.32659    377.8367    0.001992032 
+  519          475.91164    377.32032   0.001926782 
+  417          467.12163    376.80517   0.002398082 
+  423          457.14994    376.29124   0.002364066 
+  430          444.77717    375.77852   0.002325581 
+  424          434.43565    375.26702   0.002358491 
+  385          427.81018    374.75673   0.002597403 
+  468          424.36059    374.24765   0.002136752 
+  393          423.16502    373.73977   0.002544529 
+  397          423.30678    373.2331    0.002518892 
+  441          424.34553    372.72762   0.002267574 
+  418          424.22048    372.22334   0.002392344 
+  409          421.15169    371.72026   0.002444988 
+  407          417.4918     371.21837   0.002457002 
+  381          414.21791    370.71766   0.002624672 
+  376          410.40546    370.21814   0.002659574 
+  401          406.79105    369.7198    0.002493766 
+  407          404.13522    369.22264   0.002457002 
+  415          402.34716    368.72666   0.002409639 
+  361          401.15585    368.23185   0.002770083 
+  405          400.36046    367.73821   0.002469136 
+  383          399.83805    367.24574   0.002610966 
+  402          399.51634    366.75443   0.002487562 
+  396          399.35376    366.26429   0.002525253 
+  387          399.32617    365.7753    0.002583979 
+  371          399.41989    365.28747   0.002695418 
+  394          399.62881    364.8008    0.002538071 
+  414          399.95322    364.31527   0.002415459 
+  367          400.39991    363.8309    0.002724796 
+  383          400.98444    363.34766   0.002610966 
+  376          401.73352    362.86557   0.002659574 
+  358          402.6815     362.38462   0.002793296 
+  412          403.84288    361.90481   0.002427184 
+  439          405.21857    361.42613   0.002277904 
+  408          406.8422     360.94858   0.00245098 
+  396          408.59332    360.47216   0.002525253 
+  392          410.36731    359.99686   0.00255102 
+  421          412.39707    359.52269   0.002375297 
+  422          414.64649    359.04964   0.002369668 
+  383          416.7469     358.5777    0.002610966 
+  429          418.6304     358.10688   0.002331002 
+  399          420.20689    357.63717   0.002506266 
+  430          421.50609    357.16857   0.002325581 
+  397          422.70202    356.70107   0.002518892 
+  427          424.27304    356.23468   0.00234192 
+  414          426.48517    355.76939   0.002415459 
+  424          429.31121    355.3052    0.002358491 
+  455          432.67994    354.8421    0.002197802 
+  457          436.54967    354.38009   0.002188184 
+  469          440.90303    353.91918   0.002132196 
+  429          445.74961    353.45935   0.002331002 
+  438          451.1086     353.0006    0.002283105 
+  464          457.02716    352.54294   0.002155172 
+  455          463.58094    352.08636   0.002197802 
+  439          470.88142    351.63085   0.002277904 
+  453          479.07372    351.17642   0.002207506 
+  530          488.33901    350.72305   0.001886792 
+  477          498.89369    350.27076   0.002096436 
+  489          510.99159    349.81953   0.00204499 
+  530          524.93562    349.36936   0.001886792 
+  482          541.09043    348.92026   0.002074689 
+  517          559.90611    348.47221   0.001934236 
+  577          581.9654     348.02522   0.001733102 
+  541          608.03802    347.57928   0.001848429 
+  603          639.15573    347.13439   0.001658375 
+  594          676.7318     346.69054   0.001683502 
+  675          722.71673    346.24775   0.001481481 
+  714          779.84476    345.80599   0.00140056 
+  753          852.07024    345.36527   0.001328021 
+  799          945.26771    344.92559   0.001251564 
+  986          1068.47446   344.48695   0.001014199 
+  1187         1236.28695   344.04933   0.00084246 
+  1471         1473.61996   343.61275   0.00067981 
+  1837         1826.75466   343.17719   0.000544366 
+  2428         2393.70675   342.74265   0.000411862 
+  3280         3403.81783   342.30914   0.000304878 
+  5154         5344.9767    341.87665   0.000194024 
+  8099         8765.97059   341.44517   0.000123472 
+  13116        12568.44943  341.0147    0.000076243 
+  21325        17646.59032  340.58525   0.000046893 
+  26562        22766.44985  340.1568    0.000037648 
+  21135        18861.92348  339.72937   0.000047315 
+  15227        14420.6292   339.30293   0.000065673 
+  14287        13703.05059  338.8775    0.000069994 
+  11204        10602.31981  338.45306   0.000089254 
+  5832         6299.82988   338.02962   0.000171468 
+  3179         3835.25228   337.60717   0.000314564 
+  2092         2606.19878   337.18572   0.000478011 
+  1760         1947.24275   336.76525   0.000568182 
+  1402         1549.20532   336.34577   0.000713267 
+  1230         1287.11765   335.92727   0.000813008 
+  1055         1104.63478   335.50976   0.000947867 
+  990          972.17437    335.09322   0.001010101 
+  935          872.86184    334.67766   0.001069519 
+  810          796.59958    334.26307   0.001234568 
+  780          736.89431    333.84946   0.001282051 
+  717          689.3488     333.43681   0.0013947 
+  711          651.05325    333.02513   0.00140647 
+  648          620.01018    332.61441   0.00154321 
+  616          594.75242    332.20465   0.001623377 
+  591          574.21547    331.79586   0.001692047 
+  590          557.63358    331.38802   0.001694915 
+  562          544.47574    330.98113   0.001779359 
+  568          534.38101    330.57519   0.001760563 
+  549          527.08769    330.17021   0.001821494 
+  557          522.12512    329.76617   0.001795332 
+  517          518.80063    329.36308   0.001934236 
+  473          516.60965    328.96092   0.002114165 
+  471          515.98241    328.55971   0.002123142 
+  482          516.7842     328.15944   0.002074689 
+  517          518.5952     327.7601    0.001934236 
+  483          521.55032    327.36169   0.002070393 
+  545          526.01204    326.96421   0.001834862 
+  540          532.26577    326.56766   0.001851852 
+  602          540.58911    326.17204   0.00166113 
+  557          551.28107    325.77734   0.001795332 
+  602          564.62962    325.38356   0.00166113 
+  588          580.9238     324.9907    0.00170068 
+  626          600.36106    324.59875   0.001597444 
+  572          621.72153    324.20772   0.001748252 
+  643          637.85299    323.8176    0.00155521 
+  653          638.89297    323.42839   0.001531394 
+  656          629.72122    323.04009   0.00152439 
+  623          618.25068    322.65269   0.001605136 
+  644          601.86411    322.26619   0.001552795 
+  612          579.3198     321.8806    0.001633987 
+  600          555.57851    321.4959    0.001666667 
+  563          533.29963    321.11209   0.001776199 
+  535          512.73966    320.72918   0.001869159 
+  468          493.76953    320.34716   0.002136752 
+  489          476.40127    319.96603   0.00204499 
+  495          460.69758    319.58578   0.002020202 
+  480          446.6565     319.20642   0.002083333 
+  420          434.23088    318.82794   0.002380952 
+  410          423.33765    318.45034   0.002439024 
+  426          413.83823    318.07361   0.002347418 
+  429          405.56442    317.69777   0.002331002 
+  393          398.34962    317.32279   0.002544529 
+  389          392.04078    316.94868   0.002570694 
+  439          386.50478    316.57545   0.002277904 
+  406          381.6219     316.20307   0.002463054 
+  380          377.29751    315.83157   0.002631579 
+  392          373.44982    315.46092   0.00255102 
+  389          370.01183    315.09113   0.002570694 
+  408          366.92932    314.7222    0.00245098 
+  367          364.15416    314.35413   0.002724796 
+  369          361.64967    313.9869    0.002710027 
+  345          359.3853     313.62053   0.002898551 
+  389          357.33693    313.25501   0.002570694 
+  332          355.48273    312.89033   0.003012048 
+  372          353.80853    312.5265    0.002688172 
+  401          352.30315    312.1635    0.002493766 
+  362          350.95897    311.80135   0.002762431 
+  361          349.77388    311.44004   0.002770083 
+  335          348.74859    311.07956   0.002985075 
+  358          347.8912     310.71991   0.002793296 
+  360          347.21419    310.36109   0.002777778 
+  343          346.74627    310.00311   0.002915452 
+  394          346.88147    309.64595   0.002538071 
+  392          346.97103    309.28961   0.00255102 
+  410          347.384      308.9341    0.002439024 
+  382          348.42929    308.57941   0.002617801 
+  402          350.54188    308.22553   0.002487562 
+  375          353.66024    307.87247   0.002666667 
+  364          358.83008    307.52023   0.002747253 
+  353          367.38864    307.16879   0.002832861 
+  411          381.27069    306.81817   0.00243309 
+  397          401.77754    306.46836   0.002518892 
+  431          423.50651    306.11935   0.002320186 
+  440          430.24762    305.77114   0.002272727 
+  439          420.78133    305.42373   0.002277904 
+  413          411.63244    305.07713   0.002421308 
+  444          404.42996    304.73132   0.002252252 
+  390          391.50912    304.3863    0.002564103 
+  405          376.44614    304.04208   0.002469136 
+  397          365.06762    303.69865   0.002518892 
+  392          357.76649    303.35601   0.00255102 
+  369          353.23495    303.01416   0.002710027 
+  354          350.40307    302.67309   0.002824859 
+  331          348.68771    302.3328    0.003021148 
+  359          347.91315    301.9933    0.002785515 
+  376          348.17467    301.65457   0.002659574 
+  344          349.44637    301.31662   0.002906977 
+  377          350.45827    300.97945   0.00265252 
+  346          348.97224    300.64304   0.002890173 
+  388          345.90132    300.30741   0.00257732 
+  354          343.39434    299.97255   0.002824859 
+  373          341.04374    299.63845   0.002680965 
+  349          337.96498    299.30512   0.00286533 
+  338          334.96839    298.97255   0.00295858 
+  365          332.7041     298.64074   0.002739726 
+  358          331.12005    298.30969   0.002793296 
+  338          330.03166    297.9794    0.00295858 
+  365          329.29998    297.64986   0.002739726 
+  355          328.85327    297.32107   0.002816901 
+  350          328.66827    296.99304   0.002857143 
+  356          328.77383    296.66575   0.002808989 
+  356          329.24778    296.33921   0.002808989 
+  353          330.19792    296.01342   0.002832861 
+  318          331.58948    295.68837   0.003144654 
+  367          332.76905    295.36405   0.002724796 
+  336          332.91445    295.04048   0.00297619 
+  342          332.66079    294.71765   0.002923977 
+  326          332.80405    294.39555   0.003067485 
+  293          333.08265    294.07418   0.003412969 
+  346          333.28364    293.75355   0.002890173 
+  349          333.91859    293.43364   0.00286533 
+  317          335.42344    293.11446   0.003154574 
+  358          338.10375    292.79601   0.002793296 
+  352          342.3616     292.47828   0.002840909 
+  376          348.47662    292.16128   0.002659574 
+  350          355.88292    291.84499   0.002857143 
+  409          365.09837    291.52942   0.002444988 
+  370          382.06827    291.21457   0.002702703 
+  427          408.25965    290.90043   0.00234192 
+  473          437.26355    290.587     0.002114165 
+  477          469.33118    290.27429   0.002096436 
+  467          447.67981    289.96228   0.002141328 
+  430          419.27421    289.65098   0.002325581 
+  381          414.95634    289.34038   0.002624672 
+  404          412.30597    289.03049   0.002475248 
+  424          387.29424    288.7213    0.002358491 
+  374          369.62957    288.4128    0.002673797 
+  405          361.99292    288.10501   0.002469136 
+  369          359.56709    287.79791   0.002710027 
+  412          359.4599     287.4915    0.002427184 
+  419          360.60089    287.18579   0.002386635 
+  361          362.91401    286.88077   0.002770083 
+  428          366.46742    286.57643   0.002336449 
+  364          371.37813    286.27278   0.002747253 
+  379          377.90803    285.96982   0.002638522 
+  390          386.57402    285.66754   0.002564103 
+  418          398.71872    285.36594   0.002392344 
+  409          417.40461    285.06502   0.002444988 
+  473          447.82497    284.76477   0.002114165 
+  494          493.11612    284.46521   0.002024291 
+  500          544.61206    284.16631   0.002     
+  575          598.02204    283.86809   0.00173913 
+  655          606.07355    283.57054   0.001526718 
+  619          577.24641    283.27366   0.001615509 
+  599          567.3755     282.97744   0.001669449 
+  604          573.48699    282.68189   0.001655629 
+  568          560.84262    282.387     0.001760563 
+  616          547.92079    282.09277   0.001623377 
+  564          554.70157    281.79921   0.00177305 
+  622          579.72418    281.5063    0.001607717 
+  624          618.33039    281.21405   0.001602564 
+  668          660.02384    280.92245   0.001497006 
+  668          696.36312    280.6315    0.001497006 
+  715          738.80479    280.34121   0.001398601 
+  771          799.48429    280.05156   0.001297017 
+  867          879.50887    279.76257   0.001153403 
+  1041         983.95403    279.47421   0.000960615 
+  1168         1131.92012   279.18651   0.000856164 
+  1388         1350.95056   278.89944   0.000720461 
+  1686         1685.97832   278.61302   0.00059312 
+  2363         2229.82536   278.32723   0.000423191 
+  3306         3198.21471   278.04208   0.00030248 
+  5270         5061.44168   277.75757   0.000189753 
+  8548         8372.56482   277.47369   0.000116986 
+  13591        12350.8506   277.19045   0.000073578 
+  19853        17055.62508  276.90783   0.00005037 
+  20015        17738.38265  276.62584   0.000049963 
+  13930        13426.9915   276.34448   0.000071788 
+  11100        11146.19156  276.06375   0.00009009 
+  11436        11088.76857  275.78364   0.000087443 
+  8912         8817.21599   275.50415   0.000112208 
+  4935         5317.5076    275.22528   0.000202634 
+  2724         3248.62542   274.94703   0.000367107 
+  1896         2205.77148   274.6694    0.000527426 
+  1373         1648.23112   274.39238   0.000728332 
+  1161         1315.29258   274.11598   0.000861326 
+  952          1099.5062    273.84019   0.00105042 
+  892          949.8383     273.56501   0.001121076 
+  785          837.65495    273.29044   0.001273885 
+  715          751.90914    273.01648   0.001398601 
+  638          687.69012    272.74312   0.001567398 
+  617          636.72542    272.47037   0.001620746 
+  547          591.28723    272.19822   0.001828154 
+  533          551.76207    271.92667   0.001876173 
+  507          519.97283    271.65572   0.001972387 
+  442          494.24033    271.38536   0.002262443 
+  413          472.33411    271.11561   0.002421308 
+  420          454.29081    270.84644   0.002380952 
+  410          440.58966    270.57787   0.002439024 
+  391          430.89686    270.3099    0.002557545 
+  403          423.50472    270.04251   0.00248139 
+  397          415.92903    269.77571   0.002518892 
+  397          407.98865    269.50949   0.002518892 
+  400          400.03991    269.24387   0.0025    
+  375          392.70526    268.97882   0.002666667 
+  390          386.5908     268.71436   0.002564103 
+  343          381.71393    268.45047   0.002915452 
+  381          376.22625    268.18717   0.002624672 
+  360          368.66502    267.92444   0.002777778 
+  345          360.97985    267.66229   0.002898551 
+  369          354.85472    267.40071   0.002710027 
+  317          349.39837    267.13971   0.003154574 
+  316          343.44439    266.87927   0.003164557 
+  314          337.63764    266.61941   0.003184713 
+  309          332.65138    266.36011   0.003236246 
+  311          328.47346    266.10138   0.003215434 
+  341          324.92514    265.84322   0.002932551 
+  312          321.86132    265.58562   0.003205128 
+  309          319.18057    265.32858   0.003236246 
+  317          316.8056     265.0721    0.003154574 
+  300          314.67031    264.81618   0.003333333 
+  333          312.71241    264.56081   0.003003003 
+  305          310.87776    264.30601   0.003278689 
+  297          309.12448    264.05175   0.003367003 
+  301          307.42957    263.79805   0.003322259 
+  292          305.78547    263.54491   0.003424658 
+  301          304.19692    263.29231   0.003322259 
+  340          302.67347    263.04026   0.002941176 
+  272          301.22328    262.78875   0.003676471 
+  303          299.85488    262.53779   0.00330033 
+  293          298.58817    262.28738   0.003412969 
+  313          297.43918    262.03751   0.003194888 
+  296          296.40997    261.78818   0.003378378 
+  297          295.50344    261.53939   0.003367003 
+  291          294.72665    261.29114   0.003436426 
+  292          294.08776    261.04342   0.003424658 
+  278          293.59318    260.79624   0.003597122 
+  286          293.25658    260.54959   0.003496503 
+  256          293.08946    260.30348   0.00390625 
+  307          293.05992    260.05789   0.003257329 
+  287          293.09374    259.81284   0.003484321 
+  278          293.30955    259.56831   0.003597122 
+  278          293.96484    259.32431   0.003597122 
+  301          294.96629    259.08084   0.003322259 
+  275          295.46643    258.83789   0.003636364 
+  302          294.9591     258.59546   0.003311258 
+  298          294.44724    258.35356   0.003355705 
+  320          294.6884     258.11217   0.003125  
+  246          295.51364    257.8713    0.004065041 
+  267          296.91395    257.63095   0.003745318 
+  324          299.83588    257.39111   0.00308642 
+  319          305.51211    257.15179   0.003134796 
+  373          315.15665    256.91298   0.002680965 
+  381          328.73713    256.67468   0.002624672 
+  413          340.50026    256.43689   0.002421308 
+  413          341.20883    256.19961   0.002421308 
+  408          334.61255    255.96283   0.00245098 
+  391          329.18472    255.72657   0.002557545 
+  387          324.9264     255.4908    0.002583979 
+  413          317.3848     255.25554   0.002421308 
+  337          307.75459    255.02078   0.002967359 
+  340          299.45487    254.78652   0.002941176 
+  358          293.45342    254.55276   0.002793296 
+  278          289.53995    254.3195    0.003597122 
+  314          287.19291    254.08674   0.003184713 
+  258          286.07697    253.85446   0.003875969 
+  299          286.25481    253.62269   0.003344482 
+  287          288.20449    253.3914    0.003484321 
+  288          291.58337    253.16061   0.003472222 
+  297          295.70166    252.9303    0.003367003 
+  291          296.79196    252.70048   0.003436426 
+  280          292.62634    252.47115   0.003571429 
+  267          290.95051    252.24231   0.003745318 
+  266          291.89101    252.01395   0.003759398 
+  273          292.32432    251.78607   0.003663004 
+  278          290.71351    251.55868   0.003597122 
+  299          290.98479    251.33176   0.003344482 
+  305          293.66121    251.10533   0.003278689 
+  324          299.01814    250.87937   0.00308642 
+  332          308.59549    250.65389   0.003012048 
+  322          325.38067    250.42888   0.00310559 
+  359          356.0359     250.20435   0.002785515 
+  429          398.95547    249.98029   0.002331002 
+  423          443.99404    249.7567    0.002364066 
+  465          463.97323    249.53358   0.002150538 
+  420          433.89913    249.31093   0.002380952 
+  427          410.70901    249.08874   0.00234192 
+  387          405.02753    248.86703   0.002583979 
+  383          394.71458    248.64578   0.002610966 
+  384          362.02067    248.42499   0.002604167 
+  367          333.6156     248.20466   0.002724796 
+  314          316.35856    247.9848    0.003184713 
+  272          305.46386    247.76539   0.003676471 
+  319          298.53197    247.54645   0.003134796 
+  317          294.26932    247.32796   0.003154574 
+  310          291.72953    247.10993   0.003225806 
+  297          290.3206     246.89235   0.003367003 
+  337          289.70439    246.67523   0.002967359 
+  294          289.68371    246.45856   0.003401361 
+  323          290.09894    246.24234   0.003095975 
+  325          290.73069    246.02657   0.003076923 
+  316          291.47111    245.81125   0.003164557 
+  301          292.45935    245.59637   0.003322259 
+  286          293.78192    245.38195   0.003496503 
+  282          295.38152    245.16797   0.003546099 
+  290          297.21844    244.95443   0.003448276 
+  347          299.38736    244.74133   0.002881844 
+  315          301.99587    244.52868   0.003174603 
+  325          305.14411    244.31647   0.003076923 
+  356          308.97254    244.10469   0.002808989 
+  342          313.73043    243.89336   0.002923977 
+  315          319.78915    243.68246   0.003174603 
+  351          327.36763    243.472     0.002849003 
+  356          335.52086    243.26197   0.002808989 
+  377          342.11051    243.05237   0.00265252 
+  367          348.06862    242.84321   0.002724796 
+  357          357.20851    242.63448   0.00280112 
+  377          372.54908    242.42617   0.00265252 
+  401          397.06213    242.2183    0.002493766 
+  442          432.08633    242.01085   0.002262443 
+  400          454.56438    241.80383   0.0025    
+  451          443.64231    241.59724   0.002217295 
+  428          436.41662    241.39107   0.002336449 
+  464          447.47428    241.18532   0.002155172 
+  454          462.97946    240.97999   0.002202643 
+  443          465.65468    240.77508   0.002257336 
+  466          470.37941    240.5706    0.002145923 
+  482          485.75547    240.36653   0.002074689 
+  521          511.06889    240.16288   0.001919386 
+  590          545.79733    239.95964   0.001694915 
+  615          590.54167    239.75682   0.001626016 
+  691          647.36013    239.55441   0.001447178 
+  721          721.38853    239.35242   0.001386963 
+  903          820.9432     239.15084   0.00110742 
+  1023         958.38866    238.94966   0.000977517 
+  1182         1154.70457   238.7489    0.000846024 
+  1484         1449.93197   238.54855   0.000673854 
+  1960         1928.91602   238.3486    0.000510204 
+  2895         2786.03227   238.14906   0.000345423 
+  4762         4441.03704   237.94992   0.000209996 
+  7782         7441.56767   237.75119   0.000128502 
+  12353        11257.92894  237.55285   0.000080952 
+  16536        14798.0105   237.35493   0.000060474 
+  14658        13412.05837  237.1574    0.000068222 
+  9830         9836.58549   236.96027   0.000101729 
+  8432         8670.22552   236.76354   0.000118596 
+  8985         8954.67248   236.5672    0.000111297 
+  7941         7739.49494   236.37127   0.000125929 
+  4447         4843.37055   236.17572   0.000224871 
+  2552         2939.15077   235.98058   0.00039185 
+  1577         1960.80026   235.78582   0.000634115 
+  1247         1443.2945    235.59146   0.000801925 
+  944          1137.93674   235.39748   0.001059322 
+  791          939.71941    235.2039    0.001264223 
+  737          802.86401    235.01071   0.001356852 
+  591          704.32344    234.8179    0.001692047 
+  592          631.24959    234.62548   0.001689189 
+  562          576.13637    234.43345   0.001779359 
+  474          534.6474     234.2418    0.002109705 
+  498          504.92326    234.05053   0.002008032 
+  473          487.68918    233.85965   0.002114165 
+  434          484.52179    233.66914   0.002304147 
+  459          490.06861    233.47902   0.002178649 
+  421          493.54604    233.28928   0.002375297 
+  403          466.30986    233.09992   0.00248139 
+  449          440.3444     232.91093   0.002227171 
+  398          428.15889    232.72232   0.002512563 
+  423          419.0024     232.53408   0.002364066 
+  338          396.50832    232.34622   0.00295858 
+  366          370.62534    232.15874   0.00273224 
+  314          352.65939    231.97162   0.003184713 
+  325          338.79354    231.78488   0.003076923 
+  296          327.18069    231.5985    0.003378378 
+  288          317.96133    231.4125    0.003472222 
+  295          310.77855    231.22686   0.003389831 
+  271          305.08344    231.04159   0.003690037 
+  274          300.45165    230.85669   0.003649635 
+  262          296.59676    230.67216   0.003816794 
+  287          293.32225    230.48798   0.003484321 
+  264          290.47923    230.30417   0.003787879 
+  275          288.34368    230.12073   0.003636364 
+  292          286.03406    229.93764   0.003424658 
+  269          283.87426    229.75491   0.003717472 
+  272          281.8288     229.57255   0.003676471 
+  278          279.88968    229.39054   0.003597122 
+  261          278.2677     229.20889   0.003831418 
+  225          276.5973     229.0276    0.004444444 
+  268          275.12152    228.84666   0.003731343 
+  271          273.91156    228.66608   0.003690037 
+  264          273.07543    228.48585   0.003787879 
+  244          272.7692     228.30597   0.004098361 
+  252          273.20693    228.12645   0.003968254 
+  208          274.52137    227.94727   0.004807692 
+  219          276.16299    227.76845   0.00456621 
+  262          276.44897    227.58998   0.003816794 
+  271          274.99973    227.41185   0.003690037 
+  277          273.43456    227.23407   0.003610108 
+  273          272.29564    227.05663   0.003663004 
+  284          270.92884    226.87955   0.003521127 
+  244          268.80655    226.7028    0.004098361 
+  252          266.50707    226.5264    0.003968254 
+  245          264.49537    226.35034   0.004081633 
+  268          262.81574    226.17463   0.003731343 
+  276          261.50549    225.99925   0.003623188 
+  266          260.57725    225.82422   0.003759398 
+  255          260.0433     225.64952   0.003921569 
+  251          259.94557    225.47516   0.003984064 
+  261          260.36775    225.30114   0.003831418 
+  223          261.36766    225.12745   0.004484305 
+  252          262.77606    224.9541    0.003968254 
+  233          264.28063    224.78108   0.004291845 
+  260          266.13824    224.6084    0.003846154 
+  284          269.25045    224.43605   0.003521127 
+  263          274.51143    224.26403   0.003802281 
+  299          283.49597    224.09234   0.003344482 
+  300          299.93292    223.92098   0.003333333 
+  310          330.26048    223.74995   0.003225806 
+  348          376.03973    223.57925   0.002873563 
+  383          401.52204    223.40888   0.002610966 
+  391          380.77804    223.23883   0.002557545 
+  415          366.4666     223.06911   0.002409639 
+  391          374.71947    222.89971   0.002557545 
+  375          382.04431    222.73064   0.002666667 
+  358          359.87843    222.56189   0.002793296 
+  338          330.84828    222.39346   0.00295858 
+  338          314.48084    222.22535   0.00295858 
+  300          305.46607    222.05757   0.003333333 
+  285          297.34525    221.8901    0.003508772 
+  304          291.30211    221.72295   0.003289474 
+  299          289.01564    221.55612   0.003344482 
+  292          287.84404    221.38961   0.003424658 
+  328          284.18227    221.22341   0.00304878 
+  290          279.68364    221.05753   0.003448276 
+  284          276.08205    220.89196   0.003521127 
+  284          272.68734    220.7267    0.003521127 
+  227          268.35086    220.56176   0.004405286 
+  251          263.45084    220.39713   0.003984064 
+  264          259.24826    220.23281   0.003787879 
+  249          255.68589    220.06881   0.004016064 
+  242          252.7997     219.90511   0.004132231 
+  260          250.77692    219.74172   0.003846154 
+  234          249.49801    219.57864   0.004273504 
+  240          248.76925    219.41586   0.004166667 
+  202          248.45413    219.25339   0.004950495 
+  227          248.47318    219.09123   0.004405286 
+  251          248.75205    218.92937   0.003984064 
+  230          249.14807    218.76782   0.004347826 
+  239          249.56035    218.60657   0.0041841 
+  233          250.11439    218.44562   0.004291845 
+  227          250.95378    218.28497   0.004405286 
+  266          252.1253     218.12462   0.003759398 
+  244          253.63873    217.96458   0.004098361 
+  223          255.66561    217.80483   0.004484305 
+  268          258.50284    217.64538   0.003731343 
+  251          262.31971    217.48623   0.003984064 
+  260          266.49427    217.32737   0.003846154 
+  243          269.14258    217.16881   0.004115226 
+  276          269.90467    217.01055   0.003623188 
+  232          270.87014    216.85258   0.004310345 
+  250          273.11738    216.6949    0.004     
+  262          276.02246    216.53752   0.003816794 
+  252          278.649      216.38043   0.003968254 
+  314          281.55536    216.22363   0.003184713 
+  283          285.72187    216.06712   0.003533569 
+  270          291.59252    215.9109    0.003703704 
+  293          299.51054    215.75497   0.003412969 
+  293          310.02473    215.59932   0.003412969 
+  350          323.30903    215.44397   0.002857143 
+  308          340.26649    215.2889    0.003246753 
+  311          356.61667    215.13412   0.003215434 
+  332          365.89891    214.97962   0.003012048 
+  360          370.59664    214.82541   0.002777778 
+  367          376.64542    214.67148   0.002724796 
+  355          385.06803    214.51784   0.002816901 
+  396          392.43788    214.36448   0.002525253 
+  384          396.65961    214.2114    0.002604167 
+  396          400.41005    214.0586    0.002525253 
+  399          405.90218    213.90608   0.002506266 
+  420          413.3664     213.75384   0.002380952 
+  393          422.40408    213.60188   0.002544529 
+  417          432.46653    213.45019   0.002398082 
+  459          442.9202     213.29879   0.002178649 
+  461          453.13078    213.14766   0.002169197 
+  519          462.61457    212.9968    0.001926782 
+  512          471.31312    212.84623   0.001953125 
+  494          479.58769    212.69592   0.002024291 
+  460          488.1288     212.54589   0.002173913 
+  474          497.93717    212.39613   0.002109705 
+  456          509.59497    212.24665   0.002192982 
+  458          520.62104    212.09744   0.002183406 
+  555          523.50763    211.94849   0.001801802 
+  526          514.87333    211.79982   0.001901141 
+  443          506.434      211.65142   0.002257336 
+  480          498.65624    211.50329   0.002083333 
+  463          488.35289    211.35542   0.002159827 
+  436          470.54065    211.20782   0.002293578 
+  412          449.20857    211.06049   0.002427184 
+  392          428.54877    210.91343   0.00255102 
+  418          408.5655     210.76663   0.002392344 
+  370          389.28073    210.62009   0.002702703 
+  378          371.05487    210.47382   0.002645503 
+  355          354.26849    210.32781   0.002816901 
+  335          339.1616     210.18207   0.002985075 
+  309          325.80422    210.03659   0.003236246 
+  297          314.14896    209.89137   0.003367003 
+  300          304.07885    209.74641   0.003333333 
+  281          295.45606    209.60171   0.003558719 
+  256          288.15623    209.45726   0.00390625 
+  274          282.10125    209.31308   0.003649635 
+  260          277.28509    209.16916   0.003846154 
+  285          273.7926     209.02549   0.003508772 
+  279          271.72856    208.88208   0.003584229 
+  282          270.77025    208.73893   0.003546099 
+  246          269.2449     208.59603   0.004065041 
+  264          265.52549    208.45339   0.003787879 
+  242          261.05498    208.311     0.004132231 
+  243          257.64591    208.16886   0.004115226 
+  246          255.27904    208.02698   0.004065041 
+  218          252.71757    207.88535   0.004587156 
+  243          249.4384     207.74397   0.004115226 
+  239          246.30572    207.60285   0.0041841 
+  219          243.83425    207.46197   0.00456621 
+  219          241.99737    207.32134   0.00456621 
+  220          240.66325    207.18096   0.004545455 
+  227          239.7091     207.04083   0.004405286 
+  241          239.07683    206.90095   0.004149378 
+  263          238.72828    206.76132   0.003802281 
+  254          238.63938    206.62193   0.003937008 
+  220          238.79281    206.48279   0.004545455 
+  246          239.18106    206.34389   0.004065041 
+  212          239.79809    206.20524   0.004716981 
+  211          240.67906    206.06683   0.004739336 
+  226          241.86919    205.92867   0.004424779 
+  242          243.2349     205.79075   0.004132231 
+  223          243.97159    205.65307   0.004484305 
+  219          243.1403     205.51564   0.00456621 
+  216          241.43201    205.37844   0.00462963 
+  212          239.99097    205.24149   0.004716981 
+  211          239.0313     205.10477   0.004739336 
+  242          238.05516    204.9683    0.004132231 
+  226          236.79432    204.83206   0.004424779 
+  232          235.79971    204.69606   0.004310345 
+  209          235.36581    204.5603    0.004784689 
+  218          234.98882    204.42478   0.004587156 
+  217          234.31856    204.28949   0.004608295 
+  238          234.10894    204.15444   0.004201681 
+  219          235.1478     204.01963   0.00456621 
+  229          237.54064    203.88505   0.004366812 
+  241          240.26267    203.7507    0.004149378 
+  222          241.21926    203.61659   0.004504505 
+  236          240.03667    203.48271   0.004237288 
+  239          238.47349    203.34906   0.0041841 
+  221          237.5348     203.21564   0.004524887 
+  231          237.47434    203.08246   0.004329004 
+  239          237.66026    202.94951   0.0041841 
+  243          237.81125    202.81678   0.004115226 
+  246          237.275      202.68429   0.004065041 
+  218          235.08392    202.55203   0.004587156 
+  220          232.53262    202.41999   0.004545455 
+  218          231.10058    202.28818   0.004587156 
+  240          230.8283     202.1566    0.004166667 
+  237          230.81712    202.02525   0.004219409 
+  257          230.5612     201.89412   0.003891051 
+  226          230.78188    201.76322   0.004424779 
+  241          232.23926    201.63254   0.004149378 
+  238          235.49246    201.50209   0.004201681 
+  271          241.4932     201.37186   0.003690037 
+  246          252.14956    201.24186   0.004065041 
+  273          270.57766    201.11208   0.003663004 
+  328          299.66215    200.98252   0.00304878 
+  317          328.59669    200.85318   0.003154574 
+  339          324.41884    200.72407   0.002949853 
+  329          303.09507    200.59518   0.003039514 
+  324          290.72744    200.4665    0.00308642 
+  331          290.69499    200.33805   0.003021148 
+  328          292.49165    200.20982   0.00304878 
+  319          279.66053    200.0818    0.003134796 
+  300          263.50725    199.954     0.003333333 
+  278          252.27446    199.82642   0.003597122 
+  265          245.89969    199.69906   0.003773585 
+  250          242.6978     199.57192   0.004     
+  275          240.29605    199.44499   0.003636364 
+  253          237.74795    199.31828   0.003952569 
+  269          235.4718     199.19178   0.003717472 
+  252          233.95966    199.0655    0.003968254 
+  240          233.1958     198.93943   0.004166667 
+  249          232.58706    198.81357   0.004016064 
+  253          232.08218    198.68793   0.003952569 
+  259          231.97404    198.5625    0.003861004 
+  234          232.21688    198.43729   0.004273504 
+  219          232.08871    198.31228   0.00456621 
+  226          231.31058    198.18749   0.004424779 
+  213          230.64917    198.06291   0.004694836 
+  232          230.53774    197.93853   0.004310345 
+  210          230.7407     197.81437   0.004761905 
+  192          230.69325    197.69042   0.005208333 
+  204          230.29427    197.56667   0.004901961 
+  223          229.92209    197.44314   0.004484305 
+  203          229.76182    197.31981   0.004926108 
+  218          229.80921    197.19669   0.004587156 
+  214          230.04306    197.07377   0.004672897 
+  203          230.45481    196.95107   0.004926108 
+  228          231.0606     196.82856   0.004385965 
+  202          231.90416    196.70627   0.004950495 
+  235          233.0536     196.58418   0.004255319 
+  196          234.60945    196.46229   0.005102041 
+  228          236.68435    196.34061   0.004385965 
+  246          239.2777     196.21913   0.004065041 
+  226          241.88888    196.09785   0.004424779 
+  219          243.6375     195.97678   0.00456621 
+  241          244.74149    195.85591   0.004149378 
+  251          246.12328    195.73524   0.003984064 
+  249          248.05838    195.61477   0.004016064 
+  255          250.16797    195.4945    0.003921569 
+  244          251.93234    195.37444   0.004098361 
+  217          253.47881    195.25457   0.004608295 
+  251          255.24621    195.1349    0.003984064 
+  218          257.4019     195.01543   0.004587156 
+  244          259.97906    194.89617   0.004098361 
+  268          262.99816    194.77709   0.003731343 
+  260          266.51508    194.65822   0.003846154 
+  261          270.61359    194.53954   0.003831418 
+  253          275.40565    194.42106   0.003952569 
+  272          281.02525    194.30278   0.003676471 
+  279          287.63376    194.18469   0.003584229 
+  246          295.42705    194.0668    0.004065041 
+  300          304.65874    193.9491    0.003333333 
+  292          315.66961    193.8316    0.003424658 
+  326          328.92895    193.71429   0.003067485 
+  339          345.09412    193.59718   0.002949853 
+  347          365.06604    193.48026   0.002881844 
+  369          389.90027    193.36353   0.002710027 
+  403          420.13286    193.24699   0.00248139 
+  442          454.79691    193.13065   0.002262443 
+  481          494.37727    193.0145    0.002079002 
+  540          544.6116     192.89854   0.001851852 
+  601          612.83911    192.78277   0.001663894 
+  630          707.06217    192.66719   0.001587302 
+  703          839.20412    192.5518    0.001422475 
+  901          1031.64722   192.4366    0.001109878 
+  1199         1332.7138    192.32159   0.000834028 
+  1659         1846.49183   192.20676   0.000602773 
+  2525         2821.69775   192.09213   0.00039604 
+  4064         4776.00061   191.97768   0.000246063 
+  6720         8258.63574   191.86343   0.00014881 
+  9481         11063.88769  191.74935   0.000105474 
+  9801         8772.80484   191.63547   0.00010203 
+  6877         5811.96817   191.52177   0.000145412 
+  4840         4836.99271   191.40826   0.000206612 
+  4744         5594.07491   191.29493   0.000210793 
+  5588         6382.602     191.18179   0.000178955 
+  4980         4779.74655   191.06883   0.000200803 
+  3264         2897.65778   190.95606   0.000306373 
+  1997         1824.15415   190.84347   0.000500751 
+  1217         1269.78541   190.73107   0.000821693 
+  897          964.54893    190.61884   0.001114827 
+  688          777.7267     190.5068    0.001453488 
+  617          653.5409     190.39495   0.001620746 
+  563          566.34338    190.28327   0.001776199 
+  506          502.63493    190.17178   0.001976285 
+  400          454.63215    190.06047   0.0025    
+  390          417.58574    189.94934   0.002564103 
+  372          388.47211    189.83838   0.002688172 
+  343          365.29821    189.72761   0.002915452 
+  302          346.74283    189.61702   0.003311258 
+  347          331.94779    189.50661   0.002881844 
+  335          320.42057    189.39638   0.002985075 
+  336          312.00953    189.28632   0.00297619 
+  319          306.9389     189.17645   0.003134796 
+  305          305.78675    189.06675   0.003278689 
+  357          309.06378    188.95723   0.00280112 
+  326          315.05063    188.84789   0.003067485 
+  293          316.64578    188.73872   0.003412969 
+  275          308.95542    188.62973   0.003636364 
+  290          299.00498    188.52091   0.003448276 
+  307          294.01945    188.41228   0.003257329 
+  268          295.06591    188.30381   0.003731343 
+  277          298.83935    188.19552   0.003610108 
+  299          302.15775    188.08741   0.003344482 
+  289          304.54356    187.97947   0.003460208 
+  280          300.49576    187.8717    0.003571429 
+  277          287.80751    187.76411   0.003610108 
+  288          274.87891    187.65669   0.003472222 
+  256          267.224      187.54945   0.00390625 
+  235          263.68718    187.44237   0.004255319 
+  260          258.89504    187.33547   0.003846154 
+  229          249.9346     187.22874   0.004366812 
+  248          240.2078     187.12218   0.004032258 
+  262          232.43777    187.0158    0.003816794 
+  241          226.76249    186.90958   0.004149378 
+  232          222.60246    186.80354   0.004310345 
+  222          219.44612    186.69766   0.004504505 
+  196          216.95295    186.59195   0.005102041 
+  204          214.91125    186.48642   0.004901961 
+  211          213.19109    186.38105   0.004739336 
+  197          211.71077    186.27585   0.005076142 
+  200          210.4151     186.17082   0.005     
+  192          209.27088    186.06596   0.005208333 
+  189          208.25048    185.96127   0.005291005 
+  197          207.33575    185.85674   0.005076142 
+  223          206.51216    185.75238   0.004484305 
+  213          205.7714     185.64819   0.004694836 
+  196          205.10546    185.54416   0.005102041 
+  193          204.51435    185.4403    0.005181347 
+  210          203.98552    185.3366    0.004761905 
+  212          203.52243    185.23308   0.004716981 
+  219          203.12567    185.12971   0.00456621 
+  196          202.79824    185.02651   0.005102041 
+  217          202.54694    184.92348   0.004608295 
+  203          202.38645    184.82061   0.004926108 
+  218          202.33044    184.7179    0.004587156 
+  199          202.39307    184.61536   0.005025126 
+  193          202.52998    184.51298   0.005181347 
+  183          202.55397    184.41077   0.005464481 
+  211          202.38061    184.30871   0.004739336 
+  174          202.17843    184.20682   0.005747126 
+  197          202.1359     184.10509   0.005076142 
+  172          202.29876    184.00353   0.005813953 
+  215          202.60483    183.90212   0.004651163 
+  203          203.01698    183.80088   0.004926108 
+  187          203.64443    183.69979   0.005347594 
+  188          204.68727    183.59887   0.005319149 
+  198          206.35802    183.49811   0.005050505 
+  200          208.96205    183.3975    0.005     
+  221          213.0072     183.29706   0.004524887 
+  200          219.29231    183.19678   0.005     
+  232          228.80853    183.09665   0.004310345 
+  237          241.68761    182.99669   0.004219409 
+  254          253.66492    182.89688   0.003937008 
+  234          255.73375    182.79723   0.004273504 
+  221          248.09348    182.69774   0.004524887 
+  197          240.46572    182.59841   0.005076142 
+  207          237.66231    182.49923   0.004830918 
+  233          238.20594    182.40021   0.004291845 
+  212          236.78453    182.30135   0.004716981 
+  231          231.22172    182.20265   0.004329004 
+  222          225.51423    182.1041    0.004504505 
+  227          222.38983    182.0057    0.004405286 
+  220          222.00106    181.90747   0.004545455 
+  196          223.5032     181.80938   0.005102041 
+  213          224.1235     181.71146   0.004694836 
+  202          221.52451    181.61368   0.004950495 
+  193          217.81028    181.51607   0.005181347 
+  221          215.4673     181.4186    0.004524887 
+  206          214.92424    181.3213    0.004854369 
+  231          215.00883    181.22414   0.004329004 
+  233          214.10195    181.12714   0.004291845 
+  218          212.77033    181.03029   0.004587156 
+  212          212.56383    180.93359   0.004716981 
+  252          214.04861    180.83705   0.003968254 
+  261          216.8827     180.74066   0.003831418 
+  253          220.16786    180.64442   0.003952569 
+  260          224.18685    180.54834   0.003846154 
+  286          230.7765     180.4524    0.003496503 
+  261          240.87558    180.35662   0.003831418 
+  276          252.17049    180.26099   0.003623188 
+  259          258.51873    180.16551   0.003861004 
+  252          257.39483    180.07018   0.003968254 
+  243          255.40361    179.975     0.004115226 
+  274          258.80914    179.87997   0.003649635 
+  299          268.60768    179.78509   0.003344482 
+  282          281.18943    179.69035   0.003546099 
+  285          290.87287    179.59577   0.003508772 
+  286          297.25142    179.50134   0.003496503 
+  289          303.35739    179.40706   0.003460208 
+  300          313.22559    179.31292   0.003333333 
+  304          336.8799     179.21894   0.003289474 
+  333          386.31148    179.1251    0.003003003 
+  442          473.72106    179.03141   0.002262443 
+  449          587.29458    178.93787   0.002227171 
+  552          617.50604    178.84447   0.001811594 
+  477          522.10859    178.75122   0.002096436 
+  435          436.21479    178.65812   0.002298851 
+  397          408.06436    178.56517   0.002518892 
+  381          427.01512    178.47236   0.002624672 
+  373          442.89934    178.3797    0.002680965 
+  340          395.56391    178.28718   0.002941176 
+  304          332.61722    178.19481   0.003289474 
+  295          291.06084    178.10259   0.003389831 
+  228          267.49564    178.01051   0.004385965 
+  260          255.36391    177.91857   0.003846154 
+  232          251.35633    177.82678   0.004310345 
+  241          255.04357    177.73514   0.004149378 
+  267          269.47271    177.64364   0.003745318 
+  288          303.01236    177.55228   0.003472222 
+  371          365.95851    177.46107   0.002695418 
+  408          423.93504    177.37      0.00245098 
+  382          388.6342     177.27907   0.002617801 
+  416          331.02476    177.18829   0.002403846 
+  352          311.00438    177.09765   0.002840909 
+  382          327.48998    177.00716   0.002617801 
+  380          363.01471    176.9168    0.002631579 
+  367          358.921      176.82659   0.002724796 
+  343          311.75575    176.73652   0.002915452 
+  278          274.33404    176.64659   0.003597122 
+  268          253.99276    176.55681   0.003731343 
+  245          245.28515    176.46716   0.004081633 
+  256          239.89858    176.37766   0.00390625 
+  226          231.52093    176.28829   0.004424779 
+  222          221.24586    176.19907   0.004504505 
+  211          213.03245    176.10999   0.004739336 
+  177          208.1147     176.02105   0.005649718 
+  211          204.79319    175.93225   0.004739336 
+  190          202.79702    175.84359   0.005263158 
+  192          201.38594    175.75507   0.005208333 
+  168          200.23575    175.66669   0.005952381 
+  199          199.57121    175.57845   0.005025126 
+  187          199.58397    175.49034   0.005347594 
+  188          200.30187    175.40238   0.005319149 
+  196          201.69677    175.31455   0.005102041 
+  207          203.85878    175.22687   0.004830918 
+  196          207.30495    175.13932   0.005102041 
+  201          212.91827    175.05191   0.004975124 
+  215          221.92047    174.96464   0.004651163 
+  227          235.95413    174.8775    0.004405286 
+  216          256.17286    174.7905    0.00462963 
+  289          278.99772    174.70364   0.003460208 
+  326          290.61542    174.61692   0.003067485 
+  285          281.64457    174.53034   0.003508772 
+  263          265.1565     174.44389   0.003802281 
+  252          254.76561    174.35757   0.003968254 
+  240          252.64315    174.2714    0.004166667 
+  254          252.7912     174.18536   0.003937008 
+  219          245.91437    174.09945   0.00456621 
+  233          232.31277    174.01369   0.004291845 
+  180          219.27463    173.92805   0.005555556 
+  183          209.77461    173.84256   0.005464481 
+  198          203.40994    173.75719   0.005050505 
+  192          199.20674    173.67197   0.005208333 
+  175          196.41695    173.58687   0.005714286 
+  191          194.55858    173.50192   0.005235602 
+  203          193.34111    173.41709   0.004926108 
+  180          192.58964    173.33241   0.005555556 
+  199          192.20345    173.24785   0.005025126 
+  192          192.12958    173.16343   0.005208333 
+  192          192.34835    173.07914   0.005208333 
+  177          192.8353     172.99499   0.005649718 
+  210          193.41       172.91097   0.004761905 
+  180          193.56255    172.82708   0.005555556 
+  184          193.01311    172.74333   0.005434783 
+  188          192.25368    172.65971   0.005319149 
+  203          191.76188    172.57622   0.004926108 
+  198          191.6536     172.49286   0.005050505 
+  187          191.80539    172.40964   0.005347594 
+  203          192.00837    172.32655   0.004926108 
+  211          192.35636    172.24359   0.004739336 
+  197          192.90382    172.16076   0.005076142 
+  209          192.97256    172.07806   0.004784689 
+  205          192.05037    171.9955    0.004878049 
+  246          190.87298    171.91306   0.004065041 
+  231          190.20809    171.83076   0.004329004 
+  226          190.20733    171.74859   0.004424779 
+  246          190.59966    171.66655   0.004065041 
+  284          190.9296     171.58464   0.003521127 
+  254          191.26433    171.50286   0.003937008 
+  284          192.02549    171.42121   0.003521127 
+  304          193.02959    171.33969   0.003289474 
+  285          193.68606    171.2583    0.003508772 
+  262          194.30511    171.17704   0.003816794 
+  263          195.7835     171.09591   0.003802281 
+  259          198.70705    171.01491   0.003861004 
+  275          203.44395    170.93404   0.003636364 
+  272          209.39196    170.8533    0.003676471 
+  248          213.56242    170.77269   0.004032258 
+  264          212.50332    170.6922    0.003787879 
+  250          208.11299    170.61185   0.004     
+  233          204.66043    170.53162   0.004291845 
+  211          203.76957    170.45152   0.004739336 
+  214          204.78625    170.37155   0.004672897 
+  206          205.44249    170.29171   0.004854369 
+  194          204.25999    170.21199   0.005154639 
+  199          202.28517    170.13241   0.005025126 
+  218          200.52686    170.05295   0.004587156 
+  192          199.4234     169.97362   0.005208333 
+  204          198.7969     169.89441   0.004901961 
+  234          198.60481    169.81534   0.004273504 
+  199          199.37138    169.73638   0.005025126 
+  221          201.33802    169.65756   0.004524887 
+  227          204.79747    169.57886   0.004405286 
+  190          210.14438    169.50029   0.005263158 
+  210          216.53825    169.42185   0.004761905 
+  234          220.4505     169.34353   0.004273504 
+  259          218.45029    169.26534   0.003861004 
+  249          213.47243    169.18728   0.004016064 
+  227          209.99652    169.10934   0.004405286 
+  210          209.28196    169.03152   0.004761905 
+  201          210.20133    168.95383   0.004975124 
+  217          209.99205    168.87627   0.004608295 
+  225          207.39744    168.79883   0.004444444 
+  194          204.3425     168.72152   0.005154639 
+  207          202.33665    168.64433   0.004830918 
+  218          201.54561    168.56727   0.004587156 
+  209          201.74649    168.49033   0.004784689 
+  202          202.75657    168.41352   0.004950495 
+  220          204.48791    168.33683   0.004545455 
+  230          206.8714     168.26026   0.004347826 
+  245          209.65923    168.18382   0.004081633 
+  229          212.41326    168.1075    0.004366812 
+  237          215.18393    168.03131   0.004219409 
+  221          218.51554    167.95524   0.004524887 
+  241          222.74549    167.87929   0.004149378 
+  249          227.9437     167.80347   0.004016064 
+  247          233.9885     167.72777   0.004048583 
+  272          240.72848    167.6522    0.003676471 
+  264          248.31832    167.57674   0.003787879 
+  246          257.00222    167.50141   0.004065041 
+  303          266.84151    167.42621   0.00330033 
+  286          277.77759    167.35112   0.003496503 
+  289          289.73998    167.27616   0.003460208 
+  296          302.65636    167.20132   0.003378378 
+  287          316.03609    167.1266    0.003484321 
+  297          327.8535     167.05201   0.003367003 
+  329          335.20015    166.97753   0.003039514 
+  355          338.01018    166.90318   0.002816901 
+  347          339.14412    166.82895   0.002881844 
+  348          340.72929    166.75485   0.002873563 
+  291          340.75244    166.68086   0.003436426 
+  329          336.53546    166.60699   0.003039514 
+  347          328.95656    166.53325   0.002881844 
+  298          319.85742    166.45963   0.003355705 
+  341          310.87655    166.38613   0.002932551 
+  292          303.34152    166.31275   0.003424658 
+  279          296.21893    166.23949   0.003584229 
+  272          288.67222    166.16635   0.003676471 
+  237          281.39942    166.09333   0.004219409 
+  253          274.08827    166.02043   0.003952569 
+  270          266.82559    165.94765   0.003703704 
+  283          260.0037     165.875     0.003533569 
+  242          253.73293    165.80246   0.004132231 
+  227          247.88924    165.73004   0.004405286 
+  248          242.33435    165.65775   0.004032258 
+  208          237.06271    165.58557   0.004807692 
+  248          231.93424    165.51351   0.004032258 
+  233          227.07993    165.44157   0.004291845 
+  246          222.58307    165.36975   0.004065041 
+  196          218.51986    165.29805   0.005102041 
+  233          214.94304    165.22647   0.004291845 
+  236          211.87858    165.15501   0.004237288 
+  215          209.33751    165.08367   0.004651163 
+  207          207.34276    165.01244   0.004830918 
+  216          205.95378    164.94134   0.00462963 
+  202          205.22695    164.87035   0.004950495 
+  211          205.06489    164.79948   0.004739336 
+  218          204.95093    164.72873   0.004587156 
+  215          204.31934    164.6581    0.004651163 
+  205          203.56067    164.58759   0.004878049 
+  197          203.08115    164.5172    0.005076142 
+  225          202.59934    164.44692   0.004444444 
+  218          202.04609    164.37676   0.004587156 
+  218          201.58654    164.30672   0.004587156 
+  210          201.24228    164.23679   0.004761905 
+  252          201.24823    164.16699   0.003968254 
+  238          201.73178    164.0973    0.004201681 
+  217          202.28666    164.02773   0.004608295 
+  245          203.71356    163.95827   0.004081633 
+  237          206.26637    163.88894   0.004219409 
+  257          210.67544    163.81972   0.003891051 
+  284          218.3485     163.75061   0.003521127 
+  281          232.58216    163.68163   0.003558719 
+  286          261.59006    163.61276   0.003496503 
+  315          317.50233    163.544     0.003174603 
+  342          385.10792    163.47537   0.002923977 
+  350          368.8779     163.40685   0.002857143 
+  330          307.12513    163.33844   0.003030303 
+  356          275.54638    163.27016   0.002808989 
+  289          273.89956    163.20199   0.003460208 
+  318          294.13094    163.13393   0.003144654 
+  314          316.66495    163.06599   0.003184713 
+  266          294.00803    162.99817   0.003759398 
+  260          256.35514    162.93046   0.003846154 
+  257          234.7275     162.86287   0.003891051 
+  246          224.60231    162.79539   0.004065041 
+  260          218.81046    162.72803   0.003846154 
+  222          213.8992     162.66078   0.004504505 
+  245          209.97994    162.59365   0.004081633 
+  244          207.46725    162.52664   0.004098361 
+  236          205.94462    162.45974   0.004237288 
+  200          204.78376    162.39295   0.005     
+  201          203.94928    162.32628   0.004975124 
+  225          203.76379    162.25973   0.004444444 
+  213          204.41185    162.19328   0.004694836 
+  215          205.99432    162.12696   0.004651163 
+  256          208.62083    162.06075   0.00390625 
+  241          212.63784    161.99465   0.004149378 
+  249          219.13169    161.92867   0.004016064 
+  254          230.10266    161.8628    0.003937008 
+  248          248.27799    161.79704   0.004032258 
+  274          275.72117    161.7314    0.003649635 
+  312          305.96841    161.66587   0.003205128 
+  328          308.82185    161.60046   0.00304878 
+  297          281.84609    161.53516   0.003367003 
+  288          260.28147    161.46998   0.003472222 
+  281          253.75308    161.4049    0.003558719 
+  246          259.66053    161.33995   0.004065041 
+  260          271.28516    161.2751    0.003846154 
+  290          271.66248    161.21037   0.003448276 
+  251          259.76673    161.14575   0.003984064 
+  279          251.35224    161.08125   0.003584229 
+  259          246.62541    161.01686   0.003861004 
+  223          240.58275    160.95258   0.004484305 
+  243          233.95266    160.88841   0.004115226 
+  243          229.67562    160.82436   0.004115226 
+  247          228.56973    160.76042   0.004048583 
+  213          229.82637    160.69659   0.004694836 
+  258          231.38364    160.63288   0.003875969 
+  219          231.58939    160.56927   0.00456621 
+  250          231.91706    160.50578   0.004     
+  227          235.12934    160.44241   0.004405286 
+  247          243.40469    160.37914   0.004048583 
+  257          257.17167    160.31599   0.003891051 
+  280          267.14889    160.25295   0.003571429 
+  273          260.78154    160.19002   0.003663004 
+  252          250.34095    160.1272    0.003968254 
+  259          245.73791    160.06449   0.003861004 
+  258          247.3286     160.0019    0.003875969 
+  234          253.75229    159.93942   0.004273504 
+  304          259.61073    159.87705   0.003289474 
+  259          257.90388    159.81479   0.003861004 
+  267          254.19586    159.75264   0.003745318 
+  252          253.34345    159.69061   0.003968254 
+  269          255.07896    159.62868   0.003717472 
+  269          258.32215    159.56687   0.003717472 
+  261          262.41564    159.50517   0.003831418 
+  285          267.33272    159.44358   0.003508772 
+  263          273.15679    159.3821    0.003802281 
+  280          279.77501    159.32073   0.003571429 
+  274          287.09367    159.25947   0.003649635 
+  284          295.21154    159.19833   0.003521127 
+  334          304.28394    159.13729   0.002994012 
+  314          314.57154    159.07636   0.003184713 
+  312          326.32225    159.01555   0.003205128 
+  344          339.68041    158.95484   0.002906977 
+  372          354.85255    158.89425   0.002688172 
+  418          372.2434     158.83376   0.002392344 
+  405          392.35941    158.77339   0.002469136 
+  433          415.77415    158.71313   0.002309469 
+  428          443.20631    158.65297   0.002336449 
+  474          475.50901    158.59293   0.002109705 
+  560          513.53602    158.533     0.001785714 
+  639          558.39616    158.47317   0.001564945 
+  714          612.37907    158.41346   0.00140056 
+  789          678.92774    158.35386   0.001267427 
+  855          762.4365     158.29436   0.001169591 
+  962          868.91659    158.23498   0.001039501 
+  930          1007.26195   158.1757    0.001075269 
+  1080         1191.21752   158.11654   0.000925926 
+  1282         1443.41155   158.05748   0.000780031 
+  1577         1802.65316   157.99853   0.000634115 
+  2111         2340.12641   157.9397    0.000473709 
+  2920         3200.61702   157.88097   0.000342466 
+  4387         4709.58102   157.82235   0.000227946 
+  7142         7569.41209   157.76384   0.000140017 
+  12014        12931.50528  157.70544   0.000083236 
+  18270        20579.10162  157.64715   0.000054735 
+  21303        22427.64608  157.58896   0.000046942 
+  16619        15771.92422  157.53089   0.000060172 
+  10785        10302.71646  157.47292   0.000092721 
+  8073         8183.67924   157.41506   0.00012387 
+  8379         8829.49208   157.35732   0.000119346 
+  9888         11577.93633  157.29968   0.000101133 
+  11213        12673.48324  157.24214   0.000089182 
+  9161         9139.55595   157.18472   0.000109158 
+  5706         5587.50377   157.12741   0.000175254 
+  3441         3534.67136   157.0702    0.000290613 
+  2199         2436.77086   157.0131    0.000454752 
+  1582         1818.77536   156.95611   0.000632111 
+  1319         1442.2329    156.89923   0.00075815 
+  1022         1201.11545   156.84245   0.000978474 
+  958          1029.18889   156.78579   0.001043841 
+  801          878.29553    156.72923   0.001248439 
+  723          758.39357    156.67278   0.001383126 
+  640          670.44781    156.61644   0.0015625 
+  597          606.31655    156.5602    0.001675042 
+  592          560.682      156.50407   0.001689189 
+  521          524.75198    156.44805   0.001919386 
+  444          482.75468    156.39214   0.002252252 
+  486          442.64128    156.33633   0.002057613 
+  401          411.14544    156.28064   0.002493766 
+  399          386.22602    156.22505   0.002506266 
+  352          365.7261     156.16956   0.002840909 
+  369          348.3815     156.11419   0.002710027 
+  345          333.46673    156.05892   0.002898551 
+  325          320.51242    156.00375   0.003076923 
+  346          309.17678    155.9487    0.002890173 
+  304          299.20732    155.89375   0.003289474 
+  326          290.41739    155.83891   0.003067485 
+  303          282.66396    155.78418   0.00330033 
+  258          275.82247    155.72955   0.003875969 
+  272          269.78884    155.67503   0.003676471 
+  244          264.47552    155.62061   0.004098361 
+  259          259.79932    155.5663    0.003861004 
+  271          255.68564    155.5121    0.003690037 
+  254          252.06727    155.45801   0.003937008 
+  272          248.89148    155.40402   0.003676471 
+  259          246.15099    155.35014   0.003861004 
+  254          243.92549    155.29636   0.003937008 
+  252          242.40373    155.24269   0.003968254 
+  226          241.70025    155.18913   0.004424779 
+  265          240.83947    155.13567   0.003773585 
+  237          238.07101    155.08232   0.004219409 
+  225          234.6428     155.02907   0.004444444 
+  240          231.92559    154.97593   0.004166667 
+  253          229.98093    154.9229    0.003952569 
+  224          228.7461     154.86997   0.004464286 
+  212          227.85931    154.81715   0.004716981 
+  212          226.27082    154.76443   0.004716981 
+  226          224.05637    154.71182   0.004424779 
+  223          222.06316    154.65931   0.004484305 
+  232          220.45117    154.60691   0.004310345 
+  215          219.19468    154.55462   0.004651163 
+  237          218.26662    154.50243   0.004219409 
+  247          217.61598    154.45034   0.004048583 
+  224          217.17575    154.39836   0.004464286 
+  230          216.86888    154.34649   0.004347826 
+  235          216.6315     154.29472   0.004255319 
+  220          216.41206    154.24306   0.004545455 
+  254          216.17772    154.1915    0.003937008 
+  238          215.93606    154.14004   0.004201681 
+  264          215.74226    154.08869   0.003787879 
+  247          215.60468    154.03745   0.004048583 
+  261          215.26327    153.98631   0.003831418 
+  265          214.15734    153.93528   0.003773585 
+  246          212.4145     153.88435   0.004065041 
+  249          210.85474    153.83352   0.004016064 
+  261          210.03807    153.7828    0.003831418 
+  268          210.03829    153.73218   0.003731343 
+  249          210.16125    153.68167   0.004016064 
+  267          208.83298    153.63126   0.003745318 
+  233          205.67812    153.58096   0.004291845 
+  235          202.24897    153.53076   0.004255319 
+  229          199.70593    153.48067   0.004366812 
+  210          198.2686     153.43068   0.004761905 
+  222          197.6784     153.38079   0.004504505 
+  220          197.28358    153.33101   0.004545455 
+  197          196.628      153.28133   0.005076142 
+  258          196.22856    153.23176   0.003875969 
+  198          196.85847    153.18229   0.005050505 
+  226          198.95968    153.13292   0.004424779 
+  202          202.56247    153.08366   0.004950495 
+  209          206.64414    153.0345    0.004784689 
+  221          209.07473    152.98544   0.004524887 
+  232          209.49005    152.93649   0.004310345 
+  219          209.065      152.88764   0.00456621 
+  192          207.5149     152.8389    0.005208333 
+  231          205.34049    152.79026   0.004329004 
+  198          204.00389    152.74172   0.005050505 
+  241          203.34313    152.69328   0.004149378 
+  210          202.53413    152.64495   0.004761905 
+  204          201.83462    152.59672   0.004901961 
+  204          201.25703    152.5486    0.004901961 
+  224          200.57958    152.50058   0.004464286 
+  195          200.38435    152.45266   0.005128205 
+  219          200.68879    152.40484   0.00456621 
+  194          200.48282    152.35713   0.005154639 
+  190          199.59929    152.30952   0.005263158 
+  203          199.03119    152.26201   0.004926108 
+  195          199.39979    152.21461   0.005128205 
+  215          200.78274    152.16731   0.004651163 
+  198          202.9865     152.12011   0.005050505 
+  199          205.53516    152.07301   0.005025126 
+  195          208.13342    152.02602   0.005128205 
+  225          211.26865    151.97913   0.004444444 
+  208          215.48634    151.93234   0.004807692 
+  223          220.83657    151.88565   0.004484305 
+  209          227.30101    151.83907   0.004784689 
+  229          234.96596    151.79259   0.004366812 
+  228          242.79331    151.74621   0.004385965 
+  280          248.74302    151.69993   0.003571429 
+  259          253.55854    151.65376   0.003861004 
+  278          260.30545    151.60768   0.003597122 
+  279          270.94771    151.56171   0.003584229 
+  287          285.96228    151.51585   0.003484321 
+  304          304.66784    151.47008   0.003289474 
+  299          326.51957    151.42441   0.003344482 
+  326          354.43079    151.37885   0.003067485 
+  352          395.55032    151.33339   0.002840909 
+  407          458.81074    151.28803   0.002457002 
+  564          560.92066    151.24277   0.00177305 
+  666          736.70391    151.19761   0.001501502 
+  998          1062.01422   151.15256   0.001002004 
+  1522         1672.89205   151.10761   0.00065703 
+  2257         2640.2291    151.06275   0.000443066 
+  2778         3223.56509   151.018     0.000359971 
+  2264         2531.33932   150.97335   0.000441696 
+  1539         1686.99408   150.92881   0.000649773 
+  1215         1256.70208   150.88436   0.000823045 
+  1166         1181.78418   150.84001   0.000857633 
+  1298         1409.67035   150.79577   0.000770416 
+  1537         1796.88388   150.75163   0.000650618 
+  1417         1728.09715   150.70758   0.000705716 
+  1107         1211.414     150.66364   0.000903342 
+  799          812.76322    150.6198    0.001251564 
+  522          589.93588    150.57606   0.001915709 
+  457          465.66419    150.53242   0.002188184 
+  329          389.85779    150.48889   0.003039514 
+  290          340.13988    150.44545   0.003448276 
+  259          306.28917    150.40211   0.003861004 
+  293          282.85459    150.35888   0.003412969 
+  262          266.16839    150.31574   0.003816794 
+  251          252.95001    150.27271   0.003984064 
+  232          241.07129    150.22977   0.004310345 
+  225          230.55532    150.18694   0.004444444 
+  227          221.82639    150.1442    0.004405286 
+  187          214.79891    150.10157   0.005347594 
+  238          209.21182    150.05904   0.004201681 
+  201          204.81126    150.0166    0.004975124 
+  204          201.40632    149.97427   0.004901961 
+  216          198.88738    149.93204   0.00462963 
+  184          197.2178     149.8899    0.005434783 
+  186          196.35843    149.84787   0.005376344 
+  197          195.99791    149.80594   0.005076142 
+  203          195.29963    149.7641    0.004926108 
+  187          193.71186    149.72237   0.005347594 
+  203          191.9154     149.68074   0.004926108 
+  203          190.74897    149.6392    0.004926108 
+  208          190.52167    149.59777   0.004807692 
+  180          191.26885    149.55643   0.005555556 
+  192          192.83744    149.5152    0.005208333 
+  200          194.96871    149.47406   0.005     
+  216          197.97447    149.43302   0.00462963 
+  198          203.03651    149.39209   0.005050505 
+  182          211.92895    149.35125   0.005494505 
+  257          227.67593    149.31051   0.003891051 
+  225          255.86428    149.26987   0.004444444 
+  250          304.93024    149.22933   0.004     
+  293          376.19372    149.18889   0.003412969 
+  324          422.244      149.14854   0.00308642 
+  345          382.85134    149.1083    0.002898551 
+  351          318.11501    149.06816   0.002849003 
+  279          278.80702    149.02811   0.003584229 
+  263          267.37296    148.98816   0.003802281 
+  259          279.32836    148.94832   0.003861004 
+  265          304.84751    148.90857   0.003773585 
+  321          308.19174    148.86891   0.003115265 
+  242          273.4218     148.82936   0.004132231 
+  239          237.19442    148.78991   0.0041841 
+  228          213.99329    148.75055   0.004385965 
+  220          200.65014    148.7113    0.004545455 
+  204          192.90215    148.67214   0.004901961 
+  256          188.08507    148.63308   0.00390625 
+  197          185.01348    148.59411   0.005076142 
+  207          183.34823    148.55525   0.004830918 
+  219          182.99103    148.51649   0.00456621 
+  196          183.61144    148.47782   0.005102041 
+  192          184.12552    148.43925   0.005208333 
+  201          183.30636    148.40078   0.004975124 
+  200          181.62091    148.3624    0.005     
+  214          180.39297    148.32413   0.004672897 
+  174          180.2353     148.28595   0.005747126 
+  209          181.22201    148.24787   0.004784689 
+  173          183.10441    148.20988   0.005780347 
+  184          184.75634    148.172     0.005434783 
+  170          184.54264    148.13421   0.005882353 
+  181          182.62594    148.09652   0.005524862 
+  172          180.76901    148.05893   0.005813953 
+  206          180.03862    148.02143   0.004854369 
+  210          180.58763    147.98404   0.004761905 
+  180          182.07581    147.94674   0.005555556 
+  196          183.30404    147.90953   0.005102041 
+  196          182.73488    147.87243   0.005102041 
+  199          180.74304    147.83542   0.005025126 
+  201          178.91608    147.7985    0.004975124 
+  190          178.01073    147.76169   0.005263158 
+  170          178.02959    147.72497   0.005882353 
+  198          178.57877    147.68835   0.005050505 
+  187          178.9054     147.65183   0.005347594 
+  190          178.59126    147.6154    0.005263158 
+  190          178.11647    147.57907   0.005263158 
+  179          178.02396    147.54283   0.005586592 
+  173          178.2996     147.50669   0.005780347 
+  222          178.60716    147.47065   0.004504505 
+  204          178.80353    147.43471   0.004901961 
+  185          179.02871    147.39886   0.005405405 
+  208          179.45186    147.36311   0.004807692 
+  155          180.19389    147.32745   0.006451613 
+  217          181.26216    147.29189   0.004608295 
+  201          182.54796    147.25643   0.004975124 
+  213          183.91254    147.22106   0.004694836 
+  199          185.39235    147.18579   0.005025126 
+  218          187.15843    147.15061   0.004587156 
+  193          189.33426    147.11554   0.005181347 
+  208          192.00184    147.08055   0.004807692 
+  242          195.2301     147.04566   0.004132231 
+  224          198.98482    147.01087   0.004464286 
+  244          202.93283    146.97618   0.004098361 
+  199          206.64896    146.94158   0.005025126 
+  249          210.3945     146.90707   0.004016064 
+  237          214.85682    146.87266   0.004219409 
+  225          220.48854    146.83835   0.004444444 
+  261          227.55289    146.80413   0.003831418 
+  241          236.25753    146.77      0.004149378 
+  266          246.61245    146.73598   0.003759398 
+  281          258.28606    146.70204   0.003558719 
+  317          270.85569    146.66821   0.003154574 
+  354          284.88033    146.63446   0.002824859 
+  319          302.32904    146.60082   0.003134796 
+  358          325.33601    146.56726   0.002793296 
+  337          355.94685    146.53381   0.002967359 
+  378          396.47245    146.50044   0.002645503 
+  436          449.27015    146.46717   0.002293578 
+  509          517.85894    146.434     0.001964637 
+  610          612.63581    146.40092   0.001639344 
+  726          756.49504    146.36794   0.00137741 
+  1042         993.22249    146.33505   0.000959693 
+  1429         1414.33877   146.30225   0.00069979 
+  2211         2199.24407   146.26955   0.000452284 
+  3433         3586.60661   146.23694   0.00029129 
+  4783         5246.80385   146.20443   0.000209074 
+  4650         5185.75404   146.17201   0.000215054 
+  3556         3592.63921   146.13969   0.000281215 
+  2432         2405.28587   146.10746   0.000411184 
+  1817         1889.33772   146.07532   0.000550358 
+  1908         1891.49397   146.04328   0.000524109 
+  2160         2359.37468   146.01133   0.000462963 
+  2635         3029.36919   145.97948   0.000379507 
+  2568         2857.30064   145.94772   0.000389408 
+  1890         1960.4673    145.91605   0.000529101 
+  1175         1272.73577   145.88448   0.000851064 
+  857          884.15108    145.853     0.001166861 
+  620          668.40772    145.82161   0.001612903 
+  510          539.45944    145.79032   0.001960784 
+  435          455.86117    145.75912   0.002298851 
+  415          398.08602    145.72801   0.002409639 
+  367          355.87461    145.697     0.002724796 
+  343          324.07908    145.66608   0.002915452 
+  318          299.7336     145.63525   0.003144654 
+  245          280.69031    145.60452   0.004081633 
+  287          265.61626    145.57388   0.003484321 
+  252          253.67045    145.54333   0.003968254 
+  233          243.94181    145.51288   0.004291845 
+  221          235.62479    145.48252   0.004524887 
+  257          228.32685    145.45225   0.003891051 
+  211          221.79217    145.42207   0.004739336 
+  255          215.89245    145.39198   0.003921569 
+  250          210.5991     145.36199   0.004     
+  207          205.98626    145.33209   0.004830918 
+  218          202.18631    145.30229   0.004587156 
+  198          199.14972    145.27257   0.005050505 
+  230          196.6674     145.24295   0.004347826 
+  204          194.50816    145.21342   0.004901961 
+  205          192.58189    145.18398   0.004878049 
+  179          190.8145     145.15463   0.005586592 
+  194          189.03393    145.12538   0.005154639 
+  221          187.18043    145.09622   0.004524887 
+  186          185.44909    145.06715   0.005376344 
+  194          184.00793    145.03817   0.005154639 
+  190          182.88435    145.00928   0.005263158 
+  203          182.05421    144.98048   0.004926108 
+  198          181.47157    144.95178   0.005050505 
+  178          181.04748    144.92317   0.005617978 
+  203          180.77582    144.89465   0.004926108 
+  202          180.82149    144.86622   0.004950495 
+  220          181.36261    144.83788   0.004545455 
+  193          182.33157    144.80963   0.005181347 
+  213          183.5069     144.78147   0.004694836 
+  191          185.415      144.75341   0.005235602 
+  210          189.82791    144.72543   0.004761905 
+  179          198.08992    144.69755   0.005586592 
+  235          204.04035    144.66976   0.004255319 
+  200          197.63125    144.64205   0.005     
+  214          189.39254    144.61444   0.004672897 
+  196          185.26093    144.58692   0.005102041 
+  184          184.36245    144.55949   0.005434783 
+  195          186.0768     144.53215   0.005128205 
+  204          189.96997    144.5049    0.004901961 
+  202          192.80315    144.47774   0.004950495 
+  198          188.79624    144.45067   0.005050505 
+  209          182.78213    144.42369   0.004784689 
+  190          179.04826    144.3968    0.005263158 
+  167          177.27212    144.37      0.005988024 
+  179          176.63669    144.3433    0.005586592 
+  199          176.44546    144.31668   0.005025126 
+  189          176.09967    144.29015   0.005291005 
+  181          175.48004    144.26371   0.005524862 
+  177          174.89582    144.23736   0.005649718 
+  176          174.56624    144.2111    0.005681818 
+  169          174.53894    144.18493   0.00591716 
+  171          174.81795    144.15884   0.005847953 
+  200          175.44622    144.13285   0.005     
+  192          176.50088    144.10695   0.005208333 
+  201          177.41318    144.08114   0.004975124 
+  184          179.33662    144.05541   0.005434783 
+  187          180.96683    144.02977   0.005347594 
+  186          181.45644    144.00423   0.005376344 
+  181          181.06452    143.97877   0.005524862 
+  184          180.8064     143.9534    0.005434783 
+  192          180.95301    143.92812   0.005208333 
+  203          182.31823    143.90293   0.004926108 
+  181          184.60115    143.87783   0.005524862 
+  201          187.64444    143.85281   0.004975124 
+  232          191.14762    143.82788   0.004310345 
+  191          195.16316    143.80305   0.005235602 
+  193          200.13691    143.7783    0.005181347 
+  212          206.59945    143.75363   0.004716981 
+  186          214.34754    143.72906   0.005376344 
+  240          220.49159    143.70457   0.004166667 
+  243          221.31443    143.68018   0.004115226 
+  210          218.08458    143.65587   0.004761905 
+  200          215.07046    143.63164   0.005     
+  211          214.42528    143.60751   0.004739336 
+  240          216.21902    143.58346   0.004166667 
+  215          219.93316    143.5595    0.004651163 
+  225          224.45113    143.53563   0.004444444 
+  234          227.96793    143.51185   0.004273504 
+  220          230.49509    143.48815   0.004545455 
+  248          234.03755    143.46454   0.004032258 
+  257          239.13085    143.44102   0.003891051 
+  248          243.7036     143.41758   0.004032258 
+  271          246.39755    143.39423   0.003690037 
+  277          249.27138    143.37097   0.003610108 
+  280          254.90155    143.34779   0.003571429 
+  326          264.57219    143.32471   0.003067485 
+  330          278.65282    143.3017    0.003030303 
+  322          296.10301    143.27879   0.00310559 
+  344          313.80839    143.25596   0.002906977 
+  355          330.86943    143.23322   0.002816901 
+  399          352.67099    143.21056   0.002506266 
+  376          379.99565    143.18799   0.002659574 
+  417          406.0896     143.16551   0.002398082 
+  449          436.89334    143.14311   0.002227171 
+  478          467.29062    143.1208    0.00209205 
+  479          500.86238    143.09857   0.002087683 
+  530          552.20379    143.07643   0.001886792 
+  641          631.79602    143.05437   0.001560062 
+  727          751.18803    143.03241   0.001375516 
+  919          926.3728     143.01052   0.001088139 
+  1172         1200.7905    142.98872   0.000853242 
+  1718         1666.89691   142.96701   0.000582072 
+  2589         2511.50649   142.94538   0.00038625 
+  3940         4041.55947   142.92384   0.000253807 
+  5781         6277.26345   142.90238   0.00017298 
+  6455         7314.0287    142.88101   0.000154919 
+  5372         5604.80082   142.85972   0.00018615 
+  3559         3671.92549   142.83852   0.000280978 
+  2554         2611.09117   142.8174    0.000391543 
+  2284         2263.30653   142.79637   0.000437828 
+  2361         2491.44469   142.77542   0.000423549 
+  2886         3270.09343   142.75456   0.0003465 
+  3413         4056.94201   142.73378   0.000292997 
+  3064         3536.27253   142.71308   0.000326371 
+  2244         2359.61277   142.69247   0.000445633 
+  1502         1531.46558   142.67194   0.000665779 
+  1007         1062.81237   142.6515    0.000993049 
+  799          798.91073    142.63114   0.001251564 
+  592          640.40694    142.61086   0.001689189 
+  559          537.69422    142.59067   0.001788909 
+  462          467.2117     142.57056   0.002164502 
+  406          417.00691    142.55054   0.002463054 
+  400          380.29342    142.5306    0.0025    
+  367          352.76768    142.51074   0.002724796 
+  361          331.18998    142.49097   0.002770083 
+  344          313.14074    142.47127   0.002906977 
+  337          297.91259    142.45167   0.002967359 
+  289          285.7536     142.43214   0.003460208 
+  294          276.45432    142.4127    0.003401361 
+  308          269.40777    142.39334   0.003246753 
+  275          264.41199    142.37406   0.003636364 
+  245          261.58498    142.35487   0.004081633 
+  274          260.29767    142.33576   0.003649635 
+  268          258.63093    142.31673   0.003731343 
+  248          254.01009    142.29778   0.004032258 
+  258          246.34238    142.27892   0.003875969 
+  232          238.27077    142.26014   0.004310345 
+  283          231.60234    142.24144   0.003533569 
+  240          226.8941     142.22282   0.004166667 
+  231          224.18025    142.20428   0.004329004 
+  217          222.91334    142.18583   0.004608295 
+  232          221.7152     142.16745   0.004310345 
+  261          219.53449    142.14916   0.003831418 
+  241          217.33124    142.13095   0.004149378 
+  235          216.66881    142.11283   0.004255319 
+  224          218.11767    142.09478   0.004464286 
+  251          221.22269    142.07681   0.003984064 
+  242          224.43835    142.05893   0.004132231 
+  222          224.98067    142.04113   0.004504505 
+  234          221.90772    142.0234    0.004273504 
+  253          218.16668    142.00576   0.003952569 
+  254          216.57845    141.9882    0.003937008 
+  230          218.04008    141.97072   0.004347826 
+  228          222.2737     141.95332   0.004385965 
+  218          227.74582    141.936     0.004587156 
+  228          230.9736     141.91876   0.004385965 
+  236          228.98095    141.9016    0.004237288 
+  217          223.77603    141.88453   0.004608295 
+  210          219.34294    141.86753   0.004761905 
+  210          217.66245    141.85061   0.004761905 
+  200          219.05323    141.83377   0.005     
+  219          222.19721    141.81701   0.00456621 
+  230          223.46063    141.80033   0.004347826 
+  191          220.80265    141.78373   0.005235602 
+  231          215.74604    141.76721   0.004329004 
+  198          210.04251    141.75077   0.005050505 
+  217          204.21842    141.73441   0.004608295 
+  203          199.28836    141.71813   0.004926108 
+  220          196.11037    141.70192   0.004545455 
+  190          193.99627    141.6858    0.005263158 
+  198          191.58269    141.66975   0.005050505 
+  174          189.10499    141.65379   0.005747126 
+  173          187.40912    141.6379    0.005780347 
+  193          186.65229    141.62209   0.005181347 
+  188          186.95122    141.60636   0.005319149 
+  186          188.27367    141.5907    0.005376344 
+  211          188.42635    141.57513   0.004739336 
+  188          184.45751    141.55963   0.005319149 
+  168          178.83248    141.54421   0.005952381 
+  175          174.85601    141.52887   0.005714286 
+  170          173.07477    141.51361   0.005882353 
+  179          173.22728    141.49843   0.005586592 
+  218          174.88008    141.48332   0.004587156 
+  185          176.93745    141.46829   0.005405405 
+  164          177.44076    141.45334   0.006097561 
+  195          176.07984    141.43846   0.005128205 
+  172          175.37719    141.42366   0.005813953 
+  210          176.53237    141.40894   0.004761905 
+  188          178.35026    141.3943    0.005319149 
+  150          178.44618    141.37973   0.006666667 
+  168          175.62453    141.36524   0.005952381 
+  174          171.58298    141.35083   0.005747126 
+  154          168.07096    141.33649   0.006493506 
+  156          165.81161    141.32223   0.006410256 
+  171          164.90844    141.30804   0.005847953 
+  199          164.98183    141.29393   0.005025126 
+  187          165.14524    141.2799    0.005347594 
+  162          164.08804    141.26595   0.00617284 
+  166          161.79526    141.25206   0.006024096 
+  164          159.35615    141.23826   0.006097561 
+  163          157.42562    141.22453   0.006134969 
+  145          156.0848     141.21088   0.006896552 
+  159          155.23885    141.1973    0.006289308 
+  159          154.80218    141.1838    0.006289308 
+  153          154.7356     141.17037   0.006535948 
+  180          155.0395     141.15702   0.005555556 
+  158          155.74766    141.14374   0.006329114 
+  171          156.83849    141.13054   0.005847953 
+  175          157.93766    141.11741   0.005714286 
+  149          158.19717    141.10436   0.006711409 
+  161          157.27411    141.09138   0.00621118 
+  177          155.91891    141.07848   0.005649718 
+  156          154.86355    141.06565   0.006410256 
+  144          154.32182    141.05289   0.006944444 
+  151          154.19362    141.04021   0.006622517 
+  175          154.35004    141.0276    0.005714286 
+  170          154.52228    141.01507   0.005882353 
+  160          154.29901    141.00261   0.00625   
+  184          153.64208    140.99023   0.005434783 
+  151          152.94038    140.97792   0.006622517 
+  169          152.39075    140.96568   0.00591716 
+  166          151.90291    140.95351   0.006024096 
+  138          151.41361    140.94142   0.007246377 
+  163          150.97487    140.9294    0.006134969 
+  176          150.66704    140.91746   0.005681818 
+  172          150.51133    140.90558   0.005813953 
+  164          150.49738    140.89378   0.006097561 
+  157          150.5988     140.88205   0.006369427 
+  130          150.76466    140.8704    0.007692308 
+  182          150.93785    140.85882   0.005494505 
+  156          151.15063    140.84731   0.006410256 
+  127          151.48579    140.83587   0.007874016 
+  157          151.99826    140.8245    0.006369427 
+  145          152.7052     140.81321   0.006896552 
+  141          153.60866    140.80199   0.007092199 
+  157          154.76205    140.79084   0.006369427 
+  146          156.35991    140.77976   0.006849315 
+  175          158.69356    140.76875   0.005714286 
+  187          161.99768    140.75782   0.005347594 
+  170          166.10108    140.74695   0.005882353 
+  199          169.79236    140.73616   0.005025126 
+  169          171.35575    140.72543   0.00591716 
+  187          171.06809    140.71478   0.005347594 
+  205          170.72476    140.7042    0.004878049 
+  175          170.90561    140.69369   0.005714286 
+  162          170.87671    140.68325   0.00617284 
+  171          170.39949    140.67288   0.005847953 
+  164          170.1396     140.66259   0.006097561 
+  189          170.01058    140.65236   0.005291005 
+  147          169.34781    140.6422    0.006802721 
+  168          168.53327    140.63211   0.005952381 
+  193          168.48356    140.62209   0.005181347 
+  171          169.32071    140.61214   0.005847953 
+  164          170.52166    140.60226   0.006097561 
+  180          171.73474    140.59245   0.005555556 
+  182          172.63657    140.58271   0.005494505 
+  159          172.88502    140.57304   0.006289308 
+  165          173.13136    140.56344   0.006060606 
+  180          174.13036    140.55391   0.005555556 
+  191          175.33615    140.54444   0.005235602 
+  161          175.71657    140.53505   0.00621118 
+  169          175.7017     140.52572   0.00591716 
+  190          176.49074    140.51646   0.005263158 
+  197          178.5052     140.50727   0.005076142 
+  184          181.91717    140.49815   0.005434783 
+  187          187.71093    140.4891    0.005347594 
+  200          197.55944    140.48011   0.005     
+  190          213.58084    140.4712    0.005263158 
+  214          239.01359    140.46235   0.004672897 
+  239          276.87787    140.45356   0.0041841 
+  259          315.09376    140.44485   0.003861004 
+  223          314.41799    140.4362    0.004484305 
+  255          277.52237    140.42762   0.003921569 
+  234          244.6901     140.41911   0.004273504 
+  223          228.01171    140.41066   0.004484305 
+  198          225.52339    140.40228   0.005050505 
+  233          235.04053    140.39397   0.004291845 
+  232          254.2685     140.38573   0.004310345 
+  254          272.76854    140.37755   0.003937008 
+  246          268.74963    140.36944   0.004065041 
+  230          245.56703    140.36139   0.004347826 
+  212          225.64284    140.35341   0.004716981 
+  238          215.65683    140.3455    0.004201681 
+  222          214.22712    140.33765   0.004504505 
+  221          219.11175    140.32987   0.004524887 
+  198          227.89681    140.32215   0.005050505 
+  217          239.36605    140.3145    0.004608295 
+  261          256.72846    140.30691   0.003831418 
+  289          287.41366    140.29939   0.003460208 
+  276          334.12589    140.29194   0.003623188 
+  348          369.41987    140.28455   0.002873563 
+  296          350.66552    140.27722   0.003378378 
+  313          307.10995    140.26996   0.003194888 
+  277          278.41766    140.26277   0.003610108 
+  257          270.93329    140.25563   0.003891051 
+  262          284.21702    140.24857   0.003816794 
+  298          319.79485    140.24156   0.003355705 
+  310          370.47812    140.23463   0.003225806 
+  315          393.86715    140.22775   0.003174603 
+  318          355.23747    140.22094   0.003144654 
+  266          296.69019    140.21419   0.003759398 
+  232          254.37616    140.20751   0.004310345 
+  228          231.13883    140.20089   0.004385965 
+  231          222.50961    140.19433   0.004329004 
+  204          225.27998    140.18784   0.004901961 
+  215          234.59413    140.18141   0.004651163 
+  211          235.64628    140.17504   0.004739336 
+  196          219.52656    140.16874   0.005102041 
+  196          200.12262    140.1625    0.005102041 
+  202          186.01059    140.15632   0.004950495 
+  186          177.00688    140.1502    0.005376344 
+  182          171.38102    140.14415   0.005494505 
+  188          167.73152    140.13815   0.005319149 
+  163          165.17704    140.13222   0.006134969 
+  193          163.36919    140.12635   0.005181347 
+  168          162.24193    140.12055   0.005952381 
+  163          161.80289    140.1148    0.006134969 
+  152          161.95291    140.10912   0.006578947 
+  208          162.72413    140.1035    0.004807692 
+  177          164.06712    140.09794   0.005649718 
+  163          165.90802    140.09244   0.006134969 
+  170          168.23718    140.087     0.005882353 
+  172          171.72639    140.08162   0.005813953 
+  186          176.36947    140.0763    0.005376344 
+  175          181.94536    140.07105   0.005714286 
+  189          187.96179    140.06585   0.005291005 
+  178          194.54155    140.06071   0.005617978 
+  180          204.89057    140.05564   0.005555556 
+  181          223.09529    140.05062   0.005524862 
+  196          236.71537    140.04567   0.005102041 
+  195          223.31307    140.04077   0.005128205 
+  191          203.56041    140.03594   0.005235602 
+  165          192.6002     140.03116   0.006060606 
+  195          188.64609    140.02644   0.005128205 
+  192          188.6589     140.02178   0.005208333 
+  190          192.26894    140.01718   0.005263158 
+  192          200.99126    140.01264   0.005208333 
+  179          210.64692    140.00816   0.005586592 
+  198          207.67959    140.00374   0.005050505 
+  192          198.26174    139.99938   0.005208333 
+  175          193.4956     139.99507   0.005714286 
+  213          194.59937    139.99082   0.004694836 
+  217          201.74322    139.98663   0.004608295 
+  217          217.28773    139.9825    0.004608295 
+  261          247.01641    139.97843   0.003831418 
+  315          300.24349    139.97442   0.003174603 
+  365          378.13591    139.97046   0.002739726 
+  418          424.27422    139.96656   0.002392344 
+  386          375.18104    139.96271   0.002590674 
+  306          304.83253    139.95893   0.003267974 
+  272          261.63888    139.9552    0.003676471 
+  256          242.67175    139.95153   0.00390625 
+  228          241.78079    139.94791   0.004385965 
+  275          258.66637    139.94435   0.003636364 
+  293          294.69535    139.94085   0.003412969 
+  291          331.36453    139.93741   0.003436426 
+  308          324.47279    139.93402   0.003246753 
+  238          290.02064    139.93068   0.004201681 
+  229          259.0581     139.92741   0.004366812 
+  201          236.13939    139.92419   0.004975124 
+  219          220.88476    139.92102   0.00456621 
+  191          212.0846     139.91791   0.005235602 
+  186          208.7892     139.91486   0.005376344 
+  170          209.98125    139.91186   0.005882353 
+  207          212.95763    139.90891   0.004830918 
+  196          213.84561    139.90602   0.005102041 
+  204          211.51037    139.90319   0.004901961 
+  182          209.51111    139.90041   0.005494505 
+  187          212.18126    139.89768   0.005347594 
+  187          215.44456    139.89501   0.005347594 
+  165          207.07991    139.8924    0.006060606 
+  168          194.98341    139.88983   0.005952381 
+  180          187.44239    139.88733   0.005555556 
+  194          183.20005    139.88487   0.005154639 
+  206          180.99036    139.88247   0.004854369 
+  193          181.57338    139.88012   0.005181347 
+  189          186.22223    139.87783   0.005291005 
+  170          194.26085    139.87559   0.005882353 
+  182          199.03278    139.8734    0.005494505 
+  194          198.10784    139.87127   0.005154639 
+  191          194.13907    139.86919   0.005235602 
+  175          187.36802    139.86716   0.005714286 
+  172          180.25869    139.86518   0.005813953 
+  183          174.85196    139.86326   0.005464481 
+  206          171.46954    139.86139   0.004854369 
+  182          169.92896    139.85957   0.005494505 
+  186          170.04425    139.8578    0.005376344 
+  151          171.04631    139.85609   0.006622517 
+  145          171.14562    139.85443   0.006896552 
+  152          168.96559    139.85281   0.006578947 
+  170          165.38018    139.85125   0.005882353 
+  166          161.9353     139.84975   0.006024096 
+  170          159.17541    139.84829   0.005882353 
+  164          157.03022    139.84688   0.006097561 
+  140          155.3904     139.84553   0.007142857 
+  161          154.17969    139.84422   0.00621118 
+  176          153.31303    139.84297   0.005681818 
+  164          152.71414    139.84176   0.006097561 
+  165          152.31923    139.84061   0.006060606 
+  171          152.09272    139.83951   0.005847953 
+  142          152.02237    139.83845   0.007042254 
+  174          152.11489    139.83745   0.005747126 
+  154          152.38366    139.8365    0.006493506 
+  161          152.83742    139.83559   0.00621118 
+  142          153.4405     139.83474   0.007042254 
+  138          154.10799    139.83394   0.007246377 
+  155          154.82187    139.83318   0.006451613 
+  130          155.6779     139.83247   0.007692308 
+  143          156.66863    139.83182   0.006993007 
+  162          157.55019    139.83121   0.00617284 
+  176          158.23373    139.83065   0.005681818 
+  142          159.09767    139.83013   0.007042254 
+  175          160.57225    139.82967   0.005714286 
+  168          162.78131    139.82926   0.005952381 
+  166          165.38774    139.82889   0.006024096 
+  166          167.45478    139.82857   0.006024096 
+  170          168.14857    139.8283    0.005882353 
+  147          167.91069    139.82807   0.006802721 
+  144          167.76708    139.8279    0.006944444 
+  165          168.37752    139.82777   0.006060606 
+  166          170.06397    139.82769   0.006024096 
+  168          172.98197    139.82765   0.005952381 
+  171          177.14284    139.82766   0.005847953 
+  208          182.06958    139.82772   0.004807692 
+  164          186.79951    139.82783   0.006097561 
+  165          190.41089    139.82798   0.006060606 
+  176          191.34853    139.82818   0.005681818 
+  171          188.7972     139.82842   0.005847953 
+  201          184.45569    139.82871   0.004975124 
+  178          180.61963    139.82905   0.005617978 
+  143          178.26945    139.82943   0.006993007 
+  175          177.42506    139.82986   0.005714286 
+  175          177.71614    139.83033   0.005714286 
+  161          178.6748     139.83085   0.00621118 
+  165          179.52031    139.83141   0.006060606 
+  171          179.12899    139.83202   0.005847953 
+  166          177.29106    139.83268   0.006024096 
+  164          175.15041    139.83337   0.006097561 
+  170          173.63147    139.83412   0.005882353 
+  191          173.01863    139.8349    0.005235602 
+  150          173.30997    139.83574   0.006666667 
+  172          174.44418    139.83661   0.005813953 
+  176          176.28364    139.83753   0.005681818 
+  164          178.4618     139.8385    0.006097561 
+  185          180.50448    139.8395    0.005405405 
+  207          182.45799    139.84055   0.004830918 
+  148          184.86461    139.84165   0.006756757 
+  201          187.99362    139.84279   0.004975124 
+  164          191.45337    139.84397   0.006097561 
+  177          194.33657    139.84519   0.005649718 
+  173          196.10749    139.84646   0.005780347 
+  158          196.99651    139.84777   0.006329114 
+  181          197.83246    139.84912   0.005524862 
+  194          198.39735    139.85051   0.005154639 
+  174          199.12748    139.85195   0.005747126 
+  177          200.7397     139.85343   0.005649718 
+  199          203.54693    139.85495   0.005025126 
+  183          207.27608    139.85651   0.005464481 
+  203          211.09381    139.85812   0.004926108 
+  195          214.79391    139.85976   0.005128205 
+  193          218.86103    139.86145   0.005181347 
+  203          224.31255    139.86318   0.004926108 
+  215          233.06956    139.86495   0.004651163 
+  233          249.57868    139.86676   0.004291845 
+  248          281.18679    139.86861   0.004032258 
+  311          335.48108    139.8705    0.003215434 
+  333          398.05368    139.87243   0.003003003 
+  358          400.07649    139.87441   0.002793296 
+  315          338.00545    139.87642   0.003174603 
+  239          281.80359    139.87847   0.0041841 
+  273          248.78427    139.88057   0.003663004 
+  230          233.01345    139.8827    0.004347826 
+  213          230.16418    139.88487   0.004694836 
+  210          240.17998    139.88708   0.004761905 
+  251          263.89975    139.88933   0.003984064 
+  274          286.57061    139.89163   0.003649635 
+  255          272.80834    139.89396   0.003921569 
+  224          236.70029    139.89632   0.004464286 
+  204          208.51719    139.89873   0.004901961 
+  179          191.29772    139.90118   0.005586592 
+  181          181.01046    139.90366   0.005524862 
+  173          174.5693     139.90619   0.005780347 
+  163          170.25501    139.90875   0.006134969 
+  160          167.16897    139.91135   0.00625   
+  164          164.84476    139.91398   0.006097561 
+  198          163.1041     139.91666   0.005050505 
+  155          161.92335    139.91937   0.006451613 
+  144          161.31528    139.92212   0.006944444 
+  150          161.31065    139.92491   0.006666667 
+  177          161.91483    139.92773   0.005649718 
+  175          162.9251     139.9306    0.005714286 
+  170          163.68246    139.93349   0.005882353 
+  144          163.43104    139.93643   0.006944444 
+  149          162.44649    139.9394    0.006711409 
+  176          161.70499    139.94241   0.005681818 
+  141          161.09546    139.94546   0.007092199 
+  168          159.53157    139.94854   0.005952381 
+  159          157.98322    139.95165   0.006289308 
+  159          157.28858    139.95481   0.006289308 
+  163          157.24094    139.958     0.006134969 
+  149          157.30791    139.96122   0.006711409 
+  189          157.07767    139.96448   0.005291005 
+  137          156.74155    139.96777   0.00729927 
+  156          156.70508    139.9711    0.006410256 
+  175          156.71071    139.97447   0.005714286 
+  149          156.2994     139.97787   0.006711409 
+  191          156.16081    139.98131   0.005235602 
+  164          156.62619    139.98478   0.006097561 
+  149          157.24023    139.98828   0.006711409 
+  154          157.21148    139.99182   0.006493506 
+  154          156.25713    139.99539   0.006493506 
+  168          154.88539    139.999     0.005952381 
+  157          153.65504    140.00264   0.006369427 
+  157          152.77551    140.00631   0.006369427 
+  133          152.26927    140.01002   0.007518797 
+  167          152.13209    140.01376   0.005988024 
+  131          152.2906     140.01754   0.007633588 
+  164          152.48635    140.02134   0.006097561 
+  163          152.34051    140.02518   0.006134969 
+  149          151.75273    140.02906   0.006711409 
+  154          150.99981    140.03296   0.006493506 
+  163          150.36248    140.0369    0.006134969 
+  163          149.952      140.04088   0.006134969 
+  162          149.7697     140.04488   0.00617284 
+  157          149.76528    140.04892   0.006369427 
+  144          149.8318     140.05298   0.006944444 
+  143          149.83121    140.05708   0.006993007 
+  152          149.73773    140.06122   0.006578947 
+  137          149.6577     140.06538   0.00729927 
+  164          149.683      140.06957   0.006097561 
+  152          149.84574    140.0738    0.006578947 
+  129          150.15221    140.07806   0.007751938 
+  133          150.60291    140.08235   0.007518797 
+  152          151.26579    140.08667   0.006578947 
+  166          151.88963    140.09102   0.006024096 
+  155          152.42751    140.0954    0.006451613 
+  154          152.83319    140.09981   0.006493506 
+  158          153.21666    140.10425   0.006329114 
+  148          153.69529    140.10872   0.006756757 
+  146          154.3254     140.11322   0.006849315 
+  173          155.13196    140.11775   0.005780347 
+  160          156.15385    140.12232   0.00625   
+  165          157.49015    140.12691   0.006060606 
+  153          159.2958     140.13153   0.006535948 
+  174          161.84296    140.13618   0.005747126 
+  171          165.48127    140.14086   0.005847953 
+  180          171.07743    140.14557   0.005555556 
+  195          179.94156    140.1503    0.005128205 
+  201          193.48621    140.15507   0.004975124 
+  199          210.2615     140.15986   0.005025126 
+  208          219.13659    140.16469   0.004807692 
+  190          210.15304    140.16954   0.005263158 
+  175          194.71178    140.17442   0.005714286 
+  187          183.37611    140.17933   0.005347594 
+  162          177.32274    140.18426   0.00617284 
+  158          175.47414    140.18923   0.006329114 
+  186          177.24118    140.19422   0.005376344 
+  169          182.65232    140.19924   0.00591716 
+  175          190.93177    140.20429   0.005714286 
+  172          196.91083    140.20936   0.005813953 
+  195          194.88209    140.21446   0.005128205 
+  167          189.59759    140.21959   0.005988024 
+  167          185.93112    140.22475   0.005988024 
+  210          183.17269    140.22993   0.004761905 
+  172          180.0148     140.23514   0.005813953 
+  157          176.81341    140.24037   0.006369427 
+  170          174.14946    140.24563   0.005882353 
+  173          172.10464    140.25092   0.005780347 
+  155          170.90375    140.25623   0.006451613 
+  174          170.90067    140.26157   0.005747126 
+  194          172.17345    140.26694   0.005154639 
+  181          174.29342    140.27233   0.005524862 
+  184          176.32333    140.27775   0.005434783 
+  181          177.73739    140.28319   0.005524862 
+  161          179.27665    140.28866   0.00621118 
+  186          181.87636    140.29415   0.005376344 
+  163          185.39507    140.29967   0.006134969 
+  166          188.44778    140.30521   0.006024096 
+  196          189.67475    140.31078   0.005102041 
+  179          189.82878    140.31637   0.005586592 
+  164          190.85075    140.32198   0.006097561 
+  175          194.39728    140.32762   0.005714286 
+  205          202.90449    140.33329   0.004878049 
+  211          220.43286    140.33898   0.004739336 
+  248          251.22884    140.34469   0.004032258 
+  321          288.50022    140.35043   0.003115265 
+  289          295.60385    140.35619   0.003460208 
+  260          263.30415    140.36197   0.003846154 
+  222          229.94332    140.36778   0.004504505 
+  212          209.30511    140.37361   0.004716981 
+  193          199.11465    140.37946   0.005181347 
+  191          196.45649    140.38534   0.005235602 
+  194          200.25825    140.39124   0.005154639 
+  220          210.84467    140.39716   0.004545455 
+  214          226.41392    140.40311   0.004672897 
+  231          231.65572    140.40907   0.004329004 
+  209          215.06486    140.41506   0.004784689 
+  193          194.66775    140.42108   0.005181347 
+  179          180.96143    140.42711   0.005586592 
+  171          173.13785    140.43317   0.005847953 
+  168          168.91439    140.43924   0.005952381 
+  164          166.59544    140.44534   0.006097561 
+  169          165.10443    140.45147   0.00591716 
+  169          164.00489    140.45761   0.00591716 
+  152          163.13108    140.46377   0.006578947 
+  157          162.55399    140.46996   0.006369427 
+  175          162.5818     140.47616   0.005714286 
+  185          163.32761    140.48239   0.005405405 
+  150          164.5399     140.48864   0.006666667 
+  158          165.68527    140.49491   0.006329114 
+  167          166.39469    140.5012    0.005988024 
+  167          167.07639    140.50751   0.005988024 
+  160          168.63953    140.51384   0.00625   
+  179          171.80275    140.52019   0.005586592 
+  178          176.80052    140.52656   0.005617978 
+  187          183.07732    140.53295   0.005347594 
+  170          189.00654    140.53936   0.005882353 
+  166          192.40588    140.54579   0.006024096 
+  163          191.49983    140.55224   0.006134969 
+  189          186.55691    140.55871   0.005291005 
+  183          180.24065    140.5652    0.005464481 
+  164          175.03149    140.57171   0.006097561 
+  180          171.91095    140.57824   0.005555556 
+  183          170.89452    140.58478   0.005464481 
+  147          171.51871    140.59135   0.006802721 
+  161          172.82899    140.59793   0.00621118 
+  158          173.53711    140.60454   0.006329114 
+  152          172.54653    140.61116   0.006578947 
+  163          169.6061     140.6178    0.006134969 
+  169          165.74147    140.62445   0.00591716 
+  145          162.21039    140.63113   0.006896552 
+  149          159.53223    140.63782   0.006711409 
+  174          157.68149    140.64454   0.005747126 
+  139          156.47607    140.65127   0.007194245 
+  160          155.74119    140.65801   0.00625   
+  149          155.31479    140.66478   0.006711409 
+  146          155.05951    140.67156   0.006849315 
+  179          154.93243    140.67836   0.005586592 
+  150          154.99391    140.68518   0.006666667 
+  142          155.33074    140.69201   0.007042254 
+  161          156.01436    140.69886   0.00621118 
+  157          157.15869    140.70573   0.006369427 
+  146          158.7588     140.71261   0.006849315 
+  162          160.90152    140.71951   0.00617284 
+  174          163.4258     140.72643   0.005747126 
+  146          165.80034    140.73337   0.006849315 
+  169          167.48678    140.74032   0.00591716 
+  184          168.57174    140.74728   0.005434783 
+  152          169.42268    140.75427   0.006578947 
+  161          170.02439    140.76127   0.00621118 
+  173          170.4775     140.76828   0.005780347 
+  177          171.55577    140.77531   0.005649718 
+  186          174.23522    140.78236   0.005376344 
+  178          179.33325    140.78942   0.005617978 
+  202          187.87885    140.79649   0.004950495 
+  178          201.25204    140.80359   0.005617978 
+  196          220.4373     140.81069   0.005102041 
+  201          240.30732    140.81782   0.004975124 
+  208          244.55453    140.82495   0.004807692 
+  218          230.19978    140.83211   0.004587156 
+  188          213.52825    140.83927   0.005319149 
+  200          201.62915    140.84645   0.005     
+  177          193.61896    140.85365   0.005649718 
+  174          188.77997    140.86086   0.005747126 
+  213          187.71241    140.86809   0.004694836 
+  171          191.15572    140.87532   0.005847953 
+  190          198.4576     140.88258   0.005263158 
+  202          203.81903    140.88985   0.004950495 
+  182          199.60904    140.89713   0.005494505 
+  172          190.10952    140.90442   0.005813953 
+  208          182.07193    140.91173   0.004807692 
+  172          176.24422    140.91905   0.005813953 
+  179          171.71683    140.92639   0.005586592 
+  174          168.20818    140.93374   0.005747126 
+  171          165.70133    140.9411    0.005847953 
+  167          164.06072    140.94847   0.005988024 
+  183          163.09359    140.95586   0.005464481 
+  165          162.6315     140.96326   0.006060606 
+  173          162.55292    140.97068   0.005780347 
+  170          162.76341    140.97811   0.005882353 
+  161          163.19559    140.98555   0.00621118 
+  155          163.83506    140.993     0.006451613 
+  173          164.70856    141.00046   0.005780347 
+  183          165.85084    141.00794   0.005464481 
+  212          167.30172    141.01543   0.004716981 
+  187          169.11364    141.02293   0.005347594 
+  169          171.35607    141.03045   0.00591716 
+  160          174.11116    141.03797   0.00625   
+  166          177.42617    141.04551   0.006024096 
+  196          181.22369    141.05306   0.005102041 
+  180          185.30302    141.06062   0.005555556 
+  156          189.70461    141.06819   0.006410256 
+  213          194.89361    141.07578   0.004694836 
+  222          201.42307    141.08337   0.004504505 
+  201          209.77222    141.09098   0.004975124 
+  224          220.69237    141.0986    0.004464286 
+  223          235.52631    141.10623   0.004484305 
+  256          256.3455     141.11387   0.00390625 
+  295          286.44334    141.12152   0.003389831 
+  328          331.38985    141.12918   0.00304878 
+  420          400.41655    141.13686   0.002380952 
+  552          511.21028    141.14454   0.001811594 
+  736          698.80051    141.15223   0.001358696 
+  1060         998.9354     141.15994   0.000943396 
+  1253         1337.19473   141.16765   0.000798085 
+  1260         1380.96591   141.17538   0.000793651 
+  986          1076.26632   141.18312   0.001014199 
+  739          769.88651    141.19086   0.00135318 
+  603          580.75384    141.19862   0.001658375 
+  508          484.56209    141.20639   0.001968504 
+  493          451.24022    141.21416   0.002028398 
+  508          469.38112    141.22195   0.001968504 
+  574          546.34817    141.22974   0.00174216 
+  669          688.60405    141.23755   0.001494768 
+  749          824.87904    141.24536   0.001335113 
+  706          780.62811    141.25319   0.001416431 
+  558          602.44897    141.26102   0.001792115 
+  391          450.96417    141.26887   0.002557545 
+  376          355.83488    141.27672   0.002659574 
+  298          298.70329    141.28458   0.003355705 
+  278          263.08217    141.29245   0.003597122 
+  220          239.498      141.30033   0.004545455 
+  195          222.99555    141.30822   0.005128205 
+  187          211.04495    141.31612   0.005347594 
+  180          202.16508    141.32402   0.005555556 
+  176          195.3653     141.33194   0.005681818 
+  184          190.14811    141.33986   0.005434783 
+  198          186.14766    141.34779   0.005050505 
+  189          182.766      141.35574   0.005291005 
+  182          179.43481    141.36368   0.005494505 
+  191          176.09319    141.37164   0.005235602 
+  168          172.95269    141.37961   0.005952381 
+  179          170.14443    141.38758   0.005586592 
+  170          167.7632     141.39556   0.005882353 
+  186          165.85154    141.40355   0.005376344 
+  163          164.3773     141.41155   0.006134969 
+  152          163.27529    141.41956   0.006578947 
+  154          162.44987    141.42757   0.006493506 
+  187          161.76881    141.43559   0.005347594 
+  164          161.14394    141.44362   0.006097561 
+  198          160.6182     141.45166   0.005050505 
+  158          160.27888    141.45971   0.006329114 
+  144          160.15314    141.46776   0.006944444 
+  168          160.19784    141.47582   0.005952381 
+  177          160.33699    141.48388   0.005649718 
+  145          160.5222     141.49196   0.006896552 
+  172          160.76568    141.50004   0.005813953 
+  194          161.10152    141.50813   0.005154639 
+  180          161.60223    141.51622   0.005555556 
+  158          162.40446    141.52433   0.006329114 
+  153          163.66721    141.53244   0.006535948 
+  167          165.57458    141.54055   0.005988024 
+  152          168.3902     141.54868   0.006578947 
+  146          172.51983    141.55681   0.006849315 
+  186          178.57146    141.56494   0.005376344 
+  180          187.38406    141.57309   0.005555556 
+  200          199.6713     141.58124   0.005     
+  182          213.54984    141.5894    0.005494505 
+  198          220.77086    141.59756   0.005050505 
+  169          215.87495    141.60573   0.00591716 
+  186          205.46877    141.61391   0.005376344 
+  180          195.61675    141.62209   0.005555556 
+  178          188.1655     141.63028   0.005617978 
+  190          183.62311    141.63847   0.005263158 
+  169          182.07586    141.64668   0.00591716 
+  159          183.50533    141.65488   0.006289308 
+  163          187.8861     141.6631    0.006134969 
+  160          194.06399    141.67132   0.00625   
+  178          197.83072    141.67954   0.005617978 
+  152          196.45818    141.68778   0.006578947 
+  182          193.27142    141.69601   0.005494505 
+  197          191.11557    141.70426   0.005076142 
+  182          190.01318    141.71251   0.005494505 
+  202          188.38127    141.72076   0.004950495 
+  175          184.91297    141.72902   0.005714286 
+  196          180.35279    141.73729   0.005102041 
+  158          176.29336    141.74556   0.006329114 
+  170          173.55349    141.75384   0.005882353 
+  189          172.22713    141.76213   0.005291005 
+  168          172.18245    141.77042   0.005952381 
+  192          173.36079    141.77871   0.005208333 
+  200          175.74301    141.78701   0.005     
+  168          179.01338    141.79532   0.005952381 
+  195          182.35094    141.80363   0.005128205 
+  194          185.00655    141.81194   0.005154639 
+  154          186.93141    141.82026   0.006493506 
+  185          188.01113    141.82859   0.005405405 
+  145          187.46134    141.83692   0.006896552 
+  177          184.95542    141.84526   0.005649718 
+  172          181.66448    141.8536    0.005813953 
+  209          179.02122    141.86195   0.004784689 
+  179          177.55197    141.8703    0.005586592 
+  191          177.00583    141.87866   0.005235602 
+  178          176.97946    141.88702   0.005617978 
+  183          177.4124     141.89539   0.005464481 
+  182          178.31983    141.90376   0.005494505 
+  182          179.34429    141.91214   0.005494505 
+  151          179.83043    141.92052   0.006622517 
+  183          179.42652    141.92891   0.005464481 
+  182          178.62477    141.9373    0.005494505 
+  202          178.18104    141.9457    0.004950495 
+  184          178.41913    141.9541    0.005434783 
+  189          179.24663    141.96251   0.005291005 
+  197          180.46687    141.97092   0.005076142 
+  196          182.07563    141.97934   0.005102041 
+  231          184.23949    141.98776   0.004329004 
+  192          187.11518    141.99619   0.005208333 
+  226          190.82426    142.00462   0.004424779 
+  203          195.50887    142.01305   0.004926108 
+  196          201.36028    142.02149   0.005102041 
+  207          208.64182    142.02994   0.004830918 
+  232          217.6666     142.03838   0.004310345 
+  250          228.76356    142.04684   0.004     
+  241          242.36398    142.0553    0.004149378 
+  259          259.43492    142.06376   0.003861004 
+  280          281.87877    142.07223   0.003571429 
+  316          312.63973    142.0807    0.003164557 
+  385          356.26852    142.08918   0.002597403 
+  463          420.58375    142.09766   0.002159827 
+  535          519.92295    142.10614   0.001869159 
+  740          680.4151     142.11463   0.001351351 
+  1059         945.07835    142.12313   0.000944287 
+  1429         1363.07036   142.13163   0.00069979 
+  1767         1871.53784   142.14013   0.000565931 
+  1831         2050.82832   142.14864   0.00054615 
+  1567         1669.88943   142.15715   0.000638162 
+  1118         1188.91144   142.16567   0.000894454 
+  886          864.19694    142.17419   0.001128668 
+  697          684.15201    142.18272   0.00143472 
+  633          601.89281    142.19125   0.001579779 
+  642          591.83869    142.19978   0.001557632 
+  754          652.39243    142.20832   0.00132626 
+  860          798.63362    142.21687   0.001162791 
+  979          1023.60171   142.22542   0.00102145 
+  1110         1171.69304   142.23397   0.000900901 
+  953          1033.18064   142.24253   0.001049318 
+  725          767.25943    142.25109   0.00137931 
+  560          561.88965    142.25966   0.001785714 
+  429          433.77526    142.26823   0.002331002 
+  362          356.21168    142.2768    0.002762431 
+  307          307.62291    142.28538   0.003257329 
+  260          275.25096    142.29397   0.003846154 
+  233          252.28281    142.30256   0.004291845 
+  246          235.27664    142.31115   0.004065041 
+  231          222.41585    142.31975   0.004329004 
+  235          212.56774    142.32836   0.004255319 
+  226          204.95291    142.33696   0.004424779 
+  212          199.05084    142.34558   0.004716981 
+  201          194.50244    142.35419   0.004975124 
+  173          191.07261    142.36282   0.005780347 
+  231          188.57966    142.37144   0.004329004 
+  214          186.83039    142.38007   0.004672897 
+  203          185.61478    142.38871   0.004926108 
+  184          184.70064    142.39735   0.005434783 
+  170          183.69259    142.406     0.005882353 
+  212          182.20706    142.41465   0.004716981 
+  211          180.40633    142.4233    0.004739336 
+  173          178.85861    142.43196   0.005780347 
+  171          177.69454    142.44063   0.005847953 
+  167          176.90356    142.4493    0.005988024 
+  202          176.45179    142.45798   0.004950495 
+  168          176.54714    142.46666   0.005952381 
+  168          177.49361    142.47534   0.005952381 
+  190          179.56353    142.48403   0.005263158 
+  189          182.99233    142.49273   0.005291005 
+  180          187.88697    142.50143   0.005555556 
+  177          193.98161    142.51013   0.005649718 
+  212          202.14551    142.51884   0.004716981 
+  183          215.25393    142.52756   0.005464481 
+  217          233.36133    142.53628   0.004608295 
+  209          247.36916    142.54501   0.004784689 
+  249          243.36787    142.55374   0.004016064 
+  219          226.77307    142.56248   0.00456621 
+  257          212.04496    142.57122   0.003891051 
+  213          204.06074    142.57997   0.004694836 
+  191          202.48858    142.58872   0.005235602 
+  208          206.04063    142.59748   0.004807692 
+  199          212.41758    142.60625   0.005025126 
+  215          217.92373    142.61502   0.004651163 
+  202          220.92998    142.6238    0.004950495 
+  235          223.13268    142.63258   0.004255319 
+  214          220.84666    142.64137   0.004672897 
+  193          211.07984    142.65016   0.005181347 
+  195          199.85028    142.65896   0.005128205 
+  205          191.503      142.66777   0.004878049 
+  178          186.34464    142.67658   0.005617978 
+  197          183.91152    142.6854    0.005076142 
+  185          183.6239     142.69422   0.005405405 
+  180          183.91674    142.70305   0.005555556 
+  212          182.3418     142.71189   0.004716981 
+  192          178.98041    142.72073   0.005208333 
+  172          175.89633    142.72958   0.005813953 
+  184          174.04642    142.73844   0.005434783 
+  195          173.40142    142.7473    0.005128205 
+  166          173.58246    142.75617   0.006024096 
+  182          174.16692    142.76505   0.005494505 
+  182          174.89548    142.77393   0.005494505 
+  162          175.58837    142.78282   0.00617284 
+  188          176.01701    142.79172   0.005319149 
+  177          176.15405    142.80062   0.005649718 
+  175          176.08202    142.80953   0.005714286 
+  190          175.57704    142.81845   0.005263158 
+  175          174.51578    142.82737   0.005714286 
+  176          173.32324    142.8363    0.005681818 
+  187          172.52453    142.84524   0.005347594 
+  169          172.32465    142.85419   0.00591716 
+  200          172.65919    142.86314   0.005     
+  163          173.35299    142.8721    0.006134969 
+  199          174.19504    142.88107   0.005025126 
+  179          175.02958    142.89005   0.005586592 
+  196          175.87594    142.89903   0.005102041 
+  191          176.74097    142.90803   0.005235602 
+  191          177.48339    142.91703   0.005235602 
+  205          178.07903    142.92604   0.004878049 
+  186          178.65943    142.93505   0.005376344 
+  220          179.28725    142.94408   0.004545455 
+  196          180.02068    142.95311   0.005102041 
+  209          181.00198    142.96215   0.004784689 
+  206          182.36308    142.97121   0.004854369 
+  196          184.16219    142.98026   0.005102041 
+  222          186.42834    142.98933   0.004504505 
+  215          189.18791    142.99841   0.004651163 
+  215          192.4805     143.00749   0.004651163 
+  247          196.3627     143.01659   0.004048583 
+  238          200.88958    143.02569   0.004201681 
+  229          206.10783    143.03481   0.004366812 
+  215          212.11193    143.04393   0.004651163 
+  265          219.14717    143.05306   0.003773585 
+  245          227.60457    143.0622    0.004081633 
+  262          237.98956    143.07135   0.003816794 
+  270          250.96597    143.08051   0.003703704 
+  296          267.49272    143.08968   0.003378378 
+  311          289.02038    143.09886   0.003215434 
+  347          317.7387     143.10806   0.002881844 
+  367          356.67927    143.11726   0.002724796 
+  410          408.83869    143.12647   0.002439024 
+  478          473.22793    143.13569   0.00209205 
+  570          545.04989    143.14492   0.001754386 
+  673          636.85728    143.15416   0.001485884 
+  864          785.4866     143.16342   0.001157407 
+  1176         1040.7799    143.17268   0.00085034 
+  1591         1469.97885   143.18196   0.000628536 
+  2277         2124.23272   143.19125   0.000439174 
+  2707         2811.85291   143.20054   0.000369413 
+  2660         2885.03584   143.20985   0.00037594 
+  2154         2267.63005   143.21917   0.000464253 
+  1581         1620.25316   143.22851   0.000632511 
+  1202         1198.00127   143.23785   0.000831947 
+  1007         960.31867    143.24721   0.000993049 
+  904          847.31486    143.25658   0.001106195 
+  929          831.96824    143.26596   0.001076426 
+  945          908.65358    143.27535   0.001058201 
+  1218         1084.65359   143.28476   0.000821018 
+  1352         1368.7377    143.29418   0.000739645 
+  1443         1647.85084   143.30361   0.000693001 
+  1467         1597.1411    143.31305   0.000681663 
+  1239         1237.50699   143.32251   0.000807103 
+  940          892.79602    143.33198   0.00106383 
+  672          663.38773    143.34146   0.001488095 
+  612          523.69813    143.35096   0.001633987 
+  512          439.84656    143.36047   0.001953125 
+  373          389.42495    143.37      0.002680965 
+  351          357.10374    143.37954   0.002849003 
+  341          329.5133     143.38909   0.002932551 
+  315          301.64415    143.39865   0.003174603 
+  302          277.64907    143.40824   0.003311258 
+  300          259.76411    143.41783   0.003333333 
+  278          247.22261    143.42744   0.003597122 
+  229          238.55068    143.43707   0.004366812 
+  257          232.49181    143.44671   0.003891051 
+  243          227.41128    143.45637   0.004115226 
+  236          222.12616    143.46604   0.004237288 
+  230          216.62444    143.47572   0.004347826 
+  212          211.48416    143.48543   0.004716981 
+  193          206.85488    143.49515   0.005181347 
+  213          202.64579    143.50488   0.004694836 
+  210          199.03914    143.51463   0.004761905 
+  203          196.35411    143.5244    0.004926108 
+  204          194.7182     143.53418   0.004901961 
+  197          194.19504    143.54398   0.005076142 
+  190          194.47956    143.5538    0.005263158 
+  176          194.98216    143.56363   0.005681818 
+  186          194.97261    143.57349   0.005376344 
+  209          194.12347    143.58335   0.004784689 
+  206          192.68764    143.59324   0.004854369 
+  187          191.15398    143.60315   0.005347594 
+  195          189.8639     143.61307   0.005128205 
+  181          188.95556    143.62301   0.005524862 
+  186          188.51912    143.63297   0.005376344 
+  191          188.91589    143.64295   0.005235602 
+  199          190.79306    143.65294   0.005025126 
+  186          194.49699    143.66296   0.005376344 
+  212          198.37609    143.673     0.004716981 
+  177          197.87605    143.68305   0.005649718 
+  202          193.0425     143.69312   0.004950495 
+  174          187.91701    143.70322   0.005747126 
+  177          184.0866     143.71333   0.005649718 
+  178          181.64273    143.72346   0.005617978 
+  154          180.28238    143.73362   0.006493506 
+  161          179.69746    143.74379   0.00621118 
+  188          179.84499    143.75399   0.005319149 
+  192          180.96951    143.76421   0.005208333 
+  172          183.30409    143.77444   0.005813953 
+  163          186.28183    143.7847    0.006134969 
+  184          187.67089    143.79498   0.005434783 
+  191          186.67411    143.80529   0.005235602 
+  181          184.62894    143.81561   0.005524862 
+  155          181.9105     143.82596   0.006451613 
+  183          178.85244    143.83633   0.005464481 
+  177          176.06965    143.84672   0.005649718 
+  194          173.93001    143.85714   0.005154639 
+  180          172.49977    143.86757   0.005555556 
+  172          171.73393    143.87804   0.005813953 
+  187          171.59264    143.88852   0.005347594 
+  180          172.06844    143.89903   0.005555556 
+  167          173.14732    143.90956   0.005988024 
+  179          174.69688    143.92012   0.005586592 
+  160          176.33237    143.93071   0.00625   
+  193          177.48894    143.94131   0.005181347 
+  161          177.75474    143.95194   0.00621118 
+  185          177.16783    143.9626    0.005405405 
+  163          176.31122    143.97329   0.006134969 
+  185          175.92351    143.98399   0.005405405 
+  184          176.409      143.99473   0.005434783 
+  157          177.68563    144.00549   0.006369427 
+  167          179.11958    144.01628   0.005988024 
+  165          179.72635    144.02709   0.006060606 
+  160          179.051      144.03793   0.00625   
+  175          177.66243    144.0488    0.005714286 
+  203          176.369      144.0597    0.004926108 
+  186          175.45969    144.07062   0.005376344 
+  150          174.83074    144.08157   0.006666667 
+  167          174.49442    144.09255   0.005988024 
+  193          174.69449    144.10356   0.005181347 
+  184          175.64496    144.1146    0.005434783 
+  167          177.35707    144.12567   0.005988024 
+  200          179.53039    144.13676   0.005     
+  210          181.51481    144.14789   0.004761905 
+  206          182.71808    144.15904   0.004854369 
+  202          183.13463    144.17023   0.004950495 
+  204          183.09705    144.18145   0.004901961 
+  217          182.89645    144.19269   0.004608295 
+  216          182.86609    144.20397   0.00462963 
+  172          183.32418    144.21528   0.005813953 
+  187          184.44063    144.22662   0.005347594 
+  199          186.2779     144.23799   0.005025126 
+  214          188.85995    144.2494    0.004672897 
+  196          192.13478    144.26083   0.005102041 
+  216          195.95285    144.2723    0.00462963 
+  229          200.23811    144.28381   0.004366812 
+  230          205.1658     144.29534   0.004347826 
+  237          211.10339    144.30691   0.004219409 
+  233          218.49133    144.31851   0.004291845 
+  242          227.92154    144.33015   0.004132231 
+  252          240.19308    144.34182   0.003968254 
+  278          256.30527    144.35353   0.003597122 
+  291          277.62136    144.36527   0.003436426 
+  322          306.251      144.37705   0.00310559 
+  363          346.01185    144.38886   0.002754821 
+  413          404.68891    144.40071   0.002421308 
+  579          496.81405    144.41259   0.001727116 
+  751          646.46908    144.42451   0.001331558 
+  955          885.84239    144.43647   0.00104712 
+  1227         1220.8889    144.44847   0.000814996 
+  1441         1499.99488   144.4605    0.000693963 
+  1292         1433.01933   144.47257   0.000773994 
+  1144         1110.90967   144.48468   0.000874126 
+  847          818.11003    144.49683   0.001180638 
+  722          630.46942    144.50901   0.001385042 
+  581          525.68614    144.52124   0.00172117 
+  510          477.49929    144.5335    0.001960784 
+  515          472.18152    144.54581   0.001941748 
+  542          506.59522    144.55815   0.001845018 
+  612          582.568      144.57054   0.001633987 
+  764          704.20136    144.58296   0.001308901 
+  808          850.15401    144.59543   0.001237624 
+  785          896.99275    144.60794   0.001273885 
+  726          764.47332    144.62049   0.00137741 
+  583          584.16419    144.63308   0.001715266 
+  431          449.86172    144.64571   0.002320186 
+  364          364.80592    144.65839   0.002747253 
+  331          312.87248    144.67111   0.003021148 
+  323          281.56348    144.68388   0.003095975 
+  309          263.13202    144.69668   0.003236246 
+  305          251.61074    144.70954   0.003278689 
+  264          240.54952    144.72243   0.003787879 
+  256          227.36871    144.73537   0.00390625 
+  232          215.07867    144.74836   0.004310345 
+  250          205.91678    144.76139   0.004     
+  199          200.07386    144.77447   0.005025126 
+  207          196.85169    144.7876    0.004830918 
+  210          194.04969    144.80077   0.004761905 
+  205          189.18603    144.81399   0.004878049 
+  176          183.66592    144.82726   0.005681818 
+  195          179.23747    144.84057   0.005128205 
+  212          176.0064     144.85393   0.004716981 
+  167          173.6641     144.86734   0.005988024 
+  165          171.95592    144.8808    0.006060606 
+  203          170.75045    144.89431   0.004926108 
+  192          170.03892    144.90787   0.005208333 
+  210          169.79427    144.92148   0.004761905 
+  178          170.37598    144.93514   0.005617978 
+  166          171.41374    144.94885   0.006024096 
+  170          171.67603    144.96261   0.005882353 
+  158          170.49346    144.97643   0.006329114 
+  160          168.97895    144.99029   0.00625   
+  201          167.83802    145.00421   0.004975124 
+  184          167.17158    145.01818   0.005434783 
+  176          166.96397    145.03221   0.005681818 
+  154          167.18067    145.04629   0.006493506 
+  157          167.69318    145.06042   0.006369427 
+  143          168.12304    145.07461   0.006993007 
+  167          168.12895    145.08885   0.005988024 
+  180          167.44612    145.10315   0.005555556 
+  175          166.38172    145.1175    0.005714286 
+  171          165.35714    145.13191   0.005847953 
+  184          164.56941    145.14637   0.005434783 
+  153          164.07886    145.1609    0.006535948 
+  156          163.94212    145.17548   0.006410256 
+  167          164.22013    145.19012   0.005988024 
+  174          164.98094    145.20481   0.005747126 
+  177          166.27559    145.21957   0.005649718 
+  178          168.07062    145.23438   0.005617978 
+  187          170.14754    145.24925   0.005347594 
+  176          172.01273    145.26419   0.005681818 
+  165          172.97686    145.27918   0.006060606 
+  167          172.54555    145.29424   0.005988024 
+  160          170.98225    145.30935   0.00625   
+  165          169.19508    145.32453   0.006060606 
+  165          167.99158    145.33977   0.006060606 
+  177          167.76842    145.35507   0.005649718 
+  158          168.56719    145.37044   0.006329114 
+  161          169.87861    145.38587   0.00621118 
+  162          170.50391    145.40136   0.00617284 
+  172          169.94955    145.41692   0.005813953 
+  161          169.22405    145.43254   0.00621118 
+  160          169.04712    145.44823   0.00625   
+  166          169.19501    145.46399   0.006024096 
+  160          169.08463    145.47981   0.00625   
+  177          168.40782    145.49569   0.005649718 
+  165          167.32871    145.51165   0.006060606 
+  174          166.25387    145.52767   0.005747126 
+  152          165.51669    145.54376   0.006578947 
+  151          165.22024    145.55992   0.006622517 
+  181          165.11606    145.57615   0.005524862 
+  167          164.61552    145.59244   0.005988024 
+  166          163.58806    145.60881   0.006024096 
+  164          162.62095    145.62525   0.006097561 
+  180          162.12959    145.64176   0.005555556 
+  171          162.16733    145.65834   0.005847953 
+  163          162.62825    145.67499   0.006134969 
+  179          163.37209    145.69172   0.005586592 
+  144          164.35903    145.70852   0.006944444 
+  167          165.69706    145.72539   0.005988024 
+  158          167.4698     145.74234   0.006329114 
+  168          169.49142    145.75936   0.005952381 
+  165          171.17278    145.77645   0.006060606 
+  177          171.7905     145.79362   0.005649718 
+  148          171.0706     145.81087   0.006756757 
+  189          169.27518    145.82819   0.005291005 
+  183          166.95639    145.84559   0.005464481 
+  149          164.73134    145.86307   0.006711409 
+  158          162.993      145.88063   0.006329114 
+  160          161.86784    145.89826   0.00625   
+  155          161.34733    145.91598   0.006451613 
+  174          161.38969    145.93377   0.005747126 
+  158          161.92823    145.95165   0.006329114 
+  150          162.80083    145.9696    0.006666667 
+  168          163.67885    145.98764   0.005952381 
+  179          164.17728    146.00576   0.005586592 
+  167          164.14369    146.02396   0.005988024 
+  150          163.7026     146.04224   0.006666667 
+  171          163.12764    146.06061   0.005847953 
+  176          162.711      146.07906   0.005681818 
+  175          162.58756    146.09759   0.005714286 
+  167          162.67639    146.11621   0.005988024 
+  163          162.78135    146.13492   0.006134969 
+  176          162.81715    146.15371   0.005681818 
+  157          162.89028    146.17259   0.006369427 
+  159          163.1307     146.19155   0.006289308 
+  170          163.60049    146.21061   0.005882353 
+  178          164.3209     146.22975   0.005617978 
+  156          165.24012    146.24898   0.006410256 
+  141          166.17674    146.2683    0.007092199 
+  170          166.72875    146.28771   0.005882353 
+  167          166.69078    146.30721   0.005988024 
+  169          165.67857    146.32681   0.00591716 
+  167          164.3757     146.34649   0.005988024 
+  150          163.15644    146.36627   0.006666667 
+  193          162.1558     146.38614   0.005181347 
+  173          161.43591    146.4061    0.005780347 
+  141          161.02164    146.42616   0.007092199 
+  161          160.89775    146.44631   0.00621118 
+  180          161.04624    146.46656   0.005555556 
+  165          161.42398    146.4869    0.006060606 
+  160          161.94546    146.50734   0.00625   
+  173          162.44441    146.52788   0.005780347 
+  171          162.70487    146.54851   0.005847953 
+  159          162.71297    146.56925   0.006289308 
+  176          162.6786     146.59008   0.005681818 
+  167          162.70649    146.61101   0.005988024 
+  148          162.73245    146.63204   0.006756757 
+  141          162.32879    146.65318   0.007092199 
+  168          161.62005    146.67441   0.005952381 
+  148          160.81855    146.69575   0.006756757 
+  144          160.13798    146.71719   0.006944444 
+  202          159.71277    146.73873   0.004950495 
+  156          159.60001    146.76037   0.006410256 
+  167          159.80617    146.78212   0.005988024 
+  151          160.30203    146.80398   0.006622517 
+  182          161.01374    146.82594   0.005494505 
+  150          161.81301    146.84801   0.006666667 
+  165          162.54111    146.87018   0.006060606 
+  151          163.0418     146.89247   0.006622517 
+  147          163.24273    146.91486   0.006802721 
+  145          163.17889    146.93736   0.006896552 
+  151          162.87072    146.95997   0.006622517 
+  162          162.30573    146.98269   0.00617284 
+  141          161.58313    147.00552   0.007092199 
+  151          160.90312    147.02846   0.006622517 
+  160          160.43096    147.05152   0.00625   
+  162          160.24167    147.07468   0.00617284 
+  165          160.32647    147.09796   0.006060606 
+  156          160.62022    147.12136   0.006410256 
+  166          161.04103    147.14487   0.006024096 
+  143          161.53736    147.1685    0.006993007 
+  183          162.09373    147.19224   0.005464481 
+  150          162.637      147.2161    0.006666667 
+  159          162.92596    147.24008   0.006289308 
+  152          162.70286    147.26417   0.006578947 
+  162          162.00562    147.28839   0.00617284 
+  157          161.13009    147.31272   0.006369427 
+  161          160.34382    147.33717   0.00621118 
+  152          159.76697    147.36175   0.006578947 
+  158          159.24875    147.38645   0.006329114 
+  156          159.11934    147.41127   0.006410256 
+  158          159.1741     147.43621   0.006329114 
+  161          159.38078    147.46128   0.00621118 
+  155          159.70094    147.48647   0.006451613 
+  164          160.07085    147.51179   0.006097561 
+  156          160.38969    147.53723   0.006410256 
+  157          160.56511    147.5628    0.006369427 
+  160          160.60218    147.5885    0.00625   
+  142          160.59846    147.61432   0.007042254 
+  152          160.60189    147.64028   0.006578947 
+  166          160.52813    147.66636   0.006024096 
+  161          160.63267    147.69257   0.00621118 
+  187          160.92462    147.71892   0.005347594 
+  160          161.4474     147.7454    0.00625   
+  159          162.22126    147.77201   0.006289308 
+  179          163.24813    147.79875   0.005586592 
+  160          164.47399    147.82563   0.00625   
+  159          165.72798    147.85264   0.006289308 
+  188          166.73155    147.87979   0.005319149 
+  155          167.30525    147.90707   0.006451613 
+  160          167.59386    147.93449   0.00625   
+  162          167.93535    147.96205   0.00617284 
+  176          168.58917    147.98975   0.005681818 
+  158          169.69778    148.01758   0.006329114 
+  170          171.33679    148.04556   0.005882353 
+  172          173.4433     148.07368   0.005813953 
+  173          175.75773    148.10194   0.005780347 
+  176          177.68652    148.13034   0.005681818 
+  184          179.05705    148.15888   0.005434783 
+  167          179.9256     148.18757   0.005988024 
+  159          179.56547    148.21641   0.006289308 
+  166          178.02304    148.24539   0.006024096 
+  173          176.21605    148.27451   0.005780347 
+  189          174.79332    148.30379   0.005291005 
+  179          173.98912    148.33321   0.005586592 
+  163          173.82728    148.36278   0.006134969 
+  184          174.26784    148.39249   0.005434783 
+  187          175.23741    148.42236   0.005347594 
+  192          176.62151    148.45238   0.005208333 
+  178          178.17027    148.48256   0.005617978 
+  204          179.4974     148.51288   0.004901961 
+  204          180.56461    148.54336   0.004901961 
+  181          181.25774    148.57399   0.005524862 
+  188          181.40363    148.60478   0.005319149 
+  204          181.43778    148.63573   0.004901961 
+  206          181.91208    148.66683   0.004854369 
+  215          183.06215    148.69809   0.004651163 
+  177          184.89902    148.7295    0.005649718 
+  207          187.27727    148.76108   0.004830918 
+  220          189.83722    148.79282   0.004545455 
+  200          192.05171    148.82472   0.005     
+  199          193.63525    148.85678   0.005025126 
+  188          194.86182    148.889     0.005319149 
+  206          196.25352    148.92138   0.004854369 
+  204          198.1629     148.95394   0.004901961 
+  201          200.77796    148.98665   0.004975124 
+  223          204.23964    149.01953   0.004484305 
+  242          208.67054    149.05258   0.004132231 
+  219          214.15133    149.0858    0.00456621 
+  229          220.67044    149.11919   0.004366812 
+  240          228.13143    149.15274   0.004166667 
+  233          236.49069    149.18647   0.004291845 
+  274          245.93461    149.22036   0.003649635 
+  275          256.91235    149.25443   0.003636364 
+  289          270.23152    149.28868   0.003460208 
+  320          287.18739    149.32309   0.003125  
+  320          309.55727    149.35768   0.003125  
+  387          339.78639    149.39245   0.002583979 
+  389          381.6203     149.42739   0.002570694 
+  465          441.30515    149.46252   0.002150538 
+  599          529.64468    149.49782   0.001669449 
+  799          664.84518    149.5333    0.001251564 
+  1036         875.62293    149.56896   0.000965251 
+  1283         1196.97309   149.6048    0.000779423 
+  1721         1625.58404   149.64082   0.000581058 
+  1972         1979.30241   149.67703   0.000507099 
+  1771         1927.79254   149.71342   0.000564653 
+  1496         1536.42432   149.74999   0.000668449 
+  1227         1139.38255   149.78675   0.000814996 
+  920          862.17651    149.8237    0.001086957 
+  786          691.21875    149.86083   0.001272265 
+  664          593.33451    149.89816   0.001506024 
+  586          545.62118    149.93567   0.001706485 
+  604          537.45861    149.97337   0.001655629 
+  662          568.6932     150.01127   0.001510574 
+  769          648.37784    150.04936   0.00130039 
+  853          790.50253    150.08764   0.001172333 
+  1043         988.81054    150.12611   0.000958773 
+  1111         1144.38031   150.16478   0.00090009 
+  958          1094.02664   150.20365   0.001043841 
+  885          883.3603     150.24272   0.001129944 
+  670          676.73475    150.28198   0.001492537 
+  537          530.40661    150.32144   0.001862197 
+  482          435.2409     150.3611    0.002074689 
+  383          373.55674    150.40096   0.002610966 
+  367          332.45629    150.44103   0.002724796 
+  363          303.92601    150.48129   0.002754821 
+  291          283.29399    150.52176   0.003436426 
+  281          267.82413    150.56244   0.003558719 
+  293          255.85288    150.60332   0.003412969 
+  273          246.36471    150.64441   0.003663004 
+  245          238.76067    150.68571   0.004081633 
+  241          232.64973    150.72722   0.004149378 
+  237          227.70324    150.76893   0.004219409 
+  235          223.60799    150.81086   0.004255319 
+  221          220.04078    150.853     0.004524887 
+  224          216.68241    150.89535   0.004464286 
+  216          213.36189    150.93792   0.00462963 
+  205          210.13199    150.9807    0.004878049 
+  204          207.12951    151.0237    0.004901961 
+  221          204.43799    151.06691   0.004524887 
+  214          202.07623    151.11035   0.004672897 
+  207          200.03378    151.154     0.004830918 
+  221          198.29524    151.19787   0.004524887 
+  178          196.84559    151.24196   0.005617978 
+  212          195.66446    151.28628   0.004716981 
+  194          194.71862    151.33082   0.005154639 
+  189          193.96069    151.37558   0.005291005 
+  191          193.31976    151.42057   0.005235602 
+  190          192.70548    151.46579   0.005263158 
+  189          192.07381    151.51123   0.005291005 
+  191          191.4813     151.5569    0.005235602 
+  180          191.02359    151.60281   0.005555556 
+  196          190.75638    151.64894   0.005102041 
+  173          190.6838     151.6953    0.005780347 
+  192          190.7789     151.7419    0.005208333 
+  196          190.9998     151.78873   0.005102041 
+  186          191.30745    151.8358    0.005376344 
+  181          191.67985    151.8831    0.005524862 
+  217          192.1108     151.93064   0.004608295 
+  224          192.6025     151.97842   0.004464286 
+  182          193.16821    152.02644   0.005494505 
+  208          193.83735    152.0747    0.004807692 
+  208          194.66268    152.1232    0.004807692 
+  184          195.65101    152.17194   0.005434783 
+  202          197.11978    152.22093   0.004950495 
+  216          199.24086    152.27016   0.00462963 
+  207          202.42533    152.31964   0.004830918 
+  189          207.22021    152.36937   0.005291005 
+  179          213.79351    152.41934   0.005586592 
+  217          219.92268    152.46957   0.004608295 
+  197          220.68898    152.52004   0.005076142 
+  221          216.49574    152.57077   0.004524887 
+  202          211.83307    152.62175   0.004950495 
+  194          207.94792    152.67298   0.005154639 
+  219          204.3479     152.72447   0.00456621 
+  217          200.80181    152.77622   0.004608295 
+  190          197.63225    152.82822   0.005263158 
+  189          195.0676     152.88048   0.005291005 
+  200          193.26765    152.933     0.005     
+  204          192.35665    152.98579   0.004901961 
+  192          192.51362    153.03883   0.005208333 
+  196          193.88829    153.09214   0.005102041 
+  198          195.91086    153.14571   0.005050505 
+  194          196.29962    153.19955   0.005154639 
+  189          193.82722    153.25366   0.005291005 
+  211          190.56785    153.30803   0.004739336 
+  178          187.79788    153.36268   0.005617978 
+  194          185.37653    153.41759   0.005154639 
+  174          183.06874    153.47278   0.005747126 
+  187          180.90397    153.52823   0.005347594 
+  177          179.01159    153.58397   0.005649718 
+  191          177.47109    153.63997   0.005235602 
+  210          176.28167    153.69626   0.004761905 
+  200          175.3786     153.75282   0.005     
+  183          174.65786    153.80966   0.005464481 
+  180          174.03337    153.86679   0.005555556 
+  226          173.50771    153.92419   0.004424779 
+  186          173.15977    153.98187   0.005376344 
+  190          173.07351    154.03984   0.005263158 
+  177          173.28019    154.0981    0.005649718 
+  172          173.72525    154.15664   0.005813953 
+  192          174.21369    154.21547   0.005208333 
+  175          174.41919    154.27459   0.005714286 
+  189          174.09573    154.334     0.005291005 
+  171          173.32965    154.3937    0.005847953 
+  178          172.43891    154.45369   0.005617978 
+  145          171.6833     154.51397   0.006896552 
+  163          171.14995    154.57456   0.006134969 
+  159          170.82379    154.63543   0.006289308 
+  202          170.65467    154.69661   0.004950495 
+  163          170.61623    154.75808   0.006134969 
+  176          170.69452    154.81986   0.005681818 
+  179          170.89343    154.88194   0.005586592 
+  186          171.23299    154.94431   0.005376344 
+  178          171.70588    155.007     0.005617978 
+  182          172.22414    155.06999   0.005494505 
+  169          172.65271    155.13328   0.00591716 
+  187          172.95095    155.19689   0.005347594 
+  169          173.24982    155.2608    0.00591716 
+  174          173.74539    155.32503   0.005747126 
+  193          174.60106    155.38956   0.005181347 
+  174          175.93919    155.45441   0.005747126 
+  174          177.89649    155.51958   0.005747126 
+  193          180.67507    155.58506   0.005181347 
+  194          184.61042    155.65085   0.005154639 
+  194          190.29193    155.71697   0.005154639 
+  226          198.74812    155.78341   0.004424779 
+  213          211.63264    155.85016   0.004694836 
+  227          231.06949    155.91724   0.004405286 
+  259          257.58043    155.98465   0.003861004 
+  254          282.84705    156.05238   0.003937008 
+  249          287.1497     156.12044   0.004016064 
+  287          267.33137    156.18882   0.003484321 
+  240          242.85066    156.25754   0.004166667 
+  234          225.23111    156.32658   0.004273504 
+  213          215.43103    156.39596   0.004694836 
+  233          211.93858    156.46567   0.004291845 
+  205          213.70984    156.53572   0.004878049 
+  218          220.60067    156.6061    0.004587156 
+  233          233.06406    156.67682   0.004291845 
+  253          250.97218    156.74788   0.003952569 
+  228          270.78974    156.81928   0.004385965 
+  272          284.38211    156.89102   0.003676471 
+  262          287.55299    156.96311   0.003816794 
+  266          282.14442    157.03554   0.003759398 
+  242          266.15434    157.10831   0.004132231 
+  235          243.70403    157.18144   0.004255319 
+  228          224.17057    157.25491   0.004385965 
+  202          210.76338    157.32873   0.004950495 
+  215          202.62232    157.40291   0.004651163 
+  233          198.42382    157.47744   0.004291845 
+  184          197.34719    157.55232   0.005434783 
+  178          199.07645    157.62756   0.005617978 
+  219          203.51129    157.70316   0.00456621 
+  195          209.99114    157.77912   0.005128205 
+  225          215.741      157.85544   0.004444444 
+  192          216.01991    157.93212   0.005208333 
+  215          209.80425    158.00916   0.004651163 
+  175          201.34528    158.08657   0.005714286 
+  186          193.99752    158.16434   0.005376344 
+  186          188.43627    158.24248   0.005376344 
+  177          184.28868    158.321     0.005649718 
+  205          181.15973    158.39988   0.004878049 
+  213          178.82157    158.47913   0.004694836 
+  175          177.12494    158.55876   0.005714286 
+  178          175.94612    158.63877   0.005617978 
+  173          175.17943    158.71915   0.005780347 
+  155          174.7318     158.79991   0.006451613 
+  187          174.5174     158.88105   0.005347594 
+  164          174.45934    158.96257   0.006097561 
+  197          174.499      159.04447   0.005076142 
+  173          174.60484    159.12676   0.005780347 
+  154          174.77365    159.20944   0.006493506 
+  155          175.00653    159.2925    0.006451613 
+  158          175.28177    159.37595   0.006329114 
+  167          175.57645    159.45979   0.005988024 
+  155          175.90295    159.54402   0.006451613 
+  155          176.2762     159.62865   0.006451613 
+  162          176.6325     159.71367   0.00617284 
+  149          176.80735    159.79909   0.006711409 
+  152          176.65824    159.88491   0.006578947 
+  152          176.22502    159.97113   0.006578947 
+  170          175.68276    160.05774   0.005882353 
+  154          175.17387    160.14477   0.006493506 
+  171          174.74868    160.23219   0.005847953 
+  154          174.41735    160.32002   0.006493506 
+  147          174.19854    160.40826   0.006802721 
+  176          174.11857    160.49691   0.005681818 
+  177          174.19708    160.58597   0.005649718 
+  160          174.43727    160.67545   0.00625   
+  144          174.82263    160.76533   0.006944444 
+  181          175.30279    160.85563   0.005524862 
+  154          175.76208    160.94635   0.006493506 
+  161          176.01659    161.03749   0.00621118 
+  162          175.91591    161.12905   0.00617284 
+  179          175.48453    161.22103   0.005586592 
+  158          174.89826    161.31344   0.006329114 
+  168          174.32392    161.40627   0.005952381 
+  194          173.83701    161.49953   0.005154639 
+  134          173.45175    161.59321   0.007462687 
+  170          173.16234    161.68733   0.005882353 
+  182          172.96185    161.78188   0.005494505 
+  169          172.84607    161.87686   0.00591716 
+  171          172.81544    161.97228   0.005847953 
+  205          172.8694     162.06813   0.004878049 
+  150          172.99679    162.16443   0.006666667 
+  186          173.16775    162.26116   0.005376344 
+  156          173.33435    162.35833   0.006410256 
+  150          173.45339    162.45595   0.006666667 
+  155          173.52066    162.55402   0.006451613 
+  166          173.57453    162.65253   0.006024096 
+  176          173.66214    162.75149   0.005681818 
+  181          173.80715    162.8509    0.005524862 
+  189          174.00555    162.95076   0.005291005 
+  184          174.23163    163.05108   0.005434783 
+  154          174.45516    163.15185   0.006493506 
+  182          174.66652    163.25308   0.005494505 
+  156          174.88444    163.35477   0.006410256 
+  162          175.13555    163.45691   0.00617284 
+  115          175.43691    163.55952   0.008695652 
+  164          175.79394    163.6626    0.006097561 
+  193          176.2051     163.76614   0.005181347 
+  174          176.66551    163.87015   0.005747126 
+  169          177.16636    163.97463   0.00591716 
+  169          177.69954    164.07958   0.00591716 
+  153          178.27506    164.185     0.006535948 
+  163          178.92779    164.29089   0.006134969 
+  161          179.69977    164.39727   0.00621118 
+  182          180.62063    164.50412   0.005494505 
+  153          181.69747    164.61145   0.006535948 
+  177          182.90358    164.71926   0.005649718 
+  174          184.14538    164.82756   0.005747126 
+  168          185.23483    164.93634   0.005952381 
+  162          185.96324    165.04561   0.00617284 
+  156          186.28305    165.15536   0.006410256 
+  174          186.37804    165.26561   0.005747126 
+  171          186.50694    165.37635   0.005847953 
+  188          186.84969    165.48758   0.005319149 
+  177          187.48665    165.59931   0.005649718 
+  184          188.44229    165.71154   0.005434783 
+  185          189.7041     165.82427   0.005405405 
+  189          191.21543    165.9375    0.005291005 
+  152          192.89926    166.05123   0.006578947 
+  182          194.71405    166.16547   0.005494505 
+  184          196.67139    166.28021   0.005434783 
+  185          198.83025    166.39547   0.005405405 
+  185          201.32263    166.51123   0.005405405 
+  183          204.32001    166.62751   0.005464481 
+  166          207.9348     166.7443    0.006024096 
+  188          212.01147    166.86161   0.005319149 
+  232          215.70933    166.97943   0.004310345 
+  183          217.81371    167.09778   0.005464481 
+  218          218.6813     167.21665   0.004587156 
+  189          220.41281    167.33604   0.005291005 
+  215          224.92529    167.45596   0.004651163 
+  264          233.6669     167.5764    0.003787879 
+  233          248.32754    167.69737   0.004291845 
+  300          271.02681    167.81888   0.003333333 
+  270          302.42752    167.94092   0.003703704 
+  370          334.6153     168.06349   0.002702703 
+  315          345.72262    168.1866    0.003174603 
+  297          325.46111    168.31025   0.003367003 
+  270          293.46694    168.43444   0.003703704 
+  238          267.17743    168.55918   0.004201681 
+  250          249.73376    168.68446   0.004     
+  232          238.65878    168.81028   0.004310345 
+  204          231.22362    168.93666   0.004901961 
+  199          226.2952     169.06358   0.005025126 
+  197          223.74874    169.19106   0.005076142 
+  237          223.60627    169.31909   0.004219409 
+  199          226.20473    169.44768   0.005025126 
+  231          232.41947    169.57683   0.004329004 
+  235          243.3239     169.70653   0.004255319 
+  250          258.44163    169.8368    0.004     
+  248          271.40894    169.96764   0.004032258 
+  239          270.82528    170.09904   0.0041841 
+  208          256.69513    170.23101   0.004807692 
+  242          240.21088    170.36355   0.004132231 
+  219          227.39091    170.49666   0.00456621 
+  207          218.4699     170.63035   0.004830918 
+  208          212.30503    170.76461   0.004807692 
+  210          207.98842    170.89945   0.004761905 
+  182          204.93185    171.03487   0.005494505 
+  210          202.70333    171.17087   0.004761905 
+  179          200.97887    171.30746   0.005586592 
+  161          199.57332    171.44464   0.00621118 
+  198          198.41697    171.5824    0.005050505 
+  169          197.50602    171.72076   0.00591716 
+  189          196.86868    171.8597    0.005291005 
+  184          196.52711    171.99925   0.005434783 
+  188          196.45598    172.13938   0.005319149 
+  175          196.57111    172.28012   0.005714286 
+  211          196.74799    172.42146   0.004739336 
+  190          196.87165    172.5634    0.005263158 
+  190          196.89094    172.70595   0.005263158 
+  178          196.82836    172.8491    0.005617978 
+  206          196.73027    172.99286   0.004854369 
+  215          196.60865    173.13724   0.004651163 
+  203          196.46112    173.28223   0.004926108 
+  164          196.32306    173.42783   0.006097561 
+  178          196.24571    173.57405   0.005617978 
+  182          196.25654    173.72089   0.005494505 
+  187          196.37446    173.86835   0.005347594 
+  194          196.62667    174.01644   0.005154639 
+  185          197.0196     174.16515   0.005405405 
+  184          197.50333    174.3145    0.005434783 
+  196          197.98295    174.46447   0.005102041 
+  186          198.39209    174.61507   0.005376344 
+  202          198.76177    174.76631   0.004950495 
+  209          199.19084    174.91819   0.004784689 
+  187          199.7601     175.0707    0.005347594 
+  178          200.4843     175.22386   0.005617978 
+  229          201.31643    175.37766   0.004366812 
+  190          202.17431    175.5321    0.005263158 
+  195          202.96376    175.6872    0.005128205 
+  192          203.59947    175.84294   0.005208333 
+  196          204.07443    175.99934   0.005102041 
+  196          204.48875    176.15639   0.005102041 
+  186          204.97236    176.31409   0.005376344 
+  201          205.60454    176.47246   0.004975124 
+  203          206.39459    176.63148   0.004926108 
+  198          207.31091    176.79117   0.005050505 
+  197          208.33043    176.95153   0.005076142 
+  213          209.4727     177.11255   0.004694836 
+  183          210.78722    177.27424   0.005464481 
+  197          212.3271     177.43661   0.005076142 
+  202          214.1335     177.59964   0.004950495 
+  212          216.23365    177.76336   0.004716981 
+  235          218.618      177.92775   0.004255319 
+  197          221.20018    178.09283   0.005076142 
+  220          223.77334    178.25859   0.004545455 
+  226          226.03093    178.42503   0.004424779 
+  205          227.71474    178.59217   0.004878049 
+  202          228.8238     178.75999   0.004950495 
+  203          229.59866    178.9285    0.004926108 
+  220          230.24135    179.09771   0.004545455 
+  226          230.75529    179.26762   0.004424779 
+  267          231.0867     179.43823   0.003745318 
+  210          231.30758    179.60953   0.004761905 
+  226          231.59325    179.78155   0.004424779 
+  236          232.10815    179.95427   0.004237288 
+  202          232.85222    180.12769   0.004950495 
+  223          234.09985    180.30183   0.004484305 
+  231          235.76178    180.47668   0.004329004 
+  202          237.81536    180.65225   0.004950495 
+  234          240.17876    180.82854   0.004273504 
+  238          242.69675    181.00554   0.004201681 
+  236          245.20541    181.18327   0.004237288 
+  237          247.66431    181.36172   0.004219409 
+  265          250.21013    181.5409    0.003773585 
+  272          253.03142    181.72082   0.003676471 
+  235          256.24429    181.90146   0.004255319 
+  252          259.9404     182.08284   0.003968254 
+  314          264.32666    182.26495   0.003184713 
+  282          269.74511    182.4478    0.003546099 
+  310          276.82949    182.6314    0.003225806 
+  310          285.8571     182.81574   0.003225806 
+  311          296.03869    183.00083   0.003215434 
+  353          304.29753    183.18666   0.002832861 
+  321          306.98361    183.37325   0.003115265 
+  318          304.7547     183.56059   0.003144654 
+  362          301.59281    183.74869   0.002762431 
+  320          300.06869    183.93754   0.003125  
+  337          300.68613    184.12716   0.002967359 
+  348          303.17607    184.31754   0.002873563 
+  374          307.24987    184.50869   0.002673797 
+  388          312.77572    184.7006    0.00257732 
+  339          319.74182    184.89329   0.002949853 
+  354          328.21792    185.08675   0.002824859 
+  386          338.37332    185.28099   0.002590674 
+  351          350.49885    185.476     0.002849003 
+  425          364.95443    185.67179   0.002352941 
+  389          381.87281    185.86837   0.002570694 
+  439          400.52638    186.06574   0.002277904 
+  416          419.33437    186.26389   0.002403846 
+  448          437.99015    186.46283   0.002232143 
+  510          458.75513    186.66257   0.001960784 
+  518          484.28772    186.8631    0.001930502 
+  557          516.36059    187.06444   0.001795332 
+  597          556.43796    187.26657   0.001675042 
+  656          606.41676    187.4695    0.00152439 
+  751          669.08093    187.67325   0.001331558 
+  910          748.18642    187.8778    0.001098901 
+  930          848.24485    188.08316   0.001075269 
+  1147         975.78716    188.28934   0.00087184 
+  1272         1143.91724   188.49633   0.000786164 
+  1661         1376.34455   188.70414   0.000602047 
+  1935         1707.70015   188.91277   0.000516796 
+  2593         2189.27082   189.12223   0.000385654 
+  3382         2897.92084   189.33251   0.000295683 
+  4465         3914.20132   189.54362   0.000223964 
+  5717         5201.08541   189.75557   0.000174917 
+  6475         6315.17714   189.96835   0.00015444 
+  6492         6439.74142   190.18196   0.000154036 
+  5388         5468.31609   190.39642   0.000185598 
+  4457         4188.07122   190.61172   0.000224366 
+  3632         3140.64594   190.82786   0.00027533 
+  2899         2413.2701    191.04485   0.000344947 
+  2372         1938.6289    191.26269   0.000421585 
+  2008         1639.80306   191.48138   0.000498008 
+  1828         1463.10649   191.70093   0.000547046 
+  1642         1379.09469   191.92134   0.000609013 
+  1681         1377.55641   192.14261   0.000594884 
+  1764         1462.89733   192.36474   0.000566893 
+  1923         1654.91682   192.58774   0.000520021 
+  2329         1989.01771   192.8116    0.000429369 
+  2727         2494.45023   193.03634   0.000366703 
+  3227         3107.98111   193.26196   0.000309885 
+  3458         3527.24566   193.48844   0.000289184 
+  3285         3376.00254   193.71581   0.000304414 
+  2851         2769.91358   193.94406   0.000350754 
+  2342         2116.72494   194.1732    0.000426985 
+  1846         1609.41441   194.40323   0.000541712 
+  1453         1254.87425   194.63414   0.000688231 
+  1248         1012.56816   194.86595   0.000801282 
+  1027         845.13742    195.09865   0.00097371 
+  894          726.37458    195.33225   0.001118568 
+  779          639.3246     195.56676   0.001283697 
+  662          573.35806    195.80217   0.001510574 
+  606          521.97726    196.03848   0.001650165 
+  541          481.12841    196.27571   0.001848429 
+  529          448.24448    196.51385   0.001890359 
+  465          421.57571    196.7529    0.002150538 
+  458          399.83453    196.99287   0.002183406 
+  455          382.02944    197.23376   0.002197802 
+  407          367.35081    197.47558   0.002457002 
+  354          355.11693    197.71832   0.002824859 
+  349          344.81797    197.96199   0.00286533 
+  350          336.22715    198.2066    0.002857143 
+  339          329.41809    198.45214   0.002949853 
+  318          324.60722    198.69861   0.003144654 
+  306          321.70418    198.94603   0.003267974 
+  332          319.27213    199.19439   0.003012048 
+  302          314.41456    199.4437    0.003311258 
+  337          306.51413    199.69395   0.002967359 
+  289          298.09356    199.94516   0.003460208 
+  281          290.87102    200.19733   0.003558719 
+  307          285.13285    200.45045   0.003257329 
+  286          280.6995     200.70453   0.003496503 
+  271          277.34747    200.95957   0.003690037 
+  267          274.91631    201.21559   0.003745318 
+  306          273.31615    201.47257   0.003267974 
+  275          272.49562    201.73052   0.003636364 
+  286          272.45866    201.98945   0.003496503 
+  256          273.35159    202.24936   0.00390625 
+  272          275.54672    202.51024   0.003676471 
+  234          279.60855    202.77212   0.004273504 
+  295          285.96593    203.03497   0.003389831 
+  255          293.95748    203.29882   0.003921569 
+  302          300.66168    203.56366   0.003311258 
+  279          302.02743    203.8295    0.003584229 
+  280          296.33327    204.09633   0.003571429 
+  227          286.29774    204.36417   0.004405286 
+  280          276.14549    204.63301   0.003571429 
+  230          268.02825    204.90286   0.004347826 
+  274          262.2192     205.17372   0.003649635 
+  285          258.36264    205.44559   0.003508772 
+  243          256.08967    205.71848   0.004115226 
+  246          255.16778    205.99239   0.004065041 
+  218          255.49717    206.26732   0.004587156 
+  254          257.10373    206.54328   0.003937008 
+  225          260.15242    206.82027   0.004444444 
+  226          264.9623     207.09828   0.004424779 
+  232          271.93207    207.37734   0.004310345 
+  214          281.1193     207.65743   0.004672897 
+#--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--eof--#
+
+# start Validation Reply Form
+vrf_PLAT741_NEW10minmill_phase_1 # for all atoms in 1_quartz
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+vrf_PLAT741_NEW10minmill_phase_3 # for all atoms in 3_pyrrhotite
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+vrf_PLAT741_NEW10minmill_phase_4 # for all atoms in 4_rutile
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+vrf_PLAT741_NEW10minmill_phase_2 # for all atoms in 2_albite
+;
+PROBLEM: Bond Calculation Missing s.u.
+RESPONSE: atomic positions not refined
+;
+_vrf_PLAT155_NEW10minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT141_NEW10minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT142_NEW10minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT143_NEW10minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT144_NEW10minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT145_NEW10minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT146_NEW10minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+_vrf_PLAT151_NEW10minmill_phase_2 # for 2_albite
+;
+PROBLEM: s.u. Small or Missing, The Triclinic Unitcell is NOT reduced.
+RESPONSE: unit cell not refined
+;
+# end Validation Reply Form


### PR DESCRIPTION
can now read a single wavelength from a list of many
remove leading/trailing newlines from block ids.